### PR TITLE
Pin `tensorflow-hub<0.14.0`

### DIFF
--- a/.conda/bld.bat
+++ b/.conda/bld.bat
@@ -7,7 +7,7 @@ set PIP_IGNORE_INSTALLED=False
 
 @REM Install the pip dependencies. Note: Using urls to wheels might be better: 
 @REM https://docs.conda.io/projects/conda-build/en/stable/user-guide/wheel-files.html)
-pip install -r .\requirements.txt
+pip install --no-cache-dir -r .\requirements.txt
 
 @REM Install sleap itself. This does not install the requirements, but will list which 
 @REM requirements are missing (see "install_requires") when user attempts to install.

--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -7,7 +7,7 @@ export PIP_IGNORE_INSTALLED=False
 
 # Install the pip dependencies. Note: Using urls to wheels might be better: 
 # https://docs.conda.io/projects/conda-build/en/stable/user-guide/wheel-files.html)
-pip install -r ./requirements.txt
+pip install --no-cache-dir -r ./requirements.txt
 
 
 # Install sleap itself. This does not install the requirements, but will list which 

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -16,7 +16,7 @@ source:
   path: ../
 
 build:
-  number: 9
+  number: 11
 
 requirements:
   host:
@@ -83,7 +83,7 @@ requirements:
     - conda-forge::scikit-video
     - conda-forge::seaborn
     - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10, sleap channel has 2.6.3
-    - conda-forge::tensorflow-hub
+    - conda-forge::tensorflow-hub ==0.13.0
 
 test:
   imports:

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -16,7 +16,7 @@ source:
   path: ../
 
 build:
-  number: 11
+  number: 12
 
 requirements:
   host:
@@ -83,7 +83,7 @@ requirements:
     - conda-forge::scikit-video
     - conda-forge::seaborn
     - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10, sleap channel has 2.6.3
-    - conda-forge::tensorflow-hub ==0.13.0
+    - conda-forge::tensorflow-hub <0.14.0  # Causes pynwb conflicts on linux GH-1446
 
 test:
   imports:

--- a/.conda_mac/build.sh
+++ b/.conda_mac/build.sh
@@ -7,6 +7,6 @@ export PIP_NO_INDEX=False
 export PIP_NO_DEPENDENCIES=False
 export PIP_IGNORE_INSTALLED=False
 
-pip install -r requirements.txt
+pip install --no-cache-dir -r requirements.txt
 
 python setup.py install --single-version-externally-managed --record=record.txt

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
     - conda-forge::scikit-video
     - conda-forge::seaborn
     - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10
-    - conda-forge::tensorflow-hub
+    - conda-forge::tensorflow-hub  # Pinned in meta.yml, but no problems here... yet
 
     # Packages required by tensorflow to find/use GPUs
     - conda-forge::cudatoolkit ==11.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64
 
 # Conda installing results in https://github.com/h5py/h5py/issues/2037
 h5py<3.2; sys_platform == 'win32'  # Newer versions result in error above, linking issue in Linux
-pynwb>=2.3.3  # 2.0.0 required by ndx-pose, 2.3.3 fixes importlib-metadata incompatibility
+pynwb==2.3.3  # 2.0.0 required by ndx-pose, 2.3.3 fixes importlib-metadata incompatibility

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64
 
 # Conda installing results in https://github.com/h5py/h5py/issues/2037
 h5py<3.2; sys_platform == 'win32'  # Newer versions result in error above, linking issue in Linux
-pynwb==2.3.3  # 2.0.0 required by ndx-pose, 2.3.3 fixes importlib-metadata incompatibility
+pynwb>=2.3.3  # 2.0.0 required by ndx-pose, 2.3.3 fixes importlib-metadata incompatibility


### PR DESCRIPTION
### Description
In the 1.3.1 release, we had a huge dependency refactor. The gameplan was to leave dependencies unrestricted unless there was reason to narrow the allowable version range. There is now reason to narrow the version range.

This PR pins pynwb and tensorflow-hub versions.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (dependencies)

### Does this address any currently open issues?
- #1428

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
