### PR TITLE
Fix conversion to numpy array when last frame(s) do not have labels

### DIFF
--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -2453,6 +2453,7 @@ class Labels(MutableSequence):
         frame_idxs = [lf.frame_idx for lf in lfs]
         frame_idxs.sort()
         first_frame = 0 if all_frames else frame_idxs[0]
+        last_frame = len(video) - 1 if all_frames else frame_idxs[-1]
 
         # Figure out the number of tracks based on number of instances in each frame.
         #
@@ -2476,7 +2477,7 @@ class Labels(MutableSequence):
             # Case 2: We're considering only tracked instances.
             n_tracks = len(self.tracks)
 
-        n_frames = frame_idxs[-1] - first_frame + 1
+        n_frames = last_frame - first_frame + 1
         n_nodes = len(self.skeleton.nodes)
 
         if return_confidence:

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -1349,6 +1349,13 @@ def test_labels_numpy(centered_pair_predictions: Labels):
     trx = centered_pair_predictions.numpy(video=None, all_frames=True, untracked=False)
     assert trx.shape == (1100, 27, 24, 2)
 
+    centered_pair_predictions.remove_frame(centered_pair_predictions[-1])
+    trx = centered_pair_predictions.numpy(video=None, all_frames=False, untracked=False)
+    assert trx.shape == (1098, 27, 24, 2)
+
+    trx = centered_pair_predictions.numpy(video=None, all_frames=True, untracked=False)
+    assert trx.shape == (1100, 27, 24, 2)
+
     labels_single = Labels(
         [
             LabeledFrame(
@@ -1359,7 +1366,7 @@ def test_labels_numpy(centered_pair_predictions: Labels):
     )
     assert labels_single.numpy().shape == (1100, 1, 24, 2)
 
-    assert centered_pair_predictions.numpy(untracked=True).shape == (1100, 5, 24, 2)
+    assert centered_pair_predictions.numpy(untracked=True).shape == (1100, 4, 24, 2)
     for lf in centered_pair_predictions:
         for inst in lf:
             inst.track = None


### PR DESCRIPTION
### Description
Fix conversion to numpy array when last frame(s) do not have labels. This is a regression that occurred at some point.

`Labels.numpy(all_frames=True)` should return an array with length `n_frames` where `n_frames == len(video)`, but right now it's just building that array up to the last `LabeledFrame` associated with that video. This can result in truncated arrays if we're missing predictions at the _end_ of the video.

The behavior works as expected if frames are missing at the _beginning_ of the video, however. This PR fixes it for missing frames at the _end_ of the video.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
