### PR TITLE
Add video path and frame indices to metrics

### DIFF
--- a/sleap/nn/evals.py
+++ b/sleap/nn/evals.py
@@ -25,7 +25,7 @@ import os
 import numpy as np
 from typing import Any, Dict, List, Optional, Text, Tuple, Union
 import logging
-import sleap
+
 from sleap import Labels, LabeledFrame, Instance, PredictedInstance
 from sleap.nn.config import (
     TrainingJobConfig,
@@ -471,7 +471,7 @@ def compute_generalized_voc_metrics(
 
 def compute_dists(
     positive_pairs: List[Tuple[Instance, PredictedInstance, Any]]
-) -> np.ndarray:
+) -> Dict[str, Union[np.ndarray, List[int], List[str]]]:
     """Compute Euclidean distances between matched pairs of instances.
 
     Args:
@@ -481,27 +481,27 @@ def compute_dists(
     Returns:
         A dictionary with the following keys:
             dists: An array of pairwise distances of shape `(n_positive_pairs, n_nodes)`
-            instances_gt: A list of `Instance`s corresponding to the `dists`
-            instances_pr: A list of `PredictedInstance`s corresponding to the `dists`
+            frame_idxs: A list of frame indices corresponding to the `dists`
+            video_paths: A list of video paths corresponding to the `dists`
     """
     dists = []
-    instances_gt = []
-    instances_pr = []
+    frame_idxs = []
+    video_paths = []
     for instance_gt, instance_pr, _ in positive_pairs:
         points_gt = instance_gt.points_array
         points_pr = instance_pr.points_array
 
         dists.append(np.linalg.norm(points_pr - points_gt, axis=-1))
-        instances_gt.append(instance_gt)
-        instances_pr.append(instance_pr)
+        frame_idxs.append(instance_gt.frame.frame_idx)
+        video_paths.append(instance_gt.frame.video.backend.filename)
 
     dists = np.array(dists)
 
     # Bundle everything into a dictionary
     dists_dict = {
         "dists": dists,
-        "instances_gt": instances_gt,
-        "instances_pr": instances_pr,
+        "frame_idxs": frame_idxs,
+        "video_paths": video_paths,
     }
 
     return dists_dict
@@ -520,8 +520,8 @@ def compute_dist_metrics(
     """
     dists = dists_dict["dists"]
     results = {
-        "dist.instances.gt": dists_dict["instances_gt"],
-        "dist.instances.pr": dists_dict["instances_pr"],
+        "dist.frame_idxs": dists_dict["frame_idxs"],
+        "dist.video_paths": dists_dict["video_paths"],
         "dist.dists": dists,
         "dist.avg": np.nanmean(dists),
         "dist.p50": np.nan,
@@ -669,7 +669,7 @@ def evaluate(
 
 def evaluate_model(
     cfg: TrainingJobConfig,
-    labels_reader: LabelsReader,
+    labels_gt: Union[LabelsReader, Labels],
     model: Model,
     save: bool = True,
     split_name: Text = "test",
@@ -678,8 +678,8 @@ def evaluate_model(
 
     Args:
         cfg: The `TrainingJobConfig` associated with the model.
-        labels_reader: A `LabelsReader` pipeline generator that reads the ground truth
-            data to evaluate.
+        labels_gt: A `LabelsReader` pipeline generator that reads the ground truth
+            data to evaluate or a `Labels` object to be used as ground truth.
         model: The `sleap.nn.model.Model` instance to evaluate.
         save: If True, save the predictions and metrics to the model folder.
         split_name: String name to append to the saved filenames.
@@ -728,11 +728,13 @@ def evaluate_model(
         raise ValueError("Unrecognized model type:", head_config)
 
     # Predict.
-    labels_pr = predictor.predict(labels_reader, make_labels=True)
+    labels_pr: Labels = predictor.predict(labels_gt, make_labels=True)
 
     # Compute metrics.
     try:
-        metrics = evaluate(labels_reader.labels, labels_pr)
+        if isinstance(labels_gt, LabelsReader):
+            labels_gt = labels_gt.labels
+        metrics = evaluate(labels_gt, labels_pr)
     except:
         logger.warning("Failed to compute metrics.")
         metrics = None
@@ -783,8 +785,8 @@ def load_metrics(model_path: str, split: str = "val") -> Dict[str, Any]:
         - `"dist.p95"`: Distance for 95th percentile
         - `"dist.p99"`: Distance for 99th percentile
         - `"dist.dists"`: All distances
-        - `"dist.instances.gt"`: Ground truth `Instance`s corresponding to `"dist.dists"`
-        - `"dist.instances.pr"`: `PredictedInstance`s corresponding to `"dist.dists"`
+        - `"dist.frame_idxs"`: Frame indices corresponding to `"dist.dists"`
+        - `"dist.video_paths"`: Video paths corresponding to `"dist.dists"`
         - `"pck.mPCK"`: Mean Percentage of Correct Keypoints (PCK)
         - `"oks.mOKS"`: Mean Object Keypoint Similarity (OKS)
         - `"oks_voc.mAP"`: VOC with OKS scores - mean Average Precision (mAP)

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -962,14 +962,14 @@ class Trainer(ABC):
         logger.info("Saving evaluation metrics to model folder...")
         sleap.nn.evals.evaluate_model(
             cfg=self.config,
-            labels_reader=self.data_readers.training_labels_reader,
+            labels_gt=self.data_readers.training_labels_reader,
             model=self.model,
             save=True,
             split_name="train",
         )
         sleap.nn.evals.evaluate_model(
             cfg=self.config,
-            labels_reader=self.data_readers.validation_labels_reader,
+            labels_gt=self.data_readers.validation_labels_reader,
             model=self.model,
             save=True,
             split_name="val",
@@ -977,7 +977,7 @@ class Trainer(ABC):
         if self.data_readers.test_labels_reader is not None:
             sleap.nn.evals.evaluate_model(
                 cfg=self.config,
-                labels_reader=self.data_readers.test_labels_reader,
+                labels_gt=self.data_readers.test_labels_reader,
                 model=self.model,
                 save=True,
                 split_name="test",

--- a/tests/fixtures/instances.py
+++ b/tests/fixtures/instances.py
@@ -1,16 +1,18 @@
 import pytest
 
-from sleap.instance import Instance, Point, PredictedInstance
+from sleap.instance import Instance, LabeledFrame, Point, PredictedInstance
 
 
 @pytest.fixture
-def instances(skeleton):
+def instances(skeleton, centered_pair_vid):
 
     # Generate some instances
     NUM_INSTANCES = 500
 
+    video = centered_pair_vid
     instances = []
     for i in range(NUM_INSTANCES):
+
         instance = Instance(skeleton=skeleton)
         instance["head"] = Point(i * 1, i * 2)
         instance["left-wing"] = Point(10 + i * 1, 10 + i * 2)
@@ -18,6 +20,10 @@ def instances(skeleton):
 
         # Lets make an NaN entry to test skip_nan as well
         instance["thorax"]
+
+        # Add a LabeledFrame
+        labeled_frame = LabeledFrame(video=video, frame_idx=i, instances=[instance])
+        instance.frame = labeled_frame
 
         instances.append(instance)
 

--- a/tests/nn/test_evals.py
+++ b/tests/nn/test_evals.py
@@ -1,6 +1,17 @@
 import numpy as np
+
+from typing import List, Tuple
+
 import sleap
-from sleap.nn.evals import load_metrics, compute_oks
+
+from sleap import Instance, PredictedInstance
+from sleap.instance import Point
+from sleap.nn.evals import (
+    compute_dists,
+    compute_dist_metrics,
+    compute_oks,
+    load_metrics,
+)
 
 
 sleap.use_cpu_only()
@@ -25,6 +36,61 @@ def test_compute_oks():
     inst_pr = np.array([[0, 0], [1, 1], [np.nan, np.nan]]).astype("float32")
     oks = compute_oks(inst_gt, inst_pr)
     np.testing.assert_allclose(oks, 1)
+
+
+def test_compute_dists(instances, predicted_instances):
+    # Make some changes to the instances
+    error_start = 10
+    error_end = 20
+    expected_dists = []
+    for offset, zipped_insts in enumerate(
+        zip(
+            instances[error_start:error_end], predicted_instances[error_start:error_end]
+        )
+    ):
+
+        inst, pred_inst = zipped_insts
+        for node_name in inst.skeleton.node_names:
+            pred_point = pred_inst[node_name]
+            if pred_point != np.NaN:
+                inst[node_name] = Point(
+                    pred_point.x + offset, pred_point.y + offset + 1
+                )
+
+        error = ((offset ** 2) + (offset + 1) ** 2) ** (1 / 2)
+        expected_dists.append(error)
+
+    best_match_oks = np.NaN
+    positive_pairs: List[Tuple[Instance, PredictedInstance]] = [
+        (inst, pred_inst, best_match_oks)
+        for inst, pred_inst in zip(instances, predicted_instances)
+    ]
+
+    dists_dict = compute_dists(positive_pairs=positive_pairs)
+    dists = dists_dict["dists"]
+
+    # Replace nan to 0
+    dists_no_nan = np.nan_to_num(dists, nan=0)
+    np.testing.assert_allclose(dists_no_nan[0:10], 0)
+
+    # Replace nan to negative (which we never see in a norm)
+    dists_no_nan = np.nan_to_num(dists, nan=-1)
+
+    # Check distances are as expected
+    for idx, error in enumerate(expected_dists):
+        idx += error_start
+        dists_idx = dists_no_nan[idx]
+        dists_idx = dists_idx[dists_idx >= 0]
+        np.testing.assert_allclose(dists_idx, error)
+
+    # Check instances are as expected
+    dists_metric = compute_dist_metrics(dists_dict)
+    for idx, zipped_insts in enumerate(
+        zip(dists_metric["dist.instances.gt"], dists_metric["dist.instances.pr"])
+    ):
+        inst, pred_inst = zipped_insts
+        assert inst == instances[idx]
+        assert pred_inst == predicted_instances[idx]
 
 
 def test_load_metrics(min_centered_instance_model_path):


### PR DESCRIPTION
### Description
Multiple people have asked if there might be a way to link back to frames where the model has performed poorly on as a way of either determining whether a certain video is culprit or mislabeled instances are culprit. This PR specifically follows the code provided by @adam-matic in #1253.

While this PR does not tie distances to the instances like a Dataframe might accomplish, it returns the instances (in a dictionary) in the same order as the distances. Feel free to suggest improvements!

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1253

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
