### PR TITLE
Force node to be placed w/in video

### DIFF
--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -1440,6 +1440,22 @@ class QtNode(QGraphicsEllipseItem):
         x = self.scenePos().x()
         y = self.scenePos().y()
 
+        # Ensure node is placed within video boundaries
+        in_bounds = True
+        w = self.player.video.width
+        h = self.player.video.height
+        if (x > w) or (x < 0) or (y > h) or (y < 0):
+            in_bounds = False
+            if (x > w):
+                x = w
+            elif (x < 0):
+                x = 0
+            if (y > h):
+                y = h
+            elif (y < 0):
+                y = 0
+            self.setPos(x, y)
+
         context = self._parent_instance.player.context
         if user_change and context:
             context.setPointLocations(
@@ -1858,8 +1874,7 @@ class QtInstance(QGraphicsObject):
         self.updateBox()
 
     def updatePoints(self, complete: bool = False, user_change: bool = False):
-        """
-        Updates data and display for all points in skeleton.
+        """Update data and display for all points in skeleton.
 
         This is called any time the skeleton is manipulated as a whole.
 

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -1446,13 +1446,13 @@ class QtNode(QGraphicsEllipseItem):
         h = self.player.video.height
         if (x > w) or (x < 0) or (y > h) or (y < 0):
             in_bounds = False
-            if (x > w):
+            if x > w:
                 x = w
-            elif (x < 0):
+            elif x < 0:
                 x = 0
-            if (y > h):
+            if y > h:
                 y = h
-            elif (y < 0):
+            elif y < 0:
                 y = 0
             self.setPos(x, y)
 


### PR DESCRIPTION
### Description
Force nodes to be placed w/in video when dragging nodes in GUI. 

Set coordinates of node to be within video even when mouse is dragged outside video. Note that this the video may be larger/smaller than the video player size (zoomed in/out video).

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Labels (keypoints) go outside of the frame #896

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
