### PR TITLE
Recalculate crop size if user-specified crop size indivisible by max stride

### DIFF
--- a/sleap/gui/learning/datagen.py
+++ b/sleap/gui/learning/datagen.py
@@ -122,7 +122,7 @@ def make_datagen_results(reader: LabelsReader, cfg: TrainingJobConfig) -> np.nda
                 labels=reader.labels,
                 padding=cfg.data.instance_cropping.crop_size_detection_padding,
                 maximum_stride=cfg.model.backbone.which_oneof().max_stride,
-                crop_size=cfg.data.instance_cropping.crop_size,
+                min_crop_size=cfg.data.instance_cropping.crop_size,
             )
 
         pipeline += pipelines.InstanceCentroidFinder.from_config(

--- a/sleap/gui/learning/datagen.py
+++ b/sleap/gui/learning/datagen.py
@@ -81,8 +81,7 @@ def show_datagen_preview(labels: Labels, config_info_list: List[ConfigFileInfo])
 
 
 def make_datagen_results(reader: LabelsReader, cfg: TrainingJobConfig) -> np.ndarray:
-    """
-    Gets (subset of) raw images used for training.
+    """Get (subset of) raw images used for training.
 
     TODO: Refactor so we can get this data without digging into details of the
       the specific pipelines (e.g., key for confmaps depends on head type).
@@ -113,11 +112,17 @@ def make_datagen_results(reader: LabelsReader, cfg: TrainingJobConfig) -> np.nda
         output_keys["confmap"] = "centroid_confidence_maps"
 
     elif isinstance(head_config, CenteredInstanceConfmapsHeadConfig):
-        if cfg.data.instance_cropping.crop_size is None:
+        if (cfg.data.instance_cropping.crop_size is None) or (
+            cfg.data.instance_cropping.crop_size
+            % cfg.model.backbone.which_oneof().max_stride
+            > 0
+        ):
+            # Compute crop size that is divisible by max stride
             cfg.data.instance_cropping.crop_size = find_instance_crop_size(
                 labels=reader.labels,
                 padding=cfg.data.instance_cropping.crop_size_detection_padding,
                 maximum_stride=cfg.model.backbone.which_oneof().max_stride,
+                crop_size=cfg.data.instance_cropping.crop_size,
             )
 
         pipeline += pipelines.InstanceCentroidFinder.from_config(

--- a/sleap/nn/data/instance_cropping.py
+++ b/sleap/nn/data/instance_cropping.py
@@ -13,6 +13,7 @@ def find_instance_crop_size(
     padding: int = 0,
     maximum_stride: int = 2,
     input_scaling: float = 1.0,
+    crop_size: Optional[int] = None,
 ) -> int:
     """Compute the size of the largest instance bounding box from labels.
 
@@ -24,19 +25,24 @@ def find_instance_crop_size(
             architecture.
         input_scaling: Float factor indicating the scale of the input images if any
             scaling will be done before cropping.
+        crop_size: The (optional) crop size set by the user. None if not set.
 
     Returns:
         An integer crop size denoting the length of the side of the bounding boxes that
-        will contain the instances when cropped.
+        will contain the instances when cropped. The returned crop size will be larger
+        or equal to the input `crop_size`.
 
         This accounts for stride, padding and scaling when ensuring divisibility.
     """
+    crop_size = 0 if crop_size is None else crop_size
+
     max_length = 0.0
     for inst in labels.user_instances:
         pts = inst.points_array
         pts *= input_scaling
         max_length = np.maximum(max_length, np.nanmax(pts[:, 0]) - np.nanmin(pts[:, 0]))
         max_length = np.maximum(max_length, np.nanmax(pts[:, 1]) - np.nanmin(pts[:, 1]))
+        max_length = np.maximum(max_length, crop_size)
 
     max_length += float(padding)
     crop_size = np.math.ceil(max_length / float(maximum_stride)) * maximum_stride

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1233,7 +1233,7 @@ class TopdownConfmapsModelTrainer(Trainer):
                 padding=self.config.data.instance_cropping.crop_size_detection_padding,
                 maximum_stride=self.model.maximum_stride,
                 input_scaling=self.config.data.preprocessing.input_scaling,
-                crop_size=self.config.data.instance_cropping.crop_size,
+                min_crop_size=self.config.data.instance_cropping.crop_size,
             )
 
         if self.config.optimization.batches_per_epoch is None:
@@ -1644,7 +1644,7 @@ class TopDownMultiClassModelTrainer(Trainer):
                 padding=self.config.data.instance_cropping.crop_size_detection_padding,
                 maximum_stride=self.model.maximum_stride,
                 input_scaling=self.config.data.preprocessing.input_scaling,
-                crop_size=self.config.data.instance_cropping.crop_size,
+                min_crop_size=self.config.data.instance_cropping.crop_size,
             )
 
         if self.config.optimization.batches_per_epoch is None:

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1224,12 +1224,16 @@ class TopdownConfmapsModelTrainer(Trainer):
         if self.config.data.preprocessing.pad_to_stride is None:
             self.config.data.preprocessing.pad_to_stride = 1
 
-        if self.config.data.instance_cropping.crop_size is None:
+        if (self.config.data.instance_cropping.crop_size is None) or (
+            self.config.data.instance_cropping.crop_size % self.model.maximum_stride > 0
+        ):
+            # Compute crop size that is divisible by max stride
             self.config.data.instance_cropping.crop_size = sleap.nn.data.instance_cropping.find_instance_crop_size(
                 self.data_readers.training_labels,
                 padding=self.config.data.instance_cropping.crop_size_detection_padding,
                 maximum_stride=self.model.maximum_stride,
                 input_scaling=self.config.data.preprocessing.input_scaling,
+                crop_size=self.config.data.instance_cropping.crop_size,
             )
 
         if self.config.optimization.batches_per_epoch is None:
@@ -1631,12 +1635,16 @@ class TopDownMultiClassModelTrainer(Trainer):
         if self.config.data.preprocessing.pad_to_stride is None:
             self.config.data.preprocessing.pad_to_stride = self.model.maximum_stride
 
-        if self.config.data.instance_cropping.crop_size is None:
+        if (self.config.data.instance_cropping.crop_size is None) or (
+            self.config.data.instance_cropping.crop_size % self.model.maximum_stride > 0
+        ):
+            # Compute crop size which is divisible by max stride
             self.config.data.instance_cropping.crop_size = sleap.nn.data.instance_cropping.find_instance_crop_size(
                 self.data_readers.training_labels,
                 padding=self.config.data.instance_cropping.crop_size_detection_padding,
                 maximum_stride=self.model.maximum_stride,
                 input_scaling=self.config.data.preprocessing.input_scaling,
+                crop_size=self.config.data.instance_cropping.crop_size,
             )
 
         if self.config.optimization.batches_per_epoch is None:


### PR DESCRIPTION
### Description
The crop-size should always be divisible by the max-stride. Prior to this PR, SLEAP allowed users to overwrite automatic calculation of the crop size (which calculates a crop size where `crop size % max stride = 0`). However, this leads to errors later in the training pipeline.

This PR forces automatic calculation if the user-set crop size is indivisible by the max stride. The returned crop size will be greater than or equal to the user-specified crop size.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Crop size should always be compatible with max stride #826

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
