### PR TITLE
Hotfix for video save #1098

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -670,7 +670,7 @@ class LoadProjectFile(LoadLabelsObject):
                 has_loaded = True
             except ValueError as e:
                 print(e)
-                QMessageBox(text=f"Unable to load {filename}.").exec_()
+                QtWidgets.QMessageBox(text=f"Unable to load {filename}.").exec_()
 
         params["labels"] = labels
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -642,7 +642,7 @@ class LoadLabelsObject(AppCommand):
             context.state["video"] = labels.videos[0]
 
         context.state["project_loaded"] = True
-        context.state["has_changes"] = getattr(params, "changed_on_load", False)
+        context.state["has_changes"] = params.get("changed_on_load", False)
 
         # This is not listed as an edit command since we want a clean changestack
         context.app.on_data_update([UpdateTopic.project, UpdateTopic.all])

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -2582,6 +2582,7 @@ class Labels(MutableSequence):
                     if fixed_path != filename:
                         filenames[i] = fixed_path
                         missing[i] = False
+                        context["changed_on_load"] = True
 
             if use_gui:
                 # If there are still missing paths, prompt user

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -2550,6 +2550,7 @@ class Labels(MutableSequence):
             The callback function.
         """
         search_paths = search_paths or []
+        context = context or {}
 
         def video_callback(
             video_list: List[dict],
@@ -2616,6 +2617,9 @@ class Labels(MutableSequence):
                         for i, filename in enumerate(filenames):
                             if missing[i]:
                                 filenames[i] = new_paths[i]
+
+                        # Solely for testing since only gui will have a `CommandContext`
+                        context["changed_on_load"] = True
 
             # Replace the video filenames with changes by user
             for i, item in enumerate(video_list):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1,6 +1,5 @@
 from pathlib import PurePath, Path
 import shutil
-from tempfile import tempdir
 from typing import List
 
 import pytest
@@ -15,7 +14,6 @@ from sleap.gui.commands import (
     SaveProjectAs,
     get_new_version_filename,
 )
-from sleap.gui.state import GuiState
 from sleap.instance import Instance, LabeledFrame
 from sleap.io.convert import default_analysis_filename
 from sleap.io.dataset import Labels

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1,5 +1,6 @@
 from pathlib import PurePath, Path
 import shutil
+import sys
 from typing import List
 
 import pytest
@@ -504,6 +505,11 @@ def test_SetSelectedInstanceTrack(centered_pair_predictions: Labels):
     assert pred_inst.track == new_instance.track
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="Files being using in parallel by linux CI tests via Github Actions "
+    "(and linux tests give us codecov reports)",
+)
 @pytest.mark.parametrize("video_move_case", ["new_directory", "new_name"])
 def test_LoadProjectFile(
     centered_pair_predictions_slp_path: str,


### PR DESCRIPTION
### Description
In #1098, we moved the code to load a project into the `CommandContext`. The overall goal however, was to solve #848. It seems we got lost in the refactoring and used `getattr` on a dictionary! This PR uses `get` instead to discover that a project indeed has changes on load.

### Types of changes

- [x] Bugfix (spicy)
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #848

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
