### PR TITLE
Fix skeleton templates

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1947,14 +1947,27 @@ class OpenSkeleton(EditCommand):
             labels.skeletons = skeletons_used
 
     @staticmethod
+    def get_template_skeleton_filename(context: CommandContext) -> str:
+        """Helper function to get the template skeleton filename from dropdown.
+        
+        Args:
+            context: The `CommandContext`.
+        
+        Returns:
+            Path to the template skeleton shipped with SLEAP.
+        """
+
+        template = context.app.skeleton_dock.skeleton_templates.currentText()
+        filename = get_package_file(f"sleap/skeletons/{template}.json")
+        return filename
+
+    @staticmethod
     def ask(context: CommandContext, params: dict) -> bool:
         filters = ["JSON skeleton (*.json)", "HDF5 skeleton (*.h5 *.hdf5)"]
         # Check whether to load from file or preset
         if params.get("template", False):
             # Get selected template from dropdown
-            template = context.app.skeleton_dock.skeleton_templates.currentText()
-            # Load from selected preset
-            filename = get_package_file(f"sleap/skeletons/{template}.json")
+            filename = get_template_skeleton_filename(context)
         else:
             filename, selected_filter = FileDialog.open(
                 context.app,

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1949,10 +1949,10 @@ class OpenSkeleton(EditCommand):
     @staticmethod
     def get_template_skeleton_filename(context: CommandContext) -> str:
         """Helper function to get the template skeleton filename from dropdown.
-        
+
         Args:
             context: The `CommandContext`.
-        
+
         Returns:
             Path to the template skeleton shipped with SLEAP.
         """
@@ -1967,7 +1967,7 @@ class OpenSkeleton(EditCommand):
         # Check whether to load from file or preset
         if params.get("template", False):
             # Get selected template from dropdown
-            filename = get_template_skeleton_filename(context)
+            filename = OpenSkeleton.get_template_skeleton_filename(context)
         else:
             filename, selected_filter = FileDialog.open(
                 context.app,

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1952,7 +1952,7 @@ class OpenSkeleton(EditCommand):
         # Check whether to load from file or preset
         if params.get("template", False):
             # Get selected template from dropdown
-            template = context.app.skeletonTemplates.currentText()
+            template = context.app.skeleton_dock.skeleton_templates.currentText()
             # Load from selected preset
             filename = get_package_file(f"sleap/skeletons/{template}.json")
         else:

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -83,11 +83,10 @@ def test_skeleton_dock(qtbot):
 
     # This method should get called when we click the load button, but let's just call
     # the non-gui parts directly
-    assert dock.skeleton_templates.currentText() == "bees"
     fn = Path(
         OpenSkeleton.get_template_skeleton_filename(context=dock.main_window.commands)
     )
-    assert fn.name == "bees.json"
+    assert fn.name == f"{dock.skeleton_templates.currentText()}.json"
 
 
 def test_suggestions_dock(qtbot):

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -3,6 +3,7 @@
 import pytest
 from sleap import Labels, Video
 from sleap.gui.app import MainWindow
+from sleap.gui.commands import OpenSkeleton
 from sleap.gui.widgets.docks import (
     InstancesDock,
     SuggestionsDock,
@@ -79,6 +80,8 @@ def test_skeleton_dock(qtbot):
     assert dock.main_window is main_window
     assert dock.wgt_layout is dock.widget().layout()
 
+    assert dock.skeleton_templates.currentText() == "bees"
+
 
 def test_suggestions_dock(qtbot):
     """Test the `DockWidget` class."""
@@ -101,4 +104,4 @@ def test_instances_dock(qtbot):
 
 
 if __name__ == "__main__":
-    pytest.main([f"{__file__}::test_instances_dock"])
+    pytest.main([f"{__file__}::test_skeleton_dock"])

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -1,6 +1,7 @@
 """Module for testing dock widgets for the `MainWindow`."""
 
-import pytest
+from pathlib import Path
+
 from sleap import Labels, Video
 from sleap.gui.app import MainWindow
 from sleap.gui.commands import OpenSkeleton
@@ -80,7 +81,13 @@ def test_skeleton_dock(qtbot):
     assert dock.main_window is main_window
     assert dock.wgt_layout is dock.widget().layout()
 
+    # This method should get called when we click the load button, but let's just call
+    # the non-gui parts directly
     assert dock.skeleton_templates.currentText() == "bees"
+    fn = Path(
+        OpenSkeleton.get_template_skeleton_filename(context=dock.main_window.commands)
+    )
+    assert fn.name == "bees.json"
 
 
 def test_suggestions_dock(qtbot):
@@ -101,7 +108,3 @@ def test_instances_dock(qtbot):
     assert dock.name == "Instances"
     assert dock.main_window is main_window
     assert dock.wgt_layout is dock.widget().layout()
-
-
-if __name__ == "__main__":
-    pytest.main([f"{__file__}::test_skeleton_dock"])


### PR DESCRIPTION
### Description
In #1265 while moving the dock creation logic outside the `MainWindow` class, a critical line was overlooked:
https://github.com/talmolab/sleap/blob/0e7a3725d5e238b97f5daa35795829a15cd156db/sleap/gui/commands.py#L1955

The `MainWindow.skeletonTemplates` attribute was renamed to `MainWindow.skeleton_dock.skeleton_templates`, but this line (untested due to its GUI nature) was left behind.

This PR corrects the line above to correctly call the `Video_Dock.skeleton_templates` attribute. While we do not test the `OpenSkeleton.ask` method where the error originated from, this PR moves the code used to get the filename to a staticmethod on the `OpenSkeleton` class which is called in the docks tests. The code has also been manually tested to run through the `OpenSkeleton.ask` method and works as expected.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1402

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
