### PR TITLE
Add button to toggle grayscale of current video

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -935,6 +935,7 @@ class MainWindow(QMainWindow):
         videos_layout.addWidget(self.videosTable)
 
         hb = QHBoxLayout()
+        _add_button(hb, "Toggle Grayscale", self.commands.toggleGrayscale)
         _add_button(hb, "Show Video", self.videosTable.activateSelected)
         _add_button(hb, "Add Videos", self.commands.addVideo)
         _add_button(hb, "Remove Video", self.commands.removeVideo)
@@ -1172,9 +1173,10 @@ class MainWindow(QMainWindow):
     def _update_gui_state(self):
         """Enable/disable gui items based on current state."""
         has_selected_instance = self.state["instance"] is not None
-        has_selected_video = self.state["selected_video"] is not None
         has_selected_node = self.state["selected_node"] is not None
         has_selected_edge = self.state["selected_edge"] is not None
+        has_selected_video = self.state["selected_video"] is not None
+        has_video = self.state["video"] is not None
 
         has_frame_range = bool(self.state["has_frame_range"])
         has_unsaved_changes = bool(self.state["has_changes"])
@@ -1224,6 +1226,7 @@ class MainWindow(QMainWindow):
         self._buttons["add edge"].setEnabled(has_nodes_selected)
         self._buttons["delete edge"].setEnabled(has_selected_edge)
         self._buttons["delete node"].setEnabled(has_selected_node)
+        self._buttons["toggle grayscale"].setEnabled(has_video)
         self._buttons["show video"].setEnabled(has_selected_video)
         self._buttons["remove video"].setEnabled(has_selected_video)
         self._buttons["delete instance"].setEnabled(has_selected_instance)

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -369,6 +369,10 @@ class CommandContext:
 
     # Editing Commands
 
+    def toggleGrayscale(self):
+        """Toggles grayscale setting for current video."""
+        self.execute(ToggleGrayscale)
+
     def addVideo(self):
         """Shows gui for adding videos to project."""
         self.execute(AddVideo)
@@ -1440,6 +1444,30 @@ class EditCommand(AppCommand):
     """Class for commands which change data in project."""
 
     does_edits = True
+
+
+class ToggleGrayscale(EditCommand):
+    topics = [UpdateTopic.video, UpdateTopic.frame]
+
+    @staticmethod
+    def do_action(context: CommandContext, params: dict):
+        """Reset the video backend."""
+        video: Video = context.state["video"]
+        try:
+            grayscale = video.backend.grayscale
+            video.backend.reset(grayscale=(not grayscale))
+        except:
+            print(
+                f"This video type {type(video.backend)} does not support grayscale yet."
+            )
+
+    @staticmethod
+    def ask(context: CommandContext, params: dict) -> bool:
+        """Check that video can be reset."""
+        # Check that current video is set
+        if context.state["video"] is None:
+            return False
+        return True
 
 
 class AddVideo(EditCommand):

--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -461,9 +461,23 @@ class MediaVideo:
         """See :class:`Video`."""
         return self.test_frame.dtype
 
-    def reset(self):
+    def reset(self, filename: str = None, grayscale: bool = None, bgr: bool = None):
         """Reloads the video."""
-        self._reader_ = None
+        if filename is not None:
+            self.filename = filename
+            self._test_frame_ = None  # Test frame does not depend on num channels
+
+        if grayscale is not None:
+            self.grayscale = grayscale
+            self._detect_grayscale = False
+        else:
+            self._detect_grayscale = True
+
+        if bgr is not None:
+            self.bgr = bgr
+
+        if (filename is not None) or (grayscale is not None):
+            self._reader_ = None  # Reader depends on both filename and grayscale
 
     def get_frame(self, idx: int, grayscale: bool = None) -> np.ndarray:
         """See :class:`Video`."""

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -11,6 +11,7 @@ from sleap.io.convert import default_analysis_filename
 from sleap.instance import Instance
 
 from tests.info.test_h5 import extract_meta_hdf5
+from tests.io.test_video import assert_video_params
 
 from pathlib import PurePath, Path
 import shutil
@@ -234,3 +235,22 @@ def test_ExportAnalysisFile(
     params = {"all_videos": True}
     okay = ExportAnalysisFile_ask(context=context, params=params)
     assert okay == False
+
+
+def test_ToggleGrayscale(centered_pair_predictions: Labels):
+    """Test functionality for ToggleGrayscale on mp4/avi video"""
+    labels = centered_pair_predictions
+    video = labels.video
+    grayscale = video.backend.grayscale
+    filename = video.backend.filename
+
+    context = CommandContext.from_labels(labels)
+    context.state["video"] = video
+
+    # Toggle grayscale to "not grayscale"
+    context.toggleGrayscale()
+    assert_video_params(video=video, filename=filename, grayscale=(not grayscale))
+
+    # Toggle grayscale back to "grayscale"
+    context.toggleGrayscale()
+    assert_video_params(video=video, filename=filename, grayscale=grayscale)

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -408,23 +408,27 @@ def test_load_video():
 
 def assert_video_params(
     video: Video,
-    filename: str = None,
+    filename: str,
     grayscale: bool = None,
-    bgr: bool = True,
+    bgr: bool = None,
     reset: bool = False,
 ):
     assert video.backend.filename == filename
-    assert video.backend.grayscale == grayscale
-    assert video.backend.bgr == bgr
+    if grayscale is not None:
+        assert video.backend.grayscale == grayscale
+    else:
+        assert video.backend._detect_grayscale == bool(grayscale is None)
+    if bgr is not None:
+        assert video.backend.bgr == bgr
     if reset:
         assert video.backend._reader_ == None
         assert video.backend._test_frame_ == None
-        assert video.backend._detect_grayscale == bool(grayscale is None)
     # Getting the channels will assert some of the above are not None
-    assert video.backend.channels == 3 ** (not grayscale)
+    if grayscale is not None:
+        assert video.backend.channels == 3 ** (not grayscale)
 
 
-def test_reset_video(small_robot_mp4_vid: Video):
+def test_reset_video_mp4(small_robot_mp4_vid: Video):
 
     video = small_robot_mp4_vid
     filename = video.backend.filename
@@ -437,7 +441,7 @@ def test_reset_video(small_robot_mp4_vid: Video):
 
     # Test reset works for color to grayscale
 
-    # Reset the backend
+    # Reset the backend: grasyscale = True
     video.backend.reset(filename=filename, grayscale=True)
     assert_video_params(video=video, filename=filename, grayscale=True, reset=True)
 
@@ -448,7 +452,7 @@ def test_reset_video(small_robot_mp4_vid: Video):
 
     # Test reset works for grayscale to color
 
-    # Reset the backend
+    # Reset the backend: grasyscale = False
     video.backend.reset(filename=filename, grayscale=False)
     assert_video_params(
         video=video, filename=filename, grayscale=False, bgr=True, reset=True
@@ -458,3 +462,9 @@ def test_reset_video(small_robot_mp4_vid: Video):
     frame = video.get_frame(idx=0)
     assert frame.shape[2] == 3
     assert_video_params(video=video, filename=filename, grayscale=False)
+
+    # Test reset works when grayscale is None
+
+    # Reset the backend: grayscale = None (and set bgr)
+    video.backend.reset(filename=filename, bgr=True)
+    assert_video_params(video=video, filename=filename, bgr=True, reset=True)

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -1,7 +1,6 @@
 import pytest
 import os
 import h5py
-
 import numpy as np
 
 from sleap.io.video import Video, HDF5Video, MediaVideo, DummyVideo, load_video
@@ -405,3 +404,57 @@ def test_load_video():
     video = load_video(TEST_SMALL_CENTERED_PAIR_VID)
     assert video.shape == (1100, 384, 384, 1)
     assert video[:3].shape == (3, 384, 384, 1)
+
+
+def assert_video_params(
+    video: Video,
+    filename: str = None,
+    grayscale: bool = None,
+    bgr: bool = True,
+    reset: bool = False,
+):
+    assert video.backend.filename == filename
+    assert video.backend.grayscale == grayscale
+    assert video.backend.bgr == bgr
+    if reset:
+        assert video.backend._reader_ == None
+        assert video.backend._test_frame_ == None
+        assert video.backend._detect_grayscale == bool(grayscale is None)
+    # Getting the channels will assert some of the above are not None
+    assert video.backend.channels == 3 ** (not grayscale)
+
+
+def test_reset_video(small_robot_mp4_vid: Video):
+
+    video = small_robot_mp4_vid
+    filename = video.backend.filename
+
+    # Get a frame to set the video parameters in the backend
+    video.get_frame(idx=0)
+    assert_video_params(
+        video=video, filename=filename, grayscale=video.backend.grayscale
+    )
+
+    # Test reset works for color to grayscale
+
+    # Reset the backend
+    video.backend.reset(filename=filename, grayscale=True)
+    assert_video_params(video=video, filename=filename, grayscale=True, reset=True)
+
+    # Get a frame to test that reset parameters persist (namely grayscale and channels)
+    frame = video.get_frame(idx=0)
+    assert frame.shape[2] == 1
+    assert_video_params(video=video, filename=filename, grayscale=True)
+
+    # Test reset works for grayscale to color
+
+    # Reset the backend
+    video.backend.reset(filename=filename, grayscale=False)
+    assert_video_params(
+        video=video, filename=filename, grayscale=False, bgr=True, reset=True
+    )
+
+    # Get a frame to test that reset parameters persist (namely grayscale and channels)
+    frame = video.get_frame(idx=0)
+    assert frame.shape[2] == 3
+    assert_video_params(video=video, filename=filename, grayscale=False)


### PR DESCRIPTION
### Description
Allow users to toggle the grayscale of the displayed video via a button in the "Video" view. This button only toggles the grayscale of the current video. Note that grayscale is only support in mp4/avi videos as of this PR.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Set videos to RGB/Grayscale from the GUI #625

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
