### PR TITLE
Fix GUI resume training

### DIFF
--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1844,9 +1844,10 @@ def create_trainer_using_cli(args: Optional[List] = None):
     parser.add_argument(
         "--base_checkpoint",
         type=str,
+        default=None,
         help=(
             "Path to base checkpoint (directory containing best_model.h5) to resume "
-            "training from."
+            "training from. Default is None."
         ),
     )
     parser.add_argument(
@@ -1940,7 +1941,8 @@ def create_trainer_using_cli(args: Optional[List] = None):
     if len(args.video_paths) == 0:
         args.video_paths = None
 
-    job_config.model.base_checkpoint = args.base_checkpoint
+    if args.base_checkpoint is not None:
+        job_config.model.base_checkpoint = args.base_checkpoint
 
     logger.info("Versions:")
     sleap.versions()


### PR DESCRIPTION
### Description
After attempting a few rounds of training via the GUI, we were a bit surprised to find that the results when resuming training did not perform better than the results for training from scratch. When digging into this, we noticed that the `base_checkpoint` parameter in the training_config.json file was always null even when directly specifying a file path to the `base_checkpoint`. It turns out that the CLI arg `--base_checkpoint` was always overwriting the parameter set in the training config (making the GUI resume training useless). 

This PR ensure that the `base_checkpoint` is only overwritten if a non-default value is specified for `--base_checkpoint`.

Related: #1130


### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
