### PR TITLE
Add model folder to the unzip path

### DIFF
--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4824,6 +4824,7 @@ def load_model(
         # Uncompress ZIP packaged models.
         tmp_dirs = []
         for i, model_path in enumerate(model_paths):
+            mp = Path(model_path)
             if model_path.endswith(".zip"):
                 # Create temp dir on demand.
                 tmp_dir = tempfile.TemporaryDirectory()
@@ -4834,7 +4835,7 @@ def load_model(
 
                 # Extract and replace in the list.
                 shutil.unpack_archive(model_path, extract_dir=tmp_dir.name)
-                model_paths[i] = tmp_dir.name
+                model_paths[i] = str(Path(tmp_dir.name, mp.stem))
 
         return model_paths, tmp_dirs
 


### PR DESCRIPTION
### Description
Not sure how this crept in unnoticed for so long... but when unzipping a model path, the directory that contains all the model info was not being appended to the path. This PR appends the directory.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1443

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
