### PR TITLE
Fix body vs symmetry subgraph filtering

### DIFF
--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -169,6 +169,18 @@ def test_symmetry():
     with pytest.raises(ValueError):
         s1.delete_symmetry("1", "5")
 
+    s2 = Skeleton()
+    s2.add_nodes(["1", "2", "3"])
+    s2.add_edge("1", "2")
+    s2.add_edge("2", "3")
+    s2.add_symmetry("1", "3")
+    assert s2.graph.number_of_edges() == 2
+    assert s2.graph_symmetry.number_of_edges() == 2
+    assert list(s2.graph_symmetry.edges()) == [
+        (s2.nodes[0], s2.nodes[2]),
+        (s2.nodes[2], s2.nodes[0]),
+    ]
+
 
 def test_json(skeleton, tmpdir):
     """
@@ -253,6 +265,9 @@ def test_name_change(skeleton):
 
 def test_graph_property(skeleton):
     assert [node for node in skeleton.graph.nodes()] == skeleton.nodes
+
+    no_edge_skel = Skeleton.from_names_and_edge_inds(["A", "B"])
+    assert [node for node in no_edge_skel.graph.nodes()] == no_edge_skel.nodes
 
 
 def test_load_mat_format():
@@ -396,3 +411,13 @@ def test_arborescence():
     assert len(skeleton.cycles) == 0
     assert len(skeleton.root_nodes) == 1
     assert len(skeleton.in_degree_over_one) == 1
+
+    # symmetry edges should be ignored
+    skeleton = Skeleton()
+    skeleton.add_node("a")
+    skeleton.add_node("b")
+    skeleton.add_node("c")
+    skeleton.add_edge("a", "b")
+    skeleton.add_edge("b", "c")
+    skeleton.add_symmetry("a", "c")
+    assert skeleton.is_arborescence


### PR DESCRIPTION
### Description
Currently, we may not be able to train bottom-up models from the GUI if the skeleton contains symmetry edges that would result in it not being an arborescence.

This is fixed by using only the skeleton subgraph that contains body (non-symmetry) edges to test for whether it is an arborescence.

This PR uses the appropriate subgraph for arborescence testing, as well as fixing how we induced the subgraph views for body vs symmetry edges. Previously, we also had a subtle edge case where calling `Skeleton.graph` would return an empty graph if there were nodes but no body edges. We now return disconnected nodes appropriately.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
