### PR TITLE
Prune saved shifted instances

### DIFF
--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -352,6 +352,8 @@ match_policies = dict(
 
 @attr.s(auto_attribs=True)
 class BaseTracker(abc.ABC):
+    """Abstract base class for tracker."""
+
     @property
     def is_valid(self):
         return False
@@ -381,8 +383,7 @@ class BaseTracker(abc.ABC):
 
 @attr.s(auto_attribs=True)
 class Tracker(BaseTracker):
-    """
-    Instance pose tracker.
+    """Instance pose tracker.
 
     Use by instantiated with the desired parameters and then calling the
     `track` method for each frame.


### PR DESCRIPTION
Following #870, memory is continuously being filled up by saved shifted instances if `save_shifted_instances=True` (which is always the case if using Flow tracker from the GUI before #974 was merged).

This corrects this bug by pruning the dictionary of reference instances older than `track_window` before tracking a new frame.

Sorry for not seeing this bug before, if you are using a version between PR #870 and #974, you can have memory issues if you use the GUI and flow tracking.