### PR TITLE
One line fix for shifted predictions

### DIFF
--- a/sleap/nn/data/resizing.py
+++ b/sleap/nn/data/resizing.py
@@ -403,7 +403,6 @@ class SizeMatcher:
                     target_width = tf.cast(
                         tf.cast(current_shape[-2], tf.float32) * hratio, tf.int32
                     )
-                    example[self.scale_key] = example[self.scale_key] * hratio
                 # Resize the image to fill one of the dimensions by preserving aspect
                 # ratio
                 image = tf.image.resize_with_pad(


### PR DESCRIPTION
### Description
Predictions were being incorrectly scaled when inference was run on videos of different resolutions. This PR ensures predictions are scaled correctly.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #596

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/wiki/Developer-Guide) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
