### PR TITLE
Fix cattr in Python 3.9

### DIFF
--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -1232,7 +1232,10 @@ def make_instance_cattr() -> cattr.Converter:
             if "score" in inst_data.keys():
                 inst = converter.structure(inst_data, PredictedInstance)
             else:
-                if inst_data["from_predicted"] is not None:
+                if (
+                    "from_predicted" in inst_data
+                    and inst_data["from_predicted"] is not None
+                ):
                     inst_data["from_predicted"] = converter.structure(
                         inst_data["from_predicted"], PredictedInstance
                     )

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -1232,6 +1232,10 @@ def make_instance_cattr() -> cattr.Converter:
             if "score" in inst_data.keys():
                 inst = converter.structure(inst_data, PredictedInstance)
             else:
+                if inst_data["from_predicted"] is not None:
+                    inst_data["from_predicted"] = converter.structure(
+                        inst_data["from_predicted"], PredictedInstance
+                    )
                 inst = converter.structure(inst_data, Instance)
             inst_list.append(inst)
 
@@ -1243,14 +1247,13 @@ def make_instance_cattr() -> cattr.Converter:
 
     # Structure forward reference for PredictedInstance for the Instance.from_predicted
     # attribute.
-    converter.register_structure_hook(
-        ForwardRef("PredictedInstance"),
-        lambda x, _: converter.structure(x, PredictedInstance),
+    converter.register_structure_hook_func(
+        lambda t: t.__class__ is ForwardRef,
+        lambda v, t: converter.structure(v, t.__forward_value__),
     )
-
     # converter.register_structure_hook(
-    #     PredictedInstance,
-    #     lambda x, type: converter.structure(x, PredictedInstance),
+    #     ForwardRef("PredictedInstance"),
+    #     lambda x, _: converter.structure(x, PredictedInstance),
     # )
 
     # We can register structure hooks for point arrays that do nothing


### PR DESCRIPTION
### Description
cattrs seems to break in newer versions of Python when using forward references. This PR is a workaround so we can get M1 support working again.

Relevant:
- https://github.com/talmolab/sleap/discussions/966
- https://github.com/python-attrs/cattrs/issues/206

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
