### PR TITLE
GUI Table: Do not set item value if same as current value

### DIFF
--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -151,11 +151,11 @@ class GenericTableModel(QtCore.QAbstractTableModel):
 
             # If nothing changed of the item, return true. (Issue #1013)
             if isinstance(item, dict) and key in item:
-                item_name = item[key]
+                item_value = item[key]
             if hasattr(item, key):
-                item_name = getattr(item, key)
+                item_value = getattr(item, key)
 
-            if item_name == value:
+            if item_value == value:
                 return True
 
             # Otherwise set the item

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -149,6 +149,16 @@ class GenericTableModel(QtCore.QAbstractTableModel):
         if role == QtCore.Qt.EditRole:
             item, key = self.get_from_idx(index)
 
+            # If nothing changed of the item, return true. (Issue #1013)
+            if isinstance(item, dict) and key in item:
+                item_name = item[key]
+            if hasattr(item, key):
+                item_name = getattr(item, key)
+
+            if item_name == value:
+                return True
+
+            # Otherwise set the item
             if self.can_set(item, key):
                 self.set_item(item, key, value)
                 self.dataChanged.emit(index, index)


### PR DESCRIPTION
### Description
Fix the issue #1013 . Users can keep their node name while double click the item name.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
 - #1013

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
