### PR TITLE
Add more options to render video: wedges, palette, and distinctly color

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -348,13 +348,21 @@ optional arguments:
   -h, --help            show this help message and exit
   -o OUTPUT, --output OUTPUT
                         Path for saving output (default: None)
+  --video-index VIDEO_INDEX
+                        Index of video in labels dataset (default: 0)
+  --frames FRAMES       List of frames to predict. Either comma separated list (e.g. 1,2,3)
+                        or a range separated by hyphen (e.g. 1-3). (default is entire video)
   -f FPS, --fps FPS     Frames per second for output video (default: 25)
   --scale SCALE         Output image scale (default: 1.0)
   --crop CROP           Crop size as <width>,<height> (default: None)
-  --frames FRAMES       List of frames to predict. Either comma separated list (e.g. 1,2,3)
-                        or a range separated by hyphen (e.g. 1-3). (default is entire video)
-  -video-index VIDEO_INDEX
-                        Index of video in labels dataset (default: 0)
+  --show_edges SHOW_EDGES
+                        Whether to draw lines between nodes (default: 1)
+  --edge_is_wedge EDGE_IS_WEDGE
+                        Whether to draw edges as wedges (default: 0)
+  --marker_size MARKER_SIZE
+                        Size of marker in pixels before scaling by SCALE (default: 4)
+  --palette PALETTE     SLEAP color palette to use. Options include: "alphabet", "five+",
+                        "solarized", or "standard" (default: "standard")
 ```
 
 ## Debugging

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -363,6 +363,9 @@ optional arguments:
                         Size of marker in pixels before scaling by SCALE (default: 4)
   --palette PALETTE     SLEAP color palette to use. Options include: "alphabet", "five+",
                         "solarized", or "standard" (default: "standard")
+  --distinctly_color DISTINCTLY_COLOR
+                        Specify how to color instances. Options include: "instances",
+                        "edges", and "nodes" (default: "instances")
 ```
 
 ## Debugging

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1130,6 +1130,7 @@ class ExportLabeledClip(AppCommand):
             color_manager=params["color_manager"],
             show_edges=params["show edges"],
             edge_is_wedge=params["edge_is_wedge"],
+            marker_size=params["marker size"],
             scale=params["scale"],
             crop_size_xy=params["crop"],
             gui_progress=True,
@@ -1207,6 +1208,8 @@ class ExportLabeledClip(AppCommand):
         params["edge_is_wedge"] = (
             context.state.get("edge style", default="").lower() == "wedge"
         )
+
+        params["marker size"] = context.state.get("marker size", default=4)
 
         # If user selected a clip, use that; otherwise include all frames.
         if context.state["has_frame_range"]:

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1129,6 +1129,7 @@ class ExportLabeledClip(AppCommand):
             fps=params["fps"],
             color_manager=params["color_manager"],
             show_edges=params["show edges"],
+            edge_is_wedge=params["edge_is_wedge"],
             scale=params["scale"],
             crop_size_xy=params["crop"],
             gui_progress=True,
@@ -1203,6 +1204,9 @@ class ExportLabeledClip(AppCommand):
             params["color_manager"] = None
 
         params["show edges"] = context.state.get("show edges", default=True)
+        params["edge_is_wedge"] = (
+            context.state.get("edge style", default="").lower() == "wedge"
+        )
 
         # If user selected a clip, use that; otherwise include all frames.
         if context.state["has_frame_range"]:

--- a/sleap/io/visuals.py
+++ b/sleap/io/visuals.py
@@ -181,6 +181,7 @@ class VideoMarkerThread(Thread):
         crop_size_xy: Optional[Tuple[int, int]] = None,
         color_manager: Optional[ColorManager] = None,
         palette: str = "standard",
+        distinctly_color: str = "instances",
     ):
         super(VideoMarkerThread, self).__init__()
         self.in_q = in_q
@@ -194,6 +195,7 @@ class VideoMarkerThread(Thread):
         if color_manager is None:
             color_manager = ColorManager(labels=labels, palette=palette)
             color_manager.color_predicted = True
+            color_manager.distinctly_color = distinctly_color
 
         self.color_manager = color_manager
 
@@ -500,6 +502,7 @@ def save_labeled_video(
     marker_size: int = 4,
     color_manager: Optional[ColorManager] = None,
     palette: str = "standard",
+    distinctly_color: str = "instances",
     gui_progress: bool = False,
 ):
     """Function to generate and save video with annotations.
@@ -519,6 +522,8 @@ def save_labeled_video(
             for what instance/node/edge
         palette: SLEAP color palette to use. Options include: "alphabet", "five+",
             "solarized", or "standard". Only used if `color_manager` is None.
+        distinctly_color: Specify how to color instances. Options include: "instances",
+            "edges", and "nodes". Only used if `color_manager` is None.
         gui_progress: Whether to show Qt GUI progress dialog.
 
     Returns:
@@ -545,6 +550,7 @@ def save_labeled_video(
         crop_size_xy=crop_size_xy,
         color_manager=color_manager,
         palette=palette,
+        distinctly_color=distinctly_color,
     )
     thread_write = Thread(
         target=writer,
@@ -648,31 +654,46 @@ def main(args: list = None):
         "a range separated by hyphen (e.g. 1-3). (default is entire video)",
     )
     parser.add_argument(
-        "--video-index", type=int, default=0, help="Index of video in labels dataset"
+        "--video-index",
+        type=int,
+        default=0,
+        help="Index of video in labels dataset (default: 0)",
     )
     parser.add_argument(
         "--show_edges",
         type=int,
         default=1,
-        help="Whether to draw lines between nodes",
+        help="Whether to draw lines between nodes (default: 1)",
     )
     parser.add_argument(
         "--edge_is_wedge",
         type=int,
         default=0,
-        help="Whether to draw edges as wedges",
+        help="Whether to draw edges as wedges (default: 0)",
     )
     parser.add_argument(
         "--marker_size",
         type=int,
         default=4,
-        help="Size of marker in pixels before scaling by SCALE",
+        help="Size of marker in pixels before scaling by `scale` (default: 4)",
     )
     parser.add_argument(
         "--palette",
         type=str,
         default="standard",
-        help="SLEAP color palette to use",
+        help=(
+            "SLEAP color palette to use Options include: 'alphabet', 'five+', "
+            "'solarized', or 'standard' (default: 'standard')"
+        ),
+    )
+    parser.add_argument(
+        "--distinctly_color",
+        type=str,
+        default="instances",
+        help=(
+            "Specify how to color instances. Options include: 'instances', 'edges', "
+            "and 'nodes' (default: 'nodes')"
+        ),
     )
     args = parser.parse_args(args=args)
     labels = Labels.load_file(
@@ -708,7 +729,7 @@ def main(args: list = None):
         edge_is_wedge=args.edge_is_wedge > 0,
         marker_size=args.marker_size,
         palette=args.palette,
-        # color_manager=color_manager,  # TODO(LM): Add color manager
+        distinctly_color=args.distinctly_color,
     )
 
     print(f"Video saved as: {filename}")

--- a/sleap/io/visuals.py
+++ b/sleap/io/visuals.py
@@ -456,7 +456,7 @@ class VideoMarkerThread(Thread):
                         # Get vector from source to destination
                         vec_x = dst_x - src_x
                         vec_y = dst_y - src_y
-                        mag = (vec_x**2 + vec_y**2) ** 0.5
+                        mag = (pow(vec_x, 2) + pow(vec_y, 2)) ** 0.5
                         vec_x = int(r * vec_x / mag)
                         vec_y = int(r * vec_y / mag)
 

--- a/sleap/io/visuals.py
+++ b/sleap/io/visuals.py
@@ -512,6 +512,7 @@ def save_labeled_video(
         scale: scale of image (so we can scale point locations to match)
         crop_size_xy: size of crop around instances, or None for full images
         show_edges: whether to draw lines between nodes
+        edge_is_wedge: whether to draw edges as wedges (draw as line if False)
         color_manager: ColorManager object which determine what colors to use
             for what instance/node/edge
         gui_progress: Whether to show Qt GUI progress dialog.

--- a/tests/io/test_visuals.py
+++ b/tests/io/test_visuals.py
@@ -71,7 +71,6 @@ def test_sleap_render(centered_pair_predictions):
 
 @pytest.mark.parametrize("crop", ["Half", "Quarter", None])
 def test_write_visuals(tmpdir, centered_pair_predictions: Labels, crop: str):
-    labels = centered_pair_predictions
     video = centered_pair_predictions.videos[0]
 
     # Determine crop size relative to original size and scale
@@ -90,6 +89,7 @@ def test_write_visuals(tmpdir, centered_pair_predictions: Labels, crop: str):
         video=video,
         frames=(0, 1, 2),
         fps=15,
+        edge_is_wedge=True,
         crop_size_xy=crop_size_xy,
     )
     assert os.path.exists(path)

--- a/tests/io/test_visuals.py
+++ b/tests/io/test_visuals.py
@@ -64,7 +64,10 @@ def test_serial_pipeline(centered_pair_predictions, tmpdir):
 
 
 def test_sleap_render(centered_pair_predictions):
-    args = f"-o testvis.avi -f 2 --scale 1.2 --frames 1,2 --video-index 0 tests/data/json_format_v2/centered_pair_predictions.json".split()
+    args = (
+        "-o testvis.avi -f 2 --scale 1.2 --frames 1,2 --video-index 0 "
+        "tests/data/json_format_v2/centered_pair_predictions.json".split()
+    )
     sleap_render(args)
     assert os.path.exists("testvis.avi")
 


### PR DESCRIPTION
### Description
This PR adds more options when rendering the video. Namely, this PR gives use the option to draw edges as wedges, choose a color palette (CLI/API only), and select how to distinctly color instances. 

Previously, we only drew edges as lines for the rendered video and had no other coloring options other than those the GUI already used.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #997 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
