### PR TITLE
Layout docks in a tab configuration (instead of stacked)

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -986,9 +986,9 @@ class MainWindow(QMainWindow):
         """Create dock windows and connect them to GUI."""
 
         self.videos_dock = VideosDock(self)
-        self.skeleton_dock = SkeletonDock(self)
-        self.suggestions_dock = SuggestionsDock(self)
-        self.instances_dock = InstancesDock(self)
+        self.skeleton_dock = SkeletonDock(self, tab_with=self.videos_dock)
+        self.suggestions_dock = SuggestionsDock(self, tab_with=self.videos_dock)
+        self.instances_dock = InstancesDock(self, tab_with=self.videos_dock)
 
         # Bring videos tab forward.
         self.videos_dock.wgt_layout.parent().parent().raise_()

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -177,9 +177,7 @@ class VideosDock(DockWidget):
             state=main_window.state,
             row_name="video",
             is_activatable=True,
-            model=VideosTableModel(
-                items=main_window.labels.videos, context=main_window.commands
-            ),
+            model=self.model,
             ellipsis_left=True,
         )
 
@@ -407,11 +405,12 @@ class SkeletonDock(DockWidget):
 class SuggestionsDock(DockWidget):
     """Dock widget for displaying suggestions."""
 
-    def __init__(self, main_window: QMainWindow):
+    def __init__(self, main_window: QMainWindow, tab_with: Optional[QLayout] = None):
         super().__init__(
             name="Labeling Suggestions",
             main_window=main_window,
             model_type=SuggestionsTableModel,
+            tab_with=tab_with,
         )
 
     def create_models(self) -> SuggestionsTableModel:
@@ -424,10 +423,7 @@ class SuggestionsDock(DockWidget):
         self.table = GenericTableView(
             state=self.main_window.state,
             is_sortable=True,
-            model=SuggestionsTableModel(
-                items=self.main_window.labels.suggestions,
-                context=self.main_window.commands,
-            ),
+            model=self.model,
         )
 
         # Connect some actions to the table
@@ -525,12 +521,12 @@ class SuggestionsDock(DockWidget):
 class InstancesDock(DockWidget):
     """Dock widget for displaying instances."""
 
-    def __init__(
-        self,
-        main_window: QMainWindow,
-    ):
+    def __init__(self, main_window: QMainWindow, tab_with: Optional[QLayout] = None):
         super().__init__(
-            name="Instances", main_window=main_window, model_type=LabeledFrameTableModel
+            name="Instances",
+            main_window=main_window,
+            model_type=LabeledFrameTableModel,
+            tab_with=tab_with,
         )
 
     def create_models(self) -> LabeledFrameTableModel:
@@ -545,10 +541,7 @@ class InstancesDock(DockWidget):
             state=self.main_window.state,
             row_name="instance",
             name_prefix="",
-            model=LabeledFrameTableModel(
-                items=self.main_window.state["labeled_frame"],
-                context=self.main_window.commands,
-            ),
+            model=self.model,
         )
         return self.table
 

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -163,7 +163,7 @@ class VideosDock(DockWidget):
         )
 
     def create_models(self) -> VideosTableModel:
-        self.model = VideosTableModel(
+        self.model = self.model_type(
             items=self.main_window.labels.videos, context=self.main_window.commands
         )
         return self.model
@@ -414,7 +414,7 @@ class SuggestionsDock(DockWidget):
         )
 
     def create_models(self) -> SuggestionsTableModel:
-        self.model = SuggestionsTableModel(
+        self.model = self.model_type(
             items=self.main_window.labels.suggestions, context=self.main_window.commands
         )
         return self.model
@@ -530,7 +530,7 @@ class InstancesDock(DockWidget):
         )
 
     def create_models(self) -> LabeledFrameTableModel:
-        self.model = LabeledFrameTableModel(
+        self.model = self.model_type(
             items=self.main_window.state["labeled_frame"],
             context=self.main_window.commands,
         )


### PR DESCRIPTION
### Description
#1265 did a great job at organizing the docks, but also opted not to pass the `tab_with` parameter into the respective dock subclasses (making the layout of the tables stack vertically). This PR fixes that.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (aesthetic)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
