### PR TITLE
Fix config option to `split_by_inds`

### DIFF
--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -166,7 +166,9 @@ class DataReaders:
         """Create data readers from `Labels` datasets as data providers."""
         if isinstance(training, str):
             logger.info(f"Loading training labels from: {training}")
-            training = sleap.load_file(training, search_paths=video_search_paths)
+            training: Labels = sleap.load_file(
+                training, search_paths=video_search_paths
+            )
 
         if labels_config is not None and labels_config.split_by_inds:
             # First try to split by indices if specified in config.
@@ -178,13 +180,13 @@ class DataReaders:
                     "Creating validation split from explicit indices "
                     f"(n = {len(labels_config.validation_inds)})."
                 )
-                validation = Labels(training[labels_config.validation_inds])
+                validation = training.extract(labels_config.validation_inds, copy=False)
             if labels_config.test_inds is not None and len(labels_config.test_inds) > 0:
                 logger.info(
                     "Creating test split from explicit indices "
                     f"(n = {len(labels_config.test_inds)})."
                 )
-                test = Labels(training[labels_config.test_inds])
+                test = training.extract(labels_config.test_inds, copy=False)
 
             if (
                 labels_config.training_inds is not None
@@ -194,7 +196,7 @@ class DataReaders:
                     "Creating training split from explicit indices "
                     f"(n = {len(labels_config.training_inds)})."
                 )
-                training = Labels(training[labels_config.training_inds])
+                training = training.extract(labels_config.training_inds, copy=False)
 
         if isinstance(validation, str):
             # If validation is still a path, load it.

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -20,6 +20,7 @@ import json
 import copy
 
 import sleap
+from sleap import Labels
 from sleap.util import get_package_file
 
 # Config
@@ -89,11 +90,11 @@ class DataReaders:
 
     Attributes:
         training_labels_reader: LabelsReader pipeline provider for a training data from
-            a sleap.Labels instance.
+            a `Labels` instance.
         validation_labels_reader: LabelsReader pipeline provider for a validation data
-            from a sleap.Labels instance.
+            from a `Labels` instance.
         test_labels_reader: LabelsReader pipeline provider for a test set data from a
-            sleap.Labels instance. This is not necessary for training.
+            `Labels` instance. This is not necessary for training.
     """
 
     training_labels_reader: LabelsReader
@@ -104,9 +105,9 @@ class DataReaders:
     def from_config(
         cls,
         labels_config: LabelsConfig,
-        training: Union[Text, sleap.Labels],
-        validation: Union[Text, sleap.Labels, float],
-        test: Optional[Union[Text, sleap.Labels]] = None,
+        training: Union[Text, Labels],
+        validation: Union[Text, Labels, float],
+        test: Optional[Union[Text, Labels]] = None,
         video_search_paths: Optional[List[Text]] = None,
         update_config: bool = False,
         with_track_only: bool = False,
@@ -128,7 +129,7 @@ class DataReaders:
         if labels_config.search_path_hints is not None:
             video_search_paths.extend(labels_config.search_path_hints)
 
-        # Update the config fields with arguments (if not a full sleap.Labels instance).
+        # Update the config fields with arguments (if not a full Labels instance).
         if update_config:
             if isinstance(training, Text):
                 labels_config.training_labels = training
@@ -154,15 +155,15 @@ class DataReaders:
     @classmethod
     def from_labels(
         cls,
-        training: Union[Text, sleap.Labels],
-        validation: Union[Text, sleap.Labels, float],
-        test: Optional[Union[Text, sleap.Labels]] = None,
+        training: Union[Text, Labels],
+        validation: Union[Text, Labels, float],
+        test: Optional[Union[Text, Labels]] = None,
         video_search_paths: Optional[List[Text]] = None,
         labels_config: Optional[LabelsConfig] = None,
         update_config: bool = False,
         with_track_only: bool = False,
     ) -> "DataReaders":
-        """Create data readers from sleap.Labels datasets as data providers."""
+        """Create data readers from `Labels` datasets as data providers."""
         if isinstance(training, str):
             logger.info(f"Loading training labels from: {training}")
             training = sleap.load_file(training, search_paths=video_search_paths)
@@ -177,14 +178,13 @@ class DataReaders:
                     "Creating validation split from explicit indices "
                     f"(n = {len(labels_config.validation_inds)})."
                 )
-                validation = training[labels_config.validation_inds]
-
+                validation = Labels(training[labels_config.validation_inds])
             if labels_config.test_inds is not None and len(labels_config.test_inds) > 0:
                 logger.info(
                     "Creating test split from explicit indices "
                     f"(n = {len(labels_config.test_inds)})."
                 )
-                test = training[labels_config.test_inds]
+                test = Labels(training[labels_config.test_inds])
 
             if (
                 labels_config.training_inds is not None
@@ -194,14 +194,12 @@ class DataReaders:
                     "Creating training split from explicit indices "
                     f"(n = {len(labels_config.training_inds)})."
                 )
-                training = training[labels_config.training_inds]
+                training = Labels(training[labels_config.training_inds])
 
         if isinstance(validation, str):
             # If validation is still a path, load it.
             logger.info(f"Loading validation labels from: {validation}")
-            validation = sleap.Labels.load_file(
-                validation, search_paths=video_search_paths
-            )
+            validation = Labels.load_file(validation, search_paths=video_search_paths)
         elif isinstance(validation, float):
             logger.info(
                 "Creating training and validation splits from "
@@ -249,18 +247,18 @@ class DataReaders:
         )
 
     @property
-    def training_labels(self) -> sleap.Labels:
-        """Return the sleap.Labels underlying the training data reader."""
+    def training_labels(self) -> Labels:
+        """Return the `Labels` underlying the training data reader."""
         return self.training_labels_reader.labels
 
     @property
-    def validation_labels(self) -> sleap.Labels:
-        """Return the sleap.Labels underlying the validation data reader."""
+    def validation_labels(self) -> Labels:
+        """Return the `Labels` underlying the validation data reader."""
         return self.validation_labels_reader.labels
 
     @property
-    def test_labels(self) -> sleap.Labels:
-        """Return the sleap.Labels underlying the test data reader."""
+    def test_labels(self) -> Labels:
+        """Return the `Labels` underlying the test data reader."""
         if self.test_labels_reader is None:
             raise ValueError("No test labels provided to data reader.")
         return self.test_labels_reader.labels
@@ -618,9 +616,9 @@ class Trainer(ABC):
     def from_config(
         cls,
         config: TrainingJobConfig,
-        training_labels: Optional[Union[Text, sleap.Labels]] = None,
-        validation_labels: Optional[Union[Text, sleap.Labels, float]] = None,
-        test_labels: Optional[Union[Text, sleap.Labels]] = None,
+        training_labels: Optional[Union[Text, Labels]] = None,
+        validation_labels: Optional[Union[Text, Labels, float]] = None,
+        test_labels: Optional[Union[Text, Labels]] = None,
         video_search_paths: Optional[List[Text]] = None,
     ) -> "Trainer":
         """Initialize the trainer from a training job configuration.
@@ -852,16 +850,16 @@ class Trainer(ABC):
             self.config.save_json(os.path.join(self.run_path, "training_config.json"))
 
             # Save input (ground truth) labels.
-            sleap.Labels.save_file(
+            Labels.save_file(
                 self.data_readers.training_labels_reader.labels,
                 os.path.join(self.run_path, "labels_gt.train.slp"),
             )
-            sleap.Labels.save_file(
+            Labels.save_file(
                 self.data_readers.validation_labels_reader.labels,
                 os.path.join(self.run_path, "labels_gt.val.slp"),
             )
             if self.data_readers.test_labels_reader is not None:
-                sleap.Labels.save_file(
+                Labels.save_file(
                     self.data_readers.test_labels_reader.labels,
                     os.path.join(self.run_path, "labels_gt.test.slp"),
                 )

--- a/tests/nn/test_training.py
+++ b/tests/nn/test_training.py
@@ -63,6 +63,18 @@ def test_data_reader(min_labels_slp_path):
     ex = next(iter(data_readers.validation_labels_reader.make_dataset()))
     assert ex["image"].shape == (384, 384, 1)
 
+    # Test DataReaders using split_by_inds
+    data_readers = DataReaders.from_config(
+        labels_config=LabelsConfig(
+            split_by_inds=True, validation_inds=[0], test_inds=[0], training_inds=[0]
+        ),
+        training=min_labels_slp_path,
+        validation=None,
+    )
+    assert data_readers.training_labels_reader.example_indices == [0]
+    assert data_readers.validation_labels_reader.example_indices == [0]
+    assert data_readers.test_labels_reader.example_indices == [0]
+
 
 def test_train_single_instance(min_labels_robot, cfg):
     cfg.model.heads.single_instance = SingleInstanceConfmapsHeadConfig(


### PR DESCRIPTION
### Description
Fix config option to `split_by_inds`. Previously triaining would fail when `"split_by_inds": true` due to improper handling of training, test, and validation indices. This PR converts the test, train, and validation sets to the format they are expected to be in `Labels` instead of `List[LabeledFrame]`.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1059

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
