### PR TITLE
Disable data caching by default for SingleImageVideos

### DIFF
--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -816,7 +816,6 @@ class SingleImageVideo:
         elif self.filename and not self.filenames:
             self.filenames = [self.filename]
 
-        print("post init")
         self.cache_ = dict()
         self.test_frame_ = None
 
@@ -1256,7 +1255,7 @@ class Video:
             backend_class = HDF5Video
         elif filename.endswith(("npy")):
             backend_class = NumpyVideo
-        elif filename.lower().endswith(("mp4", "avi", "mov", "mj2")):
+        elif filename.lower().endswith(("mp4", "avi", "mov")):
             backend_class = MediaVideo
             kwargs["dataset"] = ""  # prevent serialization from breaking
         elif os.path.isdir(filename) or "metadata.yaml" in filename:

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -553,3 +553,36 @@ def test_reset_video_siv(small_robot_single_image_vid: Video, siv_robot: Labels)
     filename = labels.video.backend.filename
     labels.video.backend.reset(filename=filename, grayscale=True)
     assert_video_params(video=video, filenames=filenames, grayscale=True, reset=True)
+
+
+def test_singleimagevideo_caching():
+    # With caching
+    video = Video.from_filename(TEST_SMALL_ROBOT_SIV_FILE0, caching=True)
+    assert video.backend.test_frame_ is None
+    assert len(video.backend.cache_) == 0
+    assert video.backend.channels_ is None
+
+    assert video.backend.test_frame.shape == (320, 560, 3)
+    assert video.backend.test_frame_ is not None  # Test frame stored!
+    assert len(video.backend.cache_) == 0
+    assert video.backend.channels_ == 3
+
+    assert video[0].shape == (1, 320, 560, 3)
+    assert len(video.backend.cache_) == 1  # Loaded frame stored!
+
+    # No caching
+    video = Video.from_filename(TEST_SMALL_ROBOT_SIV_FILE0, caching=False)
+    assert video.backend.test_frame_ is None
+    assert len(video.backend.cache_) == 0
+    assert video.backend.channels_ is None
+
+    assert video.backend.test_frame.shape == (320, 560, 3)
+    assert video.backend.test_frame_ is None  # Test frame not stored!
+    assert len(video.backend.cache_) == 0
+    assert video.backend.channels_ == 3
+
+    assert video.shape == (1, 320, 560, 3)
+    assert video.backend.test_frame_ is None  # Test frame not stored!
+
+    assert video[0].shape == (1, 320, 560, 3)
+    assert len(video.backend.cache_) == 0  # Loaded frame not stored!


### PR DESCRIPTION
### Description
This PR disables caching in `SingleImageVideo`s by default.

This functionality was making it intractable to load large image-based datasets.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#1025

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
