### PR TITLE
Ensure data format compatibility

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2009,8 +2009,10 @@ class OpenSkeleton(EditCommand):
         # Load new skeleton
         filename = params["filename"]
         new_skeleton = OpenSkeleton.load_skeleton(filename)
-        if new_skeleton.description == None:
-            new_skeleton.description = f"Custom Skeleton loaded from {filename}"
+
+        # Description and preview image only used for template skeletons
+        new_skeleton.description = None
+        new_skeleton.preview_image = None
         context.state["skeleton_description"] = new_skeleton.description
         context.state["skeleton_preview_image"] = new_skeleton.preview_image
 

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -97,11 +97,13 @@ class Skeleton:
         preview_image: A byte string containing an encoded preview image for the
             skeleton. Used only for templates.
         description: A text description of the skeleton. Used only for templates.
+        _is_template: Whether this skeleton is a template. Used only for templates.
     """
 
     _skeleton_idx = count(0)
     preview_image: Optional[bytes] = None
     description: Optional[str] = None
+    _is_template: bool = False
 
     def __init__(self, name: str = None):
         """Initialize an empty skeleton object.
@@ -183,12 +185,24 @@ class Skeleton:
         If is_template is True, then the preview image and description are saved.
         If is_template is False, then the preview image and description are not saved.
 
-        Only provided template skeletons are considered templates.
-
-        Note to developers: To save a new template skeleton, change this to True before
-        saving.
+        Only provided template skeletons are considered templates. To save a new
+        template skeleton, change this to True before saving.
         """
-        return False
+        return self._is_template
+
+    @is_template.setter
+    def is_template(self, value: bool):
+        """Set whether this skeleton is a template."""
+
+        self._is_template = False
+        if value and ((self.preview_image is None) or (self.description is None)):
+            raise ValueError(
+                "For a skeleton to be a template, it must have both a preview image "
+                "and description. Checkout `generate_skeleton_preview_image` to "
+                "generate a preview image."
+            )
+            
+        self._is_template = value
 
     @property
     def is_arborescence(self) -> bool:

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -201,7 +201,7 @@ class Skeleton:
                 "and description. Checkout `generate_skeleton_preview_image` to "
                 "generate a preview image."
             )
-            
+
         self._is_template = value
 
     @property

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -95,8 +95,8 @@ class Skeleton:
         _skeleton_idx: An index variable used to give skeletons a default name that
             should be unique across all skeletons.
         preview_image: A byte string containing an encoded preview image for the
-            skeleton.
-        description: A text description of the skeleton. Used mostly for presets.
+            skeleton. Used only for templates.
+        description: A text description of the skeleton. Used only for templates.
     """
 
     _skeleton_idx = count(0)
@@ -175,6 +175,20 @@ class Skeleton:
                 return False
 
         return True
+
+    @property
+    def is_template(self) -> bool:
+        """Return whether this skeleton is a template.
+
+        If is_template is True, then the preview image and description are saved.
+        If is_template is False, then the preview image and description are not saved.
+
+        Only provided template skeletons are considered templates.
+
+        Note to developers: To save a new template skeleton, change this to True before
+        saving.
+        """
+        return False
 
     @property
     def is_arborescence(self) -> bool:
@@ -956,8 +970,7 @@ class Skeleton:
         return skeleton
 
     def to_json(self, node_to_idx: Optional[Dict[Node, int]] = None) -> str:
-        """
-        Convert the :class:`Skeleton` to a JSON representation.
+        """Convert the :class:`Skeleton` to a JSON representation.
 
         Args:
             node_to_idx: optional dict which maps :class:`Node`sto index
@@ -981,12 +994,22 @@ class Skeleton:
             indexed_node_graph = self._graph
 
         # Encode to JSON
-        dicts = {
-            "nx_graph": json_graph.node_link_data(indexed_node_graph),
-            "description": self.description,
-            "preview_image": self.preview_image,
-        }
-        json_str = jsonpickle.encode(dicts)
+        graph = json_graph.node_link_data(indexed_node_graph)
+
+        # SLEAP v1.3.0 added `description` and `preview_image` to `Skeleton`, but saving
+        # these fields breaks data format compatibility. Currently, these are only
+        # added in our custom template skeletons. To ensure backwards data format
+        # compatibilty of user data, we only save these fields if they are not None.
+        if self.is_template:
+            data = {
+                "nx_graph": graph,
+                "description": self.description,
+                "preview_image": self.preview_image,
+            }
+        else:
+            data = graph
+
+        json_str = jsonpickle.encode(data)
 
         return json_str
 
@@ -1020,8 +1043,7 @@ class Skeleton:
     def from_json(
         cls, json_str: str, idx_to_node: Dict[int, Node] = None
     ) -> "Skeleton":
-        """
-        Instantiate :class:`Skeleton` from JSON string.
+        """Instantiate :class:`Skeleton` from JSON string.
 
         Args:
             json_str: The JSON encoded Skeleton.
@@ -1036,9 +1058,8 @@ class Skeleton:
             An instance of the `Skeleton` object decoded from the JSON.
         """
         dicts = jsonpickle.decode(json_str)
-        if "nx_graph" not in dicts:
-            dicts = {"nx_graph": dicts, "description": None, "preview_image": None}
-        graph = json_graph.node_link_graph(dicts["nx_graph"])
+        nx_graph = dicts.get("nx_graph", dicts)
+        graph = json_graph.node_link_graph(nx_graph)
 
         # Replace graph node indices with corresponding nodes from node_map
         if idx_to_node is not None:
@@ -1046,8 +1067,8 @@ class Skeleton:
 
         skeleton = Skeleton()
         skeleton._graph = graph
-        skeleton.description = dicts["description"]
-        skeleton.preview_image = dicts["preview_image"]
+        skeleton.description = dicts.get("description", None)
+        skeleton.preview_image = dicts.get("preview_image", None)
 
         return skeleton
 
@@ -1055,8 +1076,7 @@ class Skeleton:
     def load_json(
         cls, filename: str, idx_to_node: Dict[int, Node] = None
     ) -> "Skeleton":
-        """
-        Load a skeleton from a JSON file.
+        """Load a skeleton from a JSON file.
 
         This method will load the Skeleton from JSON file saved
         with; :meth:`~Skeleton.save_json`

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -1,6 +1,7 @@
 import os
 import copy
 
+import jsonpickle
 import pytest
 
 from sleap.skeleton import Skeleton
@@ -182,11 +183,22 @@ def test_symmetry():
     ]
 
 
-def test_json(skeleton, tmpdir):
-    """
-    Test saving and loading a Skeleton object in JSON.
-    """
+def test_json(skeleton: Skeleton, tmpdir):
+    """Test saving and loading a Skeleton object in JSON."""
     JSON_TEST_FILENAME = os.path.join(tmpdir, "skeleton.json")
+
+    # Test that `to_json` does not save unused `None` fields (to ensure backwards data
+    # format compatibility)
+    skeleton.description = (
+        "Test that description is not saved when given (if is_template is False)."
+    )
+    assert skeleton.is_template == False
+    json_str = skeleton.to_json()
+    json_dict = jsonpickle.decode(json_str)
+    json_dict_keys = list(json_dict.keys())
+    assert "nx_graph" not in json_dict_keys
+    assert "preview_image" not in json_dict_keys
+    assert "description" not in json_dict_keys
 
     # Save it to a JSON filename
     skeleton.save_json(JSON_TEST_FILENAME)

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -200,6 +200,20 @@ def test_json(skeleton: Skeleton, tmpdir):
     assert "preview_image" not in json_dict_keys
     assert "description" not in json_dict_keys
 
+    # Test that `is_template` can only be set to True
+    # when has both `description` and `preview_image`
+    with pytest.raises(ValueError):
+        skeleton.is_template = True
+    assert skeleton.is_template == False
+
+    skeleton._is_template = True
+    json_str = skeleton.to_json()
+    json_dict = jsonpickle.decode(json_str)
+    json_dict_keys = list(json_dict.keys())
+    assert "nx_graph" in json_dict_keys
+    assert "preview_image" in json_dict_keys
+    assert "description" in json_dict_keys
+
     # Save it to a JSON filename
     skeleton.save_json(JSON_TEST_FILENAME)
 


### PR DESCRIPTION
### Description
In #1122, we added two new attributes in the `Skeleton` class called `description` and `preview_image`. Consequently, while you are able to open older files on v1.3.0a0, files from this version are unable to be opened on previous versions - which is not a problem if working on a single SLEAP version. However, this could easily become extremely annoying if working on multiple workstations which all have different versions of SLEAP installed - not to mention possibly breaking data format backwards compatibility.

The fields we added are currently not used except for the already provided template skeletons. Hence, this PR selectively writes the new fields depending on whether the skeleton is a template (manually specified via API - only by those looking to add to our collection of template skeletons). This should not break compatibility since template skeletons are only provided as early as 1.3.0a0.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1217

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
