### PR TITLE
Improve error message for detecting video backend

### DIFF
--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -1273,7 +1273,7 @@ class Video:
         elif filename.lower().endswith(SingleImageVideo.EXTS):
             backend_class = SingleImageVideo
         else:
-            raise ValueError("Could not detect backend for specified filename.")
+            raise ValueError(f"Could not detect backend for specified filename: {filename}")
 
         kwargs["filename"] = filename
 

--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -1273,7 +1273,9 @@ class Video:
         elif filename.lower().endswith(SingleImageVideo.EXTS):
             backend_class = SingleImageVideo
         else:
-            raise ValueError(f"Could not detect backend for specified filename: {filename}")
+            raise ValueError(
+                f"Could not detect backend for specified filename: {filename}"
+            )
 
         kwargs["filename"] = filename
 

--- a/tests/io/test_video.py
+++ b/tests/io/test_video.py
@@ -37,6 +37,9 @@ def test_from_filename(hdf5_file_path, small_robot_mp4_path):
         == SingleImageVideo
     )
 
+    with pytest.raises(ValueError):
+        Video.from_filename("this_has_no_video_extension")
+
 
 def test_backend_extra_kwargs(hdf5_file_path, small_robot_mp4_path):
     Video.from_filename(hdf5_file_path, grayscale=True, another_kwarg=False)


### PR DESCRIPTION
### Description
This error message is very annoying because it is very uninformative:
```
    raise ValueError("Could not detect backend for specified filename.")
ValueError: Could not detect backend for specified filename.
```

This PR takes away some of the annoyance by providing the filename:

```
    raise ValueError(f"Could not detect backend for specified filename: {filename}")
ValueError: Could not detect backend for specified filename: D:\social-leap-estimates-animal-poses\datasets\colab.slp.training_job
```

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (error message)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
