### PR TITLE
Integrate retracking into sleap-track

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,49 +4,59 @@ name: CI
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  push:
     paths:
-      - 'sleap/**'
-      - 'tests/**'
-      - '.github/workflows/ci.yml'
-      - 'environment_no_cuda.yml'
-      - 'requirements.txt'
-      - 'dev_requirements.txt'
+      - "sleap/**"
+      - "tests/**"
+      - ".github/workflows/ci.yml"
+      - "environment_no_cuda.yml"
+      - "requirements.txt"
+      - "dev_requirements.txt"
+  push:
+    branches:
+      - master
+      - develop
+    paths:
+      - "sleap/**"
+      - "tests/**"
+      - ".github/workflows/ci.yml"
+      - "environment_no_cuda.yml"
+      - "requirements.txt"
+      - "dev_requirements.txt"
 
 jobs:
   type_check:
     name: Type Check
     runs-on: "ubuntu-18.04"
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install Dependencies
-      run: |
-        pip install mypy
-    - name: Run MyPy
-      # TODO: remove this once all MyPy errors get fixed
-      continue-on-error: true
-      run: |
-        mypy --follow-imports=skip --ignore-missing-imports sleap tests
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install Dependencies
+        run: |
+          pip install mypy
+      - name: Run MyPy
+        # TODO: remove this once all MyPy errors get fixed
+        continue-on-error: true
+        run: |
+          mypy --follow-imports=skip --ignore-missing-imports sleap tests
   lint:
     name: Lint
     runs-on: "ubuntu-18.04"
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install Dependencies
-      run: |
-        pip install click==8.0.4
-        pip install black==21.6b0
-    - name: Run Black
-      run: |
-        black --check sleap tests
+      - uses: actions/checkout@v1
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install Dependencies
+        run: |
+          pip install click==8.0.4
+          pip install black==21.6b0
+      - name: Run Black
+        run: |
+          black --check sleap tests
   tests:
     name: Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -89,7 +99,8 @@ jobs:
           pytest
       - name: Test with pytest (Ubuntu)
         if: matrix.os == 'ubuntu-18.04'
-        shell: bash -l {0}
+        shell:
+          bash -l {0}
           # https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
           # sudo apt-get install xvfb libxkbcommon-x11-0
           # sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,7 +8,7 @@ on:
       # 'main' triggers updates to 'sleap.ai', 'develop' to 'sleap.ai/develop'
       - main
       - develop
-      - liezl/convert_output-path
+      - liezl/retracking
     paths:
       - "docs/**"
       - "README.rst"

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -142,7 +142,9 @@ optional arguments:
   -o OUTPUT, --output OUTPUT
                         The output filename to use for the predicted data. If
                         not provided, defaults to
-                        '[data_path].predictions.slp'.
+                        '[data_path].predictions.slp' if generating predictions or
+                        '[data_path].[tracker].[similarity method].[matching method].slp'
+                        if retracking predictions.
   --no-empty-frames     Clear any empty frames that did not have any detected
                         instances before saving to output.
   --verbosity {none,rich,json}

--- a/sleap/io/convert.py
+++ b/sleap/io/convert.py
@@ -93,6 +93,11 @@ def default_analysis_filename(
 
 
 def main(args: list = None):
+    """Entrypoint for `sleap-convert` CLI for converting .slp to different formats.
+
+    Args:
+        args: A list of arguments to be passed into sleap-convert.
+    """
     parser = create_parser()
     args = parser.parse_args(args=args)
 

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4248,7 +4248,7 @@ def _make_tracker_from_cli(args: argparse.Namespace) -> Optional[Tracker]:
 
 def main(args: list = None):
     """Entrypoint for `sleap-track` CLI for running inference.
-    
+
     Args:
         args: A list of arguments to be passed into sleap-track.
     """

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -50,7 +50,7 @@ import sleap
 from sleap.nn.config import TrainingJobConfig, DataConfig
 from sleap.nn.data.resizing import SizeMatcher
 from sleap.nn.model import Model
-from sleap.nn.tracking import Tracker
+from sleap.nn.tracking import Tracker, run_tracker
 from sleap.nn.paf_grouping import PAFScorer
 from sleap.nn.data.pipelines import (
     Provider,
@@ -63,6 +63,7 @@ from sleap.nn.data.pipelines import (
     InstanceCentroidFinder,
     KerasModelPredictor,
 )
+from sleap.io.dataset import Labels
 from sleap.util import frame_list
 
 
@@ -699,7 +700,7 @@ class FindInstancePeaksGroundTruth(tf.keras.layers.Layer):
             tf.int64
         )  # (batch_size, n_centroids, 1, 1, 2)
         dists = a - b  # (batch_size, n_centroids, n_insts, n_nodes, 2)
-        dists = tf.sqrt(tf.reduce_sum(dists ** 2, axis=-1))  # reduce over xy
+        dists = tf.sqrt(tf.reduce_sum(dists**2, axis=-1))  # reduce over xy
         dists = tf.reduce_min(dists, axis=-1)  # reduce over nodes
         dists = dists.to_tensor(
             tf.cast(np.NaN, tf.float32)
@@ -4206,20 +4207,26 @@ def _make_predictor_from_cli(args: argparse.Namespace) -> Predictor:
     if batch_size is None:
         batch_size = args.batch_size
 
-    predictor = load_model(
-        args.models,
-        peak_threshold=peak_threshold,
-        batch_size=batch_size,
-        refinement="integral",
-        progress_reporting=args.verbosity,
-    )
-    if type(predictor) == BottomUpPredictor:
-        predictor.inference_model.bottomup_layer.paf_scorer.max_edge_length_ratio = (
-            args.max_edge_length_ratio
+    if args.models is not None:
+        predictor: Predictor = load_model(
+            args.models,
+            peak_threshold=peak_threshold,
+            batch_size=batch_size,
+            refinement="integral",
+            progress_reporting=args.verbosity,
         )
-        predictor.inference_model.bottomup_layer.paf_scorer.dist_penalty_weight = (
-            args.dist_penalty_weight
-        )
+
+        if type(predictor) == BottomUpPredictor:
+            predictor.inference_model.bottomup_layer.paf_scorer.max_edge_length_ratio = (
+                args.max_edge_length_ratio
+            )
+            predictor.inference_model.bottomup_layer.paf_scorer.dist_penalty_weight = (
+                args.dist_penalty_weight
+            )
+    else:
+        # TODO(LM): create predictor that only uses tracker - based off load_model
+        pass
+
     return predictor
 
 
@@ -4239,8 +4246,12 @@ def _make_tracker_from_cli(args: argparse.Namespace) -> Optional[Tracker]:
     return None
 
 
-def main():
-    """Entrypoint for `sleap-track` CLI for running inference."""
+def main(args: list = None):
+    """Entrypoint for `sleap-track` CLI for running inference.
+    
+    Args:
+        args: A list of arguments to be passed into sleap-track.
+    """
     t0 = time()
     start_timestamp = str(datetime.now())
     print("Started inference at:", start_timestamp)
@@ -4249,17 +4260,12 @@ def main():
     parser = _make_cli_parser()
 
     # Parse inputs.
-    args, _ = parser.parse_known_args()
+    args, _ = parser.parse_known_args(args=args)
     print("Args:")
     pprint(vars(args))
     print()
 
-    # Check for some common errors.
-    if args.models is None:
-        raise ValueError(
-            "Path to trained models not specified. "
-            "Use \"sleap-track -m path/to/model ...' to specify models to use."
-        )
+    output_path = args.output
 
     # Setup devices.
     if args.cpu or not sleap.nn.system.is_gpu_system():
@@ -4284,15 +4290,47 @@ def main():
     # Setup data loader.
     provider, data_path = _make_provider_from_cli(args)
 
-    # Setup models.
-    predictor = _make_predictor_from_cli(args)
-
     # Setup tracker.
     tracker = _make_tracker_from_cli(args)
-    predictor.tracker = tracker
 
-    # Run inference!
-    labels_pr = predictor.predict(provider)
+    # Either run inference (and tracking) or just run tra
+    if args.models is not None:
+
+        # Setup models.
+        predictor = _make_predictor_from_cli(args)
+        predictor.tracker = tracker
+
+        # Run inference!
+        labels_pr = predictor.predict(provider)
+
+        if output_path is None:
+            output_path = data_path + ".predictions.slp"
+
+        labels_pr.provenance["model_paths"] = predictor.model_paths
+        labels_pr.provenance["predictor"] = type(predictor).__name__
+
+    elif getattr(args, "tracking.tracker") is not None:
+        # Load predictions
+        print("Loading predictions...")
+        labels_pr = sleap.load_file(args.data_path)
+        frames = sorted(labels_pr.labeled_frames, key=lambda lf: lf.frame_idx)
+
+        print("Starting tracker...")
+        frames = run_tracker(frames=frames, tracker=tracker)
+        tracker.final_pass(frames)
+
+        labels_pr = Labels(labeled_frames=frames)
+
+        if output_path is None:
+            output_path = f"{data_path}.{tracker.get_name()}.slp"
+
+    else:
+        raise ValueError(
+            "Neither tracker type nor path to trained models specified. "
+            "Use \"sleap-track -m path/to/model ...' to specify models to use. "
+            "To retrack on predictions, must specify tracker. "
+            "Use \"sleap-track --tracking.tracker ...' to specify tracker to use."
+        )
 
     if args.no_empty_frames:
         # Clear empty frames if specified.
@@ -4304,18 +4342,12 @@ def main():
     print(f"Total runtime: {total_elapsed} secs")
     print(f"Predicted frames: {len(labels_pr)}/{len(provider)}")
 
-    output_path = args.output
-    if output_path is None:
-        output_path = data_path + ".predictions.slp"
-
     # Add provenance metadata to predictions.
     labels_pr.provenance["sleap_version"] = sleap.__version__
     labels_pr.provenance["platform"] = platform.platform()
     labels_pr.provenance["command"] = " ".join(sys.argv)
     labels_pr.provenance["data_path"] = data_path
-    labels_pr.provenance["model_paths"] = predictor.model_paths
     labels_pr.provenance["output_path"] = output_path
-    labels_pr.provenance["predictor"] = type(predictor).__name__
     labels_pr.provenance["total_elapsed"] = total_elapsed
     labels_pr.provenance["start_timestamp"] = start_timestamp
     labels_pr.provenance["finish_timestamp"] = finish_timestamp

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -700,7 +700,7 @@ class FindInstancePeaksGroundTruth(tf.keras.layers.Layer):
             tf.int64
         )  # (batch_size, n_centroids, 1, 1, 2)
         dists = a - b  # (batch_size, n_centroids, n_insts, n_nodes, 2)
-        dists = tf.sqrt(tf.reduce_sum(dists ** 2, axis=-1))  # reduce over xy
+        dists = tf.sqrt(tf.reduce_sum(dists**2, axis=-1))  # reduce over xy
         dists = tf.reduce_min(dists, axis=-1)  # reduce over nodes
         dists = dists.to_tensor(
             tf.cast(np.NaN, tf.float32)

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4293,7 +4293,7 @@ def main(args: list = None):
     # Setup tracker.
     tracker = _make_tracker_from_cli(args)
 
-    # Either run inference (and tracking) or just run tra
+    # Either run inference (and tracking) or just run tracking
     if args.models is not None:
 
         # Setup models.

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -700,7 +700,7 @@ class FindInstancePeaksGroundTruth(tf.keras.layers.Layer):
             tf.int64
         )  # (batch_size, n_centroids, 1, 1, 2)
         dists = a - b  # (batch_size, n_centroids, n_insts, n_nodes, 2)
-        dists = tf.sqrt(tf.reduce_sum(dists**2, axis=-1))  # reduce over xy
+        dists = tf.sqrt(tf.reduce_sum(dists ** 2, axis=-1))  # reduce over xy
         dists = tf.reduce_min(dists, axis=-1)  # reduce over nodes
         dists = dists.to_tensor(
             tf.cast(np.NaN, tf.float32)

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -805,7 +805,7 @@ def test_retracking(
     labels: Labels = Labels.save(centered_pair_predictions, slp_path)
 
     # Create sleap-track command
-    cmd = f"{slp_path} --tracking.tracker {tracker_method}"
+    cmd = f"{slp_path} --tracking.tracker {tracker_method} --frames 1-3"
     if output_path == "not_default":
         output_path = Path(tmpdir, "tracked_slp.slp")
         cmd += f" --output {output_path}"
@@ -842,7 +842,7 @@ def test_sleap_track(
     labels: Labels = Labels.save(centered_pair_predictions, slp_path)
 
     # Create sleap-track command
-    args = f"{slp_path} --model {min_centered_instance_model_path}".split()
+    args = f"{slp_path} --model {min_centered_instance_model_path} --frames 1-3".split()
 
     # Run inference
     sleap_track(args=args)

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -833,3 +833,25 @@ def test_retracking(
     new_inst = load_instance(new_labels)
     old_inst = load_instance(centered_pair_predictions)
     assert new_inst.track != old_inst.track
+
+
+def test_sleap_track(
+    centered_pair_predictions: Labels, min_centered_instance_model_path: str, tmpdir
+):
+    slp_path = str(Path(tmpdir, "old_slp.slp"))
+    labels: Labels = Labels.save(centered_pair_predictions, slp_path)
+
+    # Create sleap-track command
+    args = f"{slp_path} --model {min_centered_instance_model_path}".split()
+
+    # Run inference
+    sleap_track(args=args)
+
+    # Assert predictions file exists
+    output_path = f"{slp_path}.predictions.slp"
+    assert Path(output_path).exists()
+
+    # Create invalid sleap-track command
+    args = [slp_path]
+    with pytest.raises(ValueError):
+        sleap_track(args=args)


### PR DESCRIPTION
### Description
Allow pre-existing predictions to be tracked using `sleap-track` CLI without generating new predictions. This feature was added in #260 and then accidentally removed in [Revert to 28a0031](https://github.com/talmolab/sleap/commit/bdb25932d2b7ea7bbc61b6b82953e71ad09a5c67).

---

Side note: Also changed the CI yaml to only run when:
1. push to develop/master or
2. open/reopen/synchronize all PRs

### Types of changes

- [x] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [x] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #867

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
