### PR TITLE
Add "Split by indices" checkbox to `TrainingEditorWidget`

### DIFF
--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -1,14 +1,18 @@
 data:
 - default: 0.1
-  help: Fraction of labeled frames to use as a validation set.
+  help: Fraction of labeled frames to use as a validation set. If "Split by indices", 
+    then uses the training, validation, and test indices specified in the loaded config.
   label: Validation fraction
   name: data.labels.validation_fraction
-  type: double
+  type: optional_double
+  default_disabled: true
+  none_label: Split by indices
 - default: 1.0
   help: ''
   label: Input Scaling
   name: data.preprocessing.input_scaling
   type: double
+  range: 0,1
 - default: null
   help: Integer size of bounding box height and width to crop out of the full image.
     This should be greater than the largest size of the instances in pixels. The crop

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1650,8 +1650,3 @@ def main(args: Optional[list] = None):
         app.exec_()
 
     pass
-
-
-if __name__ == "__main__":
-    ds = os.environ["ds-dmc"]
-    main([ds])

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1650,3 +1650,8 @@ def main(args: Optional[list] = None):
         app.exec_()
 
     pass
+
+
+if __name__ == "__main__":
+    ds = os.environ["ds-dmc"]
+    main([ds])

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1209,6 +1209,7 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         # If user wants to use trained model, then reset entire form to match config
         if use_trained_params:
             self._load_config(cfg_info)
+        self._validation_fraction.check_widget.setChecked(use_trained_params)
 
         self._set_head()
 

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -991,9 +991,11 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         self.form_widgets["model"].valueChanged.connect(self.update_receptive_field)
         self.form_widgets["data"].valueChanged.connect(self.update_receptive_field)
 
-        self._validation_fraction = self.form_widgets["data"].fields[
-            "data.labels.validation_fraction"
-        ]
+        self._split_by_inds = (
+            self.form_widgets["data"]
+            .fields["data.labels.validation_fraction"]
+            .check_widget
+        )
 
         if hasattr(skeleton, "node_names"):
             for field_name in NODE_LIST_FIELDS:
@@ -1069,7 +1071,7 @@ class TrainingEditorWidget(QtWidgets.QWidget):
             layout.addWidget(self._use_trained_model)
             layout.addWidget(self._resume_training)
         else:
-            self._validation_fraction.check_widget.setEnabled(False)
+            self._split_by_inds.setEnabled(False)
 
         layout.addWidget(self._layout_widget(col_layout))
         self.setLayout(layout)
@@ -1109,7 +1111,7 @@ class TrainingEditorWidget(QtWidgets.QWidget):
             self._resume_training.setVisible(has_trained_model)
             self._resume_training.setEnabled(has_trained_model)
 
-        self._validation_fraction.check_widget.setEnabled(has_trained_model)
+        self._split_by_inds.setEnabled(has_trained_model)
         self.update_receptive_field()
 
     def update_receptive_field(self):
@@ -1206,10 +1208,14 @@ class TrainingEditorWidget(QtWidgets.QWidget):
             ).key_val_dict
             self.set_fields_from_key_val_dict(key_val_dict)
 
+            # Disable and uncheck split by indices if resuming training
+            self._split_by_inds.setChecked(False)
+
+        self._split_by_inds.setEnabled(not use_model_params)
+
         # If user wants to use trained model, then reset entire form to match config
         if use_trained_params:
             self._load_config(cfg_info)
-        self._validation_fraction.check_widget.setChecked(use_trained_params)
 
         self._set_head()
 

--- a/tests/gui/learning/test_dialog.py
+++ b/tests/gui/learning/test_dialog.py
@@ -114,12 +114,13 @@ def test_use_hidden_params_from_loaded_config(
         "filename",
     ]
     if config_info_dict["config.data.labels.split_by_inds"] is False:
+        assert optional_validation_fraction == 0.2
         assert (
             config_info_dict["config.data.labels.validation_fraction"]
             == optional_validation_fraction
-            or 0.1
         )
     else:
+        assert optional_validation_fraction is None
         assert config_info_dict["config.data.labels.validation_fraction"] == 0.1
 
     for k, _ in config_info_dict.items():
@@ -411,7 +412,3 @@ def test_movenet_selection(qtbot, min_dance_labels):
 
         # ensure pipeline version matches model type
         assert pipeline_form_data["_pipeline"] == model
-
-
-if __name__ == "__main__":
-    pytest.main([f"{__file__}::test_use_hidden_params_from_loaded_config"])


### PR DESCRIPTION
### Description
Allow user to rerun the same experiment multiple times by selecting to "Split by Indices" for a trained model. This gives users more control over training via the GUI. Note that if a `validation_labels` is provided in the loaded `training_config.json`, then that will be used instead of either `validation_fraction` or `validation_inds`. In another PR, we can give the user even more GUI-control by providing options to use validation/test labels or indices.

"Split by Indices" is automatically unchecked and disabled if "Resume Training" is selected because this indicates that the user likely wants new labels to be included. Two possible errors that this PR may make more likely are:
1. Users selecting "Split by Indices" when they actually want to include new labels
2. The current labels project not having the indices available (training_config.json and indices generated from a different labels project)

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
