### PR TITLE
Fix typo in `Skeleton.__repr__`

### DIFF
--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -125,12 +125,12 @@ class Skeleton:
     def __repr__(self) -> str:
         """Return full description of the skeleton."""
         return (
-            f"Skeleton(name='{self.name}', ",
-            f"description='{self.description}', ",
+            f"Skeleton(name='{self.name}', "
+            f"description='{self.description}', "
             f"nodes={self.node_names}, "
             f"edges={self.edge_names}, "
             f"symmetries={self.symmetry_names}"
-            ")",
+            ")"
         )
 
     def __str__(self) -> str:


### PR DESCRIPTION
### Description
Fix typo in `Skeleton.__repr__` which was mistakenly added in #1122

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
