### PR TITLE
Tracking: robust assignment of the best score to an instance

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -271,6 +271,16 @@ inference:
       label: Elapsed Frame Window
       type: int
       default: 5
+    - name: tracking.robust
+      label: 'Robust quantile of similarity scores'
+      help: 'For a value between 0 and 1 (excluded), use a robust quantile
+      of the similarity scores to assign a track to an instance.<br />If equal to 1,
+      use the max similarity score (non-robust).'
+      type: optional_double
+      default_disabled: true
+      none_label: Use max (non-robust)
+      range: 0,1
+      default: 0.95
     - name: tracking.save_shifted_instances
       label: Save shifted instances
       type: bool
@@ -333,6 +343,16 @@ inference:
       label: Elapsed Frame Window
       type: int
       default: 5
+    - name: tracking.robust
+      label: 'Robust quantile of similarity scores'
+      help: 'For a value between 0 and 1 (excluded), use a robust quantile
+      of the similarity scores to assign a track to an instance.<br />If equal to 1,
+      use the max similarity score (non-robust).'
+      type: optional_double
+      default_disabled: true
+      none_label: Use max (non-robust)
+      range: 0,1
+      default: 0.95
     - type: text
       text: '<b>Kalman filter-based tracking</b>:<br />
         Uses the above tracking options to track instances for an initial

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -132,7 +132,7 @@ class GenericTableModel(QtCore.QAbstractTableModel):
             return None
 
         item = self.items[idx]
-        if role == QtCore.Qt.DisplayRole:
+        if role == QtCore.Qt.DisplayRole or role == QtCore.Qt.EditRole:
             if isinstance(item, dict) and key in item:
                 return item[key]
 

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -239,6 +239,7 @@ class InferenceTask:
         optional_items_as_nones = (
             "tracking.target_instance_count",
             "tracking.kf_init_frame_count",
+            "tracking.robust",
         )
 
         for key in optional_items_as_nones:

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -410,8 +410,23 @@ class FrameMatches:
         candidate_instances: List[InstanceType],
         similarity_function: Callable,
         matching_function: Callable,
+        robust_best_instance: float = 1.0,
     ):
+        """Calculates (and stores) matches for a frame from candidate instance.
 
+        Args:
+            untracked_instances: list of untracked instances in the frame.
+            candidate_instances: list of instances use as match.
+            similarity_function: a function that returns the similarity between
+                two instances (untracked and candidate).
+            matching_function: function used to find the best match from the
+                cost matrix. See the classmethod `from_cost_matrix`.
+            robust_best_instance (float): if the value is between 0 and 1
+                (excluded), use a robust quantile similarity score for the
+                track. If the value is 1, use the max similarity (non-robust).
+                For selecting a robust score, 0.95 is a good value.
+
+        """
         cost = np.ndarray((0,))
         candidate_tracks = []
 
@@ -425,9 +440,8 @@ class FrameMatches:
             # Compute similarity matrix between untracked instances and best
             # candidate for each track.
             candidate_tracks = list(candidate_instances_by_track.keys())
-            matching_similarities = np.full(
-                (len(untracked_instances), len(candidate_tracks)), np.nan
-            )
+            dims = (len(untracked_instances), len(candidate_tracks))
+            matching_similarities = np.full(dims, np.nan)
 
             for i, untracked_instance in enumerate(untracked_instances):
 
@@ -443,11 +457,16 @@ class FrameMatches:
                         for candidate_instance in track_instances
                     ]
 
-                    # Keep the best scoring instance for this track.
-                    best_ind = np.argmax(track_matching_similarities)
-
-                    # Use the best similarity score for matching.
-                    best_similarity = track_matching_similarities[best_ind]
+                    if 0 < robust_best_instance < 1:
+                        # Robust, use the similarity score in the q-quantile for matching.
+                        best_similarity = np.quantile(
+                                track_matching_similarities,
+                                robust_best_instance,
+                        )
+                    else:
+                        # Non-robust, use the max similarity score for matching.
+                        best_similarity = np.max(track_matching_similarities)
+                    # Keep the best similarity score for this track.
                     matching_similarities[i, j] = best_similarity
 
             # Perform matching between untracked instances and candidates.
@@ -455,7 +474,7 @@ class FrameMatches:
             cost[np.isnan(cost)] = np.inf
 
         return cls.from_cost_matrix(
-            cost, untracked_instances, candidate_tracks, matching_function
+            cost, untracked_instances, candidate_tracks, matching_function,
         )
 
     @classmethod

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -460,8 +460,8 @@ class FrameMatches:
                     if 0 < robust_best_instance < 1:
                         # Robust, use the similarity score in the q-quantile for matching.
                         best_similarity = np.quantile(
-                                track_matching_similarities,
-                                robust_best_instance,
+                            track_matching_similarities,
+                            robust_best_instance,
                         )
                     else:
                         # Non-robust, use the max similarity score for matching.
@@ -474,7 +474,10 @@ class FrameMatches:
             cost[np.isnan(cost)] = np.inf
 
         return cls.from_cost_matrix(
-            cost, untracked_instances, candidate_tracks, matching_function,
+            cost,
+            untracked_instances,
+            candidate_tracks,
+            matching_function,
         )
 
     @classmethod

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -360,6 +360,10 @@ class Tracker(BaseTracker):
             after the other tracking has run for all frames.
         min_new_track_points: We won't spawn a new track for an instance with
             fewer than this many points.
+        robust_best_instance (float): if the value is between 0 and 1 (excluded),
+            use a robust quantile similarity score for the track. If the value is 1,
+            use the max similarity (non-robust). For selecting a robust score,
+            0.95 is a good value.
     """
 
     track_window: int = 5
@@ -371,6 +375,7 @@ class Tracker(BaseTracker):
     target_instance_count: int = 0
     pre_cull_function: Optional[Callable] = None
     post_connect_single_breaks: bool = False
+    robust_best_instance: float = 1.0
 
     min_new_track_points: int = 0
 
@@ -467,6 +472,7 @@ class Tracker(BaseTracker):
                 candidate_instances=candidate_instances,
                 similarity_function=self.similarity_function,
                 matching_function=self.matching_function,
+                robust_best_instance=self.robust_best_instance,
             )
 
             # Store the most recent match data (for outside inspection).
@@ -553,6 +559,7 @@ class Tracker(BaseTracker):
         similarity: str = "instance",
         match: str = "greedy",
         track_window: int = 5,
+        robust: float = 1,
         min_new_track_points: int = 0,
         min_match_points: int = 0,
         # Optical flow options
@@ -619,6 +626,7 @@ class Tracker(BaseTracker):
 
         tracker_obj = cls(
             track_window=track_window,
+            robust_best_instance=robust,
             min_new_track_points=min_new_track_points,
             similarity_function=similarity_function,
             matching_function=matching_function,
@@ -705,6 +713,14 @@ class Tracker(BaseTracker):
         option = dict(name="match", default="greedy")
         option["type"] = str
         option["options"] = list(match_policies.keys())
+        options.append(option)
+
+        option = dict(name="robust", default=1)
+        option["type"] = float
+        option["help"] = (
+            "Robust quantile of similarity score for instance matching. "
+            "If equal to 1, keep the max similarity score (non-robust)."
+        )
         options.append(option)
 
         option = dict(name="track_window", default=5)

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -602,7 +602,7 @@ class Tracker(BaseTracker):
         similarity: str = "instance",
         match: str = "greedy",
         track_window: int = 5,
-        robust: float = 1,
+        robust: float = 1.0,
         min_new_track_points: int = 0,
         min_match_points: int = 0,
         # Optical flow options


### PR DESCRIPTION
Another contribution to improve the tracking algorithm :)

This change reduces identity switches (tested on videos with two mice).
The tracking algorithm creates a matrix of similarity of the instances with the existing tracks.
For that, for each track, reference instances from previous time steps are collected in a list and the similarity score between the current instance  and the reference instances are computing, resulting in a list of similarity scores.
Before this patch, the maximum score from this list was computed, to be used as the track-instance similarity entry in the matrix.

The following problem arises in some situations and time step: the similarity scores with anterior reference instances is mainly low, but erroneously high for just one frame (where keypoints were incorrectly located for instance). Because we take the maximum (a non-robust metric), it will results in a high track-instance score and the instance can be assigned incorrectly to this track. And this error propagates.
To mitigate this situation, this patch allows for taking a quantile of the list of scores, which is robust to having outliers. The quantile should be high, 0.95 is the proposed value, but 0.9 would make it even more robust.
The default remains using the maximum score, but can be changed with the CLI option `--tracker.robust 0.95` and in the GUI.
