### PR TITLE
Add max instances support to bottom up model

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -13,6 +13,14 @@ training:
       a "<u>confidence map</u>" head to predicts the
       nodes for an entire image and a "<u>part affinity field</u>" head to group
       the nodes into distinct animal instances.'
+  - label: Max Instances
+    name: max_instances
+    type: optional_int
+    help: Maximum number of instances per frame.
+    none_label: No max
+    default_disabled: true
+    range: 1,100
+    default: 1
 
   - name: model.heads.multi_instance.confmaps.sigma
     label: Sigma for Nodes
@@ -288,6 +296,14 @@ inference:
       a "<u>confidence map</u>" head to predicts the
       nodes for an entire image and a "<u>part affinity field</u>" head to group
       the nodes into distinct animal instances.'
+  - label: Max Instances
+    name: max_instances
+    type: optional_int
+    help: Maximum number of instances per frame.
+    none_label: No max
+    default_disabled: true
+    range: 1,100
+    default: 1
 
   multi-animal top-down:
   - type: text

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -3211,7 +3211,9 @@ class BottomUpPredictor(Predictor):
                         predicted_instances = sorted(
                             predicted_instances, key=lambda x: x.score, reverse=True
                         )
-                        predicted_instances = predicted_instances[: self.max_instances]
+                        predicted_instances = predicted_instances[
+                            : min(self.max_instances, len(predicted_instances))
+                        ]
 
                     if self.tracker:
                         # Set tracks for predicted instances in this frame.

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -208,7 +208,8 @@ class Predictor(ABC):
             A subclass of `Predictor`.
 
         See also: `SingleInstancePredictor`, `TopDownPredictor`, `BottomUpPredictor`,
-            `MoveNetPredictor`
+            `MoveNetPredictor`, `TopDownMultiClassPredictor`,
+            `BottomUpMultiClassPredictor`.
         """
         # Read configs and find model types.
         if isinstance(model_paths, str):
@@ -3210,7 +3211,7 @@ class BottomUpPredictor(Predictor):
                         predicted_instances = sorted(
                             predicted_instances, key=lambda x: x.score, reverse=True
                         )
-                        predicted_instances = predicted_instances[:self.max_instances]
+                        predicted_instances = predicted_instances[: self.max_instances]
 
                     if self.tracker:
                         # Set tracks for predicted instances in this frame.
@@ -5291,10 +5292,6 @@ def _make_predictor_from_cli(args: argparse.Namespace) -> Predictor:
             predictor.inference_model.bottomup_layer.paf_scorer.dist_penalty_weight = (
                 args.dist_penalty_weight
             )
-        elif (type(predictor) == TopDownPredictor) and (
-            args.max_instances is not None
-        ):  # XXX
-            predictor.inference_model.centroid_crop.max_instances = args.max_instances
     else:
         # TODO(LM): create predictor that only uses tracker - based off load_model
         pass


### PR DESCRIPTION
### Description
Adds support for post-prediction filtering of max number of instances in bottom-up models, and presents a unified interface through `load_model()` to specify this at a high level

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
