### PR TITLE
Expose attributes of NWBFile and create Labels API for exporting to NWB

### DIFF
--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -58,6 +58,7 @@ import attr
 import cattr
 import h5py as h5
 import numpy as np
+import datetime
 from sklearn.model_selection import train_test_split
 
 try:
@@ -2027,6 +2028,26 @@ class Labels(MutableSequence):
         from sleap.io.format.sleap_analysis import SleapAnalysisAdaptor
 
         SleapAnalysisAdaptor.write(filename, self)
+
+    def export_nwb(
+        self,
+        filename: str,
+        overwrite: bool = False,
+        session_description: str = "Processed SLEAP pose data",
+        identifier: Optional[str] = None,
+        session_start_time: Optional[datetime.datetime] = None,
+    ):
+        from sleap.io.format.ndx_pose import NDXPoseAdaptor
+
+        NDXPoseAdaptor.write(
+            NDXPoseAdaptor,
+            filename=filename,
+            labels=self,
+            overwrite=overwrite,
+            session_description=session_description,
+            identifier=identifier,
+            session_start_time=session_start_time,
+        )
 
     @classmethod
     def load_json(cls, filename: str, *args, **kwargs) -> "Labels":


### PR DESCRIPTION
### Description
Previously SLEAP used default placeholders for `NWBFIle` attributes and did not allow users to append SLEAP data to an existing `NWBFile`. The ideas for enhancement come from enhancing NWB support #851.

In this PR, we expose the core `NWBFile` attributes and allow users to set them through `Labels.export_nwb`. Furthermore, we allow users to either create/overwrite a `NWBFile` or append to an existing `NWBFile`.

### Types of changes
- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Enhancing NWB support #853

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
