### PR TITLE
Fix symmetric skeletons (via table input)

### DIFF
--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -150,12 +150,14 @@ class GenericTableModel(QtCore.QAbstractTableModel):
             item, key = self.get_from_idx(index)
 
             # If nothing changed of the item, return true. (Issue #1013)
-            if isinstance(item, dict) and key in item:
-                item_value = item[key]
-            if hasattr(item, key):
+            if isinstance(item, dict):
+                item_value = item.get(key, None)
+            elif hasattr(item, key):
                 item_value = getattr(item, key)
+            else:
+                item_value = None
 
-            if item_value == value:
+            if (item_value is not None) and (item_value == value):
                 return True
 
             # Otherwise set the item


### PR DESCRIPTION
### Description
In #1022 we conditionally set a variable `item_value`, but always compared the variable downstream. This isn't a problem if the `item` already exists, but when trying to set new symmetries for example, `item_value` was never being set.

This PR runs through a conditional chain ending in an `else` which always intialized `item_value`.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1135

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
