### PR TITLE
Fixes to reduce memory usage when loading large COCO datasets

### DIFF
--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -111,9 +111,13 @@ class LabelsDataCache:
             self._frame_count_cache = dict()
 
             for video in self.labels.videos:
-                self._lf_by_video[video] = [
-                    lf for lf in self.labels if lf.video == video
-                ]
+                self._lf_by_video[video] = []
+
+            for lf in self.labels:
+                if lf.video in self._lf_by_video:
+                    self._lf_by_video[lf.video].append(lf)
+
+            for video in self.labels.videos:
                 self._frame_idx_map[video] = {
                     lf.frame_idx: lf for lf in self._lf_by_video[video]
                 }

--- a/sleap/io/format/coco.py
+++ b/sleap/io/format/coco.py
@@ -59,6 +59,7 @@ class LabelsCocoAdaptor(Adaptor):
         file: FileHandle,
         img_dir: str,
         use_missing_gui: bool = False,
+        fix_all_hidden: bool = True,
         *args,
         **kwargs,
     ) -> Labels:
@@ -189,9 +190,10 @@ class LabelsCocoAdaptor(Adaptor):
             if points:
                 # If none of the points had 2 has the "visible" flag, we'll
                 # assume this incorrect and just mark all as visible.
-                if not any_visible:
-                    for point in points.values():
-                        point.visible = True
+                if fix_all_hidden:
+                    if not any_visible:
+                        for point in points.values():
+                            point.visible = True
 
                 inst = Instance(skeleton=skeleton, points=points, track=track)
 

--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -847,19 +847,21 @@ class SingleImageVideo:
 
     def _load_test_frame(self):
         if self.test_frame_ is None:
-            self.test_frame_ = self._load_idx(0)
+            test_frame = self._load_idx(0)
 
             if self._detect_grayscale is True:
                 self.grayscale = bool(
-                    np.alltrue(self.test_frame_[..., 0] == self.test_frame_[..., -1])
+                    np.alltrue(test_frame[..., 0] == test_frame[..., -1])
                 )
 
             if self.height_ is None:
-                self.height_ = self.test_frame.shape[0]
+                self.height_ = test_frame.shape[0]
             if self.width_ is None:
-                self.width_ = self.test_frame.shape[1]
+                self.width_ = test_frame.shape[1]
             if self.channels_ is None:
-                self.channels_ = self.test_frame.shape[2]
+                self.channels_ = test_frame.shape[2]
+
+            return test_frame
 
     def get_idx_from_filename(self, filename: str) -> int:
         try:
@@ -872,8 +874,8 @@ class SingleImageVideo:
 
     @property
     def test_frame(self) -> np.ndarray:
-        self._load_test_frame()
-        return self.test_frame_
+        test_frame = self._load_test_frame()
+        return test_frame
 
     def matches(self, other: "SingleImageVideo") -> bool:
         """
@@ -967,10 +969,11 @@ class SingleImageVideo:
 
     def get_frame(self, idx: int, grayscale: bool = None) -> np.ndarray:
         """See :class:`Video`."""
-        if idx not in self.__data:
-            self.__data[idx] = self._load_idx(idx)
+        #if idx not in self.__data:
+        #    self.__data[idx] = self._load_idx(idx)
 
-        frame = self.__data[idx]  # Manipulate a copy of self.__data[idx]
+        #frame = self.__data[idx]  # Manipulate a copy of self.__data[idx]
+        frame = self._load_idx(idx)
 
         if grayscale is None:
             grayscale = self.grayscale


### PR DESCRIPTION
### Description
Loading a COCO dataset can result in a large number of SingleImageVideos. As training progresses, more and more memory is consumed, causing the process to crash. This pull request disables image caching in `self.test_frame_` and `self.__data` in `SingleImageVideo`.  It also changes a O(n^2) operation in `LabelsDataCache` to a O(n) operation (when operating on large sets of `SingeImageVideos`). Finally, it makes a small tweak to `LabelsCocoAdaptor` to enable processing of frames with no visible landmarks.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
