### PR TITLE
Correctly add .h5 extension to analysis files on Linux

### DIFF
--- a/sleap/gui/dialogs/filedialog.py
+++ b/sleap/gui/dialogs/filedialog.py
@@ -7,6 +7,7 @@ on (some?) Ubuntu systems.
 """
 
 import os, re, sys
+from pathlib import Path
 
 from qtpy import QtWidgets
 
@@ -61,13 +62,16 @@ class FileDialog:
 
         # Make sure filename has appropriate file extension.
         if is_non_native and filter:
-            # Get ext from selected filter (i.e., file type).
-            match = re.search("\\(\\*(\\.[a-zA-Z0-9]+)\\)", filter)
-            if match:
-                filter_ext = match[1]
-
-                # If ext isn't already at end of filename, add it.
-                if filter_ext and not filename.endswith(filter_ext):
+            fn = Path(filename)
+            # Get extension from filter as list of "*.ext"
+            match = re.findall("\*(\.[a-zA-Z0-9]+)", filter)
+            if len(match) > 0:
+                # Add first filter extension if none of the filter extensions match
+                add_extension = True
+                for filter_ext in reversed(match):
+                    if fn.suffix == filter_ext:
+                        add_extension = False
+                if add_extension:
                     filename = f"{filename}{filter_ext}"
 
         return filename, filter

--- a/sleap/gui/dialogs/filedialog.py
+++ b/sleap/gui/dialogs/filedialog.py
@@ -62,7 +62,7 @@ class FileDialog:
         # Make sure filename has appropriate file extension.
         if is_non_native and filter:
             # Get ext from selected filter (i.e., file type).
-            match = re.search("\\(\\*(\\.[a-z]+)", filter)
+            match = re.search("\\(\\*(\\.[a-zA-Z0-9]+)\\)", filter)
             if match:
                 filter_ext = match[1]
 


### PR DESCRIPTION
### Description
On Linux, when saving the h5 analysis file from the GUI, a dialog window appears to choose the output name.
If the name has a `.h5` extension, the actual output file will end with `.h5.h`.
This was due to a bug in the regular expression not catching numbers (and uppercase) in extensions.

### Types of changes

- [X] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)
