### PR TITLE
Add option of 2 for marker size

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -630,7 +630,7 @@ class MainWindow(QMainWindow):
         add_submenu_choices(
             menu=viewMenu,
             title="Node Marker Size",
-            options=(1, 4, 6, 8, 12),
+            options=(1, 2, 4, 6, 8, 12),
             key="marker size",
         )
 


### PR DESCRIPTION
### Description
Add option an additional of 2 for marker size.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Through email, I was notified that video rendering with the default marker sizes on low-resolution images resulted in very monstrous looking instances. This is due to using opencv to draw on images (for video rendering) which uses pixels for measurement whereas Qt (used for the GUI) keeps a constant (marker) size from the user's perspective.

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
