### PR TITLE
Update Model_evaluation.ipynb

### DIFF
--- a/docs/notebooks/Model_evaluation.ipynb
+++ b/docs/notebooks/Model_evaluation.ipynb
@@ -102,7 +102,7 @@
         "- `best_model.h5`: The actual saved model and weights. This can be loaded with `tf.keras.model.load_model()` but it is recommended to use `sleap.load_model()` instead as it takes care of adding some additional inference-only procedures.\n",
         "- `training_config.json`: The configuration for the model training job, including metadata inferred during the training procedure. It can be loaded with `sleap.load_config()`.\n",
         "- `labels_gt.train.slp` and `labels_pr.train.slp`: These are SLEAP labels files containing the ground truth and predicted points for the training split. They do not contain the images, but can be used to retrieve the poses used.\n",
-        "- `labels_gt.train.slp` and `labels_pr.train.slp`: These are SLEAP labels files containing the ground truth and predicted points for the validation split. They do not contain the images, but can be used to retrieve the poses used."
+        "- `labels_gt.val.slp` and `labels_pr.val.slp`: These are SLEAP labels files containing the ground truth and predicted points for the validation split. They do not contain the images, but can be used to retrieve the poses used."
       ]
     },
     {


### PR DESCRIPTION
### Description
labels_gt.train.slp and labels_pr.train.slp: These are SLEAP labels files containing the ground truth and predicted points for the validation split. They do not contain the images, but can be used to retrieve the poses used.
--> this should be labels_gt.val.slp and labels_pr.val.slp


### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [x] Documentation Update
- [ ] Other (explain)


#### Thank you for contributing to SLEAP!
:heart:
