### PR TITLE
Custom `__repr__` methods for GUI classes

### DIFF
--- a/sleap/gui/state.py
+++ b/sleap/gui/state.py
@@ -43,6 +43,12 @@ class GuiState(object):
         self._state_vars = dict()
         self._callbacks = dict()
 
+    def __repr__(self) -> str:
+        message = f"GuiState("
+        for key in self._state_vars:
+            message += f"'{key}'={self.get(key)}, "
+        return f"{message[:-2]})"
+
     def __getitem__(self, key: GSVarType) -> Any:
         """Gets value for key, or None if no value."""
         return self.get(key, default=None)

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -1212,6 +1212,9 @@ class QtNodeLabel(QGraphicsTextItem):
 
         self.adjustStyle()
 
+    def __repr__(self) -> str:
+        return f"QtNodeLabel(pos()={self.pos()}, node={self.node})"
+
     def adjustPos(self, *args, **kwargs):
         """Update the position of the label based on the position of the node.
 
@@ -1634,6 +1637,9 @@ class QtEdge(QGraphicsPolygonItem):
         self.setPen(pen)
         self.setBrush(brush)
         self.full_opacity = 1
+
+    def __repr__(self) -> str:
+        return f"QtEdge(src={self.src}, dst={self.dst})"
 
     def line(self):
         return self._line

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -1417,6 +1417,9 @@ class QtNode(QGraphicsEllipseItem):
         self.setPos(self.point.x, self.point.y)
         self.updatePoint(user_change=False)
 
+    def __repr__(self):
+        return f"QtNode(pos()={self.pos()},point=Point{self.point},node={self.node})"
+
     def calls(self):
         """Method to call all callbacks."""
         for callback in self.callbacks:
@@ -1872,6 +1875,9 @@ class QtInstance(QGraphicsObject):
 
         # Update size of box so it includes all the nodes/edges
         self.updateBox()
+
+    def __repr__(self) -> str:
+        return f"QtInstance(pos()={self.pos()},instance={self.instance})"
 
     def updatePoints(self, complete: bool = False, user_change: bool = False):
         """Update data and display for all points in skeleton.


### PR DESCRIPTION
### Description
Currently, when printing an instance of any GUI related class, a string of not very helpful Qt mumbo-jumbo is returned. I added a few `__repr__` statements displaying attributes of GUI classes which were useful to me when debugging. A cool feature would be having a few color codes in there to distinguish attributes from their values - this was not added.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (enhance print statements for debugging)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
