### PR TITLE
Elizabeth/add tiffs as video

### DIFF
--- a/sleap/gui/dialogs/importvideos.py
+++ b/sleap/gui/dialogs/importvideos.py
@@ -206,6 +206,18 @@ class ImportParamDialog(QDialog):
             button_layout.addWidget(all_channels_first_button)
             all_channels_last_button.clicked.connect(self.set_all_channels_last)
             all_channels_first_button.clicked.connect(self.set_all_channels_first)
+        if any(
+            [
+                widget.import_type["video_type"] == "single_image"
+                for widget in self.import_widgets
+            ]
+        ):
+            all_grayscale_button = QPushButton("All grayscale")
+            all_rgb_button = QPushButton("All RGB")
+            button_layout.addWidget(all_grayscale_button)
+            button_layout.addWidget(all_rgb_button)
+            all_grayscale_button.clicked.connect(self.set_all_grayscale)
+            all_rgb_button.clicked.connect(self.set_all_rgb)
 
         cancel_button = QPushButton("Cancel")
         import_button = QPushButton("Import")
@@ -607,8 +619,11 @@ class VideoPreviewWidget(QWidget):
         frame = self.video.get_frame(idx)
         # Clear existing objects
         self.view.clear()
+        # Re-size the preview image
+        decimate = 10
+        frame_resized = frame[::decimate, ::decimate]
         # Convert ndarray to QImage
-        image = qimage2ndarray.array2qimage(frame)
+        image = qimage2ndarray.array2qimage(frame_resized)
         # Display image
         self.view.setImage(image)
 

--- a/sleap/gui/dialogs/importvideos.py
+++ b/sleap/gui/dialogs/importvideos.py
@@ -141,6 +141,12 @@ class ImportParamDialog(QDialog):
                 "video_class": Video.from_filename,
                 "params": [],
             },
+            {
+                "video_type": "single_image",
+                "match": "jpg,png,tif,jpeg,tiff",
+                "video_class": Video.from_filename,
+                "params": [{"name": "grayscale", "type": "check"}],
+            },
         ]
 
         outer_layout = QVBoxLayout()

--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -1253,6 +1253,8 @@ class Video:
             kwargs["dataset"] = ""  # prevent serialization from breaking
         elif os.path.isdir(filename) or "metadata.yaml" in filename:
             backend_class = ImgStoreVideo
+        elif filename.lower().endswith(("jpg", "jpeg", "png", "tif", "tiff")):
+            backend_class = SingleImageVideo
         else:
             raise ValueError("Could not detect backend for specified filename.")
 


### PR DESCRIPTION
### Description
Added tiffs as a video 

### Types of changes

- Added single_image as a video_type in `import_types`
- `all_grayscale_button` and `all_rgb_button` added for single_image type
- In `plot` in `VideoPreviewWidget` class, the preview image is decimated by a factor of 10 to make the preview appear faster
- In `video` class in `from_filename` if the file ends with "jpg", "jpeg", "png", "tif", "tiff" it will be imported as a SingleImageVideo
- Tested by making a new sleap project with 3 tiffs and choosing all greyscale. Saved the project and re-opened it. 

### Does this address any currently open issues?
(https://github.com/talmolab/sleap/issues/1152)

### Outside contributors checklist

#### Thank you for contributing to SLEAP!
:heart:
