### PR TITLE
Change existing skeleton to match skeleton loaded via "Load Skeleton" button

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1737,13 +1737,13 @@ class OpenSkeleton(EditCommand):
                 # Warn about mismatching skeletons
                 title = "Replace Skeleton"
                 message = (
-                    "<p><strong>Warning:</strong> Pre-existing skeleton found. "
-                    "The following nodes will be deleted from all instances:<p>"
-                    f"<p><em>From base labels</em>: {','.join(delete_nodes)}<br>"
-                    "The following nodes will be added to all instances:<p>"
+                    "<p><b>Warning:</b> Pre-existing skeleton found."
+                    "<p>The following nodes will be <b>deleted</b> from all instances:"
+                    f"<br><em>From base labels</em>: {','.join(delete_nodes)}<br></p>"
+                    "<p>The following nodes will be <b>added</b> to all instances:<br>"
                     f"<em>From new labels</em>: {','.join(add_nodes)}</p>"
                     "<p>Nodes can be deleted or merged from the skeleton editor after "
-                    "merging labels.</p><br>"
+                    "merging labels.</p>"
                 )
                 query = QueryDialog(title=title, message=message)
                 query.exec_()

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1770,11 +1770,11 @@ class OpenSkeleton(EditCommand):
             context.labels.skeletons.append(context.state["skeleton"])
             return
 
-        # Case 2: Skeleton already exists in project
-        skeleton = context.labels.skeleton  # Assume single skeleton
+        # Case 2: Skeleton(s) already exist(s) in project
 
         # Delete extra skeletons in project
         OpenSkeleton.delete_extra_skeletons(context.labels)
+        skeleton = context.labels.skeleton  # Assume single skeleton
 
         if "delete_nodes" in params.keys():
             # We already compared skeletons in ask() method

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1856,7 +1856,7 @@ class OpenSkeleton(EditCommand):
         for src, dst in new_skeleton.symmetries:
             skeleton.add_symmetry(src.name, dst.name)
 
-        # Only add skeleton if no errors occur above
+        # Set state of context
         context.state["skeleton"] = skeleton
 
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -56,6 +56,7 @@ from sleap.gui.dialogs.filedialog import FileDialog
 from sleap.gui.dialogs.missingfiles import MissingFilesDialog
 from sleap.gui.dialogs.merge import MergeDialog
 from sleap.gui.dialogs.message import MessageDialog
+from sleap.gui.dialogs.query import QueryDialog
 from sleap.gui.suggestions import VideoFrameSuggestions
 from sleap.gui.state import GuiState
 
@@ -1666,7 +1667,52 @@ class OpenSkeleton(EditCommand):
     topics = [UpdateTopic.skeleton]
 
     @staticmethod
+    def load_skeleton(filename: str):
+        if filename.endswith(".json"):
+            new_skeleton = Skeleton.load_json(filename)
+        elif filename.endswith((".h5", ".hdf5")):
+            sk_list = Skeleton.load_all_hdf5(filename)
+            new_skeleton = sk_list[0]
+        return new_skeleton
+
+    @staticmethod
+    def compare_skeletons(
+        skeleton: Skeleton, new_skeleton: Skeleton
+    ) -> Tuple[List[str], List[str]]:
+
+        delete_nodes = []
+        add_nodes = []
+        if skeleton.node_names != new_skeleton.node_names:
+            # Compare skeletons
+            base_nodes = skeleton.node_names
+            new_nodes = new_skeleton.node_names
+            delete_nodes = [node for node in base_nodes if node not in new_nodes]
+            add_nodes = [node for node in new_nodes if node not in base_nodes]
+
+        return delete_nodes, add_nodes
+
+    @staticmethod
+    def delete_extra_skeletons(labels: Labels):
+        if len(labels.skeletons) > 1:
+            skeletons_used = list(
+                set(
+                    [
+                        inst.skeleton
+                        for lf in labels.labeled_frames
+                        for inst in lf.instances
+                    ]
+                )
+            )
+            try:
+                assert len(skeletons_used) == 1
+            except AssertionError:
+                raise ValueError("Too many skeletons used in project.")
+
+            labels.skeletons = skeletons_used
+
+    @staticmethod
     def ask(context: CommandContext, params: dict) -> bool:
+
         filters = ["JSON skeleton (*.json)", "HDF5 skeleton (*.h5 *.hdf5)"]
         filename, selected_filter = FileDialog.open(
             context.app, dir=None, caption="Open skeleton...", filter=";;".join(filters)
@@ -1675,21 +1721,94 @@ class OpenSkeleton(EditCommand):
         if len(filename) == 0:
             return False
 
+        okay = True
+        if len(context.labels.skeletons) > 0:
+            # Ask user permission to merge skeletons
+            okay = False
+            skeleton: Skeleton = context.labels.skeleton  # Assumes single skeleton
+
+            # Load new skeleton and compare
+            new_skeleton = OpenSkeleton.load_skeleton(filename)
+            (delete_nodes, add_nodes) = OpenSkeleton.compare_skeletons(
+                skeleton, new_skeleton
+            )
+
+            if (len(delete_nodes) > 0) or (len(add_nodes) > 0):
+                # Warn about mismatching skeletons
+                title = "Replace Skeleton"
+                message = (
+                    "<p><strong>Warning:</strong> Pre-existing skeleton found. "
+                    "The following nodes will be deleted from all instances:<p>"
+                    f"<p><em>From base labels</em>: {','.join(delete_nodes)}<br>"
+                    "The following nodes will be added to all instances:<p>"
+                    f"<em>From new labels</em>: {','.join(add_nodes)}</p>"
+                    "<p>Nodes can be deleted or merged from the skeleton editor after "
+                    "merging labels.</p><br>"
+                )
+                query = QueryDialog(title=title, message=message)
+                query.exec_()
+
+                # Give the okay to add/delete nodes
+                okay = bool(query.result())
+
+            params["delete_nodes"] = delete_nodes
+            params["add_nodes"] = add_nodes
+
         params["filename"] = filename
-        return True
+        return okay
 
     @staticmethod
     def do_action(context: CommandContext, params: dict):
-        filename = params["filename"]
-        if filename.endswith(".json"):
-            context.state["skeleton"] = Skeleton.load_json(filename)
-        elif filename.endswith((".h5", ".hdf5")):
-            sk_list = Skeleton.load_all_hdf5(filename)
-            if len(sk_list):
-                context.state["skeleton"] = sk_list[0]
 
-        if context.state["skeleton"] not in context.labels:
+        # Load new skeleton
+        filename = params["filename"]
+        new_skeleton = OpenSkeleton.load_skeleton(filename)
+
+        # Case 1: No skeleton exists in project
+        if len(context.labels.skeletons) == 0:
+            context.state["skeleton"] = new_skeleton
             context.labels.skeletons.append(context.state["skeleton"])
+            return
+
+        # Case 2: Skeleton already exists in project
+        skeleton = context.labels.skeleton  # Assume single skeleton
+
+        # Delete extra skeletons in project
+        OpenSkeleton.delete_extra_skeletons(context.labels)
+
+        if "delete_nodes" in params.keys():
+            # We already compared skeletons in ask() method
+            delete_nodes: List[str] = params["delete_nodes"]
+            add_nodes: List[str] = params["add_nodes"]
+        else:
+            # Otherwise, load new skeleton and compare
+            (delete_nodes, add_nodes) = OpenSkeleton.compare_skeletons(
+                skeleton, new_skeleton
+            )
+
+        # Delete pre-existing symmetry
+        for src, dst in skeleton.symmetries:
+            skeleton.delete_symmetry(src, dst)
+
+        # Delete nodes from skeleton that are not in new skeleton
+        for node in delete_nodes:
+            skeleton.delete_node(node)
+
+        # Add nodes that only exist in the new skeleton
+        for node in add_nodes:
+            skeleton.add_node(node)
+
+        # Add edges
+        skeleton.clear_edges()
+        for src, dest in new_skeleton.edges:
+            skeleton.add_edge(src.name, dest.name)
+
+        # Add new symmetry
+        for src, dst in new_skeleton.symmetries:
+            skeleton.add_symmetry(src.name, dst.name)
+
+        # Only add skeleton if no errors occur above
+        context.state["skeleton"] = skeleton
 
 
 class SaveSkeleton(AppCommand):

--- a/sleap/gui/dialogs/query.py
+++ b/sleap/gui/dialogs/query.py
@@ -1,0 +1,31 @@
+"""
+Generic module to ask user permission to complete an action.
+"""
+
+from PySide2.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QVBoxLayout,
+    QLabel,
+)
+
+
+class QueryDialog(QDialog):
+    def __init__(self, title: str, message: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.user_response = False
+
+        self.setWindowTitle(title)
+
+        QBtn = QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+
+        self.buttonBox = QDialogButtonBox(QBtn)
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)
+
+        self.layout = QVBoxLayout()
+        message = QLabel(message)
+        self.layout.addWidget(message)
+        self.layout.addWidget(self.buttonBox)
+        self.setLayout(self.layout)

--- a/sleap/gui/dialogs/query.py
+++ b/sleap/gui/dialogs/query.py
@@ -11,7 +11,15 @@ from PySide2.QtWidgets import (
 
 
 class QueryDialog(QDialog):
+    """Opens `QDialog` to ask user permission to complete an action.
+
+    Args:
+        title: Text to be displayed in the header of dialog box.
+        message: Test to be displayed in the body of dialog box.
+    """
+
     def __init__(self, title: str, message: str, *args, **kwargs):
+        """Initialize and display `QDialog`."""
         super().__init__(*args, **kwargs)
 
         self.user_response = False

--- a/tests/fixtures/skeletons.py
+++ b/tests/fixtures/skeletons.py
@@ -2,6 +2,14 @@ import pytest
 
 from sleap.skeleton import Skeleton
 
+TEST_FLY_LEGS_SKELETON = "tests/data/skeleton/fly_skeleton_legs.json"
+
+
+@pytest.fixture
+def fly_legs_skeleton_json():
+    """Path to fly_skeleton_legs.json"""
+    return TEST_FLY_LEGS_SKELETON
+
 
 @pytest.fixture
 def stickman():

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -368,11 +368,15 @@ def test_OpenSkeleton(
     skeleton.add_symmetry(skeleton.nodes[0].name, skeleton.nodes[1].name)
     context = CommandContext.from_labels(labels)
 
+    # Add multiple skeletons to and ensure the unused skeleton is removed
+    labels.skeletons.append(stickman)
+
     # Run without OpenSkeleton.ask()
     params = {"filename": fly_legs_skeleton_json}
     new_skeleton = OpenSkeleton.load_skeleton(fly_legs_skeleton_json)
     new_skeleton.add_symmetry(new_skeleton.nodes[0], new_skeleton.nodes[1])
     OpenSkeleton.do_action(context, params)
+    assert len(labels.skeletons) == 1
 
     # State is updated
     assert context.state["skeleton"] == skeleton

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -3,6 +3,7 @@ from sleap.gui.commands import (
     ImportDeepLabCutFolder,
     ExportAnalysisFile,
     ReplaceVideo,
+    OpenSkeleton,
     get_new_version_filename,
 )
 from sleap.io.dataset import Labels
@@ -10,6 +11,7 @@ from sleap.io.pathutils import fix_path_separator
 from sleap.io.video import Video
 from sleap.io.convert import default_analysis_filename
 from sleap.instance import Instance, LabeledFrame
+from sleap import Skeleton
 
 from tests.info.test_h5 import extract_meta_hdf5
 from tests.io.test_video import assert_video_params
@@ -307,3 +309,81 @@ def test_ReplaceVideo(
     # Attempt to replace an mp4 with an hdf5 video
     with pytest.raises(TypeError):
         replace_video(hdf5_vid, labels.videos, context)
+
+
+def test_OpenSkeleton(
+    centered_pair_predictions: Labels, stickman: Skeleton, fly_legs_skeleton_json: str
+):
+    def assert_skeletons_match(new_skeleton: Skeleton, skeleton: Skeleton):
+        # Node names match
+        for new_node, node in zip(new_skeleton.nodes, skeleton.nodes):
+            assert new_node.name == node.name
+
+        # Edges match
+        for (new_src, new_dst), (src, dst) in zip(new_skeleton.edges, skeleton.edges):
+            assert new_src.name == src.name
+            assert new_dst.name == dst.name
+
+        # Symmetries match
+        for (new_src, new_dst), (src, dst) in zip(
+            new_skeleton.symmetries, skeleton.symmetries
+        ):
+            assert new_src.name == src.name
+            assert new_dst.name == dst.name
+
+    def OpenSkeleton_ask(context: CommandContext, params: dict) -> bool:
+        """Implement `OpenSkeleton.ask` without GUI elements."""
+
+        # Original function opens FileDialog here
+        filename = params["filename_in"]
+
+        if len(filename) == 0:
+            return False
+
+        okay = True
+        if len(context.labels.skeletons) > 0:
+            # Ask user permission to merge skeletons
+            okay = False
+            skeleton: Skeleton = context.labels.skeleton  # Assumes single skeleton
+
+            # Load new skeleton and compare
+            new_skeleton = OpenSkeleton.load_skeleton(filename)
+            (delete_nodes, add_nodes) = OpenSkeleton.compare_skeletons(
+                skeleton, new_skeleton
+            )
+
+            # Original function shows pop-up warning here
+            if (len(delete_nodes) > 0) or (len(add_nodes) > 0):
+                # Warn about mismatching skeletons
+                pass
+
+            params["delete_nodes"] = delete_nodes
+            params["add_nodes"] = add_nodes
+
+        params["filename"] = filename
+        return okay
+
+    labels = centered_pair_predictions
+    skeleton = labels.skeleton
+    skeleton.add_symmetry(skeleton.nodes[0].name, skeleton.nodes[1].name)
+    context = CommandContext.from_labels(labels)
+
+    # Run without OpenSkeleton.ask()
+    params = {"filename": fly_legs_skeleton_json}
+    new_skeleton = OpenSkeleton.load_skeleton(fly_legs_skeleton_json)
+    new_skeleton.add_symmetry(new_skeleton.nodes[0], new_skeleton.nodes[1])
+    OpenSkeleton.do_action(context, params)
+
+    # State is updated
+    assert context.state["skeleton"] == skeleton
+
+    # Structure is identical
+    assert_skeletons_match(new_skeleton, skeleton)
+
+    # Run again with OpenSkeleton_ask()
+    labels.skeletons = [stickman]
+    params = {"filename_in": fly_legs_skeleton_json}
+    OpenSkeleton_ask(context, params)
+    assert params["filename"] == fly_legs_skeleton_json
+    OpenSkeleton.do_action(context, params)
+    assert_skeletons_match(new_skeleton, stickman)


### PR DESCRIPTION
### Description
Prior to this PR, any skeleton that was loaded via the "Load Skeleton" button was appended to the list of skeletons in the project `Labels.skeletons`; however, the skeleton referenced by the pre-existing instances in the project was not updated when loading a new skeleton (see this [comment](https://github.com/talmolab/sleap/pull/730#pullrequestreview-970126729)). 

In this PR, we modify the pre-existing skeleton to match the structure of the loaded skeleton. Furthermore, we attempt to delete any pre-existing unused skeletons that may already be present in the project.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Skeleton incompatibility [713](https://github.com/talmolab/sleap/issues/713)

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
