### PR TITLE
Add video search to "robustify" (excessively) fragile test

### DIFF
--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -60,7 +60,7 @@ def min_labels_robot():
 @pytest.fixture
 def siv_robot():
     """Created before grayscale attribute was added to SingleImageVideo backend."""
-    return Labels.load_file(TEST_SLP_SIV_ROBOT)
+    return Labels.load_file(TEST_SLP_SIV_ROBOT, video_search="tests/data/videos/")
 
 
 @pytest.fixture

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -495,7 +495,7 @@ def test_reset_video_mp4(small_robot_mp4_vid: Video):
     assert_video_params(video=video, filename=filename, bgr=True, reset=True)
 
 
-def test_reset_video_siv(small_robot_single_image_vid: Video, siv_robot: Labels):
+def test_reset_video_siv(small_robot_single_image_vid: Video):
     video = small_robot_single_image_vid
     filename = video.backend.filename
 
@@ -548,7 +548,9 @@ def test_reset_video_siv(small_robot_single_image_vid: Video, siv_robot: Labels)
     assert_video_params(video=video, filenames=filenames, reset=True)
 
     # Test reset does not break deserialization of older slp
-    labels: Labels = Labels.load_file(TEST_SLP_SIV_ROBOT)
+    labels: Labels = Labels.load_file(
+        TEST_SLP_SIV_ROBOT, video_search="tests/data/videos/"
+    )
     video: Video = labels.video
     filename = labels.video.backend.filename
     labels.video.backend.reset(filename=filename, grayscale=True)


### PR DESCRIPTION
### Description
This PR adds a `video_search` argument for `Labels.load_file` to prevent a fragile test from breaking. Is this a good idea? If a test breaks, isn't that a sign that our code could be better? Well, seeing that the `video_search` argument is always provided through the GUI, available through the API, and this particular test is not even written to test video search, I think this PR is fine.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other ("robustify" test)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
