### PR TITLE
GUI Training: Use hidden params from loaded config

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1879,3 +1879,9 @@ def main(args: Optional[list] = None):
         app.exec_()
 
     pass
+
+if __name__ == "__main__":
+    import os
+    ds = os.environ["ds-dmc"]
+    main([ds, "--no-usage-data"])
+    

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1879,10 +1879,3 @@ def main(args: Optional[list] = None):
         app.exec_()
 
     pass
-
-if __name__ == "__main__":
-    import os
-    ds = os.environ["ds-dmc"]
-    main([ds, "--no-usage-data"])
-
-    

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1884,4 +1884,5 @@ if __name__ == "__main__":
     import os
     ds = os.environ["ds-dmc"]
     main([ds, "--no-usage-data"])
+
     

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1076,7 +1076,7 @@ class ExportAnalysisFile(AppCommand):
             )
             filename = default_name if use_default else ask_for_filename(default_name)
 
-            # Check that filename is valid and create list of video / ouput paths
+            # Check that filename is valid and create list of video / output paths
             if len(filename) != 0:
                 analysis_videos.append(video)
                 output_paths.append(filename)

--- a/sleap/gui/learning/scopedkeydict.py
+++ b/sleap/gui/learning/scopedkeydict.py
@@ -2,7 +2,7 @@
 Conversion between flat (form data) and hierarchical (config object) dicts.
 """
 
-from typing import Any, Dict, Optional, Text, Tuple
+from typing import Any, Dict, Optional, Text, Tuple, Union
 
 import attr
 import cattr
@@ -174,7 +174,9 @@ def resolve_strides_from_key_val_dict(
     return max_stride, output_stride
 
 
-def make_training_config_from_key_val_dict(key_val_dict: dict) -> TrainingJobConfig:
+def make_training_config_from_key_val_dict(
+    key_val_dict: Union[dict, ScopedKeyDict]
+) -> TrainingJobConfig:
     """
     Make :py:class:`TrainingJobConfig` object from flat dictionary.
 
@@ -183,9 +185,11 @@ def make_training_config_from_key_val_dict(key_val_dict: dict) -> TrainingJobCon
     Returns:
         The :py:class:`TrainingJobConfig` object.
     """
-    apply_cfg_transforms_to_key_val_dict(key_val_dict)
-    cfg_dict = ScopedKeyDict(key_val_dict).to_hierarchical_dict()
+    if not isinstance(key_val_dict, ScopedKeyDict):
+        apply_cfg_transforms_to_key_val_dict(key_val_dict)
+        key_val_dict = ScopedKeyDict(key_val_dict)
 
+    cfg_dict = key_val_dict.to_hierarchical_dict()
     cfg = cattr.structure(cfg_dict, TrainingJobConfig)
 
     return cfg

--- a/tests/gui/learning/test_dialog.py
+++ b/tests/gui/learning/test_dialog.py
@@ -6,6 +6,7 @@ from sleap.gui.learning.scopedkeydict import (
     ScopedKeyDict,
     apply_cfg_transforms_to_key_val_dict,
 )
+from sleap.gui.app import MainWindow
 
 import pytest
 import cattr
@@ -13,12 +14,14 @@ from pathlib import Path
 from qtpy import QtWidgets
 
 
-def test_use_hidden_params_from_loaded_config(min_labels_slp, min_bottomup_model_path):
+def test_use_hidden_params_from_loaded_config(
+    qtbot, min_labels_slp, min_bottomup_model_path
+):
 
     model_path = Path(min_bottomup_model_path)
 
     # Create a learning dialog
-    app = QtWidgets.QApplication([])
+    app = MainWindow(no_usage_data=True)
     ld = LearningDialog(
         mode="training",
         labels_filename=Path(

--- a/tests/gui/learning/test_dialog.py
+++ b/tests/gui/learning/test_dialog.py
@@ -1,0 +1,89 @@
+from sleap.gui.learning.dialog import LearningDialog, TrainingEditorWidget
+from sleap.gui.learning.configs import TrainingConfigFilesWidget
+from sleap.gui.learning.configs import ConfigFileInfo
+from sleap.gui.learning.scopedkeydict import (
+    make_training_config_from_key_val_dict,
+    ScopedKeyDict,
+    apply_cfg_transforms_to_key_val_dict,
+)
+
+import pytest
+import cattr
+from pathlib import Path
+from qtpy import QtWidgets
+
+
+def test_use_hidden_params_from_loaded_config(min_labels_slp, min_bottomup_model_path):
+
+    model_path = Path(min_bottomup_model_path)
+
+    # Create a learning dialog
+    app = QtWidgets.QApplication([])
+    ld = LearningDialog(
+        mode="training",
+        labels_filename=Path(
+            model_path
+        ).parent.absolute(),  # Hack to get correct config
+        labels=min_labels_slp,
+    )
+
+    # Make pipeline_form_widget
+    ld.pipeline_form_widget.current_pipeline = "bottom-up"
+    tab_name = "multi_instance"
+
+    # Select a loaded config for pipeline form data
+    bottom_up_tab: TrainingEditorWidget = ld.tabs[tab_name]
+    cfg_list_widget: TrainingConfigFilesWidget = bottom_up_tab._cfg_list_widget
+    cfg_list_widget.update()
+    training_cfg_info: ConfigFileInfo = list(
+        filter(
+            lambda cfg: model_path.name in cfg.path,
+            cfg_list_widget._cfg_list,
+        )
+    )[0]
+    training_cfg_info_dict: dict = ScopedKeyDict.from_hierarchical_dict(
+        cattr.unstructure(training_cfg_info)
+    ).key_val_dict
+    menu_idx = cfg_list_widget._cfg_list.index(training_cfg_info)
+    cfg_list_widget.onSelectionIdxChange(menu_idx)
+
+    # Make some changes to pipeline form data
+    training_cfg_setting = training_cfg_info.config.data.preprocessing.input_scaling
+    bottom_up_tab.set_fields_from_key_val_dict(
+        {"data.preprocessing.input_scaling": training_cfg_setting - 0.1}
+    )
+
+    # Create config to use in new round of training
+    pipeline_form_data = ld.pipeline_form_widget.get_form_data()
+    config_info = ld.get_every_head_config_data(pipeline_form_data)[0]
+    config_info_dict: dict = ScopedKeyDict.from_hierarchical_dict(
+        cattr.unstructure(config_info)
+    ).key_val_dict
+
+    # Load pipeline form data
+    tab_cfg_key_val_dict = bottom_up_tab.get_all_form_data()
+    apply_cfg_transforms_to_key_val_dict(tab_cfg_key_val_dict)
+    assert (
+        tab_cfg_key_val_dict["data.preprocessing.input_scaling"] != training_cfg_setting
+    )
+
+    # Assert that config info list:
+    params_set_in_tab = [f"config.{k}" for k in tab_cfg_key_val_dict.keys()]
+    params_reset = [
+        "config.data.labels.skeletons",
+        "config.outputs.run_name",
+        "config.outputs.run_name_suffix",
+        "config.outputs.tags",
+        "path",
+        "filename",
+    ]
+    for k, _ in config_info_dict.items():
+        if k in params_set_in_tab:
+            # 1. Prefers data from widget over loaded config
+            try:
+                assert config_info_dict[k] == tab_cfg_key_val_dict[k[7:]]
+            except:
+                assert str(config_info_dict[k]) == tab_cfg_key_val_dict[k[7:]]
+        elif k not in params_reset:
+            # 2. Uses hidden parameters from loaded config
+            assert config_info_dict[k] == training_cfg_info_dict[k]


### PR DESCRIPTION
### Description

---

In the Training Pipeline, SLEAP allows users to load a config file s.t. users do not need to reenter previously used model parameters. However, some model parameters listed in the config files are not exposed to the user through the Training Pipeline. In the case that the user loads a config file, the user would expect that the parameters in the config file (even those not exposed to the GUI) will be used - this is not currently the case.

---

This PR creates a `TrainingJobConfig` from the loaded config file and then updates the `TrainingJobConfig` with the (select) params set/exposed in the GUI. 

Certain parameters should definitely not be retained:
- labels.skeletons
- optimization.run_name
- optimization.run_name_prefix
- optimization.run_name_suffix

And other parameters _arguably_ should not be retained:
- labels.split_by_inds
AND/OR
- labels.training_inds
- labels.validation_inds
- labels.test_inds

---

### Types of changes

- [x] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1052

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
