### PR TITLE
Update labelled frames in the GUI after removing a video from a project

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -161,7 +161,6 @@ class MainWindow(QMainWindow):
             self.state["share usage data"] = False
         self.state["clipboard_track"] = None
         self.state["clipboard_instance"] = None
-        self.state["video_removed"]: False
         self.state.connect("marker size", self.plotFrame)
         self.state.connect("node label size", self.plotFrame)
         self.state.connect("show non-visible nodes", self.plotFrame)
@@ -259,7 +258,6 @@ class MainWindow(QMainWindow):
             event.acceptProposedAction()
 
     def dropEvent(self, event):
-
         # Parse filenames
         filenames = event.mimeData().data("text/uri-list").data().decode()
         filenames = [parse_uri_path(f.strip()) for f in filenames.strip().split("\n")]

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -161,6 +161,7 @@ class MainWindow(QMainWindow):
             self.state["share usage data"] = False
         self.state["clipboard_track"] = None
         self.state["clipboard_instance"] = None
+        self.state["video_removed"]: False
         self.state.connect("marker size", self.plotFrame)
         self.state.connect("node label size", self.plotFrame)
         self.state.connect("show non-visible nodes", self.plotFrame)

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1851,7 +1851,7 @@ class RemoveVideo(EditCommand):
                 context.state["video"] = context.labels.videos[0]
             else:
                 context.state["video"] = None
-        # Update view if it weas not the current video
+        # Update view if it was not the current video
         elif context.state["video"] is not video:
             context.state.emit("video")
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1848,9 +1848,12 @@ class RemoveVideo(EditCommand):
         # Update view if this was the current video
         if context.state["video"] == video:
             if len(context.labels.videos) > 0:
-                context.state["video"] = context.labels.videos[-1]
+                context.state["video"] = context.labels.videos[0]
             else:
                 context.state["video"] = None
+        # Update view if it weas not the current video
+        elif context.state["video"] is not video:
+            context.state.emit("video")
 
     @staticmethod
     def ask(context: CommandContext, params: dict) -> bool:

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -301,6 +301,9 @@ class LabelsDataCache:
         self, video: Optional[Video] = None, filter: Text = ""
     ) -> Set[Tuple[int, int]]:
         """Return list of (video_idx, frame_idx) tuples matching video/filter."""
+        if video is not None and video not in self.labels.videos:
+            return set()  # Return an empty set if the video is not in the videos list
+
         if filter == "":
             filter_func = lambda lf: video is None or lf.video == video
         elif filter == "user":

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -1589,13 +1589,6 @@ class Labels(MutableSequence):
         self._cache.remove_video(video)
 
         # Update the frame count cache for all videos
-        # if None in self._cache._frame_count_cache:
-        #     for type_key in self._cache._frame_count_cache[None]:
-        #         self._cache._frame_count_cache[None][type_key] = {
-        #             idx_pair
-        #             for idx_pair in self._cache._frame_count_cache[None][type_key]
-        #             if idx_pair[0] != video_index
-        #         }
         if None in self._cache._frame_count_cache:
             for type_key in self._cache._frame_count_cache[None]:
                 video_idx_pairs = self._cache.get_filtered_frame_idxs(filter=type_key)

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -1585,6 +1585,9 @@ class Labels(MutableSequence):
         if video in self._cache._frame_count_cache:
             del self._cache._frame_count_cache[video]
 
+        # Remove video from the cache
+        self._cache.remove_video(video)
+
         # Update the frame count cache for all videos
         if None in self._cache._frame_count_cache:
             for type_key in self._cache._frame_count_cache[None]:
@@ -1593,9 +1596,6 @@ class Labels(MutableSequence):
                     for idx_pair in self._cache._frame_count_cache[None][type_key]
                     if idx_pair[0] != video_index
                 }
-
-        # Remove video from the cache
-        self._cache.remove_video(video)
 
     @classmethod
     def from_json(cls, *args, **kwargs):

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -1584,17 +1584,19 @@ class Labels(MutableSequence):
         self.videos.remove(video)
         self._cache.remove_video(video)
 
-        # Update the frame count cache for all videos combined
-        for type_key in self._cache._frame_count_cache[None]:
-            updated_cache = set()
-            for idx_pair in self._cache._frame_count_cache[None][type_key]:
-                if idx_pair[0] == video_index:
-                    continue  # Skip the removed video
-                updated_video_index = (
-                    idx_pair[0] - 1 if idx_pair[0] > video_index else idx_pair[0]
+        cache_items = self._cache._frame_count_cache[None].items()
+        new_cache_items = []
+        for type_key, idx_pairs in cache_items:
+            new_idx_pairs = [
+                (
+                    idx_pair[0] - 1 if idx_pair[0] > video_index else idx_pair[0],
+                    idx_pair[1],
                 )
-                updated_cache.add((updated_video_index, idx_pair[1]))
-            self._cache._frame_count_cache[None][type_key] = updated_cache
+                for idx_pair in idx_pairs
+                if idx_pair[0] != video_index
+            ]
+            new_cache_items.append((type_key, set(new_idx_pairs)))
+        self._cache._frame_count_cache[None] = dict(new_cache_items)
 
     @classmethod
     def from_json(cls, *args, **kwargs):

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -442,6 +442,37 @@ def test_remove_video():
     assert labels._cache._frame_count_cache[None] == expected_cache
 
 
+def test_remove_video_multiple():
+    # Create dummy videos, skeletons, instances, and labeled frames
+    dummy_videos = [
+        Video(backend=MediaVideo(filename=f"dummy_video_{i}.mp4")) for i in range(5)
+    ]
+    dummy_skeletons = [Skeleton() for _ in range(5)]
+    dummy_instances = [Instance(dummy_skeletons[i % 5]) for i in range(10)]
+    dummy_frames = [
+        LabeledFrame(
+            dummy_videos[i % 5], frame_idx=i % 5, instances=[dummy_instances[i]]
+        )
+        for i in range(10)
+    ]
+
+    # Create Labels object and append the dummy frames
+    labels = Labels()
+    labels.videos.extend(dummy_videos)  # Add dummy videos to labels
+    labels.extend(dummy_frames)
+
+    # Remove multiple videos by Video instances
+    for video in dummy_videos:
+        labels.remove_video(video)
+
+    # Assert that all videos are removed from the labels
+    for video in dummy_videos:
+        assert len(labels.find(video)) == 0
+
+    # Assert that the frame count cache is empty for all videos
+    assert labels._cache.get_frame_count() is 0
+
+
 def test_labels_merge():
     dummy_video = Video(backend=MediaVideo)
     dummy_skeleton = Skeleton()

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -433,45 +433,6 @@ def test_remove_video_multiple():
     assert len(labels.find(dummy_videos[0])) == 0
 
 
-# def test_update_frame_count_cache():
-#     # Create dummy videos, skeletons, instances, and labeled frames
-#     dummy_videos = [
-#         Video(backend=MediaVideo(filename=f"dummy_video_{i}.mp4")) for i in range(5)
-#     ]
-#     dummy_skeletons = [Skeleton() for _ in range(5)]
-#     dummy_instances = [Instance(dummy_skeletons[i % 5]) for i in range(10)]
-#     dummy_frames = [
-#         LabeledFrame(
-#             dummy_videos[i % 5], frame_idx=i % 5, instances=[dummy_instances[i]]
-#         )
-#         for i in range(10)
-#     ]
-
-#     # Create Labels object and append the dummy frames
-#     labels = Labels()
-#     labels.videos.extend(dummy_videos)  # Add dummy videos to labels
-#     labels.extend(dummy_frames)
-
-#     total_frame_count = labels._cache.get_frame_count()
-#     expected_frame_count = total_frame_count
-
-#     # Remove multiple videos by Video instances
-#     for video in labels.videos.copy():
-#         vid_frame_count = labels._cache.get_frame_count(video)
-#         labels.remove_video(video)  # expand this
-
-#         # Calculate expected frame count after removing video
-#         expected_frame_count -= vid_frame_count
-
-#         # Pull current total frame count after removal
-#         total_frame_count = labels._cache.get_frame_count()
-
-#         # Assert that the total frame count matches the expected frame count
-#         assert total_frame_count == expected_frame_count
-
-#     # Assert that the frame count cache is empty
-#     assert labels._cache.get_frame_count() == 0
-
 def test_update_frame_count_cache():
     # Create dummy videos, skeletons, instances, and labeled frames
     dummy_videos = [
@@ -520,7 +481,9 @@ def test_update_frame_count_cache():
         assert total_frame_count == expected_frame_count
 
         # Assert frame count cache predictions for the removed video
-        assert labels._cache._frame_count_cache.get(video, {}) == frame_count_cache_predictions.get(video, {})
+        assert labels._cache._frame_count_cache.get(
+            video, {}
+        ) == frame_count_cache_predictions.get(video, {})
 
         # Assert that all frame indices associated with the removed video have been deleted
         for frame_idx in frame_indices:

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -419,15 +419,25 @@ def test_remove_video_multiple():
     labels.videos.extend(dummy_videos)  # Add dummy videos to labels
     labels.extend(dummy_frames)
 
+    # Set video counter to 5 videos
+    i = 5
+
     # Remove multiple videos by Video instances
     for video in labels.videos.copy():
+        # Assert that the there are i videos in the labels
+        assert len(labels.videos) == i
+
         labels.remove_video(video)
+
+        # Subtract video counter
+        i -= 1
 
         # Assert that the video is no longer found in the labels
         assert len(labels.find(video)) == 0
 
-    # Assert that the video is no longer found in the labels
+    # Assert that there are no videos in the labels
     assert len(labels.find(dummy_videos[0])) == 0
+    assert len(labels.videos) == 0
 
 
 def test_update_frame_count_cache():

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -419,11 +419,8 @@ def test_remove_video_multiple():
     labels.videos.extend(dummy_videos)  # Add dummy videos to labels
     labels.extend(dummy_frames)
 
-    total_frame_count = labels._cache.get_frame_count()
-
     # Remove multiple videos by Video instances
     for video in labels.videos.copy():
-        vid_frame_count = labels._cache.get_frame_count(video)
         labels.remove_video(video)
 
         # Assert that the video is no longer found in the labels

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -32,7 +32,6 @@ def _check_labels_match(expected_labels, other_labels, format="png"):
 
     # Check the top level objects
     for x, y in zip(expected_labels.skeletons, other_labels.skeletons):
-
         # Inline the skeleton matches check to see if we can get a better
         # idea of why this test fails non-deterministically. The callstack
         # doesn't go deeper than the method call in pytest for some reason.
@@ -69,7 +68,6 @@ def _check_labels_match(expected_labels, other_labels, format="png"):
 
     # Check that we have the same thing
     for expected_label, label in zip(expected_labels.labels, other_labels.labels):
-
         assert expected_label.frame_idx == label.frame_idx
 
         frame_idx = label.frame_idx
@@ -398,6 +396,34 @@ def test_label_mutability():
 
     labels.remove_video(dummy_video)
     assert len(labels.find(dummy_video)) == 0
+
+
+def test_remove_video():
+    # Create dummy video, skeleton, instance, and labeled frame
+    dummy_video = Video(backend=MediaVideo)
+    dummy_skeleton = Skeleton()
+    dummy_instance = Instance(dummy_skeleton)
+    dummy_frame = LabeledFrame(dummy_video, frame_idx=0, instances=[dummy_instance])
+
+    # Create Labels object and append the dummy frame
+    labels = Labels()
+    labels.append(dummy_frame)
+
+    # Create dummy video, skeleton, instance, and labeled frame
+    dummy_video2 = Video(backend=MediaVideo)
+    dummy_skeleton2 = Skeleton()
+    dummy_instance2 = Instance(dummy_skeleton2)
+    dummy_frame2 = LabeledFrame(dummy_video2, frame_idx=0, instances=[dummy_instance2])
+
+    # Append the dummy frame 2
+    labels.append(dummy_frame2)
+
+    # Remove the dummy video
+    labels.remove_video(dummy_video)
+
+    # Assert that the video is no longer found in the labels
+    assert len(labels.find(dummy_video)) == 0
+    assert len(labels.find(dummy_video2)) == 1
 
 
 def test_labels_merge():
@@ -1019,7 +1045,6 @@ def test_labels_append_hdf5(multi_skel_vid_labels, tmpdir):
     # Save each frame of the Labels dataset one by one in append
     # mode
     for label in labels:
-
         # Just do the first 20 to speed things up
         if label.frame_idx > 20:
             break
@@ -1181,7 +1206,6 @@ def test_load_file(tmpdir):
 
 
 def test_local_path_save(tmpdir, monkeypatch):
-
     filename = "test.h5"
 
     # Set current working directory (monkeypatch isolates other tests)

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -409,6 +409,15 @@ def test_remove_video():
     labels = Labels()
     labels.append(dummy_frame)
 
+    # Create a dummy frame index cache
+    dummy_cache = {
+        "type_key": {(0, 0), (1, 0)},  # Add some dummy frame index pairs
+        "other_key": {(0, 1), (1, 1)},
+    }
+
+    # Set the dummy frame index cache for the labels
+    labels._cache._frame_count_cache[None] = dummy_cache
+
     # Create dummy video, skeleton, instance, and labeled frame
     dummy_video2 = Video(backend=MediaVideo)
     dummy_skeleton2 = Skeleton()
@@ -424,6 +433,13 @@ def test_remove_video():
     # Assert that the video is no longer found in the labels
     assert len(labels.find(dummy_video)) == 0
     assert len(labels.find(dummy_video2)) == 1
+
+    # Assert that the frame index cache has been updated correctly
+    expected_cache = {
+        "type_key": {(1, 0)},  # The frame index pair (2, 0) should be removed
+        "other_key": {(1, 1)},
+    }
+    assert labels._cache._frame_count_cache[None] == expected_cache
 
 
 def test_labels_merge():

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -419,12 +419,25 @@ def test_remove_video_multiple():
     labels.videos.extend(dummy_videos)  # Add dummy videos to labels
     labels.extend(dummy_frames)
 
+    total_frame_count = labels._cache.get_frame_count()
+    expected_frame_count = total_frame_count
+
     # Remove multiple videos by Video instances
     for video in labels.videos.copy():
+        vid_frame_count = labels._cache.get_frame_count(video)
         labels.remove_video(video)
 
         # Assert that the video is no longer found in the labels
         assert len(labels.find(video)) == 0
+
+        # calculate expected frame count after removing video
+        expected_frame_count = total_frame_count - vid_frame_count
+
+        # Pull current total frame count after removal
+        total_frame_count = labels._cache.get_frame_count()
+
+        # Assert that the total frame count matches the total minus the current video
+        assert total_frame_count == expected_frame_count
 
     # Assert that the frame count cache is empty
     assert labels._cache.get_frame_count() == 0

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -473,6 +473,36 @@ def test_remove_video_multiple():
     assert labels._cache.get_frame_count() is 0
 
 
+def test_videos_order_in_cache():
+    # Create dummy videos, skeletons, instances, and labeled frames
+    dummy_videos = [
+        Video(backend=MediaVideo(filename=f"dummy_video_{i}.mp4")) for i in range(5)
+    ]
+    dummy_skeletons = [Skeleton() for _ in range(5)]
+    dummy_instances = [Instance(dummy_skeletons[i % 5]) for i in range(10)]
+    dummy_frames = [
+        LabeledFrame(
+            dummy_videos[i % 5], frame_idx=i % 5, instances=[dummy_instances[i]]
+        )
+        for i in range(10)
+    ]
+
+    # Create Labels object and append the dummy frames
+    labels = Labels()
+    labels.videos.extend(dummy_videos)  # Add dummy videos to labels
+    labels.extend(dummy_frames)
+
+    assert len(labels.videos) == len(
+        [v.filename for v, _ in labels._cache._frame_count_cache]
+    )
+
+    # Check the order of video filenames in self.videos and self._cache
+    for i, video in enumerate(labels.videos):
+        video_filename = video.filename
+        cache_videos = [v.filename for v, _ in labels._cache._frame_count_cache]
+        assert video_filename == cache_videos[i]
+
+
 def test_labels_merge():
     dummy_video = Video(backend=MediaVideo)
     dummy_skeleton = Skeleton()

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -463,9 +463,7 @@ def test_update_frame_count_cache():
         # Predictions for frame count cache
         frame_count_cache_predictions = {
             video: {
-                "": set(),
-                "user": set(),
-                "predicted": set(),
+                "": set(frame_indices),
             }
         }
 

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -462,6 +462,9 @@ def test_update_frame_count_cache():
     total_frame_count = labels._cache.get_frame_count()
     expected_frame_count = total_frame_count
 
+    # Set up video counter
+    i = 5
+
     # Remove multiple videos by Video instances
     for video in labels.videos.copy():
         vid_frame_count = labels._cache.get_frame_count(video)
@@ -473,6 +476,9 @@ def test_update_frame_count_cache():
                 "": set(frame_indices),
             }
         }
+
+        # Assert that the dummy video i deleft in the labels list
+        assert len(labels._cache.labels.videos) == i
 
         labels.remove_video(video)
 
@@ -494,11 +500,11 @@ def test_update_frame_count_cache():
         for frame_idx in frame_indices:
             assert labels._cache.find_frames(video, frame_idx) is None
 
+        # Increment video counter
+        i -= 1
+
     # Assert that the frame count cache is empty
     assert labels._cache.get_frame_count() == 0
-
-    # Assert that there are no videos left in the labels list
-    assert len(labels.find(dummy_videos[0])) == 0
 
 
 def test_labels_merge():


### PR DESCRIPTION
### Description
- Updates labelled frames cache after removing a video and its associated labels from a project. 
- Remove video was updated to include clearing the cache as well as the video
- Now updates the labeled frame number in both the case when the removed video was currently in view and also when it was not currently in view 
- Tests were added to make sure the videos are deleted and their frame counts match expected values as each is deleted

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
This addresses issue #1261 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
