### PR TITLE
Increase GUI crop size range from 512 to 832

### DIFF
--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -20,7 +20,7 @@ data:
   name: data.instance_cropping.crop_size
   type: optional_int
   none_label: Auto
-  range: 0,512
+  range: 0,832
 
 model:
 - default: unet


### PR DESCRIPTION
### Description
Increase GUI crop size range from 512 to 832

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (more inclusive, but old feature)

### Does this address any currently open issues?
- #1290

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
