### PR TITLE
Do not choose `top_k` instances if `max_instances` < num centroids

### DIFF
--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -1838,9 +1838,11 @@ class CentroidCrop(InferenceLayer):
                 )
 
                 for sample in range(samples):
-
                     top_points = tf.math.top_k(
-                        centroid_vals[sample], k=self.max_instances
+                        centroid_vals[sample],
+                        k=tf.minimum(
+                            self.max_instances, tf.shape(centroid_vals[sample])[0]
+                        ),
                     )
                     top_inds = top_points.indices
 

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -643,12 +643,19 @@ def test_topdown_predictor_centroid(min_labels, min_centroid_model_path):
     inds1, inds2 = sleap.nn.utils.match_points(points_gt, points_pr)
     assert_allclose(points_gt[inds1.numpy()], points_pr[inds2.numpy()], atol=1.5)
 
-    # test max_instances (>2 will fail)
-    predictor.inference_model.centroid_crop.max_instances = 2
-    labels_pr = predictor.predict(min_labels)
 
-    assert len(labels_pr) == 1
-    assert len(labels_pr[0].instances) == 2
+def test_topdown_predictor_centroid_max_instances(min_labels, min_centroid_model_path):
+    predictor = TopDownPredictor.from_trained_models(
+        centroid_model_path=min_centroid_model_path
+    )
+
+    # Test max_instances <, =, and > than number of expected instances
+    for i in [1, 2, 3]:
+        predictor.inference_model.centroid_crop.max_instances = i
+        labels_pr = predictor.predict(min_labels)
+
+        assert len(labels_pr) == 1
+        assert len(labels_pr[0].instances) == i
 
 
 def test_topdown_predictor_centroid_high_threshold(min_labels, min_centroid_model_path):

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -651,11 +651,12 @@ def test_topdown_predictor_centroid_max_instances(min_labels, min_centroid_model
 
     # Test max_instances <, =, and > than number of expected instances
     for i in [1, 2, 3]:
+        predictor._initialize_inference_model()
         predictor.inference_model.centroid_crop.max_instances = i
         labels_pr = predictor.predict(min_labels)
 
         assert len(labels_pr) == 1
-        assert len(labels_pr[0].instances) == i
+        assert len(labels_pr[0].instances) == min(i, 2)
 
 
 def test_topdown_predictor_centroid_high_threshold(min_labels, min_centroid_model_path):


### PR DESCRIPTION
### Description
Previously, for the top-down model, the `tensorflow.math.top_k` centroids were chosen where `k = max_instances`. However, this resulted in an error if the `max_instances` > number centroids. This PR only selects the top_k centroids if max_instances < number centroids.


### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
