### PR TITLE
Allow returning PAF graph during low level inference

### DIFF
--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -539,7 +539,6 @@ class Predictor(ABC):
         unrag_outputs: bool = True,
         max_instances: Optional[int] = None,
     ):
-
         """Export a trained SLEAP model as a frozen graph. Initializes model,
         creates a dummy tracing batch and passes it through the model. The
         frozen graph is saved along with training meta info.
@@ -1112,7 +1111,6 @@ class InferenceModel(tf.keras.Model):
         os.makedirs(save_path, exist_ok=True)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-
             self.save(tmp_dir, save_format="tf", save_traces=save_traces)
 
             imported = tf.saved_model.load(tmp_dir)
@@ -1600,7 +1598,6 @@ class SingleInstancePredictor(Predictor):
         unrag_outputs: bool = True,
         max_instances: Optional[int] = None,
     ):
-
         super().export_model(
             save_path,
             signatures,
@@ -1814,9 +1811,7 @@ class CentroidCrop(InferenceLayer):
         n_peaks = tf.shape(centroid_points)[0]
 
         if n_peaks > 0:
-
             if self.max_instances is not None:
-
                 centroid_points = tf.RaggedTensor.from_value_rowids(
                     centroid_points, crop_sample_inds, nrows=samples
                 )
@@ -2259,7 +2254,6 @@ class TopDownInferenceModel(InferenceModel):
         crop_output = self.centroid_crop(example)
 
         if isinstance(self.instance_peaks, FindInstancePeaksGroundTruth):
-
             if "instances" in example:
                 peaks_output = self.instance_peaks(example, crop_output)
             else:
@@ -2598,7 +2592,6 @@ class TopDownPredictor(Predictor):
                     ex["instance_peak_vals"],
                     ex["centroid_vals"],
                 ):
-
                     # Loop over instances.
                     predicted_instances = []
                     for pts, confs, score in zip(points, confidences, scores):
@@ -2658,7 +2651,6 @@ class TopDownPredictor(Predictor):
         unrag_outputs: bool = True,
         max_instances: Optional[int] = None,
     ):
-
         super().export_model(
             save_path,
             signatures,
@@ -2916,7 +2908,9 @@ class BottomUpInferenceLayer(InferenceLayer):
             predicted_instances,
             predicted_peak_scores,
             predicted_instance_scores,
-            edge_inds, edge_peak_inds, line_scores
+            edge_inds,
+            edge_peak_inds,
+            line_scores,
         ) = self.paf_scorer.predict(pafs, peaks, peak_vals, peak_channel_inds)
 
         # Adjust for input scaling.
@@ -3222,7 +3216,6 @@ class BottomUpPredictor(Predictor):
                     ex["instance_peak_vals"],
                     ex["instance_scores"],
                 ):
-
                     # Loop over instances.
                     predicted_instances = []
                     for pts, confs, score in zip(points, confidences, scores):
@@ -3740,7 +3733,6 @@ class BottomUpMultiClassPredictor(Predictor):
                     ex["instance_peak_vals"],
                     ex["instance_scores"],
                 ):
-
                     # Loop over instances.
                     predicted_instances = []
                     for i, (pts, confs, score) in enumerate(
@@ -4120,7 +4112,6 @@ class TopDownMultiClassInferenceModel(InferenceModel):
         tensors: Optional[Dict[str, str]] = None,
         unrag_outputs: bool = True,
     ):
-
         self.instance_peaks.optimal_grouping = False
 
         super().export_model(
@@ -4429,7 +4420,6 @@ class TopDownMultiClassPredictor(Predictor):
                     ex["instance_peak_vals"],
                     ex["instance_scores"],
                 ):
-
                     # Loop over instances.
                     predicted_instances = []
                     for i, (pts, confs, score) in enumerate(
@@ -4483,7 +4473,6 @@ class TopDownMultiClassPredictor(Predictor):
         unrag_outputs: bool = True,
         max_instances: Optional[int] = None,
     ):
-
         super().export_model(
             save_path,
             signatures,
@@ -4655,7 +4644,6 @@ class MoveNetPredictor(Predictor):
 
     @property
     def data_config(self) -> DataConfig:
-
         if self.inference_model is None:
             self._initialize_inference_model()
 
@@ -4697,7 +4685,6 @@ class MoveNetPredictor(Predictor):
     def _make_labeled_frames_from_generator(
         self, generator: Iterator[Dict[str, np.ndarray]], data_provider: Provider
     ) -> List[sleap.LabeledFrame]:
-
         skeleton = MOVENET_SKELETON
         predicted_frames = []
 
@@ -5417,7 +5404,6 @@ def main(args: Optional[list] = None):
 
     # Either run inference (and tracking) or just run tracking
     if args.models is not None:
-
         # Setup models.
         predictor = _make_predictor_from_cli(args)
         predictor.tracker = tracker

--- a/sleap/nn/paf_grouping.py
+++ b/sleap/nn/paf_grouping.py
@@ -1700,4 +1700,8 @@ class PAFScorer:
             match_dst_peak_inds,
             match_line_scores,
         )
-        return predicted_instances, predicted_peak_scores, predicted_instance_scores
+        return (
+            predicted_instances, 
+            predicted_peak_scores, 
+            predicted_instance_scores,
+            edge_inds, edge_peak_inds, line_scores)

--- a/sleap/nn/paf_grouping.py
+++ b/sleap/nn/paf_grouping.py
@@ -613,7 +613,6 @@ def match_candidates_sample(
     )
 
     for k in range(n_edges):
-
         is_edge_k = tf.squeeze(tf.where(edge_inds_sample == k), axis=1)
         edge_peak_inds_k = tf.gather(edge_peak_inds_sample, is_edge_k, axis=0)
         line_scores_k = tf.gather(line_scores_sample, is_edge_k, axis=0)
@@ -836,10 +835,8 @@ def assign_connections_to_instances(
 
     # Loop through edge types.
     for edge_type, edge_connections in connections.items():
-
         # Loop through connections for the current edge.
         for connection in edge_connections:
-
             # Notation: specific peaks are identified by (node_ind, peak_ind).
             src_id = PeakID(edge_type.src_node_ind, connection.src_peak_ind)
             dst_id = PeakID(edge_type.dst_node_ind, connection.dst_peak_ind)
@@ -887,7 +884,6 @@ def assign_connections_to_instances(
 
     if min_instance_peaks > 0:
         if isinstance(min_instance_peaks, float):
-
             if n_nodes is None:
                 # Infer number of nodes if not specified.
                 all_node_types = set()
@@ -1240,7 +1236,6 @@ def group_instances_batch(
     )
 
     for sample in range(n_samples):
-
         # Call sample-wise function in Eager mode.
         (
             predicted_instances_sample,
@@ -1701,7 +1696,10 @@ class PAFScorer:
             match_line_scores,
         )
         return (
-            predicted_instances, 
-            predicted_peak_scores, 
+            predicted_instances,
+            predicted_peak_scores,
             predicted_instance_scores,
-            edge_inds, edge_peak_inds, line_scores)
+            edge_inds,
+            edge_peak_inds,
+            line_scores,
+        )


### PR DESCRIPTION
This PR creates the option to return the parsed PAF graph during low-level inference. Here's a minimal example:
```
import sleap

model_directory = "kp_moseq_bottomup_1230512_153003.multi_instance.n=358/"
video_name = "Session Labeled 2023-05-05T10 37 02_De3ob3_2M_2.mp4"

predictor = sleap.load_model(model_directory)
predictor.inference_model.bottomup_layer.return_paf_graph = True

video = sleap.load_video(video_name)
predictions = predictor.inference_model.predict(video[:10])

for k in ['peaks','peak_vals','peak_channel_inds','edge_inds','edge_peak_inds','line_scores']:
    print(predictions[k].shape, k)
    
# RETURNS
# (10, 16, 2) peaks
# (10, 16) peak_vals
# (10, 16) peak_channel_inds
# (10, 28) edge_inds
# (10, 28, 2) edge_peak_inds
# (10, 28) line_scores
```
I added an entry for `return_paf_graph` to the relevant docstrings. Currently the docs don't describe the contents of every single key, but I think it's pretty clear from the names. 

