### PR TITLE
Allow tracking on `Instance`s (by not assigning a `tracking_score`)

### DIFF
--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -362,7 +362,7 @@ class Match:
     """Stores a match between a specific instance and specific track."""
 
     track: Track
-    instance: Instance
+    instance: InstanceType
     score: Optional[float] = None
     is_first_choice: bool = False
 


### PR DESCRIPTION
### Description
Prior to [Allow Retracking](#867), we did not allow any tracking on user instances. Since re-tracking enables users to run tracking on user instances, we now need to either add a `tracking_score` attribute to user-instances, or refrain from assigning the tracking score if the matched instance is a user instance. I am in favor of adding the tracking score to user instances (see #1302), but this PR just refrains from assigning.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1296

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
