### PR TITLE
Fix `Filedialog` to work across (mac)OS

### DIFF
--- a/sleap/gui/dialogs/filedialog.py
+++ b/sleap/gui/dialogs/filedialog.py
@@ -16,8 +16,8 @@ from qtpy import QtWidgets
 
 def os_specific_method(func) -> Callable:
     """Check if native dialog should be used and update kwargs based on OS.
-    
-    Native Mac/Win file dialogs add file extension based on selected file type but 
+
+    Native Mac/Win file dialogs add file extension based on selected file type but
     non-native dialog (used for Linux) does not do this by default.
     """
 
@@ -34,10 +34,11 @@ def os_specific_method(func) -> Callable:
         # Make sure we don't send empty options argument
         if "options" in kwargs and not kwargs["options"]:
             del kwargs["options"]
-        
+
         return func(cls, *args, **kwargs)
 
     return set_dialog_type
+
 
 class FileDialog:
     """Substitute for QFileDialog; see class methods for details."""
@@ -56,7 +57,6 @@ class FileDialog:
         """
         return QtWidgets.QFileDialog.getOpenFileName(*args, **kwargs)
 
-
     @classmethod
     @os_specific_method
     def openMultiple(cls, *args, **kwargs):
@@ -68,7 +68,6 @@ class FileDialog:
         Passes along everything except empty "options" arg.
         """
         return QtWidgets.QFileDialog.getOpenFileNames(*args, **kwargs)
-
 
     @classmethod
     @os_specific_method
@@ -117,4 +116,3 @@ class FileDialog:
         Passes along everything except empty "options" arg.
         """
         return QtWidgets.QFileDialog.getExistingDirectory(*args, **kwargs)
-

--- a/sleap/gui/dialogs/filedialog.py
+++ b/sleap/gui/dialogs/filedialog.py
@@ -7,15 +7,52 @@ on (some?) Ubuntu systems.
 """
 
 import os, re, sys
-from pathlib import Path
 
+from functools import wraps
+from pathlib import Path
+from typing import Callable
 from qtpy import QtWidgets
 
+
+def os_specific_method(func) -> Callable:
+    """Check if native dialog should be used and update kwargs based on OS."""
+
+    @wraps(func)
+    def modify_kwargs_then_call(cls, *args, **kwargs):
+        is_win = sys.platform.startswith("win")
+        env_var_set = os.environ.get("USE_NON_NATIVE_FILE", False)
+        cls.is_non_native = not is_win or env_var_set
+
+        if cls.is_non_native:
+            kwargs["options"] = kwargs.get("options", 0)
+            kwargs["options"] |= QtWidgets.QFileDialog.DontUseNativeDialog
+
+            if "directory" in kwargs:
+                kwargs["dir"] = kwargs["directory"]
+                del kwargs["directory"]
+            
+            if "filter" in kwargs:
+                filters = kwargs["filter"].split(";;")
+                if filters and "dir" in kwargs:
+                    filename = kwargs["dir"]
+                    if ".slp" in filters[0] and not filename.endswith(".slp"):
+                        kwargs["dir"] = f"{filename}.slp"
+
+        # Make sure we don't send empty options argument
+        if "options" in kwargs and not kwargs["options"]:
+            del kwargs["options"]
+        
+        return func(cls, *args, **kwargs)
+
+    return modify_kwargs_then_call
 
 class FileDialog:
     """Substitute for QFileDialog; see class methods for details."""
 
+    is_non_native = False
+
     @classmethod
+    @os_specific_method
     def open(cls, *args, **kwargs):
         """
         Wrapper for `QFileDialog.getOpenFileName()`
@@ -24,10 +61,11 @@ class FileDialog:
 
         Passes along everything except empty "options" arg.
         """
-        cls._non_native_if_set(kwargs)
         return QtWidgets.QFileDialog.getOpenFileName(*args, **kwargs)
 
+
     @classmethod
+    @os_specific_method
     def openMultiple(cls, *args, **kwargs):
         """
         Wrapper for `QFileDialog.getOpenFileNames()`
@@ -36,10 +74,11 @@ class FileDialog:
 
         Passes along everything except empty "options" arg.
         """
-        cls._non_native_if_set(kwargs)
         return QtWidgets.QFileDialog.getOpenFileNames(*args, **kwargs)
 
+
     @classmethod
+    @os_specific_method
     def save(cls, *args, **kwargs):
         """Wrapper for `QFileDialog.getSaveFileName()`
 
@@ -47,11 +86,10 @@ class FileDialog:
 
         Passes along everything except empty "options" arg.
         """
-        is_non_native = cls._non_native_if_set(kwargs)
 
         # The non-native file dialog doesn't add file extensions from the
         # file-type menu in the dialog, so we need to do this ourselves.
-        if is_non_native and "filter" in kwargs and "dir" in kwargs:
+        if cls.is_non_native and "filter" in kwargs and "dir" in kwargs:
             filename = kwargs["dir"]
             filters = kwargs["filter"].split(";;")
             if filters:
@@ -61,7 +99,7 @@ class FileDialog:
         filename, filter = QtWidgets.QFileDialog.getSaveFileName(*args, **kwargs)
 
         # Make sure filename has appropriate file extension.
-        if is_non_native and filter:
+        if cls.is_non_native and filter:
             fn = Path(filename)
             # Get extension from filter as list of "*.ext"
             match = re.findall("\*(\.[a-zA-Z0-9]+)", filter)
@@ -77,6 +115,7 @@ class FileDialog:
         return filename, filter
 
     @classmethod
+    @os_specific_method
     def openDir(cls, *args, **kwargs):
         """Wrapper for `QFileDialog.getExistingDirectory()`
 
@@ -86,19 +125,3 @@ class FileDialog:
         """
         return QtWidgets.QFileDialog.getExistingDirectory(*args, **kwargs)
 
-    @staticmethod
-    def _non_native_if_set(kwargs) -> bool:
-        is_non_native = False
-        is_linux = sys.platform.startswith("linux")
-        env_var_set = os.environ.get("USE_NON_NATIVE_FILE", False)
-
-        if is_linux or env_var_set:
-            is_non_native = True
-            kwargs["options"] = kwargs.get("options", 0)
-            kwargs["options"] |= QtWidgets.QFileDialog.DontUseNativeDialog
-
-        # Make sure we don't send empty options argument
-        if "options" in kwargs and not kwargs["options"]:
-            del kwargs["options"]
-
-        return is_non_native

--- a/sleap/gui/dialogs/formbuilder.py
+++ b/sleap/gui/dialogs/formbuilder.py
@@ -579,7 +579,7 @@ class FormBuilderLayout(QtWidgets.QFormLayout):
             def select_file(*args, x=field):
                 filter = item.get("filter", "Any File (*.*)")
                 filename, _ = FileDialog.open(
-                    None, directory=None, caption="Open File", filter=filter
+                    None, dir=None, caption="Open File", filter=filter
                 )
                 if len(filename):
                     x.setText(filename)
@@ -588,7 +588,7 @@ class FormBuilderLayout(QtWidgets.QFormLayout):
         elif item["type"].split("_")[-1] == "dir":
             # Define function for button to trigger
             def select_file(*args, x=field):
-                filename = FileDialog.openDir(None, directory=None, caption="Open File")
+                filename = FileDialog.openDir(None, dir=None, caption="Open File")
                 if len(filename):
                     x.setText(filename)
                 self.valueChanged.emit()

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -722,9 +722,10 @@ class LearningDialog(QtWidgets.QDialog):
     ):
         """Save scripts and configs to run pipeline."""
         if output_dir is None:
-            models_dir = os.path.join(os.path.dirname(self.labels_filename), "/models")
+            labels_fn = Path(self.labels_filename)
+            models_dir = Path(labels_fn.parent, "models")
             output_dir = FileDialog.openDir(
-                None, dir=models_dir, caption="Select directory to save scripts"
+                None, dir=models_dir.as_posix(), caption="Select directory to save scripts"
             )
 
             if not output_dir:

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -725,7 +725,9 @@ class LearningDialog(QtWidgets.QDialog):
             labels_fn = Path(self.labels_filename)
             models_dir = Path(labels_fn.parent, "models")
             output_dir = FileDialog.openDir(
-                None, dir=models_dir.as_posix(), caption="Select directory to save scripts"
+                None,
+                dir=models_dir.as_posix(),
+                caption="Select directory to save scripts",
             )
 
             if not output_dir:

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -724,7 +724,7 @@ class LearningDialog(QtWidgets.QDialog):
         if output_dir is None:
             models_dir = os.path.join(os.path.dirname(self.labels_filename), "/models")
             output_dir = FileDialog.openDir(
-                None, directory=models_dir, caption="Select directory to save scripts"
+                None, dir=models_dir, caption="Select directory to save scripts"
             )
 
             if not output_dir:

--- a/tests/gui/test_filedialog.py
+++ b/tests/gui/test_filedialog.py
@@ -3,26 +3,38 @@ import sys
 
 from qtpy import QtWidgets
 
-from sleap.gui.dialogs.filedialog import FileDialog
+from sleap.gui.dialogs.filedialog import os_specific_method, FileDialog
 
 
 def test_non_native_dialog():
+    @os_specific_method
+    def dummy_function(cls, *args, **kwargs):
+        """This function returns the `kwargs` modified by the wrapper.
+
+        Args:
+            cls: The `FileDialog` class.
+
+        Returns:
+            kwargs: Modified by the wrapper.
+        """
+        return kwargs
+
+    FileDialog.dummy_function = dummy_function
     save_env_non_native = os.environ.get("USE_NON_NATIVE_FILE", None)
-
     os.environ["USE_NON_NATIVE_FILE"] = ""
-
     d = dict()
-    FileDialog._non_native_if_set(d)
+
+    # Wrapper doesn't mutate `d` outside of scope, so need to return `modified_d`
+    modified_d = FileDialog.dummy_function(FileDialog, d)
     is_linux = sys.platform.startswith("linux")
     if is_linux:
-        assert d["options"] == QtWidgets.QFileDialog.DontUseNativeDialog
+        assert modified_d["options"] == QtWidgets.QFileDialog.DontUseNativeDialog
     else:
-        assert "options" not in d
+        assert "options" not in modified_d
 
     os.environ["USE_NON_NATIVE_FILE"] = "1"
-    d = dict()
-    FileDialog._non_native_if_set(d)
-    assert d["options"] == QtWidgets.QFileDialog.DontUseNativeDialog
+    modified_d = FileDialog.dummy_function(FileDialog, d)
+    assert modified_d["options"] == QtWidgets.QFileDialog.DontUseNativeDialog
 
     if save_env_non_native is not None:
         os.environ["USE_NON_NATIVE_FILE"] = save_env_non_native


### PR DESCRIPTION
### Description
Previously, we would use the `directory` keyword occasionally when calling certain `FileDialog` methods. The `directory` keyword is not able to be used on macOS, but the `dir` keyword seems to work well across all OS's (Windows, Mac, and Linux). 

This PR substitutes the `directory` keyword with `dir` instead when calling `FileDialog` methods.

No automated tests, but manually tested the Save Configuration button on all three OS's.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1251

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
