### PR TITLE
Redraw overlays on plot change

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1222,6 +1222,8 @@ class MainWindow(QMainWindow):
         # Select instance if there was already selection
         if selected_inst is not None:
             player.view.selectInstance(selected_inst)
+        else:
+            self.state["instance"] = None
 
         if self.state["fit"]:
             player.zoomToFit()

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1207,14 +1207,17 @@ class MainWindow(QMainWindow):
     def _after_plot_change(self, player, frame_idx, selected_inst):
         """Called each time a new frame is drawn."""
 
-        # Store the current LabeledFrame (or make new, empty object)
-        self.state["labeled_frame"] = self.labels.find(
-            self.state["video"], frame_idx, return_new=True
-        )[0]
+        # Store the current frame_idx and LabeledFrame (or make new, empty object)
+        self.state["frame_idx"] = frame_idx
+        self.state["labeled_frame"] = (
+            self.labels.find(self.state["video"], frame_idx, return_new=True)[0]
+            if frame_idx is not None
+            else None
+        )
 
         # Show instances, etc, for this frame
         for overlay in self.overlays.values():
-            overlay.add_to_scene(self.state["video"], frame_idx)
+            overlay.redraw(self.state["video"], frame_idx)
 
         # Select instance if there was already selection
         if selected_inst is not None:

--- a/sleap/gui/overlays/base.py
+++ b/sleap/gui/overlays/base.py
@@ -61,6 +61,8 @@ class BaseOverlay(abc.ABC):
 
         This method does not need to be called when changing the plot to a new frame.
         """
+        if self.items is None:
+            return
         for item in self.items:
             self.player.scene.removeItem(item)
 

--- a/sleap/gui/overlays/tracks.py
+++ b/sleap/gui/overlays/tracks.py
@@ -256,4 +256,4 @@ class TrackListOverlay(BaseOverlay):
                 self.text_box.setPos(pos)
             else:
                 self.text_box.setPos(10, 10)
-            self.text_box.setVisible(val)
+        self.text_box.setVisible(val)

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -410,10 +410,10 @@ class QtVideoPlayer(QWidget):
 
         self.video = video
 
-        # Is this necessary?
         if self.video is None:
             self.reset()
         else:
+            # Is this necessary?
             self.view.scene.setSceneRect(0, 0, video.width, video.height)
 
             self.seekbar.setMinimum(0)
@@ -426,12 +426,19 @@ class QtVideoPlayer(QWidget):
 
     def reset(self):
         """Reset viewer by removing all video data."""
+        # Reset view and video
         self.video = None
-        self.state["frame_idx"] = None
         self.view.clear()
         self.view.setImage(
             QImage(sleap.util.get_package_file("sleap/gui/background.png"))
         )
+
+        # Handle overlays and gui state in callback
+        frame_idx = None
+        selected_instances = None
+        self.changedPlot.emit(self, frame_idx, selected_instances)
+
+        # Reset seekbar
         self.seekbar.setMaximum(0)
         self.seekbar.setEnabled(False)
 

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -435,8 +435,8 @@ class QtVideoPlayer(QWidget):
 
         # Handle overlays and gui state in callback
         frame_idx = None
-        selected_instances = None
-        self.changedPlot.emit(self, frame_idx, selected_instances)
+        selected_instance = None
+        self.changedPlot.emit(self, frame_idx, selected_instance)
 
         # Reset seekbar
         self.seekbar.setMaximum(0)


### PR DESCRIPTION
### Description
Previously, overlays had an open reference even after they were cleared from the player. This PR Ensures that when `QtVideoPlayer.reset` is called, the `changedPlot` signal is emitted which handles overlays and gui states.
> Note: When a video is removed via the `RemoveVideo` command, this will call the `MainWindow.on_data_update` function with a topic of `UpdateTopic.frame`. The `MainWindow.on_data_update` will then be called a second time with the `UpdateTopic.frame` if the video removed is the last video (which then calls `QtVideoPlayer.reset`). Although redundant, this will not be an expensive operation since most the data from the slp will be removed at this point (all `LabeledFrames`, `Suggestions`, and `Videos`).

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
