### PR TITLE
Correct GUI state emulation

### DIFF
--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -240,9 +240,12 @@ def test_app_workflow(
 
     # Set up to test labeled frames data cache
     app.labels = min_tracks_2node_labels
-    video = app.labels.video
+    video_clip = app.labels.video
+    app.state["labels"] = app.labels
+    app.state["video"] = video_clip
+    app.on_data_update([UpdateTopic.all])
     num_samples = 5
-    frame_delta = video.num_frames // num_samples
+    frame_delta = video_clip.num_frames // num_samples
 
     # Add suggestions
     app.labels.suggestions = VideoFrameSuggestions.suggest(
@@ -274,7 +277,7 @@ def test_app_workflow(
             (l_suggestion.video, l_suggestion.frame_idx), use_cache=True
         )
         assert type(lf) == LabeledFrame
-        assert lf.video == video
+        assert lf.video == video_clip
         assert lf.frame_idx == prev_idx + frame_delta
         prev_idx = l_suggestion.frame_idx
 
@@ -283,8 +286,6 @@ def test_app_workflow(
     app.on_data_update([UpdateTopic.video])
 
     assert len(app.labels.videos) == 2
-
-    app.state["video"] = centered_pair_vid
 
     # Generate suggested frames in both videos
     app.labels.clear_suggestions()
@@ -311,11 +312,11 @@ def test_app_workflow(
     assert app.state["selected_video"] == small_robot_mp4_vid
     app.commands.removeVideo()
     assert len(app.labels.videos) == 1
-    assert app.state["video"] == centered_pair_vid
+    assert app.state["video"] == video_clip
 
     # Verify frame suggestions from video 1 are removed
     for sugg in app.labels.suggestions:
-        assert sugg.video == app.labels.videos[0]
+        assert sugg.video == video_clip
 
 
 def test_app_new_window(qtbot):


### PR DESCRIPTION
### Description
In [the tests for the first commit](https://github.com/talmolab/sleap/pull/1411/checks?sha=ef43970b495bfade97a99af3c0170f866516e73f) of #1411, the `test_app_workflow` was running into a strange error which was not expected based on the line of code being called. Further inspection revealed that the problem lay in the gui state emulation within the test (my bad! #709) where we change the `Labels` of the `MainWindow` without setting the `GuiState` to reflect this change. Basically, the video we had in the `GuiState` was not in the new labels that were loaded:
https://github.com/talmolab/sleap/blob/465165220c5799e55da36f78cdd4c816593f6b5a/tests/gui/test_app.py#L214

which was now only being caught when we try to update the seekbar after removing videos in #1411.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (Bugfix in test)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
