### PR TITLE
Fix naming convention for sleap-convert

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,7 +8,7 @@ on:
       # 'main' triggers updates to 'sleap.ai', 'develop' to 'sleap.ai/develop'
       - main
       - develop
-      - liezl/convert-output-path
+      - liezl/convert_output-path
     paths:
       - "docs/**"
       - "README.rst"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,7 +8,7 @@ on:
       # 'main' triggers updates to 'sleap.ai', 'develop' to 'sleap.ai/develop'
       - main
       - develop
-      - liezl/docs-nwb
+      - liezl/convert-output-path
     paths:
       - "docs/**"
       - "README.rst"

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -241,9 +241,25 @@ optional arguments:
                         Path to output file (optional). The analysis format expects an
                         output path per video in the project. Otherwise, the default
                         naming convention
-                        <input path>.<video index>_<video filename>.analysis.h5 will be
+                        <slp path>.<video index>_<video filename>.analysis.h5 will be
                         used for every video without a specified output path. Multiple
                         outputs can be specified, each preceeded by --output.
+
+                        Example (analysis format):
+                          Input:
+                            predictions.slp: Path to .slp file to convert which has two
+                            videos:
+                            - first-video.mp4 at video index 0 and
+                            - second-video.mp4 at video index 1.
+                          Command:
+                            sleap-convert predictions.slp --format analysis --output analysis_video_0.h5
+                          Output analysis files:
+                            analysis_video_0.h5: Analysis file for first-video.mp4
+                              (at index 0) in predictions.slp.
+                            predictions.001_second-video.analysis.h5: Analysis file for
+                              second-video.mp4 (at index 1) in predictions.slp. Since
+                              only a single --output argument was specified, the
+                              analysis file for the latter video is given a default name.,
   --format FORMAT       Output format. Default ('slp') is SLEAP dataset;
                         'analysis' results in analysis.h5 file; 'h5' or 'json'
                         results in SLEAP dataset with specified file format.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -238,7 +238,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -o OUTPUT, --output OUTPUT
-                        Path to output file (optional).
+                        Path to output file (optional). The analysis format expects an output path per video in the project. Otherwise, the default naming convention `<input path>.<video index>_<video filename>.analysis.h5` will be used for every video without a specified output path. Multiple outputs can be specified, each preceeded by --output.
   --format FORMAT       Output format. Default ('slp') is SLEAP dataset;
                         'analysis' results in analysis.h5 file; 'h5' or 'json'
                         results in SLEAP dataset with specified file format.
@@ -292,7 +292,7 @@ optional arguments:
   -f FPS, --fps FPS     Frames per second for output video (default: 25)
   --scale SCALE         Output image scale (default: 1.0)
   --crop CROP           Crop size as <width>,<height> (default: None)
-  --frames FRAMES       List of frames to predict. Either comma separated list (e.g. 1,2,3) 
+  --frames FRAMES       List of frames to predict. Either comma separated list (e.g. 1,2,3)
                         or a range separated by hyphen (e.g. 1-3). (default is entire video)
   -video-index VIDEO_INDEX
                         Index of video in labels dataset (default: 0)

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -259,7 +259,7 @@ optional arguments:
                             predictions.001_second-video.analysis.h5: Analysis file for
                               second-video.mp4 (at index 1) in predictions.slp. Since
                               only a single --output argument was specified, the
-                              analysis file for the latter video is given a default name.,
+                              analysis file for the latter video is given a default name.
   --format FORMAT       Output format. Default ('slp') is SLEAP dataset;
                         'analysis' results in analysis.h5 file; 'h5' or 'json'
                         results in SLEAP dataset with specified file format.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -238,7 +238,12 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -o OUTPUT, --output OUTPUT
-                        Path to output file (optional). The analysis format expects an output path per video in the project. Otherwise, the default naming convention `<input path>.<video index>_<video filename>.analysis.h5` will be used for every video without a specified output path. Multiple outputs can be specified, each preceeded by --output.
+                        Path to output file (optional). The analysis format expects an
+                        output path per video in the project. Otherwise, the default
+                        naming convention
+                        <input path>.<video index>_<video filename>.analysis.h5 will be
+                        used for every video without a specified output path. Multiple
+                        outputs can be specified, each preceeded by --output.
   --format FORMAT       Output format. Default ('slp') is SLEAP dataset;
                         'analysis' results in analysis.h5 file; 'h5' or 'json'
                         results in SLEAP dataset with specified file format.

--- a/sleap/io/convert.py
+++ b/sleap/io/convert.py
@@ -60,7 +60,7 @@ def create_parser():
         default=[],
         help="Path to output file (optional). The analysis format expects an output "
         "path per video in the project. Otherwise, the default naming convention "
-        "`<input path>.<video index>_<video filename>.analysis.h5` will be used for "
+        "`<slp path>.<video index>_<video filename>.analysis.h5` will be used for "
         "every video without a specified output path. Multiple outputs can be "
         "specified, each preceeded by --output.",
     )

--- a/tests/io/test_convert.py
+++ b/tests/io/test_convert.py
@@ -5,6 +5,7 @@ from sleap.instance import Instance
 
 from pathlib import PurePath, Path
 import re
+import pytest
 
 
 def test_analysis_format(
@@ -80,3 +81,44 @@ def test_analysis_format(
 
     output_paths = [str(tmpdir.with_name("prefix"))]
     sleap_convert_assert(output_paths, slp_path)
+
+
+def test_sleap_format(
+    min_labels_slp: Labels,
+    min_labels_slp_path: Labels,
+    tmpdir,
+):
+    def sleap_convert_assert(output_path, slp_path):
+        args = f"-o {output_path} {slp_path}".split()
+        sleap_convert(args)
+        assert Path(output_path).exists()
+
+    labels = min_labels_slp
+    slp_path = PurePath(min_labels_slp_path)
+    tmpdir = PurePath(tmpdir)
+
+    output_path = Path(tmpdir, slp_path)
+    sleap_convert_assert(output_path, slp_path)
+
+
+@pytest.mark.parametrize("suffix", [".slp", ".json", ".h5"])
+def test_auto_slp_h5_json_format(
+    min_labels_slp: Labels,
+    min_labels_slp_path: Labels,
+    tmpdir,
+    suffix,
+):
+    def sleap_convert_assert(output_path: Path, slp_path):
+        args = f"--format {output_path.suffix[1:]} {slp_path}".split()
+        print(f"args = {args}")
+        sleap_convert(args)
+        assert Path(output_path).exists()
+
+    labels = min_labels_slp
+    slp_path = PurePath(min_labels_slp_path)
+    new_slp_path = PurePath(tmpdir, slp_path.name)
+    labels.save(new_slp_path)
+
+    output_path = Path(f"{new_slp_path}{suffix}")
+    print(f"output_path = {output_path}")
+    sleap_convert_assert(output_path, new_slp_path)

--- a/tests/io/test_convert.py
+++ b/tests/io/test_convert.py
@@ -4,6 +4,7 @@ from sleap.io.video import Video
 from sleap.instance import Instance
 
 from pathlib import PurePath, Path
+import re
 
 
 def test_analysis_format(
@@ -16,45 +17,58 @@ def test_analysis_format(
     slp_path = PurePath(min_labels_slp_path)
     tmpdir = PurePath(tmpdir)
 
-    def assert_analysis_existance(output_prefix: str):
-        output_prefix = PurePath(output_prefix)
-        for video in labels.videos:
-            output_name = default_analysis_filename(
+    def generate_filenames(paths):
+        output_paths = [path for path in paths]
+
+        # Generate filenames if user has not specified (enough) output filenames
+        labels_path = str(slp_path)
+        fn = re.sub("(\\.json(\\.zip)?|\\.h5|\\.slp)$", "", labels_path)
+        fn = PurePath(fn)
+        default_names = [
+            default_analysis_filename(
                 labels=labels,
                 video=video,
-                output_path=str(output_prefix.parent),
-                output_prefix=str(output_prefix.stem),
+                output_path=str(fn.parent),
+                output_prefix=str(fn.stem),
             )
-            video_exists = Path(output_name).exists()
+            for video in labels.videos[len(paths) :]
+        ]
+
+        output_paths.extend(default_names)
+        return output_paths
+
+    def assert_analysis_existance(output_paths: list):
+        output_paths = generate_filenames(output_paths)
+        for video, path in zip(labels.videos, output_paths):
+            video_exists = Path(path).exists()
             if len(labels.get(video)) == 0:
                 assert not video_exists
             else:
                 assert video_exists
 
-    def sleap_convert_assert(output_prefix, slp_path, with_output: bool = True):
-        args = (
-            f"--format analysis -o {output_prefix} {slp_path}".split()
-            if with_output
-            else f"--format analysis {slp_path}".split()
-        )
+    def sleap_convert_assert(output_paths, slp_path):
+        output_args = ""
+        for path in output_paths:
+            output_args += f"-o {path} "
+        args = f"--format analysis {output_args}{slp_path}".split()
         sleap_convert(args)
-        assert_analysis_existance(output_prefix)
+        assert_analysis_existance(output_paths)
 
     # No output specified
-    output_prefix = slp_path.with_suffix("")
-    sleap_convert_assert(output_prefix, slp_path, with_output=False)
+    output_paths = []
+    sleap_convert_assert(output_paths, slp_path)
 
     # Specify output and retest
-    output_prefix = tmpdir.with_name("prefix")
-    sleap_convert_assert(output_prefix, slp_path, with_output=True)
+    output_paths = [str(tmpdir.with_name("prefix")), str(tmpdir.with_name("prefix2"))]
+    sleap_convert_assert(output_paths, slp_path)
 
     # Add video and retest
     labels.add_video(small_robot_mp4_vid)
     slp_path = tmpdir.with_name("new_slp.slp")
     labels.save(filename=slp_path)
 
-    output_prefix = tmpdir.with_name("prefix")
-    sleap_convert_assert(output_prefix, slp_path, with_output=True)
+    output_paths = [str(tmpdir.with_name("prefix"))]
+    sleap_convert_assert(output_paths, slp_path)
 
     # Add labeled frame to video and retest
     labeled_frame = labels.find(video=labels.videos[1], frame_idx=0, return_new=True)[0]
@@ -64,5 +78,5 @@ def test_analysis_format(
     slp_path = tmpdir.with_name("new_slp.slp")
     labels.save(filename=slp_path)
 
-    output_prefix = tmpdir.with_name("prefix")
-    sleap_convert_assert(output_prefix, slp_path, with_output=True)
+    output_paths = [str(tmpdir.with_name("prefix"))]
+    sleap_convert_assert(output_paths, slp_path)


### PR DESCRIPTION
### Description
In #768, we added a feature to handle creating analysis files for multi-video projects; however, we also implemented a semi-automatic naming convention which is unintuitive to users.

This PR gives users control over the output path (as it should have always been) and only starts creating default names if no output path is given for a video in the project. 

Ex. 3 output names given with 4 videos will generate 1 default name. Output names are mapped to videos based on ordering of names given and video index in the project.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
sleap-convert names files with 000.filename #876

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
