### PR TITLE
Flexibly resize input layer of `tf.keras.Model` upon loading trained model

### DIFF
--- a/sleap/nn/data/resizing.py
+++ b/sleap/nn/data/resizing.py
@@ -25,8 +25,8 @@ def find_padding_for_stride(
         A tuple of (pad_bottom, pad_right), integers with the number of pixels that the
         image would need to be padded by to meet the divisibility requirement.
     """
-    pad_bottom = (max_stride - (image_height % max_stride)) % max_stride
-    pad_right = (max_stride - (image_width % max_stride)) % max_stride
+    pad_bottom = max_stride - (image_height % max_stride)
+    pad_right = max_stride - (image_width % max_stride)
     return pad_bottom, pad_right
 
 

--- a/sleap/nn/data/resizing.py
+++ b/sleap/nn/data/resizing.py
@@ -25,8 +25,9 @@ def find_padding_for_stride(
         A tuple of (pad_bottom, pad_right), integers with the number of pixels that the
         image would need to be padded by to meet the divisibility requirement.
     """
-    pad_bottom = max_stride - (image_height % max_stride)
-    pad_right = max_stride - (image_width % max_stride)
+    # The outer-most modulo handles edge case when image_height % max_stride == 0
+    pad_bottom = (max_stride - (image_height % max_stride)) % max_stride
+    pad_right = (max_stride - (image_width % max_stride)) % max_stride
     return pad_bottom, pad_right
 
 

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -3462,7 +3462,7 @@ class BottomUpMultiClassPredictor(Predictor):
         keras_model_path = get_keras_model_path(model_path)
         model = Model.from_config(config.model)
         model.keras_model = tf.keras.models.load_model(keras_model_path, compile=False)
-        if reset_input_layer:
+        if resize_input_layer:
             model.keras_model = reset_input_layer(
                 keras_model=model.keras_model, new_shape=None
             )

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -1095,10 +1095,12 @@ def get_model_output_stride(
             `model.input.shape[1] // model.output.shape[1]`
 
         Raises a warning if the shapes do not divide evenly.
+        If either the size_in or size_out is None, returns None.
     """
     size_in = model.inputs[input_ind].shape[1]
     size_out = model.outputs[output_ind].shape[1]
-    # TODO(LM): Add check for None size
+    # if size_in is None or size_out is None:
+    #     return None
     if size_in % size_out != 0:
         warnings.warn(
             f"Model input of shape {model.inputs[input_ind].shape} does not divide "
@@ -3425,6 +3427,7 @@ class BottomUpMultiClassPredictor(Predictor):
         peak_threshold: float = 0.2,
         integral_refinement: bool = True,
         integral_patch_size: int = 5,
+        resize_input_layer: bool = True,
     ) -> "BottomUpMultiClassPredictor":
         """Create predictor from a saved model.
 

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4061,9 +4061,10 @@ class TopDownMultiClassPredictor(Predictor):
             centroid_model.keras_model = tf.keras.models.load_model(
                 centroid_keras_model_path, compile=False
             )
-            centroid_model.keras_model = reset_input_layer(
-                keras_model=centroid_model.keras_model, new_shape=None
-            )
+            if resize_input_layer:
+                centroid_model.keras_model = reset_input_layer(
+                    keras_model=centroid_model.keras_model, new_shape=None
+                )
         else:
             centroid_config = None
             centroid_model = None
@@ -4076,9 +4077,10 @@ class TopDownMultiClassPredictor(Predictor):
             confmap_model.keras_model = tf.keras.models.load_model(
                 confmap_keras_model_path, compile=False
             )
-            confmap_model.keras_model = reset_input_layer(
-                keras_model=confmap_model.keras_model, new_shape=None
-            )
+            if resize_input_layer:
+                confmap_model.keras_model = reset_input_layer(
+                    keras_model=confmap_model.keras_model, new_shape=None
+                )
         else:
             confmap_config = None
             confmap_model = None
@@ -4404,7 +4406,7 @@ def export_model(
             multi-instance model returns. This is enforced during centroid
             cropping and therefore only compatible with TopDown models.
     """
-    predictor = load_model(model_path)  # XXX: turn off arbitrary shape here if needed?
+    predictor = load_model(model_path, resize_input_layer=False)
 
     predictor.export_model(
         save_path,

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -1095,12 +1095,9 @@ def get_model_output_stride(
             `model.input.shape[1] // model.output.shape[1]`
 
         Raises a warning if the shapes do not divide evenly.
-        If either the size_in or size_out is None, returns None.
     """
     size_in = model.inputs[input_ind].shape[1]
     size_out = model.outputs[output_ind].shape[1]
-    # if size_in is None or size_out is None:
-    #     return None
     if size_in % size_out != 0:
         warnings.warn(
             f"Model input of shape {model.inputs[input_ind].shape} does not divide "

--- a/sleap/nn/utils.py
+++ b/sleap/nn/utils.py
@@ -149,22 +149,21 @@ def reset_input_layer(
 
     model_config = keras_model.get_config()
 
-    input_layer_name = model_config["layers"][0]["name"]  # XXX(LM): Remove or...
+    input_layer_name = model_config["layers"][0]["name"]
     model_config["layers"][0] = {
-        "name": "new_input",  # XXX(LM): ...change to input_layer_name
+        "name": f"{input_layer_name}",
         "class_name": "InputLayer",
         "config": {
             "batch_input_shape": new_shape,
             "dtype": "float32",
             "sparse": False,
-            "name": "new_input",  # XXX(LM): ...change to input_layer_name
+            "name": f"{input_layer_name}",
         },
         "inbound_nodes": [],
     }
 
-    # XXX(LM): ...change to input_layer_name
-    model_config["layers"][1]["inbound_nodes"] = [[["new_input", 0, 0, {}]]]
-    model_config["input_layers"] = [["new_input", 0, 0]]
+    model_config["layers"][1]["inbound_nodes"] = [[[f"{input_layer_name}", 0, 0, {}]]]
+    model_config["input_layers"] = [[f"{input_layer_name}", 0, 0]]
 
     new_model: tf.keras.Model = keras_model.__class__.from_config(
         model_config, custom_objects={}

--- a/sleap/nn/utils.py
+++ b/sleap/nn/utils.py
@@ -3,7 +3,7 @@
 import tensorflow as tf
 import numpy as np
 from collections import defaultdict
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 from scipy.optimize import linear_sum_assignment
 
 
@@ -126,3 +126,53 @@ def match_points(points1: tf.Tensor, points2: tf.Tensor) -> Tuple[tf.Tensor, tf.
         axis=-1,
     )
     return tf_linear_sum_assignment(dists)
+
+
+def reset_input_layer(
+    keras_model: tf.keras.Model,
+    new_shape: Optional[Tuple[Optional[int], Optional[int], Optional[int], int]] = None,
+):
+    """Returns a copy of `keras_model` with input shape reset to `new_shape`.
+
+    This method was modeified from https://stackoverflow.com/a/58485055.
+
+    Args:
+        keras_model: `tf.keras.Model` to return a copy of (with input shape reset).
+        new_shape: Shape of the returned model's input layer.
+
+    Returns:
+        A copy of `keras_model` with input shape `new_shape`.
+    """
+
+    if new_shape is None:
+        new_shape = (None, None, None, keras_model.input_shape[-1])
+
+    model_config = keras_model.get_config()
+
+    input_layer_name = model_config["layers"][0]["name"]  # XXX(LM): Remove or...
+    model_config["layers"][0] = {
+        "name": "new_input",  # XXX(LM): ...change to input_layer_name
+        "class_name": "InputLayer",
+        "config": {
+            "batch_input_shape": new_shape,
+            "dtype": "float32",
+            "sparse": False,
+            "name": "new_input",  # XXX(LM): ...change to input_layer_name
+        },
+        "inbound_nodes": [],
+    }
+
+    # XXX(LM): ...change to input_layer_name
+    model_config["layers"][1]["inbound_nodes"] = [[["new_input", 0, 0, {}]]]
+    model_config["input_layers"] = [["new_input", 0, 0]]
+
+    new_model: tf.keras.Model = keras_model.__class__.from_config(
+        model_config, custom_objects={}
+    )  # Change custom objects if necessary
+
+    # Iterate over all the layers that we want to get weights from
+    weights = [layer.get_weights() for layer in keras_model.layers[1:]]
+    for layer, weight in zip(new_model.layers[1:], weights):
+        layer.set_weights(weight)
+
+    return new_model

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -824,13 +824,13 @@ def test_load_model(resize_input_shape, model_fixture_name, request):
             "bottomup_multiclass",
             "model",
             BottomUpMultiClassPredictor,
-            (None, None, None, 1),
+            (None, 512, 512, 1),
         ),
         (
             "topdown_multiclass",
             "confmap_model",
             TopDownMultiClassPredictor,
-            (None, None, None, 1),
+            (None, 128, 128, 1),
         ),
     ]
     expected_model_name = None
@@ -1335,7 +1335,3 @@ def test_flow_tracker(centered_pair_predictions: Labels, tmpdir):
         for key in tracker.candidate_maker.shifted_instances.keys():
             assert lf.frame_idx - key[0] <= track_window  # Keys are pruned
             assert abs(key[0] - key[1]) <= track_window  # References within window
-
-
-if __name__ == "__main__":
-    pytest.main([r"tests\nn\test_inference.py::test_topdown_id_predictor_save", "-rP"])

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -1114,13 +1114,15 @@ def test_single_instance_predictor_save(min_single_instance_robot_model_path, tm
 
     # directly initialize predictor
     predictor = SingleInstancePredictor.from_trained_models(
-        min_single_instance_robot_model_path
+        min_single_instance_robot_model_path, resize_input_layer=False
     )
 
     predictor.export_model(save_path=tmp_path.as_posix())
 
     # high level load to predictor
-    predictor = load_model(min_single_instance_robot_model_path)
+    predictor = load_model(
+        min_single_instance_robot_model_path, resize_input_layer=False
+    )
 
     predictor.export_model(save_path=tmp_path.as_posix())
 
@@ -1152,12 +1154,16 @@ def test_topdown_predictor_save(
     predictor = TopDownPredictor.from_trained_models(
         centroid_model_path=min_centroid_model_path,
         confmap_model_path=min_centered_instance_model_path,
+        resize_input_layer=False,
     )
 
     predictor.export_model(save_path=tmp_path.as_posix())
 
     # high level load to predictor
-    predictor = load_model([min_centroid_model_path, min_centered_instance_model_path])
+    predictor = load_model(
+        [min_centroid_model_path, min_centered_instance_model_path],
+        resize_input_layer=False,
+    )
 
     predictor.export_model(save_path=tmp_path.as_posix())
 
@@ -1191,12 +1197,16 @@ def test_topdown_id_predictor_save(
     predictor = TopDownMultiClassPredictor.from_trained_models(
         centroid_model_path=min_centroid_model_path,
         confmap_model_path=min_topdown_multiclass_model_path,
+        resize_input_layer=False,
     )
 
     predictor.export_model(save_path=tmp_path.as_posix())
 
     # high level load to predictor
-    predictor = load_model([min_centroid_model_path, min_topdown_multiclass_model_path])
+    predictor = load_model(
+        [min_centroid_model_path, min_topdown_multiclass_model_path],
+        resize_input_layer=False,
+    )
 
     predictor.export_model(save_path=tmp_path.as_posix())
 
@@ -1328,4 +1338,4 @@ def test_flow_tracker(centered_pair_predictions: Labels, tmpdir):
 
 
 if __name__ == "__main__":
-    pytest.main([r"tests\nn\test_inference.py::test_load_model", "-rP"])
+    pytest.main([r"tests\nn\test_inference.py::test_topdown_id_predictor_save", "-rP"])

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -858,6 +858,28 @@ def test_load_model(resize_input_shape, model_fixture_name, request):
         assert keras_model.input_shape == input_shape
 
 
+def test_topdown_multi_size_inference(
+    min_centroid_model_path,
+    min_centered_instance_model_path,
+    centered_pair_labels,
+    min_tracks_2node_labels,
+):
+    imgs = centered_pair_labels.video[:2]
+    assert imgs.shape == (2, 384, 384, 1)
+
+    predictor = load_model(
+        [min_centroid_model_path, min_centered_instance_model_path],
+        resize_input_layer=True,
+    )
+    preds = predictor.predict(imgs)
+    assert len(preds) == 2
+
+    imgs = min_tracks_2node_labels.video[:2]
+    assert imgs.shape == (2, 1024, 1024, 1)
+    preds = predictor.predict(imgs)
+    assert len(preds) == 2
+
+
 def test_ensure_numpy(
     min_centroid_model_path, min_centered_instance_model_path, min_labels_slp
 ):

--- a/tests/nn/test_nn_utils.py
+++ b/tests/nn/test_nn_utils.py
@@ -1,8 +1,10 @@
 import sleap
 import tensorflow as tf
 import numpy as np
+import pytest
 from numpy.testing import assert_array_equal, assert_allclose
-from sleap.nn.utils import tf_linear_sum_assignment, match_points
+from sleap.nn.inference import TopDownPredictor
+from sleap.nn.utils import tf_linear_sum_assignment, match_points, reset_input_layer
 
 sleap.use_cpu_only()
 
@@ -20,3 +22,27 @@ def test_match_points():
 
     assert_array_equal(inds1, [0, 1])
     assert_array_equal(inds2, [1, 0])
+
+
+def test_reset_input_layer(min_centroid_model_path):
+    """Verify that input layer size is reset."""
+
+    predictor = TopDownPredictor.from_trained_models(
+        centroid_model_path=min_centroid_model_path, resize_input_layer=False
+    )
+    og_keras_model: tf.keras.Model = predictor.centroid_model.keras_model
+    og_weights = [layer.get_weights() for layer in og_keras_model.layers[1:]]
+    assert og_keras_model.input_shape == (None, 384, 384, 1)
+
+    keras_model = reset_input_layer(keras_model=og_keras_model)
+    new_weights = [layer.get_weights() for layer in keras_model.layers[1:]]
+    assert keras_model.input_shape == (None, None, None, 1)
+    assert len(keras_model.layers) == len(og_keras_model.layers)
+    for og_weight, new_weight in zip(og_weights, new_weights):
+        for ogw, nw in zip(og_weight, new_weight):
+            assert ogw.shape == nw.shape
+            np.testing.assert_array_equal(ogw.flatten(), nw.flatten())
+
+    new_shape = (None, 384, 384, 1)
+    keras_model = reset_input_layer(keras_model=keras_model, new_shape=new_shape)
+    assert keras_model.input_shape == new_shape


### PR DESCRIPTION
### Description
Flexibly resize the input layer of the `tf.keras.Model` to `(None, None, None, num_channels)` upon loading a trained model. This allows users to use a trained model for inference on any sized video/image.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1035

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
