### PR TITLE
Fix Save As bug

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -953,6 +953,7 @@ class SaveProjectAs(AppCommand):
         success = False
         try:
             extension = (PurePath(filename).suffix)[1:]
+            extension = None if (extension == "slp") else extension
             Labels.save_file(labels=labels, filename=filename, as_format=extension)
             success = True
             # Mark savepoint in change stack

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -449,3 +449,18 @@ def test_OpenSkeleton(
     assert params["filename"] == fly_legs_skeleton_json
     OpenSkeleton.do_action(context, params)
     assert_skeletons_match(new_skeleton, stickman)
+
+
+def test_SaveProjectAs(centered_pair_predictions: Labels, tmpdir):
+    """Test that project can be saved as default slp extension"""
+
+    context = CommandContext.from_labels(centered_pair_predictions)
+    # Add fake method required by SaveProjectAs.do_action
+    context.app.__setattr__("plotFrame", lambda: None)
+    params = {}
+    fn = PurePath(tmpdir, "test_save-project-as.slp")
+    params["filename"] = str(fn)
+    context.state["labels"] = centered_pair_predictions
+
+    SaveProjectAs.do_action(context=context, params=params)
+    assert Path(params["filename"]).exists()


### PR DESCRIPTION
### Description
Setting `as_format` in the `SaveProjectAs` command expects a registered adaptor to be used downstream (otherwise, if `as_format is None`, the default slp read/write is used). This bug was introduced in Add read/write adaptor for ndx-pose #835.

This PR sets `as_format = None` if the detected extension (from output filename) is `slp`.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
