### PR TITLE
Fix export cli arg parsing

### DIFF
--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4238,7 +4238,7 @@ def export_cli():
     )
 
     args, _ = parser.parse_known_args()
-    export_model(args["models"], args["export_path"])
+    export_model(args.models, args.export_path)
 
 
 def _make_cli_parser() -> argparse.ArgumentParser:


### PR DESCRIPTION
### Description
Parser expects dot notation to avoid NameSpace error.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
