### PR TITLE
Allow retracking of old predictions

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -225,6 +225,10 @@ inference:
       multi-animal pipeline (even if your training data has one instance per frame).'
 
   load predictions:
+  - type: bool
+    label: Use predictions from other file
+    name: use_prediction_file
+    default: false
   - type: file_open
     label: Predictions file
     name: _predicted_labels

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -197,7 +197,7 @@ inference:
   label: Training/Inference Pipeline Type
   type: stacked
   default: "multi-animal bottom-up "
-  options: "multi-animal bottom-up,multi-animal top-down,single animal,none"
+  options: "multi-animal bottom-up,multi-animal top-down,single animal,load predictions,none"
 
   multi-animal bottom-up:
   - type: text
@@ -223,6 +223,12 @@ inference:
       these nodes into a single animal instance.<br /><br />
       For predicting on videos with more than one animal per frame, use a
       multi-animal pipeline (even if your training data has one instance per frame).'
+
+  load predictions:
+  - type: file_open
+    label: Predictions file
+    name: _predicted_labels
+    filter: '*.slp'
 
   none:
 

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4687,11 +4687,11 @@ def main(args: list = None):
             labels_pr = sleap.load_file(labels_path)
         else:
             labels_pr = sleap.load_file(args.data_path)
- 
+
             if isinstance(provider, VideoReader):
                 fr_list = frame_list(args.frames)
-                labels_pr = [lf for lf in labels_pr 
-                    if lf.video.filename == provider.video.filename and 
+                labels_pr = [lf for lf in labels_pr
+                    if lf.video.filename == provider.video.filename and
                     lf.frame_idx in fr_list
                 ]
             elif isinstance(provider, LabelsReader):
@@ -4704,9 +4704,9 @@ def main(args: list = None):
         frames = sorted(labels_pr, key=lambda lf: lf.frame_idx)
         n_infer = len(frames)
         print(f"... found {n_infer} frames to track")
-        
+
         print("Starting tracker...")
-        frames = run_tracker(frames=frames, tracker=tracker)
+        frames = run_tracker(frames=frames, tracker=tracker, verbosity=args.verbosity)
         tracker.final_pass(frames)
 
         labels_pr = Labels(labeled_frames=frames)

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4319,6 +4319,17 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--use_prediction_file",
+        action="store_true",
+        default=False,
+        help=(
+            "For tracking-only, use the --labels argument to define the file "
+            "containing the predicted instances to be tracked. "
+            "If this option is not defined, use all the frames from the project "
+            "or the specified frames in the specified video."
+        ),
+    )
+    parser.add_argument(
         "--verbosity",
         type=str,
         choices=["none", "rich", "json"],
@@ -4670,8 +4681,9 @@ def main(args: list = None):
     elif getattr(args, "tracking.tracker") is not None:
         # Load predictions
         print("Loading predictions...")
+        use_labels_predictions = getattr(args, "use_prediction_file", False)
         labels_path = getattr(args, "labels", None)
-        if labels_path:
+        if use_labels_predictions and labels_path:
             labels_pr = sleap.load_file(labels_path)
         else:
             labels_pr = sleap.load_file(args.data_path)

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4690,9 +4690,11 @@ def main(args: list = None):
 
             if isinstance(provider, VideoReader):
                 fr_list = frame_list(args.frames)
-                labels_pr = [lf for lf in labels_pr
-                    if lf.video.filename == provider.video.filename and
-                    lf.frame_idx in fr_list
+                labels_pr = [
+                    lf
+                    for lf in labels_pr
+                    if lf.video.filename == provider.video.filename
+                    and lf.frame_idx in fr_list
                 ]
             elif isinstance(provider, LabelsReader):
                 labels_pr = provider.labels.labeled_frames

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -88,17 +88,6 @@ def get_keras_model_path(path: Text) -> str:
     return os.path.join(path, "best_model.h5")
 
 
-class RateColumn(rich.progress.ProgressColumn):
-    """Renders the progress rate."""
-
-    def render(self, task: "Task") -> rich.progress.Text:
-        """Show progress rate."""
-        speed = task.speed
-        if speed is None:
-            return rich.progress.Text("?", style="progress.data.speed")
-        return rich.progress.Text(f"{speed:.1f} FPS", style="progress.data.speed")
-
-
 @attr.s(auto_attribs=True)
 class Predictor(ABC):
     """Base interface class for predictors."""
@@ -4707,7 +4696,6 @@ def main(args: list = None):
         n_infer = len(frames)
         print(f"... found {n_infer} frames to track")
 
-        print("Starting tracker...")
         frames = run_tracker(frames=frames, tracker=tracker, verbosity=args.verbosity)
         tracker.final_pass(frames)
 

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -31,6 +31,7 @@ from sleap.nn.data.normalization import ensure_int
 
 logger = logging.getLogger(__name__)
 
+
 @attr.s(eq=False, slots=True, auto_attribs=True)
 class ShiftedInstance:
     points_array: np.ndarray = attr.ib()
@@ -1109,7 +1110,9 @@ class TrackCleaner:
         connect_single_track_breaks(frames, self.instance_count)
 
 
-def run_tracker(frames: List[LabeledFrame], tracker: BaseTracker, verbosity: str = "") -> List[LabeledFrame]:
+def run_tracker(
+    frames: List[LabeledFrame], tracker: BaseTracker, verbosity: str = ""
+) -> List[LabeledFrame]:
     """Run a tracker on a set of labeled frames.
 
     Args:

--- a/sleap/util.py
+++ b/sleap/util.py
@@ -21,10 +21,22 @@ import psutil
 import json
 import rapidjson
 import yaml
+import rich.progress
 
 from typing import Any, Dict, Hashable, Iterable, List, Optional
 
 import sleap.version as sleap_version
+
+
+class RateColumn(rich.progress.ProgressColumn):
+    """Renders the progress rate."""
+
+    def render(self, task: "Task") -> rich.progress.Text:
+        """Show progress rate."""
+        speed = task.speed
+        if speed is None:
+            return rich.progress.Text("?", style="progress.data.speed")
+        return rich.progress.Text(f"{speed:.1f} FPS", style="progress.data.speed")
 
 
 def json_loads(json_str: str) -> Dict:


### PR DESCRIPTION
Software versions:
SLEAP: 1.2.8

### Description
PR #898 allows to retrack predictions, but for using with the GUI, it would be nice to have the option to define a prediction file to retrack.
This PR adds options to the GUI for that. It also makes retrack work with the GUI, it's currently broken.

It could be done better if the option was added in the predict_on combo_list at the bottom of the inference window, but it was a bit too complicated to understand how this widget is populated...
This is work in progress.

### Types of changes

- [x] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)
