### PR TITLE
[dataviews] GenericTableModel/View improvements ...

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -987,6 +987,7 @@ class MainWindow(QMainWindow):
             row_name="video",
             is_activatable=True,
             model=VideosTableModel(items=self.labels.videos, context=self.commands),
+            ellipsis_left=True,
         )
         videos_layout.addWidget(self.videosTable)
 

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -74,7 +74,6 @@ class GenericTableModel(QtCore.QAbstractTableModel):
         super(GenericTableModel, self).__init__()
         self.properties = properties or self.properties or []
         self.context = context
-
         self.items = items
 
     def object_to_items(self, item_list):
@@ -141,6 +140,13 @@ class GenericTableModel(QtCore.QAbstractTableModel):
 
         elif role == QtCore.Qt.ForegroundRole:
             return self.get_item_color(self.original_items[idx], key)
+
+        elif role == QtCore.Qt.ToolTipRole:
+            if isinstance(item, dict) and key in item:
+                return item[key]
+
+            if hasattr(item, key):
+                return getattr(item, key)
 
         return None
 
@@ -272,6 +278,11 @@ class GenericTableView(QtWidgets.QTableView):
     for some reason you need this to be different. For instance, the table
     of instances in the GUI sets this to "" so that the row for an instance
     is automatically selected when `state["instance"]` is set outside the table.
+
+    "ellipsis_left" can be used to make the TableView truncate cell content on
+    the left instead of the right side. By default, the argument is set to
+    False, i.e. truncation on the right side, which is also the default for
+    QTableView.
     """
 
     row_name: Optional[str] = None
@@ -287,6 +298,7 @@ class GenericTableView(QtWidgets.QTableView):
         name_prefix: Optional[str] = None,
         is_sortable: bool = False,
         is_activatable: bool = False,
+        ellipsis_left: bool = False,
     ):
         super(GenericTableView, self).__init__()
 
@@ -298,6 +310,10 @@ class GenericTableView(QtWidgets.QTableView):
 
         self.setModel(model)
 
+        if ellipsis_left:
+            self.setTextElideMode(QtCore.Qt.ElideLeft)
+            self.setWordWrap(False)
+        self.horizontalHeader().setStretchLastSection(True)
         self.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
         self.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
         self.setSortingEnabled(self.is_sortable)


### PR DESCRIPTION
### Description
The "video table" shows the full filenames of the videos in the first column. In my case the full filenames are longer paths and I basically can't see the information that may be relevant for me, i.e. the name of the file, not the path.
To improve on this, I did these changes:
* The model's ``data`` function now also recognizes  the ``Qt.ToolTipRole`` and returns the full cell content. 
* GenericTableView got an init argument to define whether long cell content should be abbreviated with an ellipsis on the left instead of the default right side.
* GenericTableView uses all the space available to the table.
* app.py uses the new argument to set the ellipisi to the left side for the video table

Not sure, how I would test this...

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ x] Other (explain)

### Does this address any currently open issues?
no

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
