### PR TITLE
Bug fix: Update suggestions upon video removal

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1671,7 +1671,7 @@ class ReplaceVideo(EditCommand):
 
 
 class RemoveVideo(EditCommand):
-    topics = [UpdateTopic.video]
+    topics = [UpdateTopic.video, UpdateTopic.suggestions]
 
     @staticmethod
     def do_action(context: CommandContext, params: dict):


### PR DESCRIPTION
### Description
Solved the bug in issue #1008 
Added `UpdateTopic.uggestion` in RemoveVideo so that the labeling suggestions will be removed alongside the video.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#1008 

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [x] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [x] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
