### PR TITLE
Fix printing of auto-selected GPU free memory

### DIFF
--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4620,9 +4620,10 @@ def main(args: list = None):
                 free_gpu_memory = sleap.nn.system.get_gpu_memory()
                 if len(free_gpu_memory) > 0:
                     gpu_ind = np.argmax(free_gpu_memory)
+                    mem = free_gpu_memory[gpu_ind]
                     logger.info(
-                        f"Auto-selected GPU {gpu_ind} with {free_gpu_memory} MiB of "
-                        "free memory."
+                        f"Auto-selected GPU {gpu_ind} with {mem} MiB of free "
+                        "memory."
                     )
                 else:
                     logger.info(

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4622,8 +4622,7 @@ def main(args: list = None):
                     gpu_ind = np.argmax(free_gpu_memory)
                     mem = free_gpu_memory[gpu_ind]
                     logger.info(
-                        f"Auto-selected GPU {gpu_ind} with {mem} MiB of free "
-                        "memory."
+                        f"Auto-selected GPU {gpu_ind} with {mem} MiB of free memory."
                     )
                 else:
                     logger.info(

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1947,9 +1947,10 @@ def main():
                 free_gpu_memory = sleap.nn.system.get_gpu_memory()
                 if len(free_gpu_memory) > 0:
                     gpu_ind = np.argmax(free_gpu_memory)
+                    mem = free_gpu_memory[gpu_ind]
                     logger.info(
-                        f"Auto-selected GPU {gpu_ind} with {free_gpu_memory} MiB of "
-                        "free memory."
+                        f"Auto-selected GPU {gpu_ind} with {mem} MiB of free "
+                        "memory."
                     )
                 else:
                     logger.info(

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1949,8 +1949,7 @@ def main():
                     gpu_ind = np.argmax(free_gpu_memory)
                     mem = free_gpu_memory[gpu_ind]
                     logger.info(
-                        f"Auto-selected GPU {gpu_ind} with {mem} MiB of free "
-                        "memory."
+                        f"Auto-selected GPU {gpu_ind} with {mem} MiB of free memory."
                     )
                 else:
                     logger.info(


### PR DESCRIPTION
### Description
Small fix: we're currently printing the free memory for all GPUs, not just the selected one.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
