### PR TITLE
Remove `--labels` and redundant `data_path`

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -1,6 +1,4 @@
-"""
-Run training/inference in background process via CLI.
-"""
+"""Run training/inference in background process via CLI."""
 import abc
 import attr
 import os
@@ -41,8 +39,7 @@ def kill_process(pid: int):
 
 @attr.s(auto_attribs=True)
 class ItemForInference(abc.ABC):
-    """
-    Abstract base class for item on which we can run inference via CLI.
+    """Abstract base class for item on which we can run inference via CLI.
 
     Must have `path` and `cli_args` properties, used to build CLI call.
     """
@@ -60,8 +57,7 @@ class ItemForInference(abc.ABC):
 
 @attr.s(auto_attribs=True)
 class VideoItemForInference(ItemForInference):
-    """
-    Encapsulate data about video on which inference should run.
+    """Encapsulate data about video on which inference should run.
 
     This allows for inference on an arbitrary list of frames from video.
 
@@ -119,8 +115,7 @@ class VideoItemForInference(ItemForInference):
 
 @attr.s(auto_attribs=True)
 class DatasetItemForInference(ItemForInference):
-    """
-    Encapsulate data about frame selection based on dataset data.
+    """Encapsulate data about frame selection based on dataset data.
 
     Attributes:
         labels_path: path to the saved :py:class:`Labels` dataset.
@@ -142,7 +137,7 @@ class DatasetItemForInference(ItemForInference):
 
     @property
     def cli_args(self):
-        args_list = ["--labels", self.path]
+        args_list = [self.path]
         if self.frame_filter == "user":
             args_list.append("--only-labeled-frames")
         elif self.frame_filter == "suggested":
@@ -200,17 +195,7 @@ class InferenceTask:
     ) -> List[Text]:
         """Makes list of CLI arguments needed for running inference."""
         cli_args = ["sleap-track"]
-
         cli_args.extend(item_for_inference.cli_args)
-
-        # TODO: encapsulate in inference item class
-        if (
-            not self.trained_job_paths
-            and "tracking.tracker" in self.inference_params
-            and self.labels_filename
-        ):
-            # No models so we must want to re-track previous predictions
-            cli_args.extend(("--labels", self.labels_filename))
 
         # Make path where we'll save predictions (if not specified)
         if output_path is None:


### PR DESCRIPTION
### Description
The retracking code was implementing a legacy argument `--labels` and also adding a redundant data path. This lead to some issues with determining what the actual data path should be. This PR remove the `--labels` implementation and adding the redundant data path and directly solves #1287.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1287

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
