### PR TITLE
Generate suggestions for videos with less frames than samples per video

### DIFF
--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -81,8 +81,8 @@ class VideoFrameSuggestions(object):
         for video in labels.videos:
             if sampling_method == "stride":
                 frame_increment = video.frames // per_video
-                if (frame_increment) == 0:
-                    frame_increment = 1
+                if frame_increment == 0:
+                    frame_increment = per_video
                 vid_suggestions = list(range(0, video.frames, frame_increment))[
                     :per_video
                 ]

--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -82,10 +82,10 @@ class VideoFrameSuggestions(object):
             if sampling_method == "stride":
                 frame_increment = video.frames // per_video
                 if (frame_increment) == 0:
-                    frame_increment = per_video
-                vid_suggestions = list(
-                    range(0, video.frames, frame_increment)
-                )[:per_video]
+                    frame_increment = 1
+                vid_suggestions = list(range(0, video.frames, frame_increment))[
+                    :per_video
+                ]
             else:
                 # random sampling
                 vid_suggestions = random.sample(range(video.frames), per_video)

--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -80,8 +80,11 @@ class VideoFrameSuggestions(object):
 
         for video in labels.videos:
             if sampling_method == "stride":
+                frame_increment = video.frames // per_video
+                if (frame_increment) == 0:
+                    frame_increment = per_video
                 vid_suggestions = list(
-                    range(0, video.frames, video.frames // per_video)
+                    range(0, video.frames, frame_increment)
                 )[:per_video]
             else:
                 # random sampling

--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -81,8 +81,7 @@ class VideoFrameSuggestions(object):
         for video in labels.videos:
             if sampling_method == "stride":
                 frame_increment = video.frames // per_video
-                if frame_increment == 0:
-                    frame_increment = per_video
+                frame_increment = per_video if frame_increment == 0 else frame_increment
                 vid_suggestions = list(range(0, video.frames, frame_increment))[
                     :per_video
                 ]

--- a/tests/gui/test_suggestions.py
+++ b/tests/gui/test_suggestions.py
@@ -1,4 +1,5 @@
 from sleap.gui.suggestions import VideoFrameSuggestions
+from sleap.io.dataset import Labels
 
 
 def test_velocity_suggestions(centered_pair_predictions):
@@ -9,3 +10,33 @@ def test_velocity_suggestions(centered_pair_predictions):
     assert len(suggestions) == 45
     assert suggestions[0].frame_idx == 21
     assert suggestions[1].frame_idx == 45
+
+
+def test_frame_increment(centered_pair_predictions: Labels):
+
+    # Testing videos that have less frames than desired Samples per Video value using stride method.
+    # Expected result is one suggested frame.
+
+    vid_frames = centered_pair_predictions.video.num_frames
+    suggestions = VideoFrameSuggestions.suggest(
+        labels=centered_pair_predictions,
+        params={
+            "method": "sample",
+            "per_video": 2 * vid_frames,
+            "sampling_method": "stride",
+        },
+    )
+    assert len(suggestions) == 1
+
+    # Testing typical videos that have more frames than desired Samples per Video value using stride method.
+    # Expected result is the desired Samples per Video number of frames.
+
+    suggestions = VideoFrameSuggestions.suggest(
+        labels=centered_pair_predictions,
+        params={
+            "method": "sample",
+            "per_video": 20,
+            "sampling_method": "stride",
+        },
+    )
+    assert len(suggestions) == 20


### PR DESCRIPTION
### Description
Handle videos which contain less frames than the samples per video for sampling method stride.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Generate Sample Suggestions with less than number of sampled frames #773

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
