### PR TITLE
Add `Track` when add `Instance`

### DIFF
--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -255,16 +255,13 @@ class LabelsDataCache:
 
     def add_instance(self, frame: LabeledFrame, instance: Instance):
         """Add an instance to the labels."""
-        if frame.video not in self._track_occupancy:
-            self._track_occupancy[frame.video] = dict()
 
         # Add track in its not already present in labels
-        if instance.track not in self._track_occupancy[frame.video]:
-            self._track_occupancy[frame.video][instance.track] = RangeList()
-
-        self._track_occupancy[frame.video][instance.track].insert(
-            (frame.frame_idx, frame.frame_idx + 1)
+        track_occupancy = self.get_track_occupancy(
+            video=frame.video, track=instance.track
         )
+
+        track_occupancy.insert((frame.frame_idx, frame.frame_idx + 1))
 
         self.update_counts_for_frame(frame)
 
@@ -1335,8 +1332,12 @@ class Labels(MutableSequence):
         if instance.track in tracks_in_frame:
             instance.track = None
 
+        # Add instance and track to labels
         frame.instances.append(instance)
+        if (instance.track is not None) and (instance.track not in self.tracks):
+            self.add_track(video=frame.video, track=instance.track)
 
+        # Update cache
         self._cache.add_instance(frame, instance)
 
     def find_track_occupancy(

--- a/tests/io/test_dataset.py
+++ b/tests/io/test_dataset.py
@@ -1384,6 +1384,19 @@ def test_labels_numpy(centered_pair_predictions: Labels):
     np.testing.assert_array_equal(labels_np[lf.frame_idx, 0, :, :-1], user_inst.numpy())
 
 
+def test_add_instance(centered_pair_labels: Labels):
+    labels = centered_pair_labels
+    lf = labels[0]
+    track = Track()
+    inst = Instance(skeleton=labels.skeleton, track=track, frame=lf)
+
+    labels.add_instance(lf, inst)
+    assert inst in labels.instances()
+    assert inst in lf.instances
+    assert track in labels.tracks
+    assert track in labels._cache._track_occupancy[lf.video]
+
+
 def test_remove_track(centered_pair_predictions):
     labels = centered_pair_predictions
 


### PR DESCRIPTION
### Description
Previously, the `Labels.add_instance` method would add the track associated with the instance to the cache, but not to the `Labels` object itself. I did not verify this, but I am sure this is handled in the call sequence when SLEAP adds tracks; however, it makes the SLEAP API a bit difficult to use (leading to KeyErrors in the LabelsDataCache dictionaries).

This PR adds the `Track` associated with an `Instance` to the `Labels.tracks` list when calling `Labels.add_instance`.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (better API)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
