### PR TITLE
Update no-cuda-env to fix pillow errors

### DIFF
--- a/environment_no_cuda.yml
+++ b/environment_no_cuda.yml
@@ -7,7 +7,7 @@ dependencies:
   - conda-forge::pyside2>=5.13.2,<=5.14.1
   - conda-forge::h5py=3.1.0
   - conda-forge::scipy>=1.4.1,<=1.7.3
-  - pillow=8.4.0
+  - conda-forge::pillow=8.4.0
   - shapely=1.7.1
   - conda-forge::pandas
   - ffmpeg
@@ -17,7 +17,7 @@ dependencies:
   # - sleap::tensorflow=2.7.0
   # - sleap::pyside2=5.14.1
   - qtpy>=2.0.1
-  - conda-forge::pip!=22.0.4
+  - conda-forge::pip  # !=22.0.4
   - pip:
       - "--editable=."
       - "--requirement=./dev_requirements.txt"


### PR DESCRIPTION
### Description
Update the `environment_no_cuda.yml` to [specify a channel for pillow](https://stackoverflow.com/questions/43267754/importing-pil-more-specifically-image-from-pil-isnt-working?noredirect=1&lq=1#comment84341832_43299802) that allows our tests to pass in #1197 and #1200

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (dependencies)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
