### PR TITLE
Add new track to linked predicted instance

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -472,8 +472,7 @@ class CommandContext:
         location: Optional[QtCore.QPoint] = None,
         mark_complete: bool = False,
     ):
-        """
-        Creates a new instance, copying node coordinates as appropriate.
+        """Creates a new instance, copying node coordinates as appropriate.
 
         Args:
             copy_instance: The :class:`Instance` (or
@@ -2304,7 +2303,7 @@ class SetSelectedInstanceTrack(EditCommand):
 
     @staticmethod
     def do_action(context: CommandContext, params: dict):
-        selected_instance = context.state["instance"]
+        selected_instance: Instance = context.state["instance"]
         new_track = params["new_track"]
         if selected_instance is None:
             return
@@ -2330,6 +2329,9 @@ class SetSelectedInstanceTrack(EditCommand):
             context.labels.track_set_instance(
                 context.state["labeled_frame"], selected_instance, new_track
             )
+            # Add linked predicted instance to new track
+            if selected_instance.from_predicted is not None:
+                selected_instance.from_predicted.track = new_track
 
         # When the instance does already have a track, then we want to update
         # the track for a range of frames.

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -313,8 +313,6 @@ class InferenceTask:
 
         def remove_empty_instances_and_frames(lf: LabeledFrame):
             """Removes instances without visible points and empty frames."""
-            for inst in lf.instances:
-                print(f"inst.points = {inst.points}\n")
             lf.remove_empty_instances()
             return len(lf.instances) > 0
 

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -394,7 +394,7 @@ class Instance:
         if from_predicted is not None and type(from_predicted) != PredictedInstance:
             raise TypeError(
                 f"Instance.from_predicted type must be PredictedInstance (not "
-                "{type(from_predicted)})"
+                f"{type(from_predicted)})"
             )
 
     @_points.validator

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -15,7 +15,7 @@ from sleap.io.pathutils import fix_path_separator
 from sleap.io.video import Video
 from sleap.io.convert import default_analysis_filename
 from sleap.instance import Instance, LabeledFrame
-from sleap import Skeleton
+from sleap import Skeleton, Track
 
 from tests.info.test_h5 import extract_meta_hdf5
 from tests.io.test_video import assert_video_params
@@ -464,3 +464,34 @@ def test_SaveProjectAs(centered_pair_predictions: Labels, tmpdir):
 
     SaveProjectAs.do_action(context=context, params=params)
     assert Path(params["filename"]).exists()
+
+
+def test_SetSelectedInstanceTrack(centered_pair_predictions: Labels):
+    """Test that setting new track on instance also sets track on linked prediction."""
+    # Extract labeled frame and instance
+    labels = centered_pair_predictions
+    lf: LabeledFrame = labels[0]
+    pred_inst = lf.instances[0]
+
+    # Set-up command context
+    context: CommandContext = CommandContext.from_labels(labels)
+    context.state["labeled_frame"] = lf
+    context.state["frame_idx"] = lf.frame_idx
+    context.state["skeleton"] = labels.skeleton
+    context.state["video"] = labels.videos[0]
+
+    # Remove all tracks
+    labels.remove_all_tracks()
+
+    # Create instance from predicted instance
+    context.newInstance(copy_instance=pred_inst, mark_complete=False)
+
+    # Set track on new instance
+    new_instance = [inst for inst in lf.instances if inst.from_predicted is not None][0]
+    context.state["instance"] = new_instance
+    track = Track(name="test_track")
+    context.setInstanceTrack(new_track=track)
+
+    # Ensure that both instance and predicted instance have same track
+    assert new_instance.track == track
+    assert pred_inst.track == new_instance.track


### PR DESCRIPTION
### Description
Previously, if 
1. an instance was created from a predicted instance with no track assigned, 
2. then a track was assigned to the new instance, 
the predicted instance would not be assigned the track.

This PR ensures that the linked predicted instance is assigned the same track as its linked counterpart.

---

Other minor fixes:
* Remove unnecessary print statement from `runners.py` added in  #817
* Fix `TypeError` print statement in `instance.py`

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Assigning user instances to tracks unlinks them from predicted #866

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
