### PR TITLE
Toggle grayscale of all videos using "Toggle Grayscale" button

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1655,14 +1655,14 @@ class ToggleGrayscale(EditCommand):
     @staticmethod
     def do_action(context: CommandContext, params: dict):
         """Reset the video backend."""
-        video: Video = context.state["video"]
-        try:
-            grayscale = video.backend.grayscale
-            video.backend.reset(grayscale=(not grayscale))
-        except:
-            print(
-                f"This video type {type(video.backend)} does not support grayscale yet."
-            )
+        for video in context.labels.videos:
+            try:
+                grayscale = video.backend.grayscale
+                video.backend.reset(grayscale=(not grayscale))
+            except:
+                print(
+                    f"This video type {type(video.backend)} does not support grayscale yet."
+                )
 
     @staticmethod
     def ask(context: CommandContext, params: dict) -> bool:


### PR DESCRIPTION
### Description
Previous the "Toggle Grayscale" button in the GUI toggled the grayscale of videos on a video-by-video basis. However, this does not make sense since all projects (at the current SLEAP state) need to be either grayscale projects or color projects (see: #759). This PR broadens the functionality of the "Toggle Grayscale" button to toggle all videos to grayscale/color at once

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
