### PR TITLE
Create signal that updates plot instead of redrawing

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -311,7 +311,8 @@ class MainWindow(QMainWindow):
         self.player = QtVideoPlayer(
             color_manager=self.color_manager, state=self.state, context=self.commands
         )
-        self.player.changedPlot.connect(self._after_plot_update)
+        self.player.changedPlot.connect(self._after_plot_change)
+        self.player.updatedPlot.connect(self._after_plot_update)
 
         self.player.view.instanceDoubleClicked.connect(
             self._handle_instance_double_click
@@ -1185,14 +1186,16 @@ class MainWindow(QMainWindow):
 
     def _load_overlays(self):
         """Load all standard video overlays."""
-        self.overlays["track_labels"] = TrackListOverlay(self.labels, self.player)
+        self.overlays["track_labels"] = TrackListOverlay(
+            labels=self.labels, player=self.player
+        )
         self.overlays["trails"] = TrackTrailOverlay(
             labels=self.labels,
             player=self.player,
             trail_shade=self.state["trail_shade"],
         )
         self.overlays["instance"] = InstanceOverlay(
-            self.labels, self.player, self.state
+            labels=self.labels, player=self.player, state=self.state
         )
 
         # When gui state changes, we also want to set corresponding attribute
@@ -1380,7 +1383,12 @@ class MainWindow(QMainWindow):
 
         self.player.plot()
 
-    def _after_plot_update(self, player, frame_idx, selected_inst):
+    def _after_plot_update(self, frame_idx):
+        """Run after plot is updated, but stay on same frame."""
+        overlay: TrackTrailOverlay = self.overlays["trails"]
+        overlay.redraw(self.state["video"], frame_idx)
+
+    def _after_plot_change(self, player, frame_idx, selected_inst):
         """Called each time a new frame is drawn."""
 
         # Store the current LabeledFrame (or make new, empty object)
@@ -1827,3 +1835,10 @@ def main(args: Optional[list] = None):
         app.exec_()
 
     pass
+
+
+if __name__ == "__main__":
+    import os
+
+    ds = os.environ["ds-mouse"]
+    main([ds])

--- a/sleap/gui/overlays/base.py
+++ b/sleap/gui/overlays/base.py
@@ -13,7 +13,9 @@ from qtpy import QtWidgets
 import attr
 import abc
 import numpy as np
-from typing import Sequence, Union
+from typing import Sequence, Union, Optional, List
+
+from qtpy.QtWidgets import QGraphicsItem
 
 from sleap import Labels, Video
 from sleap.gui.widgets.video import QtVideoPlayer
@@ -23,20 +25,52 @@ from sleap.nn.inference import VisualPredictor
 
 @attr.s(auto_attribs=True)
 class BaseOverlay(abc.ABC):
-    """
-    Abstract base class for overlays.
+    """Abstract base class for overlays.
 
     Most overlays need rely on the `Labels` from which to get data and need the
-    `QtVideoPlayer` to which a `QGraphicsObject` item will be added, so these
+    `QtVideoPlayer` to which a `QGraphicsItem` will be added, so these
     attributes are included in the base class.
+
+    Args:
+        labels: the `Labels` from which to get data
+        player: the `QtVideoPlayer` to which a `QGraphicsObject` item will be added
+        items: stores all `QGraphicsItem`s currently added to the player from this
+            overlay
     """
 
-    labels: Labels = None
-    player: QtVideoPlayer = None
+    labels: Optional[Labels] = None
+    player: Optional[QtVideoPlayer] = None
+    items: Optional[List[QGraphicsItem]] = None
 
     @abc.abstractmethod
     def add_to_scene(self, video: Video, frame_idx: int):
-        pass
+        """Add items to scene.
+
+        To use the `remove_from_scene` and `redraw` methods, keep track of a list of
+        `QGraphicsItem`s added in this function.
+        """
+        # Start you method with:
+        self.items = []
+
+        # As items are added to the `QtVideoPlayer`, keep track of these items:
+        item = self.player.scene.addItem(...)
+        self.items.append(item)
+
+    def remove_from_scene(self):
+        """Remove all items added to scene by this overlay.
+
+        This method does not need to be called when changing the plot to a new frame.
+        """
+        for item in self.items:
+            self.player.scene.removeItem(item)
+
+    def redraw(self, video, frame_idx, *args, **kwargs):
+        """Remove all items from the scene before adding new items to the scene.
+
+        This method does not need to be called when changing the plot to a new frame.
+        """
+        self.remove_from_scene(*args, **kwargs)
+        self.add_to_scene(video, frame_idx, *args, **kwargs)
 
 
 @attr.s(auto_attribs=True)

--- a/sleap/gui/overlays/tracks.py
+++ b/sleap/gui/overlays/tracks.py
@@ -144,6 +144,7 @@ class TrackTrailOverlay(BaseOverlay):
             frame_idx: index of the frame to which the trail is attached
 
         """
+        self.items = []
 
         if not self.show or self.trail_length == 0:
             return
@@ -188,7 +189,8 @@ class TrackTrailOverlay(BaseOverlay):
                 for segment in segments:
                     pen.setWidthF(width)
                     path = self.map_to_qt_path(segment)
-                    self.player.scene.addPath(path, pen)
+                    item = self.player.scene.addPath(path, pen)
+                    self.items.append(item)
                     width /= 2
 
     @staticmethod

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -193,6 +193,7 @@ class QtVideoPlayer(QWidget):
 
     Signals:
         * changedPlot: Emitted whenever the plot is redrawn
+        * updatedPlot: Emitted whenever a node is moved (updates overlays s.a. trails)
 
     Attributes:
         video: The :class:`Video` to display
@@ -202,6 +203,7 @@ class QtVideoPlayer(QWidget):
     """
 
     changedPlot = QtCore.Signal(QWidget, int, Instance)
+    updatedPlot = QtCore.Signal(int)
 
     def __init__(
         self,
@@ -488,6 +490,10 @@ class QtVideoPlayer(QWidget):
         # for too long before they were received by the loader).
         self._video_image_loader.video = self.video
         self._video_image_loader.request(idx)
+
+    def update_plot(self):
+        idx = self.state["frame_idx"] or 0
+        self.updatedPlot.emit(idx)
 
     def showInstances(self, show):
         """Show/hide all instances in viewer.
@@ -1568,7 +1574,7 @@ class QtNode(QGraphicsEllipseItem):
             super(QtNode, self).mouseReleaseEvent(event)
             self.updatePoint(user_change=True)
         self.dragParent = False
-        self.player.plot()  # Redraw trails after node is moved
+        self.player.update_plot()  # Redraw trails after node is moved
 
     def wheelEvent(self, event):
         """Custom event handler for mouse scroll wheel."""


### PR DESCRIPTION
### Description
Previously, in #910, we added a fix to update the trails whenever a node is released by calling `self.player.plot()` which completely redraws the entire plot and was only intended to be used when switching between frames.

This resulted in some problem when trying to implement #1110 during the hackathon which requires references to `QtNode`s to stay alive.

This PR resolves this issue of disappearing `QtNode`s by updating the overlays (namely `"trails"`) instead of redrawing all items on the scene (i.e. the `QtNode`s, etc.).


### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1110
- #910 (closed)

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
