### PR TITLE
Register ForwardRef('PredictedInstance') structure hook

### DIFF
--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -23,7 +23,7 @@ import numpy as np
 import cattr
 
 from copy import copy
-from typing import Dict, List, Optional, Union, Tuple
+from typing import Dict, List, Optional, Union, Tuple, ForwardRef
 
 from numpy.lib.recfunctions import structured_to_unstructured
 
@@ -1239,6 +1239,13 @@ def make_instance_cattr() -> cattr.Converter:
 
     converter.register_structure_hook(
         Union[List[Instance], List[PredictedInstance]], structure_instances_list
+    )
+
+    # Structure forward reference for PredictedInstance for the Instance.from_predicted
+    # attribute.
+    converter.register_structure_hook(
+        ForwardRef("PredictedInstance"),
+        lambda x, _: converter.structure(x, PredictedInstance),
     )
 
     # converter.register_structure_hook(

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -509,3 +509,23 @@ def test_labeledframe_remove_untracked(
 
     lf.remove_untracked()
     assert all([inst.track is not None for inst in lf.instances])
+
+
+def test_instance_structuring_from_predicted(centered_pair_predictions):
+    labels = centered_pair_predictions.copy()
+    pred_inst = labels[0][0]
+    assert type(pred_inst) == PredictedInstance
+
+    inst = Instance.from_numpy(pred_inst.numpy(), pred_inst.skeleton)
+    labels[0].instances.append(inst)
+
+    # Force a unstructuring -> structuring and check that we can copy without setting
+    # the Instance.from_predicted field
+    labels_copy = labels.copy()
+
+    # Set from_predicted
+    inst.from_predicted = pred_inst
+    assert inst.from_predicted == pred_inst
+
+    # Unstructure -> structure
+    labels_copy = labels.copy()


### PR DESCRIPTION
### Description
We ran into an error when copying the labels to be used in training. Copying the labels involves unstructuring and restructuring - however, since the `Instance` class generically type-hints the the "`PredictedInstance`" class, we ran into the Traceback seen below. This PR registers a structure hook for `ForwardRef('PredictedInstance')` per the typing [docs](https://docs.python.org/3/library/typing.html#typing.ForwardRef):
> Note [PEP 585](https://www.python.org/dev/peps/pep-0585) generic types such as list["SomeClass"] will not be implicitly transformed into list[ForwardRef("SomeClass")] and thus will not automatically resolve to list[SomeClass].

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Fix this Traceback:
```
INFO:sleap.nn.training:Creating training and validation splits from validation fraction: 0.1
Traceback (most recent call last):
  File "C:\Miniconda3\envs\sleap_v1-2-6\Scripts\sleap-train-script.py", line 33, in <module>
    sys.exit(load_entry_point('sleap', 'console_scripts', 'sleap-train')())
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\nn\training.py", line 1967, in main
    video_search_paths=args.video_paths,
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\nn\training.py", line 675, in from_config
    with_track_only=is_id_model,
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\nn\training.py", line 151, in from_config
    with_track_only=with_track_only,
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\nn\training.py", line 218, in from_labels
    with_track_only=with_track_only, copy=True
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\io\dataset.py", line 1067, in with_user_labels_only
    new_labels = self.extract(self.user_labeled_frame_inds, copy=copy)
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\io\dataset.py", line 806, in extract
    new_labels = new_labels.copy()
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\io\dataset.py", line 816, in copy
    return type(self).from_json(self.to_json())
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\io\dataset.py", line 1569, in from_json
    return LabelsJsonAdaptor.from_json_data(*args, **kwargs)
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\io\format\labels_json.py", line 520, in from_json_data
    labels = label_cattr.structure(dicts["labels"], List[LabeledFrame])
  File "C:\Miniconda3\envs\sleap_v1-2-6\lib\site-packages\cattr\converters.py", line 201, in structure
    return self._structure_func.dispatch(cl)(obj, cl)
  File "C:\Miniconda3\envs\sleap_v1-2-6\lib\site-packages\cattr\converters.py", line 336, in _structure_list
    for e in obj
  File "C:\Miniconda3\envs\sleap_v1-2-6\lib\site-packages\cattr\converters.py", line 336, in <listcomp>
    for e in obj
  File "C:\Miniconda3\envs\sleap_v1-2-6\lib\site-packages\cattr\converters.py", line 323, in structure_attrs_fromdict
    dispatch(type_)(val, type_) if type_ is not None else val
  File "C:\Miniconda3\envs\sleap_v1-2-6\lib\site-packages\cattr\converters.py", line 401, in _structure_union
    return handler(obj, union)
  File "d:\sleap-estimates-animal-poses\other\sleap_v1-2-6\sleap\sleap\instance.py", line 1235, in structure_instances_list
    inst = converter.structure(inst_data, Instance)
  File "C:\Miniconda3\envs\sleap_v1-2-6\lib\site-packages\cattr\converters.py", line 201, in structure
    return self._structure_func.dispatch(cl)(obj, cl)
  File "C:\Miniconda3\envs\sleap_v1-2-6\lib\site-packages\cattr\converters.py", line 323, in structure_attrs_fromdict
    dispatch(type_)(val, type_) if type_ is not None else val
  File "C:\Miniconda3\envs\sleap_v1-2-6\lib\site-packages\cattr\converters.py", line 396, in _structure_union
    return self._structure_func.dispatch(other)(obj, other)
  File "C:\Miniconda3\envs\sleap_v1-2-6\lib\site-packages\cattr\converters.py", line 268, in _structure_default
    raise ValueError(msg)
ValueError: Unsupported type: ForwardRef('PredictedInstance'). Register a structure hook for it.
```

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
