### PR TITLE
Shifted instances: make sure ref_instances is not empty

### DIFF
--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -150,17 +150,18 @@ class FlowCandidateMaker:
                 matched_item.instances_t,
             )
 
-            if len(ref_instances) > 0:
-                # Check if shifted instance was computed at earlier time
-                if self.save_shifted_instances:
-                    for ti in reversed(range(ref_t, t)):
-                        if (ref_t, ti) in self.shifted_instances:
-                            ref_shifted_instances = self.shifted_instances[(ref_t, ti)]
-                            # Use shifted instance as a reference
+            # Check if shifted instance was computed at earlier time
+            if self.save_shifted_instances:
+                for ti in reversed(range(ref_t, t)):
+                    if (ref_t, ti) in self.shifted_instances:
+                        ref_shifted_instances = self.shifted_instances[(ref_t, ti)]
+                        # Use shifted instance as a reference
+                        if len(ref_shifted_instances.instances_t) > 0:
                             ref_img = ref_shifted_instances.img_t
                             ref_instances = ref_shifted_instances.instances_t
                             break
 
+            if len(ref_instances) > 0:
                 # Flow shift reference instances to current frame.
                 shifted_instances = self.flow_shift_instances(
                     ref_instances,


### PR DESCRIPTION
### Description
Correction of another bug introduced by `save_shifted_instances=True`. Hopefully the last one...
I had corrected it locally but forgot to include it in the last correction PR #1001.

Loading frames from `self.shifted_instances`, `ref_instances` changes and can become an empty list.
But the test for `ref_instances` being non-empty was before these lines, therefore the following lines crash because `ref_instances` is unexpectedly an empty list.
There are two changes to correct this bug:
- put the code for loading from `self.shifted_instances` above the `len(ref_instances) > 0` test (this is not really needed but it makes the code easier to read).
- `ref_instances` (and `ref_img`) is modified only if it is not empty.

### Types of changes

- [X] Bugfix
