### PR TITLE
Set `split_by_inds`, `test_labels`, and `validation_labels` to default (GUI)

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1261,6 +1261,9 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         else:
             # Set certain parameters to defaults
             trained_config = trained_config_info.config
+            trained_config.data.labels.validation_labels = None
+            trained_config.data.labels.test_labels = None
+            trained_config.data.labels.split_by_inds = False
             trained_config.data.labels.skeletons = []
             trained_config.outputs.run_name = None
             trained_config.outputs.run_name_prefix = ""

--- a/tests/gui/learning/test_dialog.py
+++ b/tests/gui/learning/test_dialog.py
@@ -24,10 +24,28 @@ from sleap.util import get_package_file
 
 
 def test_use_hidden_params_from_loaded_config(
-    qtbot, min_labels_slp, min_bottomup_model_path
+    qtbot, min_labels_slp, min_bottomup_model_path, tmpdir
 ):
+    model_type = Path(min_bottomup_model_path).name
+    model_path = Path(tmpdir, "models")
+    model_path.mkdir()
+    model_path = Path(model_path, model_type)
+    model_path.mkdir()
 
-    model_path = Path(min_bottomup_model_path)
+    model_dir = str(model_path)
+
+    best_model_path = str(Path(min_bottomup_model_path, "best_model.h5"))
+    shutil.copy(best_model_path, model_dir)
+
+    cfg_path = str(Path(model_dir, "training_config.json"))
+    cfg = TrainingJobConfig.load_json(min_bottomup_model_path)
+    cfg.data.labels.split_by_inds = True
+    cfg.data.labels.training_inds = [0, 1, 2]
+    cfg.data.labels.validation_inds = [3, 4, 5]
+    cfg.data.labels.test_inds = [6, 7, 8]
+    cfg.filename = cfg_path
+
+    TrainingJobConfig.save_json(cfg, cfg_path)
 
     # Create a learning dialog
     app = MainWindow(no_usage_data=True)
@@ -80,6 +98,9 @@ def test_use_hidden_params_from_loaded_config(
     # Assert that config info list:
     params_set_in_tab = [f"config.{k}" for k in tab_cfg_key_val_dict.keys()]
     params_reset = [
+        "config.data.labels.validation_labels",
+        "config.data.labels.test_labels",
+        "config.data.labels.split_by_inds",
         "config.data.labels.skeletons",
         "config.outputs.run_name",
         "config.outputs.run_name_suffix",


### PR DESCRIPTION
### Description
#1053 allowed some unseen parameter to be used in GUI training when a trained model was used as a template. While certain parameters were set to defaults, others were controversially left to the values used in the trained model.

This PR sets more parameters to defaults, namely
- labels.split_by_inds
- labels.validation_labels
- labels.test_labels

which aims to ensure training is run on the labels in the current project. #1324 attempted to give the GUI user a bit more control, but ultimately it was decided that #1324 might cause more confusion than clarity.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1291

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
