### PR TITLE
Add central padding to SizeMatcher

### DIFF
--- a/sleap/nn/data/normalization.py
+++ b/sleap/nn/data/normalization.py
@@ -46,8 +46,8 @@ def ensure_float(image: tf.Tensor) -> tf.Tensor:
 
     See also: tf.image.convert_image_dtype
     """
-    image = tf.image.convert_image_dtype(image, tf.float32)
-    image = tf.cast(image, tf.float32)
+    image = tf.image.convert_image_dtype(image, tf.float32) # This returns an image concerted to dtype.
+    image = tf.cast(image, tf.float32) # This returns a Tensor with the same shape as image and same type as dtype. 
     return image
 
 

--- a/sleap/nn/data/normalization.py
+++ b/sleap/nn/data/normalization.py
@@ -46,13 +46,7 @@ def ensure_float(image: tf.Tensor) -> tf.Tensor:
 
     See also: tf.image.convert_image_dtype
     """
-    image = tf.image.convert_image_dtype(
-        image, tf.float32
-    )  # This returns an image concerted to dtype.
-    image = tf.cast(
-        image, tf.float32
-    )  # This returns a Tensor with the same shape as image and same type as dtype.
-    return image
+    return tf.image.convert_image_dtype(image, tf.float32)
 
 
 def ensure_int(image: tf.Tensor) -> tf.Tensor:

--- a/sleap/nn/data/normalization.py
+++ b/sleap/nn/data/normalization.py
@@ -46,7 +46,9 @@ def ensure_float(image: tf.Tensor) -> tf.Tensor:
 
     See also: tf.image.convert_image_dtype
     """
-    return tf.image.convert_image_dtype(image, tf.float32)
+    image = tf.image.convert_image_dtype(image, tf.float32)
+    image = tf.cast(image, tf.float32)
+    return image
 
 
 def ensure_int(image: tf.Tensor) -> tf.Tensor:

--- a/sleap/nn/data/normalization.py
+++ b/sleap/nn/data/normalization.py
@@ -46,8 +46,12 @@ def ensure_float(image: tf.Tensor) -> tf.Tensor:
 
     See also: tf.image.convert_image_dtype
     """
-    image = tf.image.convert_image_dtype(image, tf.float32) # This returns an image concerted to dtype.
-    image = tf.cast(image, tf.float32) # This returns a Tensor with the same shape as image and same type as dtype. 
+    image = tf.image.convert_image_dtype(
+        image, tf.float32
+    )  # This returns an image concerted to dtype.
+    image = tf.cast(
+        image, tf.float32
+    )  # This returns a Tensor with the same shape as image and same type as dtype.
     return image
 
 

--- a/sleap/nn/data/resizing.py
+++ b/sleap/nn/data/resizing.py
@@ -267,6 +267,8 @@ class SizeMatcher:
         full_image_key: String name of the key containing the full images.
         max_image_height: int The target height to which all smaller images will be resized/padded to.
         max_image_width: int The target width to which all smaller images will be resized/padded to.
+        center_pad: If True, pad on the left/top to center the non-zero pixels rather than aligning
+            them to the top-left. The offsets will be stored in the "offset_x" and "offset_y" keys.
     """
 
     image_key: Text = "image"
@@ -276,6 +278,7 @@ class SizeMatcher:
     full_image_key: Text = "full_image"
     max_image_height: int = None
     max_image_width: int = None
+    center_pad: bool = False
 
     @classmethod
     def from_config(
@@ -331,6 +334,7 @@ class SizeMatcher:
             full_image_key=full_image_key,
             max_image_height=max_height,
             max_image_width=max_width,
+            center_pad=False,  # TODO(jiaying): Add center padding to the configs.
         )
 
     @property
@@ -347,6 +351,7 @@ class SizeMatcher:
         output_keys = self.input_keys
         if self.keep_full_image:
             output_keys.append(self.full_image_key)
+        output_keys.extend(["offset_x", "offset_y"])
         return output_keys
 
     def transform_dataset(self, ds_input: tf.data.Dataset) -> tf.data.Dataset:
@@ -379,6 +384,7 @@ class SizeMatcher:
             current_shape = tf.shape(image)
             channels = image.shape[-1]
             effective_scaling_ratio = 1.0
+            offset_x, offset_y = 0, 0
 
             # Only apply this transform if image shape differs from target
             if (
@@ -410,12 +416,19 @@ class SizeMatcher:
                 image = tf.image.resize_with_pad(
                     image, target_height=target_height, target_width=target_width
                 )
-                # Pad the image on bottom/right with zeroes to match specified
-                # dimensions
+
+                # Switch between center padding and bottom/right padding.
+                if self.center_pad:
+                    offset_x = (self.max_image_width - target_width) // 2
+                    offset_y = (self.max_image_height - target_height) // 2
+                else:
+                    offset_x, offset_y = 0, 0
+                
+                # Pad the image with zeroes to match specified dimensions.
                 image = tf.image.pad_to_bounding_box(
                     image,
-                    offset_height=0,
-                    offset_width=0,
+                    offset_height=offset_y,
+                    offset_width=offset_x,
                     target_height=self.max_image_height,
                     target_width=self.max_image_width,
                 )
@@ -430,10 +443,22 @@ class SizeMatcher:
 
             # Update the scale factor
             example[self.scale_key] = example[self.scale_key] * effective_scaling_ratio
+
             # Scale the instance points accordingly
             if self.points_key and self.points_key in example:
                 example[self.points_key] = (
                     example[self.points_key] * effective_scaling_ratio
+                )
+
+            # Update the offsets
+            example["offset_x"] = offset_x
+            example["offset_y"] = offset_y
+
+            # Translate the instance points accordingly
+            if self.points_key and self.points_key in example:
+                offsets = tf.cast(tf.reshape([offset_x, offset_y], [1, 1, 2]), tf.float32)
+                example[self.points_key] = (
+                    example[self.points_key] + offsets
                 )
 
             return example

--- a/sleap/nn/data/resizing.py
+++ b/sleap/nn/data/resizing.py
@@ -423,7 +423,7 @@ class SizeMatcher:
                     offset_y = (self.max_image_height - target_height) // 2
                 else:
                     offset_x, offset_y = 0, 0
-                
+
                 # Pad the image with zeroes to match specified dimensions.
                 image = tf.image.pad_to_bounding_box(
                     image,
@@ -456,10 +456,10 @@ class SizeMatcher:
 
             # Translate the instance points accordingly
             if self.points_key and self.points_key in example:
-                offsets = tf.cast(tf.reshape([offset_x, offset_y], [1, 1, 2]), tf.float32)
-                example[self.points_key] = (
-                    example[self.points_key] + offsets
+                offsets = tf.cast(
+                    tf.reshape([offset_x, offset_y], [1, 1, 2]), tf.float32
                 )
+                example[self.points_key] = example[self.points_key] + offsets
 
             return example
 

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -334,6 +334,9 @@ class Predictor(ABC):
                 ex["frame_ind"] = ex["frame_ind"].numpy().flatten()
 
             # Adjust for potential SizeMatcher scaling.
+            offset_x = ex.get("offset_x", 0)
+            offset_y = ex.get("offset_y", 0)
+            ex["instance_peaks"] -= np.reshape([offset_x, offset_y], [-1, 1, 1, 2])
             ex["instance_peaks"] /= np.expand_dims(
                 np.expand_dims(ex["scale"], axis=1), axis=1
             )

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -831,6 +831,8 @@ class InferenceLayer(tf.keras.layers.Layer):
         ensure_grayscale: If `True`, converts inputs to grayscale if not already. If
             `False`, converts inputs to RGB if not already. If `None` (default), infer
             from the shape of the input layer of the model.
+        ensure_float: If `True`, converts inputs to `float32` and scales the values to
+            be between 0 and 1.
     """
 
     def __init__(
@@ -839,6 +841,7 @@ class InferenceLayer(tf.keras.layers.Layer):
         input_scale: float = 1.0,
         pad_to_stride: int = 1,
         ensure_grayscale: Optional[bool] = None,
+        ensure_float: bool = True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -848,6 +851,7 @@ class InferenceLayer(tf.keras.layers.Layer):
         if ensure_grayscale is None:
             ensure_grayscale = self.keras_model.inputs[0].shape[-1] == 1
         self.ensure_grayscale = ensure_grayscale
+        self.ensure_float = ensure_float
 
     def preprocess(self, imgs: tf.Tensor) -> tf.Tensor:
         """Apply all preprocessing operations configured for this layer.
@@ -866,7 +870,8 @@ class InferenceLayer(tf.keras.layers.Layer):
         else:
             imgs = sleap.nn.data.normalization.ensure_rgb(imgs)
 
-        imgs = sleap.nn.data.normalization.ensure_float(imgs)
+        if self.ensure_float:
+            imgs = sleap.nn.data.normalization.ensure_float(imgs)
 
         if self.input_scale != 1.0:
             imgs = sleap.nn.data.resizing.resize_image(imgs, self.input_scale)

--- a/tests/fixtures/videos.py
+++ b/tests/fixtures/videos.py
@@ -10,6 +10,11 @@ TEST_H5_INPUT_FORMAT = "channels_first"
 
 
 @pytest.fixture
+def hdf5_file_path():
+    return TEST_H5_FILE
+
+
+@pytest.fixture
 def hdf5_vid():
     return Video.from_hdf5(
         filename=TEST_H5_FILE, dataset=TEST_H5_DSET, input_format=TEST_H5_INPUT_FORMAT
@@ -37,6 +42,11 @@ def hdf5_affinity():
 
 TEST_SMALL_ROBOT_MP4_FILE = "tests/data/videos/small_robot.mp4"
 TEST_SMALL_CENTERED_PAIR_VID = "tests/data/videos/centered_pair_small.mp4"
+
+
+@pytest.fixture
+def small_robot_mp4_path():
+    return TEST_SMALL_ROBOT_MP4_FILE
 
 
 @pytest.fixture

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -14,8 +14,6 @@ from sleap.io.video import (
 )
 from tests.fixtures.datasets import TEST_SLP_SIV_ROBOT
 from tests.fixtures.videos import (
-    TEST_H5_FILE,
-    TEST_SMALL_ROBOT_MP4_FILE,
     TEST_H5_DSET,
     TEST_H5_INPUT_FORMAT,
     TEST_SMALL_CENTERED_PAIR_VID,
@@ -31,20 +29,18 @@ from typing import List
 # See: https://github.com/pytest-dev/pytest/issues/349
 
 
-def test_from_filename():
-    assert type(Video.from_filename(TEST_H5_FILE).backend) == HDF5Video
-    assert type(Video.from_filename(TEST_SMALL_ROBOT_MP4_FILE).backend) == MediaVideo
+def test_from_filename(hdf5_file_path, small_robot_mp4_path):
+    assert type(Video.from_filename(hdf5_file_path).backend) == HDF5Video
+    assert type(Video.from_filename(small_robot_mp4_path).backend) == MediaVideo
 
 
-def test_backend_extra_kwargs():
-    Video.from_filename(TEST_H5_FILE, grayscale=True, another_kwarg=False)
-    Video.from_filename(
-        TEST_SMALL_ROBOT_MP4_FILE, dataset="no dataset", fake_kwarg=True
-    )
+def test_backend_extra_kwargs(hdf5_file_path, small_robot_mp4_path):
+    Video.from_filename(hdf5_file_path, grayscale=True, another_kwarg=False)
+    Video.from_filename(small_robot_mp4_path, dataset="no dataset", fake_kwarg=True)
 
 
-def test_grayscale_video():
-    assert Video.from_filename(TEST_SMALL_ROBOT_MP4_FILE, grayscale=True).shape[-1] == 1
+def test_grayscale_video(small_robot_mp4_path):
+    assert Video.from_filename(small_robot_mp4_path, grayscale=True).shape[-1] == 1
 
 
 def test_hdf5_get_shape(hdf5_vid):
@@ -123,14 +119,12 @@ def test_numpy_frames(small_robot_mp4_vid):
     assert np.all(np.equal(np_vid.get_frame(1), small_robot_mp4_vid.get_frame(7)))
 
 
-def test_is_missing():
-    vid = Video.from_media(TEST_SMALL_ROBOT_MP4_FILE)
+def test_is_missing(small_robot_mp4_path):
+    vid = Video.from_media(small_robot_mp4_path)
     assert not vid.is_missing
     vid = Video.from_media("non-existent-filename.mp4")
     assert vid.is_missing
-    vid = Video.from_numpy(
-        Video.from_media(TEST_SMALL_ROBOT_MP4_FILE).get_frames((3, 7, 9))
-    )
+    vid = Video.from_numpy(Video.from_media(small_robot_mp4_path).get_frames((3, 7, 9)))
     assert not vid.is_missing
 
 
@@ -331,8 +325,8 @@ def test_hdf5_indexing(small_robot_mp4_vid, tmpdir):
         hdf5_vid2.get_frames([0, 1, 2])
 
 
-def test_hdf5_vid_from_open_dataset():
-    with h5py.File(TEST_H5_FILE, "r") as f:
+def test_hdf5_vid_from_open_dataset(hdf5_file_path):
+    with h5py.File(hdf5_file_path, "r") as f:
         dataset = f[TEST_H5_DSET]
 
         vid = Video(

--- a/tests/nn/data/test_providers.py
+++ b/tests/nn/data/test_providers.py
@@ -3,7 +3,6 @@ import tensorflow as tf
 from sleap.nn.system import use_cpu_only
 
 use_cpu_only()  # hide GPUs for test
-from tests.fixtures.videos import TEST_H5_FILE, TEST_SMALL_ROBOT_MP4_FILE
 import sleap
 from sleap.nn.data import providers
 
@@ -81,8 +80,8 @@ def test_labels_reader_subset(min_labels):
     assert examples[1]["example_ind"] == 1
 
 
-def test_video_reader_mp4():
-    video_reader = providers.VideoReader.from_filepath(TEST_SMALL_ROBOT_MP4_FILE)
+def test_video_reader_mp4(small_robot_mp4_path):
+    video_reader = providers.VideoReader.from_filepath(small_robot_mp4_path)
     ds = video_reader.make_dataset()
     example = next(iter(ds))
 
@@ -101,9 +100,9 @@ def test_video_reader_mp4():
     assert example["scale"].dtype == tf.float32
 
 
-def test_video_reader_mp4_subset():
+def test_video_reader_mp4_subset(small_robot_mp4_path):
     video_reader = providers.VideoReader.from_filepath(
-        TEST_SMALL_ROBOT_MP4_FILE, example_indices=[2, 1, 4]
+        small_robot_mp4_path, example_indices=[2, 1, 4]
     )
 
     assert len(video_reader) == 3
@@ -117,9 +116,9 @@ def test_video_reader_mp4_subset():
     assert examples[2]["frame_ind"] == 4
 
 
-def test_video_reader_mp4_grayscale():
+def test_video_reader_mp4_grayscale(small_robot_mp4_path):
     video_reader = providers.VideoReader.from_filepath(
-        TEST_SMALL_ROBOT_MP4_FILE, grayscale=True
+        small_robot_mp4_path, grayscale=True
     )
     ds = video_reader.make_dataset()
     example = next(iter(ds))
@@ -133,9 +132,9 @@ def test_video_reader_mp4_grayscale():
     np.testing.assert_array_equal(example["raw_image_size"], (320, 560, 1))
 
 
-def test_video_reader_hdf5():
+def test_video_reader_hdf5(hdf5_file_path):
     video_reader = providers.VideoReader.from_filepath(
-        TEST_H5_FILE, dataset="/box", input_format="channels_first"
+        hdf5_file_path, dataset="/box", input_format="channels_first"
     )
     ds = video_reader.make_dataset()
     example = next(iter(ds))
@@ -149,16 +148,14 @@ def test_video_reader_hdf5():
     np.testing.assert_array_equal(example["raw_image_size"], (512, 512, 1))
 
 
-def test_labels_reader_multi_size():
+def test_labels_reader_multi_size(small_robot_mp4_path, hdf5_file_path):
     # Create some fake data using two different size videos.
     skeleton = sleap.Skeleton.from_names_and_edge_inds(["A"])
     labels = sleap.Labels(
         [
             sleap.LabeledFrame(
                 frame_idx=0,
-                video=sleap.Video.from_filename(
-                    TEST_SMALL_ROBOT_MP4_FILE, grayscale=True
-                ),
+                video=sleap.Video.from_filename(small_robot_mp4_path, grayscale=True),
                 instances=[
                     sleap.Instance.from_pointsarray(
                         np.array([[128, 128]]), skeleton=skeleton
@@ -168,7 +165,7 @@ def test_labels_reader_multi_size():
             sleap.LabeledFrame(
                 frame_idx=0,
                 video=sleap.Video.from_filename(
-                    TEST_H5_FILE, dataset="/box", input_format="channels_first"
+                    hdf5_file_path, dataset="/box", input_format="channels_first"
                 ),
                 instances=[
                     sleap.Instance.from_pointsarray(

--- a/tests/nn/data/test_resizing.py
+++ b/tests/nn/data/test_resizing.py
@@ -213,3 +213,17 @@ def test_size_matcher():
     check_padding(im1, 700, 750, 0, 750)
     im2 = next(transform_iter)["image"]
     assert im2.shape == (750, 750, 1)
+
+    # Check SizeMatcher when target is larger in both dimensions
+    size_matcher = SizeMatcher(max_image_height=560, max_image_width=560, center_pad=True)
+    transform_iter = iter(size_matcher.transform_dataset(ds))
+    ex = next(transform_iter)
+    im1 = ex["image"]
+    assert im1.shape == (560, 560, 1)
+    # Check padding is on the top and bottom
+    check_padding(im1, 440, 560, 0, 560)
+    check_padding(im1, 0, 120, 0, 560)
+    assert ex["offset_x"] == 0
+    assert ex["offset_y"] == 120
+    im2 = next(transform_iter)["image"]
+    assert im2.shape == (560, 560, 1)

--- a/tests/nn/data/test_resizing.py
+++ b/tests/nn/data/test_resizing.py
@@ -13,8 +13,6 @@ from sleap.nn.data import resizing
 from sleap.nn.data import providers
 from sleap.nn.data.resizing import SizeMatcher
 
-from tests.fixtures.videos import TEST_H5_FILE, TEST_SMALL_ROBOT_MP4_FILE
-
 
 def test_find_padding_for_stride():
     assert resizing.find_padding_for_stride(
@@ -132,16 +130,14 @@ def test_resizer_from_config():
         )
 
 
-def test_size_matcher():
+def test_size_matcher(small_robot_mp4_path, hdf5_file_path):
     # Create some fake data using two different size videos.
     skeleton = sleap.Skeleton.from_names_and_edge_inds(["A"])
     labels = sleap.Labels(
         [
             sleap.LabeledFrame(
                 frame_idx=0,
-                video=sleap.Video.from_filename(
-                    TEST_SMALL_ROBOT_MP4_FILE, grayscale=True
-                ),
+                video=sleap.Video.from_filename(small_robot_mp4_path, grayscale=True),
                 instances=[
                     sleap.Instance.from_pointsarray(
                         np.array([[128, 128]]), skeleton=skeleton
@@ -151,7 +147,7 @@ def test_size_matcher():
             sleap.LabeledFrame(
                 frame_idx=0,
                 video=sleap.Video.from_filename(
-                    TEST_H5_FILE, dataset="/box", input_format="channels_first"
+                    hdf5_file_path, dataset="/box", input_format="channels_first"
                 ),
                 instances=[
                     sleap.Instance.from_pointsarray(

--- a/tests/nn/data/test_resizing.py
+++ b/tests/nn/data/test_resizing.py
@@ -215,7 +215,9 @@ def test_size_matcher():
     assert im2.shape == (750, 750, 1)
 
     # Check SizeMatcher when target is larger in both dimensions
-    size_matcher = SizeMatcher(max_image_height=560, max_image_width=560, center_pad=True)
+    size_matcher = SizeMatcher(
+        max_image_height=560, max_image_width=560, center_pad=True
+    )
     transform_iter = iter(size_matcher.transform_dataset(ds))
     ex = next(transform_iter)
     im1 = ex["image"]

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -385,13 +385,34 @@ def test_inference_layer():
     x = tf.keras.layers.Lambda(lambda x: x)(x_in)
     keras_model = tf.keras.Model(x_in, x)
     layer = sleap.nn.inference.InferenceLayer(
-        keras_model=keras_model, input_scale=1.0, pad_to_stride=1, ensure_grayscale=None
+        keras_model=keras_model,
+        input_scale=1.0,
+        pad_to_stride=1,
+        ensure_grayscale=None,
+        ensure_float=True,
     )
     data = tf.cast(tf.fill([1, 4, 4, 1], 255), tf.uint8)
     out = layer(data)
     assert out.dtype == tf.float32
     assert tuple(out.shape) == (1, 4, 4, 1)
     assert tf.reduce_all(out == 1.0)
+
+    # Not convert to float
+    x_in = tf.keras.layers.Input([4, 4, 1], dtype="uint8")
+    x = tf.keras.layers.Lambda(lambda x: x)(x_in)
+    keras_model = tf.keras.Model(x_in, x)
+    layer = sleap.nn.inference.InferenceLayer(
+        keras_model=keras_model,
+        input_scale=1.0,
+        pad_to_stride=1,
+        ensure_grayscale=True,
+        ensure_float=False,
+    )
+    data = tf.cast(tf.fill([1, 4, 4, 1], 255), tf.uint8)
+    out = layer(data)
+    assert out.dtype == tf.uint8
+    assert tuple(out.shape) == (1, 4, 4, 1)
+    assert tf.reduce_all(out == 255)
 
     # Convert from rgb to grayscale, infer ensure grayscale
     x_in = tf.keras.layers.Input([4, 4, 1])


### PR DESCRIPTION
### Description
We want to override the [pipeline creation](https://github.com/talmolab/sleap/blob/9ae2941649c81ca5b8e8301ccd99725732599fa5/sleap/nn/inference.py#L254), to support center padding as done in the example

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
 #1119

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [x] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [x] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [x] Add tests that prove your fix is effective or that your feature works
- [x] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
