### PR TITLE
Add `--max_instances` to `sleap-track` and GUI

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -104,7 +104,7 @@ optional arguments:
                         Defaults to True.
   -n, --max_instances MAX_INSTANCES
                         Limit maximum number of instances in multi-instance models.
-                        Defaults to None.
+                        Not available for ID models. Defaults to None.
 ```
 
 ## Inference and Tracking
@@ -180,7 +180,7 @@ optional arguments:
                         instances before saving to output.
   -n, --max_instances MAX_INSTANCES
                         Limit maximum number of instances in multi-instance models.
-                        Defaults to None.
+                        Not available for ID models. Defaults to None.
   --verbosity {none,rich,json}
                         Verbosity of inference progress reporting. 'none' does
                         not output anything during inference, 'rich' displays

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -102,7 +102,7 @@ optional arguments:
   -u, --unrag UNRAG
                         Convert ragged tensors into regular tensors with NaN padding.
                         Defaults to True.
-  -i, --max_instances MAX_INSTANCES
+  -n, --max_instances MAX_INSTANCES
                         Limit maximum number of instances in multi-instance models.
                         Defaults to None.
 ```
@@ -178,7 +178,7 @@ optional arguments:
                         if retracking predictions.
   --no-empty-frames     Clear any empty frames that did not have any detected
                         instances before saving to output.
-  -i, --max_instances MAX_INSTANCES
+  -n, --max_instances MAX_INSTANCES
                         Limit maximum number of instances in multi-instance models.
                         Defaults to None.
   --verbosity {none,rich,json}

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -178,6 +178,9 @@ optional arguments:
                         if retracking predictions.
   --no-empty-frames     Clear any empty frames that did not have any detected
                         instances before saving to output.
+  -i, --max_instances MAX_INSTANCES
+                        Limit maximum number of instances in multi-instance models.
+                        Defaults to None.
   --verbosity {none,rich,json}
                         Verbosity of inference progress reporting. 'none' does
                         not output anything during inference, 'rich' displays

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -44,7 +44,15 @@ training:
     This pipeline uses two models: a "<u>centroid</u>" model to
     locate and crop around each animal in the frame, and a
     "<u>centered-instance confidence map</u>" model for predicted node locations
-    for each individual animal predicted by the centroid model.'
+    for each individual animal predicted by the centroid model.' 
+  - label: Max Instances
+    name: max_instances
+    type: optional_int
+    help: Maximum number of instances per frame.
+    none_label: No max
+    default_disabled: true
+    range: 1,100
+    default: 1
 
   - default: 5.0
     help: Spread of the Gaussian distribution of the confidence maps as a scalar float.
@@ -288,6 +296,14 @@ inference:
     locate and crop around each animal in the frame, and a
     "<u>centered-instance confidence map</u>" model for predicted node locations
     for each individual animal predicted by the centroid model.'
+  - label: Max Instances
+    name: max_instances
+    type: optional_int
+    help: Maximum number of instances per frame.
+    none_label: No max
+    default_disabled: true
+    range: 1,100
+    default: 1
 
   multi-animal bottom-up-id:
   - type: text

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -13,6 +13,14 @@ training:
       a "<u>confidence map</u>" head to predicts the
       nodes for an entire image and a "<u>part affinity field</u>" head to group
       the nodes into distinct animal instances.'
+  - label: Max Instances
+    name: max_instances
+    type: optional_int
+    help: Maximum number of instances per frame.
+    none_label: No max
+    default_disabled: true
+    range: 1,100
+    default: 1
 
   - name: model.heads.multi_instance.confmaps.sigma
     label: Sigma for Nodes
@@ -288,6 +296,14 @@ inference:
       a "<u>confidence map</u>" head to predicts the
       nodes for an entire image and a "<u>part affinity field</u>" head to group
       the nodes into distinct animal instances.'
+  - label: Max Instances
+    name: max_instances
+    type: optional_int
+    help: Maximum number of instances per frame.
+    none_label: No max
+    default_disabled: true
+    range: 1,100
+    default: 1
 
   multi-animal top-down:
   - type: text

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -240,6 +240,7 @@ class InferenceTask:
             "tracking.target_instance_count",
             "tracking.kf_init_frame_count",
             "tracking.robust",
+            "max_instances",
         )
 
         for key in optional_items_as_nones:

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -5239,7 +5239,7 @@ def _make_predictor_from_cli(args: argparse.Namespace) -> Predictor:
             refinement="integral",
             progress_reporting=args.verbosity,
         )
-        
+
         if type(predictor) == BottomUpPredictor:
             predictor.inference_model.bottomup_layer.paf_scorer.max_edge_length_ratio = (
                 args.max_edge_length_ratio

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -180,6 +180,7 @@ class Predictor(ABC):
         integral_patch_size: int = 5,
         batch_size: int = 4,
         resize_input_layer: bool = True,
+        max_instances: Optional[int] = None,
     ) -> "Predictor":
         """Create the appropriate `Predictor` subclass from a list of model paths.
 
@@ -198,12 +199,17 @@ class Predictor(ABC):
                 usage.
             resize_input_layer: If True, the the input layer of the `tf.Keras.model` is
                 resized to (None, None, None, num_color_channels).
+            max_instances: If not `None`, discard instances beyond this count when
+                predicting, regardless of whether filtering is done at the tracking
+                stage. This is useful for preventing extraneous instances from being
+                created when tracking is not being applied.
 
         Returns:
             A subclass of `Predictor`.
 
         See also: `SingleInstancePredictor`, `TopDownPredictor`, `BottomUpPredictor`,
-            `MoveNetPredictor`
+            `MoveNetPredictor`, `TopDownMultiClassPredictor`,
+            `BottomUpMultiClassPredictor`.
         """
         # Read configs and find model types.
         if isinstance(model_paths, str):
@@ -272,6 +278,7 @@ class Predictor(ABC):
                     integral_refinement=integral_refinement,
                     integral_patch_size=integral_patch_size,
                     resize_input_layer=resize_input_layer,
+                    max_instances=max_instances,
                 )
 
         elif "multi_instance" in model_types:
@@ -282,6 +289,7 @@ class Predictor(ABC):
                 integral_patch_size=integral_patch_size,
                 batch_size=batch_size,
                 resize_input_layer=resize_input_layer,
+                max_instances=max_instances,
             )
 
         elif "multi_class_bottomup" in model_types:
@@ -2290,6 +2298,10 @@ class TopDownPredictor(Predictor):
             head.
         integral_patch_size: Size of patches to crop around each rough peak for integral
             refinement as an integer scalar.
+        max_instances: If not `None`, discard instances beyond this count when
+            predicting, regardless of whether filtering is done at the tracking stage.
+            This is useful for preventing extraneous instances from being created when
+            tracking is not being applied.
     """
 
     centroid_config: Optional[TrainingJobConfig] = attr.ib(default=None)
@@ -2303,6 +2315,7 @@ class TopDownPredictor(Predictor):
     peak_threshold: float = 0.2
     integral_refinement: bool = True
     integral_patch_size: int = 5
+    max_instances: Optional[int] = None
 
     def _initialize_inference_model(self):
         """Initialize the inference model from the trained models and configuration."""
@@ -2328,6 +2341,7 @@ class TopDownPredictor(Predictor):
                 refinement="integral" if self.integral_refinement else "local",
                 integral_patch_size=self.integral_patch_size,
                 return_confmaps=False,
+                max_instances=self.max_instances,
             )
 
         if use_gt_confmap:
@@ -2366,6 +2380,7 @@ class TopDownPredictor(Predictor):
         integral_refinement: bool = True,
         integral_patch_size: int = 5,
         resize_input_layer: bool = True,
+        max_instances: Optional[int] = None,
     ) -> "TopDownPredictor":
         """Create predictor from saved models.
 
@@ -2389,6 +2404,10 @@ class TopDownPredictor(Predictor):
                 integral refinement as an integer scalar.
             resize_input_layer: If True, the the input layer of the `tf.Keras.model` is
                 resized to (None, None, None, num_color_channels).
+            max_instances: If not `None`, discard instances beyond this count when
+                predicting, regardless of whether filtering is done at the tracking
+                stage. This is useful for preventing extraneous instances from being
+                created when tracking is not being applied.
 
         Returns:
             An instance of `TopDownPredictor` with the loaded models.
@@ -2444,6 +2463,7 @@ class TopDownPredictor(Predictor):
             peak_threshold=peak_threshold,
             integral_refinement=integral_refinement,
             integral_patch_size=integral_patch_size,
+            max_instances=max_instances,
         )
         obj._initialize_inference_model()
         return obj
@@ -2986,6 +3006,10 @@ class BottomUpPredictor(Predictor):
         min_line_scores: Minimum line score (between -1 and 1) required to form a match
             between candidate point pairs. Useful for rejecting spurious detections when
             there are no better ones.
+        max_instances: If not `None`, discard instances beyond this count when
+            predicting, regardless of whether filtering is done at the tracking stage.
+            This is useful for preventing extraneous instances from being created when
+            tracking is not being applied.
     """
 
     bottomup_config: TrainingJobConfig
@@ -3001,6 +3025,7 @@ class BottomUpPredictor(Predictor):
     dist_penalty_weight: float = 1.0
     paf_line_points: int = 10
     min_line_scores: float = 0.25
+    max_instances: Optional[int] = None
 
     def _initialize_inference_model(self):
         """Initialize the inference model from the trained model and configuration."""
@@ -3047,6 +3072,7 @@ class BottomUpPredictor(Predictor):
         paf_line_points: int = 10,
         min_line_scores: float = 0.25,
         resize_input_layer: bool = True,
+        max_instances: Optional[int] = None,
     ) -> "BottomUpPredictor":
         """Create predictor from a saved model.
 
@@ -3077,6 +3103,10 @@ class BottomUpPredictor(Predictor):
                 detections when there are no better ones.
             resize_input_layer: If True, the the input layer of the `tf.Keras.model` is
                 resized to (None, None, None, num_color_channels).
+            max_instances: If not `None`, discard instances beyond this count when
+                predicting, regardless of whether filtering is done at the tracking
+                stage. This is useful for preventing extraneous instances from being
+                created when tracking is not being applied.
 
         Returns:
             An instance of `BottomUpPredictor` with the loaded model.
@@ -3103,6 +3133,7 @@ class BottomUpPredictor(Predictor):
             dist_penalty_weight=dist_penalty_weight,
             paf_line_points=paf_line_points,
             min_line_scores=min_line_scores,
+            max_instances=max_instances,
         )
         obj._initialize_inference_model()
         return obj
@@ -3174,6 +3205,15 @@ class BottomUpPredictor(Predictor):
                                 skeleton=skeleton,
                             )
                         )
+
+                    if self.max_instances is not None:
+                        # Filter by score.
+                        predicted_instances = sorted(
+                            predicted_instances, key=lambda x: x.score, reverse=True
+                        )
+                        predicted_instances = predicted_instances[
+                            : min(self.max_instances, len(predicted_instances))
+                        ]
 
                     if self.tracker:
                         # Set tracks for predicted instances in this frame.
@@ -4191,7 +4231,7 @@ class TopDownMultiClassPredictor(Predictor):
                 resized to (None, None, None, num_color_channels).
 
         Returns:
-            An instance of `TopDownPredictor` with the loaded models.
+            An instance of `TopDownMultiClassPredictor` with the loaded models.
 
             One of the two models can be left as `None` to perform inference with ground
             truth data. This will only work with `LabelsReader` as the provider.
@@ -4693,6 +4733,7 @@ def load_model(
     disable_gpu_preallocation: bool = True,
     progress_reporting: str = "rich",
     resize_input_layer: bool = True,
+    max_instances: Optional[int] = None,
 ) -> Predictor:
     """Load a trained SLEAP model.
 
@@ -4728,6 +4769,10 @@ def load_model(
             machines where the output is captured to a log file.
         resize_input_layer: If True, the the input layer of the `tf.Keras.model` is
             resized to (None, None, None, num_color_channels).
+        max_instances: If not `None`, discard instances beyond this count when
+            predicting, regardless of whether filtering is done at the tracking stage.
+            This is useful for preventing extraneous instances from being created when
+            tracking is not being applied.
 
     Returns:
         An instance of a `Predictor` based on which model type was detected.
@@ -4789,6 +4834,7 @@ def load_model(
         integral_refinement=refinement == "integral",
         batch_size=batch_size,
         resize_input_layer=resize_input_layer,
+        max_instances=max_instances,
     )
     predictor.verbosity = progress_reporting
     if tracker is not None:
@@ -5238,6 +5284,7 @@ def _make_predictor_from_cli(args: argparse.Namespace) -> Predictor:
             batch_size=batch_size,
             refinement="integral",
             progress_reporting=args.verbosity,
+            max_instances=args.max_instances,
         )
 
         if type(predictor) == BottomUpPredictor:
@@ -5247,8 +5294,6 @@ def _make_predictor_from_cli(args: argparse.Namespace) -> Predictor:
             predictor.inference_model.bottomup_layer.paf_scorer.dist_penalty_weight = (
                 args.dist_penalty_weight
             )
-        elif (type(predictor) == TopDownPredictor) and (args.max_instances is not None):
-            predictor.inference_model.centroid_crop.max_instances = args.max_instances
     else:
         # TODO(LM): create predictor that only uses tracker - based off load_model
         pass

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4908,8 +4908,8 @@ def _make_export_cli_parser() -> argparse.ArgumentParser:
         "--max_instances",
         type=int,
         help=(
-            "Limit maximum number of instances in multi-instance models"
-            "Defaults to None"
+            "Limit maximum number of instances in multi-instance models. "
+            "Defaults to None."
         ),
     )
 
@@ -5085,6 +5085,15 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         default=0.2,
         help="Minimum confidence map value to consider a peak as valid.",
     )
+    parser.add_argument(
+        "-i",
+        "--max_instances",
+        type=int,
+        help=(
+            "Limit maximum number of instances in multi-instance models. "
+            "Defaults to None."
+        ),
+    )
 
     # Deprecated legacy args. These will still be parsed for backward compatibility but
     # are hidden from the CLI help.
@@ -5230,7 +5239,7 @@ def _make_predictor_from_cli(args: argparse.Namespace) -> Predictor:
             refinement="integral",
             progress_reporting=args.verbosity,
         )
-
+        
         if type(predictor) == BottomUpPredictor:
             predictor.inference_model.bottomup_layer.paf_scorer.max_edge_length_ratio = (
                 args.max_edge_length_ratio
@@ -5238,6 +5247,8 @@ def _make_predictor_from_cli(args: argparse.Namespace) -> Predictor:
             predictor.inference_model.bottomup_layer.paf_scorer.dist_penalty_weight = (
                 args.dist_penalty_weight
             )
+        elif (type(predictor) == TopDownPredictor) and (args.max_instances is not None):
+            predictor.inference_model.centroid_crop.max_instances = args.max_instances
     else:
         # TODO(LM): create predictor that only uses tracker - based off load_model
         pass

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4955,7 +4955,7 @@ def _make_export_cli_parser() -> argparse.ArgumentParser:
         type=int,
         help=(
             "Limit maximum number of instances in multi-instance models. "
-            "Defaults to None."
+            "Not available for ID models. Defaults to None."
         ),
     )
 
@@ -5137,7 +5137,7 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         type=int,
         help=(
             "Limit maximum number of instances in multi-instance models. "
-            "Defaults to None."
+            "Not available for ID models. Defaults to None."
         ),
     )
 

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4904,7 +4904,7 @@ def _make_export_cli_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "-i",
+        "-n",
         "--max_instances",
         type=int,
         help=(
@@ -5086,7 +5086,7 @@ def _make_cli_parser() -> argparse.ArgumentParser:
         help="Minimum confidence map value to consider a peak as valid.",
     )
     parser.add_argument(
-        "-i",
+        "-n",
         "--max_instances",
         type=int,
         help=(

--- a/tests/gui/test_inference_gui.py
+++ b/tests/gui/test_inference_gui.py
@@ -41,13 +41,14 @@ def test_scoped_key_dict():
 
 
 @pytest.mark.parametrize(
-    "labels_path, video_path", [("labels.slp", "video.mp4"), (None, "video.mp4")]
+    "labels_path, video_path, max_instances",
+    [("labels.slp", "video.mp4", None), (None, "video.mp4", 2)],
 )
-def test_inference_cli_builder(labels_path, video_path):
+def test_inference_cli_builder(labels_path, video_path, max_instances):
 
     inference_task = runners.InferenceTask(
         trained_job_paths=["model1", "model2"],
-        inference_params={"tracking.tracker": "simple"},
+        inference_params={"tracking.tracker": "simple", "max_instances": max_instances},
     )
 
     item_for_inference = runners.VideoItemForInference(
@@ -63,6 +64,11 @@ def test_inference_cli_builder(labels_path, video_path):
     assert "model2" in cli_args
     assert "--frames" in cli_args
     assert "--tracking.tracker" in cli_args
+    assert (
+        "--max_instances" in cli_args
+        if max_instances is not None
+        else max_instances is None
+    )
 
     assert output_path.startswith(data_path)
     assert output_path.endswith("predictions.slp")

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -20,6 +20,7 @@ from sleap.nn.inference import (
     InferenceLayer,
     InferenceModel,
     Predictor,
+    _make_predictor_from_cli,
     get_model_output_stride,
     find_head,
     SingleInstanceInferenceLayer,
@@ -1336,6 +1337,29 @@ def test_valid_cli_command(cmd):
     assert args.max_instances == 1
 
 
+def test_make_predictor_from_cli(
+    centered_pair_predictions: Labels,
+    min_centroid_model_path: str,
+    min_centered_instance_model_path: str,
+    tmpdir,
+):
+    slp_path = str(Path(tmpdir, "old_slp.slp"))
+    Labels.save(centered_pair_predictions, slp_path)
+
+    # Create sleap-track command
+    args = (
+        f"{slp_path} --model {min_centroid_model_path} "
+        f"--model {min_centered_instance_model_path} --video.index 0 --frames 1-3 "
+        "--cpu --max_instances 5"
+    ).split()
+    parser = _make_cli_parser()
+    args, _ = parser.parse_known_args(args=args)
+
+    # Create predictor
+    predictor = _make_predictor_from_cli(args=args)
+    assert predictor.inference_model.centroid_crop.max_instances == 5
+
+
 def test_sleap_track(
     centered_pair_predictions: Labels,
     min_centroid_model_path: str,
@@ -1343,10 +1367,9 @@ def test_sleap_track(
     tmpdir,
 ):
     slp_path = str(Path(tmpdir, "old_slp.slp"))
-    labels: Labels = Labels.save(centered_pair_predictions, slp_path)
+    Labels.save(centered_pair_predictions, slp_path)
 
     # Create sleap-track command
-    args = f"{slp_path} --model {min_centered_instance_model_path} --frames 1-3 --cpu".split()
     args = (
         f"{slp_path} --model {min_centroid_model_path} "
         f"--model {min_centered_instance_model_path} --video.index 0 --frames 1-3 --cpu"

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -1328,7 +1328,7 @@ def test_retracking(
     assert new_inst.track != old_inst.track
 
 
-@pytest.mark.parametrize("cmd", ["--max_instances 1", "-i 1"])
+@pytest.mark.parametrize("cmd", ["--max_instances 1", "-n 1"])
 def test_valid_cli_command(cmd):
     """Test that sleap-track CLI command is valid."""
     parser = _make_cli_parser()

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -1328,6 +1328,14 @@ def test_retracking(
     assert new_inst.track != old_inst.track
 
 
+@pytest.mark.parametrize("cmd", ["--max_instances 1", "-i 1"])
+def test_valid_cli_command(cmd):
+    """Test that sleap-track CLI command is valid."""
+    parser = _make_cli_parser()
+    args = parser.parse_args(cmd.split())
+    assert args.max_instances == 1
+
+
 def test_sleap_track(
     centered_pair_predictions: Labels,
     min_centroid_model_path: str,


### PR DESCRIPTION
### Description
In #1070, we added the ability to set a max number of instances returned in the centroid crop (top-down model only). This PR adds a CLI optional argument `--max_instances` or `-i` for the `sleap-track` command and exposes the argument to the GUI (only for top-down):
![image](https://github.com/talmolab/sleap/assets/38435167/1d133896-ba92-405d-8315-ed4454a7cc5b)
![image](https://github.com/talmolab/sleap/assets/38435167/17ef36b4-74ca-4d92-8634-e327e7a35ee6)

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1011 (Partially)

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
