### PR TITLE
Fixes GPU memory polling using environment variable filtering

### DIFF
--- a/sleap/nn/system.py
+++ b/sleap/nn/system.py
@@ -188,56 +188,6 @@ def best_logical_device_name() -> Text:
     return device_name
 
 
-# def get_gpu_memory() -> List[int]:
-#     """Return list of available GPU memory.
-
-#     Returns:
-#         List of available GPU memory (in MiB) with indices corresponding to GPU indices.
-
-#     Notes:
-#         This function depends on the `nvidia-smi` system utility. If it cannot be found
-#         in the `PATH`, this function returns an empty list.
-#     """
-#     if shutil.which("nvidia-smi") is None:
-#         return []
-
-#     command = [
-#         "nvidia-smi",
-#         "--query-gpu=memory.free",
-#         "--format=csv",
-#     ]
-
-#     if "CUDA_VISIBLE_DEVICES" in os.environ.keys():
-#         command.append("-i")
-#         command.append(os.environ["CUDA_VISIBLE_DEVICES"])
-#         command.extend(["-i", os.environ["CUDA_VISIBLE_DEVICES"]])
-
-#         # nvidia-smi --query-gpu=memory.free --format=csv | awk -F"," 'BEGIN{OFS=","} {if ($1 in ENVIRON["CUDA_VISIBLE_DEVICES"]) print $2}'
-
-#     try:
-#         memory_poll = subprocess.run(command, capture_output=True)
-#     except (subprocess.SubprocessError, FileNotFoundError):
-#         return []
-
-#     # Capture subprocess standard output
-#     subprocess_result = memory_poll.stdout
-
-#     # nvidia-smi returns an ascii encoded byte string separated by newlines (\n)
-#     # Splitting gives a list where the final entry is an empty string. Slice it off
-#     # and finally slice off the csv header in the 0th element.
-#     memory_string = subprocess_result.decode("ascii").split("\n")[1:-1]
-
-#     memory_list = []
-#     for row in memory_string:
-#         # Removing megabyte text returned by nvidia-smi
-#         available_memory = row.split(" MiB")[0]
-
-#         # Append percent of GPU available to GPU ID, assume GPUs returned in index order
-#         memory_list.append(int(available_memory))
-
-#     return memory_list
-
-
 def get_gpu_memory() -> List[int]:
     if shutil.which("nvidia-smi") is None:
         return []

--- a/sleap/nn/system.py
+++ b/sleap/nn/system.py
@@ -189,6 +189,12 @@ def best_logical_device_name() -> Text:
 
 
 def get_gpu_memory() -> List[int]:
+    """Get the available memory on each GPU.
+
+    Returns:
+        A list of the available memory on each GPU in MiB.
+
+    """
     if shutil.which("nvidia-smi") is None:
         return []
 

--- a/sleap/nn/system.py
+++ b/sleap/nn/system.py
@@ -13,9 +13,6 @@ import os
 
 def get_all_gpus() -> List[tf.config.PhysicalDevice]:
     """Return a list of GPUs including unavailable devices."""
-
-    # Set CUDA device order according to PCI bus ID
-    os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
     return tf.config.list_physical_devices("GPU")
 
 

--- a/sleap/nn/system.py
+++ b/sleap/nn/system.py
@@ -13,6 +13,9 @@ import os
 
 def get_all_gpus() -> List[tf.config.PhysicalDevice]:
     """Return a list of GPUs including unavailable devices."""
+
+    # Set CUDA device order according to PCI bus ID
+    os.environ['CUDA_DEVICE_ORDER'] = 'PCI_BUS_ID'
     return tf.config.list_physical_devices("GPU")
 
 
@@ -24,7 +27,6 @@ def is_gpu_system() -> bool:
 def get_available_gpus() -> List[tf.config.PhysicalDevice]:
     """Return a list of available GPUs."""
     return tf.config.get_visible_devices("GPU")
-
 
 def get_current_gpu() -> tf.config.PhysicalDevice:
     """Return the current (single) GPU device.

--- a/sleap/nn/system.py
+++ b/sleap/nn/system.py
@@ -15,7 +15,7 @@ def get_all_gpus() -> List[tf.config.PhysicalDevice]:
     """Return a list of GPUs including unavailable devices."""
 
     # Set CUDA device order according to PCI bus ID
-    os.environ['CUDA_DEVICE_ORDER'] = 'PCI_BUS_ID'
+    os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
     return tf.config.list_physical_devices("GPU")
 
 
@@ -27,6 +27,7 @@ def is_gpu_system() -> bool:
 def get_available_gpus() -> List[tf.config.PhysicalDevice]:
     """Return a list of available GPUs."""
     return tf.config.get_visible_devices("GPU")
+
 
 def get_current_gpu() -> tf.config.PhysicalDevice:
     """Return the current (single) GPU device.

--- a/sleap/nn/system.py
+++ b/sleap/nn/system.py
@@ -188,48 +188,85 @@ def best_logical_device_name() -> Text:
     return device_name
 
 
+# def get_gpu_memory() -> List[int]:
+#     """Return list of available GPU memory.
+
+#     Returns:
+#         List of available GPU memory (in MiB) with indices corresponding to GPU indices.
+
+#     Notes:
+#         This function depends on the `nvidia-smi` system utility. If it cannot be found
+#         in the `PATH`, this function returns an empty list.
+#     """
+#     if shutil.which("nvidia-smi") is None:
+#         return []
+
+#     command = [
+#         "nvidia-smi",
+#         "--query-gpu=memory.free",
+#         "--format=csv",
+#     ]
+
+#     if "CUDA_VISIBLE_DEVICES" in os.environ.keys():
+#         command.append("-i")
+#         command.append(os.environ["CUDA_VISIBLE_DEVICES"])
+#         command.extend(["-i", os.environ["CUDA_VISIBLE_DEVICES"]])
+
+#         # nvidia-smi --query-gpu=memory.free --format=csv | awk -F"," 'BEGIN{OFS=","} {if ($1 in ENVIRON["CUDA_VISIBLE_DEVICES"]) print $2}'
+
+#     try:
+#         memory_poll = subprocess.run(command, capture_output=True)
+#     except (subprocess.SubprocessError, FileNotFoundError):
+#         return []
+
+#     # Capture subprocess standard output
+#     subprocess_result = memory_poll.stdout
+
+#     # nvidia-smi returns an ascii encoded byte string separated by newlines (\n)
+#     # Splitting gives a list where the final entry is an empty string. Slice it off
+#     # and finally slice off the csv header in the 0th element.
+#     memory_string = subprocess_result.decode("ascii").split("\n")[1:-1]
+
+#     memory_list = []
+#     for row in memory_string:
+#         # Removing megabyte text returned by nvidia-smi
+#         available_memory = row.split(" MiB")[0]
+
+#         # Append percent of GPU available to GPU ID, assume GPUs returned in index order
+#         memory_list.append(int(available_memory))
+
+#     return memory_list
+
+
 def get_gpu_memory() -> List[int]:
-    """Return list of available GPU memory.
-
-    Returns:
-        List of available GPU memory (in MiB) with indices corresponding to GPU indices.
-
-    Notes:
-        This function depends on the `nvidia-smi` system utility. If it cannot be found
-        in the `PATH`, this function returns an empty list.
-    """
     if shutil.which("nvidia-smi") is None:
         return []
 
     command = [
         "nvidia-smi",
-        "--query-gpu=memory.free",
+        "--query-gpu=index,memory.free",
         "--format=csv",
     ]
-
-    if "CUDA_VISIBLE_DEVICES" in os.environ.keys():
-        command.append("-i")
-        command.append(os.environ["CUDA_VISIBLE_DEVICES"])
 
     try:
         memory_poll = subprocess.run(command, capture_output=True)
     except (subprocess.SubprocessError, FileNotFoundError):
         return []
 
-    # Capture subprocess standard output
     subprocess_result = memory_poll.stdout
-
-    # nvidia-smi returns an ascii encoded byte string separated by newlines (\n)
-    # Splitting gives a list where the final entry is an empty string. Slice it off
-    # and finally slice off the csv header in the 0th element.
     memory_string = subprocess_result.decode("ascii").split("\n")[1:-1]
+
+    if "CUDA_VISIBLE_DEVICES" in os.environ.keys():
+        cuda_visible_devices = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
+    else:
+        cuda_visible_devices = None
 
     memory_list = []
     for row in memory_string:
-        # Removing megabyte text returned by nvidia-smi
-        available_memory = row.split(" MiB")[0]
+        gpu_index, available_memory = row.split(", ")
+        available_memory = available_memory.split(" MiB")[0]
 
-        # Append percent of GPU available to GPU ID, assume GPUs returned in index order
-        memory_list.append(int(available_memory))
+        if cuda_visible_devices is None or gpu_index in cuda_visible_devices:
+            memory_list.append(int(available_memory))
 
     return memory_list

--- a/sleap/nn/system.py
+++ b/sleap/nn/system.py
@@ -7,6 +7,8 @@ environment by wrapping `tf.config` module functions.
 import tensorflow as tf
 from typing import List, Optional, Text
 import subprocess
+import shutil
+import os
 
 
 def get_all_gpus() -> List[tf.config.PhysicalDevice]:
@@ -196,11 +198,18 @@ def get_gpu_memory() -> List[int]:
         This function depends on the `nvidia-smi` system utility. If it cannot be found
         in the `PATH`, this function returns an empty list.
     """
+    if shutil.which("nvidia-smi") is None:
+        return []
+
     command = [
         "nvidia-smi",
         "--query-gpu=memory.free",
         "--format=csv",
     ]
+
+    if "CUDA_VISIBLE_DEVICES" in os.environ.keys():
+        command.append("-i")
+        command.append(os.environ["CUDA_VISIBLE_DEVICES"])
 
     try:
         memory_poll = subprocess.run(command, capture_output=True)

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -18,7 +18,7 @@ def test_get_gpu_memory_visible():
 
     cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
 
-    if cuda_visible_devices is None:
+    if cuda_visible_devices is None or cuda_visible_devices is []:
         pytest.skip("CUDA_VISIBLE_DEVICES not set.")
 
     elif cuda_visible_devices == "0":

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -15,16 +15,29 @@ def test_get_gpu_memory():
 
 
 def test_get_gpu_memory_visible():
+
     cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
 
-    os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"
+    if cuda_visible_devices is None:
+        pytest.skip("CUDA_VISIBLE_DEVICES not set.")
 
-    gpu_memory = get_gpu_memory()
+    elif cuda_visible_devices == "0":
+        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
-    assert len(gpu_memory) > 0
-    assert len(gpu_memory) == 2
+        gpu_memory = get_gpu_memory()
 
-    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        assert len(gpu_memory) > 0
+        assert len(gpu_memory) == 1
 
-    # if cuda_visible_devices is None:
-    #     pytest.skip("CUDA_VISIBLE_DEVICES not set.")
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+
+    elif cuda_visible_devices == "0,1":
+
+        os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"
+
+        gpu_memory = get_gpu_memory()
+
+        assert len(gpu_memory) > 0
+        assert len(gpu_memory) == 2
+
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -18,7 +18,6 @@ def test_get_gpu_memory():
 
 @pytest.mark.parametrize("cuda_visible_devices", ["0", "1", "0,1"])
 def test_get_gpu_memory_visible(cuda_visible_devices):
-
     # Get GPU indices from nvidia-smi
     command = ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"]
     nvidia_indices = subprocess.check_output(command).decode('utf-8').strip().split('\n')
@@ -39,7 +38,6 @@ def test_get_gpu_memory_visible(cuda_visible_devices):
         assert len(gpu_memory) == 2
 
 def test_gpu_order_and_length():
-
     # Get GPU indices from sleap.nn.system.get_all_gpus
     sleap_indices = [int(gpu.name.split(':')[-1]) for gpu in get_all_gpus()]
     

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -10,6 +10,7 @@ import os
 import pytest
 import subprocess
 import tensorflow as tf
+import shutil
 
 
 def test_get_gpu_memory():
@@ -19,6 +20,9 @@ def test_get_gpu_memory():
 
 @pytest.mark.parametrize("cuda_visible_devices", ["0", "1", "0,1"])
 def test_get_gpu_memory_visible(cuda_visible_devices):
+    if shutil.which("nvidia-smi") is None:
+        pytest.skip("nvidia-smi not available.")
+
     # Get GPU indices from nvidia-smi
     command = ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"]
     nvidia_indices = (
@@ -29,10 +33,7 @@ def test_get_gpu_memory_visible(cuda_visible_devices):
 
     gpu_memory = get_gpu_memory()
 
-    if nvidia_indices is None or nvidia_indices is []:
-        pytest.skip("CUDA_VISIBLE_DEVICES not set.")
-
-    elif nvidia_indices == "0" or nvidia_indices == "1":
+    if nvidia_indices == "0" or nvidia_indices == "1":
         assert len(gpu_memory) > 0
         assert len(gpu_memory) == 1
 
@@ -42,6 +43,9 @@ def test_get_gpu_memory_visible(cuda_visible_devices):
 
 
 def test_gpu_order_and_length():
+    if shutil.which("nvidia-smi") is None:
+        pytest.skip("nvidia-smi not available.")
+
     # Get GPU indices from sleap.nn.system.get_all_gpus
     sleap_indices = [int(gpu.name.split(":")[-1]) for gpu in get_all_gpus()]
 

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -42,6 +42,7 @@ def test_get_gpu_memory_visible(cuda_visible_devices):
         assert len(gpu_memory) > 0
         assert len(gpu_memory) == 2
 
+
 def test_get_gpu_memory_no_nvidia_smi():
     # Backup current PATH
     old_path = os.environ["PATH"]
@@ -56,6 +57,7 @@ def test_get_gpu_memory_no_nvidia_smi():
 
     assert memory == []
 
+
 @pytest.mark.parametrize("cuda_visible_devices", ["invalid", "3,5", "-1"])
 def test_get_gpu_memory_invalid_cuda_visible_devices(cuda_visible_devices):
     for value in cuda_visible_devices:
@@ -67,6 +69,7 @@ def test_get_gpu_memory_invalid_cuda_visible_devices(cuda_visible_devices):
         os.environ.pop("CUDA_VISIBLE_DEVICES", None)
 
         assert len(memory) == 0
+
 
 def test_gpu_order_and_length():
     if shutil.which("nvidia-smi") is None:
@@ -84,4 +87,3 @@ def test_gpu_order_and_length():
 
     # Assert that the order and length of GPU indices match
     assert sleap_indices == nvidia_indices
-

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -5,8 +5,37 @@ be available.
 """
 
 from sleap.nn.system import get_gpu_memory
+import os
+import pytest
 
 
 def test_get_gpu_memory():
     # Make sure this doesn't throw an exception
     memory = get_gpu_memory()
+
+
+def test_get_gpu_memory_visible():
+    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+
+    if cuda_visible_devices is None:
+        pytest.skip("CUDA_VISIBLE_DEVICES not set.")
+
+    elif cuda_visible_devices == "0":
+        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+
+        gpu_memory = get_gpu_memory()
+
+        assert len(gpu_memory) > 0
+        assert len(gpu_memory) == 1
+
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+
+    elif "," in cuda_visible_devices:
+        os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"
+
+        gpu_memory = get_gpu_memory()
+
+        assert len(gpu_memory) > 0
+        assert len(gpu_memory) == len(cuda_visible_devices.split(","))
+
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -5,39 +5,44 @@ be available.
 """
 
 from sleap.nn.system import get_gpu_memory
+from sleap.nn.system import get_all_gpus
 import os
 import pytest
+import subprocess
+import tensorflow as tf
 
 
 def test_get_gpu_memory():
     # Make sure this doesn't throw an exception
     memory = get_gpu_memory()
 
+@pytest.mark.parametrize("cuda_visible_devices", ["0", "1", "0,1"])
+def test_get_gpu_memory_visible(cuda_visible_devices):
 
-def test_get_gpu_memory_visible():
+    os.environ["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
 
-    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+    gpu_memory = get_gpu_memory()
 
     if cuda_visible_devices is None or cuda_visible_devices is []:
         pytest.skip("CUDA_VISIBLE_DEVICES not set.")
 
-    elif cuda_visible_devices == "0":
-        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
-
-        gpu_memory = get_gpu_memory()
-
+    elif cuda_visible_devices == "0" or cuda_visible_devices == "1":
         assert len(gpu_memory) > 0
         assert len(gpu_memory) == 1
 
-        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-
     elif cuda_visible_devices == "0,1":
-
-        os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"
-
-        gpu_memory = get_gpu_memory()
-
         assert len(gpu_memory) > 0
         assert len(gpu_memory) == 2
 
-        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+def test_gpu_order_and_length():
+
+    # Get GPU indices from sleap.nn.system.get_all_gpus
+    sleap_indices = [int(gpu.name.split(':')[-1]) for gpu in get_all_gpus()]
+    
+    # Get GPU indices from nvidia-smi
+    command = ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"]
+    nvidia_indices = subprocess.check_output(command).decode('utf-8').strip().split('\n')
+    nvidia_indices = [int(idx) for idx in nvidia_indices]
+
+    # Assert that the order and length of GPU indices match
+    assert sleap_indices == nvidia_indices

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -17,25 +17,14 @@ def test_get_gpu_memory():
 def test_get_gpu_memory_visible():
     cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
 
-    if cuda_visible_devices is None:
-        pytest.skip("CUDA_VISIBLE_DEVICES not set.")
+    os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"
 
-    elif cuda_visible_devices == "0":
-        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+    gpu_memory = get_gpu_memory()
 
-        gpu_memory = get_gpu_memory()
+    assert len(gpu_memory) > 0
+    assert len(gpu_memory) == 2
 
-        assert len(gpu_memory) > 0
-        assert len(gpu_memory) == 1
+    os.environ.pop("CUDA_VISIBLE_DEVICES", None)
 
-        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-
-    elif "," in cuda_visible_devices:
-        os.environ["CUDA_VISIBLE_DEVICES"] = "0,1"
-
-        gpu_memory = get_gpu_memory()
-
-        assert len(gpu_memory) > 0
-        assert len(gpu_memory) == len(cuda_visible_devices.split(","))
-
-        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+    # if cuda_visible_devices is None:
+    #     pytest.skip("CUDA_VISIBLE_DEVICES not set.")

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -19,18 +19,22 @@ def test_get_gpu_memory():
 @pytest.mark.parametrize("cuda_visible_devices", ["0", "1", "0,1"])
 def test_get_gpu_memory_visible(cuda_visible_devices):
 
+    # Get GPU indices from nvidia-smi
+    command = ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"]
+    nvidia_indices = subprocess.check_output(command).decode('utf-8').strip().split('\n')
+
     os.environ["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
 
     gpu_memory = get_gpu_memory()
 
-    if cuda_visible_devices is None or cuda_visible_devices is []:
+    if nvidia_indices is None or nvidia_indices is []:
         pytest.skip("CUDA_VISIBLE_DEVICES not set.")
 
-    elif cuda_visible_devices == "0" or cuda_visible_devices == "1":
+    elif nvidia_indices == "0" or nvidia_indices == "1":
         assert len(gpu_memory) > 0
         assert len(gpu_memory) == 1
 
-    elif cuda_visible_devices == "0,1":
+    elif nvidia_indices == "0,1":
         assert len(gpu_memory) > 0
         assert len(gpu_memory) == 2
 

--- a/tests/nn/test_system.py
+++ b/tests/nn/test_system.py
@@ -16,11 +16,14 @@ def test_get_gpu_memory():
     # Make sure this doesn't throw an exception
     memory = get_gpu_memory()
 
+
 @pytest.mark.parametrize("cuda_visible_devices", ["0", "1", "0,1"])
 def test_get_gpu_memory_visible(cuda_visible_devices):
     # Get GPU indices from nvidia-smi
     command = ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"]
-    nvidia_indices = subprocess.check_output(command).decode('utf-8').strip().split('\n')
+    nvidia_indices = (
+        subprocess.check_output(command).decode("utf-8").strip().split("\n")
+    )
 
     os.environ["CUDA_VISIBLE_DEVICES"] = cuda_visible_devices
 
@@ -37,13 +40,16 @@ def test_get_gpu_memory_visible(cuda_visible_devices):
         assert len(gpu_memory) > 0
         assert len(gpu_memory) == 2
 
+
 def test_gpu_order_and_length():
     # Get GPU indices from sleap.nn.system.get_all_gpus
-    sleap_indices = [int(gpu.name.split(':')[-1]) for gpu in get_all_gpus()]
-    
+    sleap_indices = [int(gpu.name.split(":")[-1]) for gpu in get_all_gpus()]
+
     # Get GPU indices from nvidia-smi
     command = ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"]
-    nvidia_indices = subprocess.check_output(command).decode('utf-8').strip().split('\n')
+    nvidia_indices = (
+        subprocess.check_output(command).decode("utf-8").strip().split("\n")
+    )
     nvidia_indices = [int(idx) for idx in nvidia_indices]
 
     # Assert that the order and length of GPU indices match


### PR DESCRIPTION
### Description
- Fixes bug where nvidia-smi memory poling doesn’t respect visibility masking. 
- Auto-detected GPU now picks from the masked GPUs listed in os.environ[‘CUDA_VISIBLE_DEVICES’]. 
- Tests added, but it is possible that the test might not be included due to cpu only during test. 

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
Addresses Issue #1028  

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
