### PR TITLE
Fix cropping when rendering video

### DIFF
--- a/sleap/io/visuals.py
+++ b/sleap/io/visuals.py
@@ -274,7 +274,14 @@ class VideoMarkerThread(Thread):
         # Add the instances to the image
         overlay = self._plot_instances_cv(video_frame.copy(), frame_idx)
 
-        return overlay
+        # Crop video_frame to same size as overlay
+        video_frame_cropped = (
+            self._crop_frame(video_frame.copy())[0] if self.crop else video_frame
+        )
+
+        return cv2.addWeighted(
+            overlay, self.alpha, video_frame_cropped, 1 - self.alpha, 0
+        )
 
     def _plot_instances_cv(
         self,

--- a/tests/io/test_visuals.py
+++ b/tests/io/test_visuals.py
@@ -1,5 +1,7 @@
 import numpy as np
 import os
+import pytest
+from sleap.io.dataset import Labels
 from sleap.io.visuals import (
     save_labeled_video,
     resize_images,
@@ -67,13 +69,27 @@ def test_sleap_render(centered_pair_predictions):
     assert os.path.exists("testvis.avi")
 
 
-def test_write_visuals(tmpdir, centered_pair_predictions):
+@pytest.mark.parametrize("crop", ["Half", "Quarter", None])
+def test_write_visuals(tmpdir, centered_pair_predictions: Labels, crop: str):
+    labels = centered_pair_predictions
+    video = centered_pair_predictions.videos[0]
+
+    # Determine crop size relative to original size and scale
+    crop_size = None
+    w = int(video.backend.width)
+    h = int(video.backend.height)
+    if crop == "Half":
+        crop_size_xy = (w // 2, h // 2)
+    elif crop == "Quarter":
+        crop_size_xy = (w // 4, h // 4)
+
     path = os.path.join(tmpdir, "clip.avi")
     save_labeled_video(
         filename=path,
         labels=centered_pair_predictions,
-        video=centered_pair_predictions.videos[0],
+        video=video,
         frames=(0, 1, 2),
         fps=15,
+        crop_size_xy=crop_size_xy,
     )
     assert os.path.exists(path)

--- a/tests/io/test_visuals.py
+++ b/tests/io/test_visuals.py
@@ -75,7 +75,7 @@ def test_write_visuals(tmpdir, centered_pair_predictions: Labels, crop: str):
     video = centered_pair_predictions.videos[0]
 
     # Determine crop size relative to original size and scale
-    crop_size = None
+    crop_size_xy = None
     w = int(video.backend.width)
     h = int(video.backend.height)
     if crop == "Half":


### PR DESCRIPTION
### Description
Although we allowed users to attempt to export a cropped version of their video - and had most of the code set-up to do so - there were still a few bugs making the crop feature unusable.

This PR allows users to render a cropped video that attempts to track instances in the frame - sometimes if instances move too fast, the crop does not follow in time due to smoothing or the crop may be too tiny to fit the instances.

### Types of changes

- [x] Bugfix
- [x] New feature (doubt this feature ever worked beforehand)
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Render Video > Crop Size: Half results in cv2.error #672

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
