### PR TITLE
Replace skeleton in project when Load Skeleton (GUI)

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1527,7 +1527,7 @@ class OpenSkeleton(EditCommand):
                 context.state["skeleton"] = sk_list[0]
 
         if context.state["skeleton"] not in context.labels:
-            context.labels.skeletons.append(context.state["skeleton"])
+            context.labels.skeletons = [context.state["skeleton"]]
 
 
 class SaveSkeleton(AppCommand):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -76,7 +76,7 @@ def test_open_skeleton(min_labels):
 
     # Create command context and params. Load skeleton.
     commands: CommandContext = CommandContext.from_labels(labels)
-    skeleton_filename = "tests\\data\\skeleton\\fly_skeleton_legs.json"
+    skeleton_filename = "tests/data/skeleton/fly_skeleton_legs.json"
     params: dict = {"filename": skeleton_filename}
 
     # Check that new skeleton replaced skeleton instead of appending to skeletons list.

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -2,8 +2,10 @@ from sleap.gui.commands import (
     CommandContext,
     ImportDeepLabCutFolder,
     get_new_version_filename,
+    OpenSkeleton,
 )
 from sleap.io.pathutils import fix_path_separator
+from sleap.io.dataset import Labels
 from pathlib import PurePath
 
 
@@ -63,3 +65,20 @@ def test_get_new_version_filename():
     assert get_new_version_filename("/a/b/labels.v01.slp") == str(
         PurePath("/a/b/labels.v02.slp")
     )
+
+
+def test_open_skeleton(min_labels):
+    """Ensure CommandContext.OpenSkeleton only allows one skeleton in Labels.skeletons."""
+
+    # Load in labels with a single skeleton.
+    labels: Labels = min_labels
+    assert len(labels.skeletons) == 1
+
+    # Create command context and params. Load skeleton.
+    commands: CommandContext = CommandContext.from_labels(labels)
+    skeleton_filename = "tests\\data\\skeleton\\fly_skeleton_legs.json"
+    params: dict = {"filename": skeleton_filename}
+
+    # Check that new skeleton replaced skeleton instead of appending to skeletons list.
+    OpenSkeleton().do_action(context=commands, params=params)
+    assert len(labels.skeletons) == 1

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -73,6 +73,7 @@ def test_open_skeleton(min_labels):
     # Load in labels with a single skeleton.
     labels: Labels = min_labels
     assert len(labels.skeletons) == 1
+    assert labels.skeleton.name == "Skeleton-0"
 
     # Create command context and params. Load skeleton.
     commands: CommandContext = CommandContext.from_labels(labels)
@@ -82,3 +83,20 @@ def test_open_skeleton(min_labels):
     # Check that new skeleton replaced skeleton instead of appending to skeletons list.
     OpenSkeleton().do_action(context=commands, params=params)
     assert len(labels.skeletons) == 1
+    assert labels.skeleton.name == "skeleton_legs.mat"
+
+    # Check that skeletons, nodes, and edges for instances are updated to new skeleton.
+    # TODO: Instance skeletons are unchanged and need to be merged.
+    #   Possibly reuse code from MergeDialog.__init__, Labels.complex_merge_between,
+    #   LabeledFrame.complex_merge_between, and LabeledFrame.complex_frame_merge.
+    #       Code could be implemented in OpenSkeleton.do_action or in callback
+    #       MainWindow.on_data_update.
+    print(f"\n\nlabels.skeleton.nodes = {labels.skeleton.nodes}")
+    print(f"\nlabels.nodes = {labels.nodes}")
+    print(f"\n\nlabels.skeleton.name = {labels.skeleton.name}")
+    print(
+        f"\nlabels.labeled_frames[0].instances[0].skeleton.name = "
+        "{labels.labeled_frames[0].instances[0].skeleton.name}"
+    )
+    assert labels.labeled_frames[0].instances[0].skeleton.name == labels.skeleton.name
+    assert labels.nodes == labels.skeleton.nodes


### PR DESCRIPTION
### Description
Remove ability to add multiple skeletons to project through "Load Skeleton" on gui.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Skeleton incompatibility #713

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [x] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [x] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
