### PR TITLE
Fix typo in save_shifted_instances

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -271,7 +271,7 @@ inference:
       label: Elapsed Frame Window
       type: int
       default: 5
-    - name: tracking.save_shifted_instance
+    - name: tracking.save_shifted_instances
       label: Save shifted instances
       type: bool
       default: false

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -254,6 +254,7 @@ class InferenceTask:
         bool_items_as_ints = (
             "tracking.pre_cull_to_target",
             "tracking.post_connect_single_breaks",
+            "tracking.save_shifted_instance",
         )
 
         for key in bool_items_as_ints:

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -254,7 +254,7 @@ class InferenceTask:
         bool_items_as_ints = (
             "tracking.pre_cull_to_target",
             "tracking.post_connect_single_breaks",
-            "tracking.save_shifted_instance",
+            "tracking.save_shifted_instances",
         )
 
         for key in bool_items_as_ints:

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -740,11 +740,12 @@ class Tracker(BaseTracker):
         option["help"] = "For optical-flow: Number of pyramid scale levels to consider"
         options.append(option)
 
-        option = dict(name="save_shifted_instances", default=False)
-        option["type"] = bool
-        option[
-            "help"
-        ] = "For optical-flow: Save the shifted instances between elapsed frames"
+        option = dict(name="save_shifted_instances", default=0)
+        option["type"] = int
+        option["help"] = (
+            "If non-zero and tracking.tracker is set to flow, save the shifted "
+            "instances between elapsed frames"
+        )
         options.append(option)
 
         def int_list_func(s):


### PR DESCRIPTION
Correct PR #870 
There was a typo in the Yaml form so the 'save_shifted_instances' was not correctly passed to the command line for inference.
In fact  'save_shifted_instances' was always set to True, while the default is False.