### PR TITLE
Fix add suggestions when target is current video

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2413,11 +2413,20 @@ class GenerateSuggestions(EditCommand):
         else:
             params["videos"] = context.labels.videos
 
-        new_suggestions = VideoFrameSuggestions.suggest(
-            labels=context.labels, params=params
-        )
+        try:
+            new_suggestions = VideoFrameSuggestions.suggest(
+                labels=context.labels, params=params
+            )
 
-        context.labels.append_suggestions(new_suggestions)
+            context.labels.append_suggestions(new_suggestions)
+        except Exception as e:
+            win.hide()
+            QtWidgets.QMessageBox(
+                text=f"An error occurred while generating suggestions. "
+                "Your command line terminal may have more information about "
+                "the error."
+            ).exec_()
+            raise e
 
         win.hide()
 

--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -82,7 +82,8 @@ class VideoFrameSuggestions(object):
     ):
         """Method to generate suggestions randomly or by taking strides through video."""
         suggestions = []
-        sugg_idx_dict: Dict[Video, list] = {video: [] for video in videos}
+        sugg_idx_dict: Dict[Video, list] = {video: [] for video in labels.videos}
+
         for sugg in labels.suggestions:
             sugg_idx_dict[sugg.video].append(sugg.frame_idx)
 
@@ -287,7 +288,7 @@ class VideoFrameSuggestions(object):
         proposed_suggestions: List[SuggestionFrame],
     ) -> List[SuggestionFrame]:
         # Create log of suggestions that already exist
-        sugg_idx_dict: Dict[Video, list] = {video: [] for video in videos}
+        sugg_idx_dict: Dict[Video, list] = {video: [] for video in labels.videos}
         for sugg in labels.suggestions:
             sugg_idx_dict[sugg.video].append(sugg.frame_idx)
 

--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -66,8 +66,10 @@ class VideoFrameSuggestions(object):
         if method_functions.get(method, None) is not None:
             return method_functions[method](labels=labels, **params)
         else:
-            print(f"No {method} method found for generating suggestions.")
-            return []
+            raise ValueError(
+                f"No{'' if method == '_' else method + ' '} method found for "
+                "generating suggestions."
+            )
 
     # Functions corresponding to "method" param
 

--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -67,7 +67,7 @@ class VideoFrameSuggestions(object):
             return method_functions[method](labels=labels, **params)
         else:
             raise ValueError(
-                f"No{'' if method == '_' else method + ' '} method found for "
+                f"No {'' if method == '_' else method + ' '}method found for "
                 "generating suggestions."
             )
 

--- a/tests/gui/test_suggestions.py
+++ b/tests/gui/test_suggestions.py
@@ -81,11 +81,13 @@ def test_frame_increment(centered_pair_predictions: Labels):
     print(centered_pair_predictions.videos)
 
 
-def test_video_selection(centered_pair_predictions: Labels):
+def test_video_selection(
+    centered_pair_predictions: Labels, small_robot_3_frame_vid: Video
+):
     # Testing the functionality of choosing a specific video in a project and
     # only generating suggestions for the video
 
-    centered_pair_predictions.add_video(Video.from_filename(filename="test.mp4"))
+    centered_pair_predictions.add_video(small_robot_3_frame_vid)
     # Testing suggestion generation from Image Features
     suggestions = VideoFrameSuggestions.suggest(
         labels=centered_pair_predictions,
@@ -149,6 +151,18 @@ def test_video_selection(centered_pair_predictions: Labels):
     for i in range(len(suggestions)):
         # Confirming every suggestion is only for the video that is chosen and no other videos
         assert suggestions[i].video == centered_pair_predictions.videos[0]
+
+    # Ensure video target works given suggestions from another video already exist
+    centered_pair_predictions.set_suggestions(suggestions)
+    suggestions = VideoFrameSuggestions.suggest(
+        labels=centered_pair_predictions,
+        params={
+            "videos": [centered_pair_predictions.videos[1]],
+            "method": "sample",
+            "per_video": 3,
+            "sampling_method": "random",
+        },
+    )
 
 
 def assert_suggestions_unique(labels: Labels, new_suggestions: List[SuggestionFrame]):


### PR DESCRIPTION
### Description
There was a bug when trying to add suggestions only to the "current video" as we created a log of suggestions based off the videos passed in (not all the videos in the project - as it should be).

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #957 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
