### PR TITLE
Add `Video` to cache when adding `Track`

### DIFF
--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -194,9 +194,7 @@ class LabelsDataCache:
 
     def get_track_occupancy(self, video: Video, track: Track) -> RangeList:
         """Access track occupancy cache that adds video/track as needed."""
-        if video not in self._track_occupancy:
-            self._track_occupancy[video] = dict()
-
+        self.get_video_track_occupancy(video=video)
         if track not in self._track_occupancy[video]:
             self._track_occupancy[video][track] = RangeList()
         return self._track_occupancy[video][track]
@@ -251,9 +249,7 @@ class LabelsDataCache:
 
     def add_track(self, video: Video, track: Track):
         """Add a track to the labels."""
-        if video not in self._track_occupancy:
-            self._track_occupancy[video] = dict()
-        self._track_occupancy[video][track] = RangeList()
+        self.get_track_occupancy(video=video, track=track)
 
     def add_instance(self, frame: LabeledFrame, instance: Instance):
         """Add an instance to the labels."""

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -251,6 +251,8 @@ class LabelsDataCache:
 
     def add_track(self, video: Video, track: Track):
         """Add a track to the labels."""
+        if video not in self._track_occupancy:
+            self._track_occupancy[video] = dict()
         self._track_occupancy[video][track] = RangeList()
 
     def add_instance(self, frame: LabeledFrame, instance: Instance):

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -1384,6 +1384,16 @@ def test_labels_numpy(centered_pair_predictions: Labels):
     np.testing.assert_array_equal(labels_np[lf.frame_idx, 0, :, :-1], user_inst.numpy())
 
 
+def test_add_track(centered_pair_labels: Labels, small_robot_mp4_vid: Video):
+    labels = centered_pair_labels
+    new_video = small_robot_mp4_vid
+
+    track = Track()
+    labels.add_track(new_video, track)
+    assert track in labels.tracks
+    assert new_video in labels._cache._track_occupancy
+
+
 def test_remove_track(centered_pair_predictions):
     labels = centered_pair_predictions
 


### PR DESCRIPTION
### Description
When using the API, some users have been running into [confusing problems](https://github.com/talmolab/sleap/discussions/1316#discussioncomment-6532183) (specifically when calling `Labels.add_track`). The `Labels.add_track` method assumed that the `Video` was already in the `LabelsDataCache` (used to speed-up frame/instance/track look-up), so when `Labels.add_track` is called before the video is in the cache, an error pops up. The `Video` is added to the cache when SLEAP calls the `Labels.add_track` method (after Labels.append(LabeledFrame)), but it isn't intuitive to do this via the API.

This PR adds the video to the cache if it is not there already when calling `Labels.add_tracks` by itself.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (better API)

### Does this address any currently open issues?
- #1316

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
