### PR TITLE
Add one-line fix to VideoWriterSkyvideo

### DIFF
--- a/sleap/io/videowriter.py
+++ b/sleap/io/videowriter.py
@@ -96,6 +96,7 @@ class VideoWriterSkvideo(VideoWriter):
             outputdict={
                 "-c:v": "libx264",
                 "-preset": preset,
+                "-vf": "scale=trunc(iw/2)*2:trunc(ih/2)*2",  # Need even dims for libx264
                 "-framerate": fps,
                 "-crf": str(crf),
                 "-pix_fmt": "yuv420p",


### PR DESCRIPTION
### Description
Add an output argument to `skyvideo.io.FFmpegWriter` to scale the video to an even size which is compatible with the lbx264 codec.

---

During manual testing, I found that the back-up video writer `cv2.VideoWriter` (only used when `skyvideo` is not available) is having trouble writing _readable_ videos regardless of dimension parity. The videos are a non-zero output size, but the default Windows video player complains the video compression used may not be supported.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #958

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
