### PR TITLE
Fix single frame GUI increment

### DIFF
--- a/sleap/gui/state.py
+++ b/sleap/gui/state.py
@@ -21,7 +21,7 @@ some specific type.
 """
 
 import inspect
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List, Union, Optional
 
 
 GSVarType = str
@@ -83,13 +83,13 @@ class GuiState(object):
         """Toggle boolean value for specified key."""
         self[key] = not self.get(key, default=default)
 
-    def increment(self, key: GSVarType, step: int = 1, mod: int = 1, default: int = 0):
+    def increment(self, key: GSVarType, step: int = 1, mod: Optional[int] = None, default: int = 0):
         """Increment numeric value for specified key.
 
         Args:
             key: The key.
             step: What to add to current value.
-            mod: Wrap value (i.e., apply modulus) if not 1.
+            mod: Wrap value (i.e., apply modulus) if not None.
             default: Set value to this if there's no current value for key.
 
         Returns:
@@ -97,14 +97,15 @@ class GuiState(object):
         """
         if key not in self._state_vars:
             self[key] = default
-        else:
-            new_value = self.get(key) + step
+            return
+        
+        new_value = self.get(key) + step
 
-            # take modulo of value if mod arg is not 1
-            if mod != 1:
-                new_value %= mod
+        # Wrap the value if it's out of bounds.
+        if mod is not None:
+            new_value %= mod
 
-            self[key] = new_value
+        self[key] = new_value
 
     def increment_in_list(
         self, key: GSVarType, value_list: list, reverse: bool = False

--- a/sleap/gui/state.py
+++ b/sleap/gui/state.py
@@ -83,7 +83,9 @@ class GuiState(object):
         """Toggle boolean value for specified key."""
         self[key] = not self.get(key, default=default)
 
-    def increment(self, key: GSVarType, step: int = 1, mod: Optional[int] = None, default: int = 0):
+    def increment(
+        self, key: GSVarType, step: int = 1, mod: Optional[int] = None, default: int = 0
+    ):
         """Increment numeric value for specified key.
 
         Args:
@@ -98,7 +100,7 @@ class GuiState(object):
         if key not in self._state_vars:
             self[key] = default
             return
-        
+
         new_value = self.get(key) + step
 
         # Wrap the value if it's out of bounds.

--- a/tests/gui/test_state.py
+++ b/tests/gui/test_state.py
@@ -50,9 +50,14 @@ def test_gui_state():
     assert times_x_changed == 4
     assert state["x"] == 2
 
+    # Test incrementing value with modulus of 1
+    state.increment("x", mod=1)
+    assert times_x_changed == 5
+    assert state["x"] == 0
+
     # test emitting callbacks without changing value
     state.emit("x")
-    assert times_x_changed == 5
+    assert times_x_changed == 6
 
 
 def test_gui_state_bool():


### PR DESCRIPTION
### Description
Previously, if a video contains only a single frame, then we do not perform wrapping on that video (perhaps this code was written when SLEAP only expected videos with multiple frames). This results in some strange behavior in the GUI state `"frame_idx"` as seen in the screenshot below:
![image](https://user-images.githubusercontent.com/38435167/229205494-feabe80d-8c81-4533-a8ea-1159c7acda6c.png)

This PR performs wrapping for any modulus, including the formerly excluded modulus of 1.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
