### PR TITLE
Create copy of config info to modify (gui)

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1245,12 +1245,17 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         if self._cfg_list_widget is None:
             return None
 
-        trained_config_info: Optional[
+        selected_config_info: Optional[
             configs.ConfigFileInfo
         ] = self._cfg_list_widget.getSelectedConfigInfo()
-        if (trained_config_info is None) or (not trained_config_info.has_trained_model):
+        if (selected_config_info is None) or (
+            not selected_config_info.has_trained_model
+        ):
             return None
 
+        trained_config_info = configs.ConfigFileInfo.from_config_file(
+            selected_config_info.path
+        )
         if self.use_trained:
             trained_config_info.dont_retrain = True
         else:

--- a/tests/gui/learning/test_dialog.py
+++ b/tests/gui/learning/test_dialog.py
@@ -33,9 +33,7 @@ def test_use_hidden_params_from_loaded_config(
     app = MainWindow(no_usage_data=True)
     ld = LearningDialog(
         mode="training",
-        labels_filename=Path(
-            model_path
-        ).parent.absolute(),  # Hack to get correct config
+        labels_filename=model_path.parent.absolute(),  # Hack to get correct config
         labels=min_labels_slp,
     )
 
@@ -378,3 +376,35 @@ def test_movenet_selection(qtbot, min_dance_labels):
 
         # ensure pipeline version matches model type
         assert pipeline_form_data["_pipeline"] == model
+
+
+def test_immutablilty_of_trained_config_info(
+    qtbot, min_labels_slp, min_bottomup_model_path, tmpdir
+):
+
+    model_path = Path(min_bottomup_model_path)
+
+    # Create a learning dialog
+    app = MainWindow(no_usage_data=True)
+    ld = LearningDialog(
+        mode="training",
+        labels_filename=model_path.parent.absolute(),  # Hack to get correct config
+        labels=min_labels_slp,
+    )
+
+    # Select a loaded config for pipeline form data
+    bottom_up_tab: TrainingEditorWidget = ld.tabs["multi_instance"]
+    cfg_list_widget: TrainingConfigFilesWidget = bottom_up_tab._cfg_list_widget
+    cfg_list_widget.update()
+    pre_config = bottom_up_tab._cfg_list_widget.getSelectedConfigInfo()
+    post_config = bottom_up_tab.trained_config_info_to_use
+
+    # Check that the config info is not mutated when calling trained_config_info_to_use
+    # run_name is just one of many parameters that are changed during call
+    assert pre_config.config.outputs.run_name is not None
+    assert post_config.config.outputs.run_name is None
+
+    # Previously, trained_config_info_to_use would mutate the config info and fail when
+    # saving multiple configs from one config info.
+    ld.save(output_dir=tmpdir)
+    ld.save(output_dir=tmpdir)


### PR DESCRIPTION
### Description
Previously, when using the GUI to run training, upon hitting `Run`, `Save configuration files...`, or `Export training job package...`, the `TrainingEditorWidget.trained_config_info_to_use` would mutate the `ConfigFileInfo` that was currently selected. This set certain parameters to defaults, including `ConfigFileInfo.run_path` which lead to errors if saving multiple configuration files from the same `ConfigFileInfo`.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
