### PR TITLE
Handle changing backbones in training editor GUI

### DIFF
--- a/sleap/gui/learning/scopedkeydict.py
+++ b/sleap/gui/learning/scopedkeydict.py
@@ -39,7 +39,7 @@ class ScopedKeyDict:
             current_dict[key] = val
         else:
             top_key, *subkey_list = key.split(".")
-            if top_key not in current_dict:
+            if top_key not in current_dict or current_dict[top_key] is None:
                 current_dict[top_key] = dict()
             subkey = ".".join(subkey_list)
             cls.set_hierarchical_key_val(current_dict[top_key], subkey, val)


### PR DESCRIPTION
### Description
Currently, it is not possible to change the backbone model architecture from the training editor form as the learning dialog fails to remove keys from the base `TrainingJobConfig` for the previous model architecture.

Basically this means that in order to change a model architecture, you'd need to create a new training job config JSON file with the appropriate `model.backbone` fields set in order to edit those parameters. We hadn't run into this since we have enough preset profiles that cover the common model backbones.

This PR fixes this issue by appropriately setting the `model.backbone` sub-fields in the base config to `None`. This is ok since the GUI will have all of those fields set appropriately for the selected backbone.

We are now also testing for the appropriate overriding behavior.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
