### PR TITLE
Limit max tracks via track-local queues

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -118,158 +118,166 @@ optional arguments:
 If you specify how many identities there should be in a frame (i.e., the number of animals) with the {code}`--tracking.clean_instance_count` argument, then we will use a heuristic method to connect "breaks" in the track identities where we lose one identity and spawn another. This can be used as part of the inference pipeline (if models are specified), as part of the tracking-only pipeline (if the predictions file is specified and no models are specified), or by itself on predictions with pre-tracked identities (if you specify {code}`--tracking.tracker none`). See {ref}`proofreading` for more details on tracking.
 
 ```none
-usage: sleap-track [-h] [-m MODELS] [--frames FRAMES] [--only-labeled-frames]
-                   [--only-suggested-frames] [-o OUTPUT] [--no-empty-frames]
-                   [--verbosity {none,rich,json}]
-                   [--video.dataset VIDEO.DATASET]
-                   [--video.input_format VIDEO.INPUT_FORMAT]
-                   [--video.index VIDEO.INDEX]
-                   [--cpu | --first-gpu | --last-gpu | --gpu GPU]
-                   [--peak_threshold PEAK_THRESHOLD] [--batch_size BATCH_SIZE]
-                   [--open-in-gui] [--tracking.tracker TRACKING.TRACKER]
-                   [--tracking.target_instance_count TRACKING.TARGET_INSTANCE_COUNT]
-                   [--tracking.pre_cull_to_target TRACKING.PRE_CULL_TO_TARGET]
-                   [--tracking.pre_cull_iou_threshold TRACKING.PRE_CULL_IOU_THRESHOLD]
+usage: sleap-track [-h] [-m MODELS] [--frames FRAMES] [--only-labeled-frames] [--only-suggested-frames] [-o OUTPUT] [--no-empty-frames]
+                   [--verbosity {none,rich,json}] [--video.dataset VIDEO.DATASET] [--video.input_format VIDEO.INPUT_FORMAT]
+                   [--video.index VIDEO.INDEX] [--cpu | --first-gpu | --last-gpu | --gpu GPU] [--max_edge_length_ratio MAX_EDGE_LENGTH_RATIO]
+                   [--dist_penalty_weight DIST_PENALTY_WEIGHT] [--batch_size BATCH_SIZE] [--open-in-gui] [--peak_threshold PEAK_THRESHOLD]
+                   [-n MAX_INSTANCES] [--tracking.tracker TRACKING.TRACKER] [--tracking.max_tracking TRACKING.MAX_TRACKING]
+                   [--tracking.max_tracks TRACKING.MAX_TRACKS] [--tracking.target_instance_count TRACKING.TARGET_INSTANCE_COUNT]
+                   [--tracking.pre_cull_to_target TRACKING.PRE_CULL_TO_TARGET] [--tracking.pre_cull_iou_threshold TRACKING.PRE_CULL_IOU_THRESHOLD]
                    [--tracking.post_connect_single_breaks TRACKING.POST_CONNECT_SINGLE_BREAKS]
-                   [--tracking.clean_instance_count TRACKING.CLEAN_INSTANCE_COUNT]
-                   [--tracking.clean_iou_threshold TRACKING.CLEAN_IOU_THRESHOLD]
-                   [--tracking.similarity TRACKING.SIMILARITY]
-                   [--tracking.match TRACKING.MATCH]
-                   [--tracking.track_window TRACKING.TRACK_WINDOW]
-                   [--tracking.save_shifted_instances TRACKING.SAVE_SHIFTED_INSTANCES]
-                   [--tracking.min_new_track_points TRACKING.MIN_NEW_TRACK_POINTS]
-                   [--tracking.min_match_points TRACKING.MIN_MATCH_POINTS]
-                   [--tracking.img_scale TRACKING.IMG_SCALE]
-                   [--tracking.of_window_size TRACKING.OF_WINDOW_SIZE]
-                   [--tracking.of_max_levels TRACKING.OF_MAX_LEVELS]
-                   [--tracking.kf_node_indices TRACKING.KF_NODE_INDICES]
+                   [--tracking.clean_instance_count TRACKING.CLEAN_INSTANCE_COUNT] [--tracking.clean_iou_threshold TRACKING.CLEAN_IOU_THRESHOLD]
+                   [--tracking.similarity TRACKING.SIMILARITY] [--tracking.match TRACKING.MATCH] [--tracking.robust TRACKING.ROBUST]
+                   [--tracking.track_window TRACKING.TRACK_WINDOW] [--tracking.min_new_track_points TRACKING.MIN_NEW_TRACK_POINTS]
+                   [--tracking.min_match_points TRACKING.MIN_MATCH_POINTS] [--tracking.img_scale TRACKING.IMG_SCALE]
+                   [--tracking.of_window_size TRACKING.OF_WINDOW_SIZE] [--tracking.of_max_levels TRACKING.OF_MAX_LEVELS]
+                   [--tracking.save_shifted_instances TRACKING.SAVE_SHIFTED_INSTANCES] [--tracking.kf_node_indices TRACKING.KF_NODE_INDICES]
                    [--tracking.kf_init_frame_count TRACKING.KF_INIT_FRAME_COUNT]
                    [data_path]
 
 positional arguments:
-  data_path             Path to data to predict on. This can be a labels
-                        (.slp) file or any supported video format.
+  data_path             Path to data to predict on. This can be a labels (.slp) file or any supported video format.
 
 optional arguments:
   -h, --help            show this help message and exit
   -m MODELS, --model MODELS
-                        Path to trained model directory (with
-                        training_config.json). Multiple models can be
-                        specified, each preceded by --model.
-  --frames FRAMES       List of frames to predict when running on a video. Can
-                        be specified as a comma separated list (e.g. 1,2,3) or
-                        a range separated by hyphen (e.g., 1-3, for 1,2,3). If
-                        not provided, defaults to predicting on the entire
-                        video.
+                        Path to trained model directory (with training_config.json). Multiple models can be specified, each preceded by --model.
+  --frames FRAMES       List of frames to predict when running on a video. Can be specified as a comma separated list (e.g. 1,2,3) or a range
+                        separated by hyphen (e.g., 1-3, for 1,2,3). If not provided, defaults to predicting on the entire video.
   --only-labeled-frames
-                        Only run inference on user labeled frames when running
-                        on labels dataset. This is useful for generating
-                        predictions to compare against ground truth.
+                        Only run inference on user labeled frames when running on labels dataset. This is useful for generating predictions to compare
+                        against ground truth.
   --only-suggested-frames
-                        Only run inference on unlabeled suggested frames when
-                        running on labels dataset. This is useful for
-                        generating predictions for initialization during
-                        labeling.
+                        Only run inference on unlabeled suggested frames when running on labels dataset. This is useful for generating predictions for
+                        initialization during labeling.
   -o OUTPUT, --output OUTPUT
-                        The output filename to use for the predicted data. If
-                        not provided, defaults to
-                        '[data_path].predictions.slp' if generating predictions or
-                        '[data_path].[tracker].[similarity method].[matching method].slp'
-                        if retracking predictions.
-  --no-empty-frames     Clear any empty frames that did not have any detected
-                        instances before saving to output.
-  -n, --max_instances MAX_INSTANCES
-                        Limit maximum number of instances in multi-instance models.
-                        Not available for ID models. Defaults to None.
+                        The output filename to use for the predicted data. If not provided, defaults to '[data_path].predictions.slp'.
+  --no-empty-frames     Clear any empty frames that did not have any detected instances before saving to output.
   --verbosity {none,rich,json}
-                        Verbosity of inference progress reporting. 'none' does
-                        not output anything during inference, 'rich' displays
-                        an updating progress bar, and 'json' outputs the
-                        progress as a JSON encoded response to the console.
+                        Verbosity of inference progress reporting. 'none' does not output anything during inference, 'rich' displays an updating
+                        progress bar, and 'json' outputs the progress as a JSON encoded response to the console.
   --video.dataset VIDEO.DATASET
                         The dataset for HDF5 videos.
   --video.input_format VIDEO.INPUT_FORMAT
                         The input_format for HDF5 videos.
   --video.index VIDEO.INDEX
-                        The index of the video to run inference on. Only used if
-                        data_path points to a labels file.
-  --cpu                 Run inference only on CPU. If not specified, will use
-                        available GPU.
+                        Integer index of video in .slp file to predict on. To be used with an .slp path as an alternative to specifying the video
+                        path.
+  --cpu                 Run inference only on CPU. If not specified, will use available GPU.
   --first-gpu           Run inference on the first GPU, if available.
   --last-gpu            Run inference on the last GPU, if available.
-  --gpu GPU             Run training on the i-th GPU on the system. If 'auto', run on
-                        the GPU with the highest percentage of available memory.
+  --gpu GPU             Run training on the i-th GPU on the system. If 'auto', run on the GPU with the highest percentage of available memory.
   --max_edge_length_ratio MAX_EDGE_LENGTH_RATIO
-                        The maximum expected length of a connected pair of points as a
-                        fraction of the image size. Candidate connections longer than
-                        this length will be penalized during matching. Only applies to
-                        bottom-up (PAF) models.
+                        The maximum expected length of a connected pair of points as a fraction of the image size. Candidate connections longer than
+                        this length will be penalized during matching. Only applies to bottom-up (PAF) models.
   --dist_penalty_weight DIST_PENALTY_WEIGHT
-                        A coefficient to scale weight of the distance penalty. Set to
-                        values greater than 1.0 to enforce the distance penalty more
+                        A coefficient to scale weight of the distance penalty. Set to values greater than 1.0 to enforce the distance penalty more
                         strictly. Only applies to bottom-up (PAF) models.
-  --peak_threshold PEAK_THRESHOLD
-                        Minimum confidence map value to consider a peak as
-                        valid.
   --batch_size BATCH_SIZE
-                        Number of frames to predict at a time. Larger values
-                        result in faster inference speeds, but require more
-                        memory.
-  --open-in-gui         Open the resulting predictions in the GUI when
-                        finished.
+                        Number of frames to predict at a time. Larger values result in faster inference speeds, but require more memory.
+  --open-in-gui         Open the resulting predictions in the GUI when finished.
+  --peak_threshold PEAK_THRESHOLD
+                        Minimum confidence map value to consider a peak as valid.
+  -n MAX_INSTANCES, --max_instances MAX_INSTANCES
+                        Limit maximum number of instances in multi-instance models. Not available for ID models. Defaults to None.
   --tracking.tracker TRACKING.TRACKER
-                        Options: simple, flow, None (default: None)
+                        Options: simple, flow, simplemaxtracks, flowmaxtracks, None (default: None)
+  --tracking.max_tracking TRACKING.MAX_TRACKING
+                        If true then the tracker will cap the max number of tracks. (default: False)
+  --tracking.max_tracks TRACKING.MAX_TRACKS
+                        Maximum number of tracks to be tracked by the tracker. (default: None)
   --tracking.target_instance_count TRACKING.TARGET_INSTANCE_COUNT
-                        Target number of instances to track per frame.
-                        (default: 0)
+                        Target number of instances to track per frame. (default: 0)
   --tracking.pre_cull_to_target TRACKING.PRE_CULL_TO_TARGET
-                        If non-zero and target_instance_count is also non-
-                        zero, then cull instances over target count per frame
-                        *before* tracking. (default: 0)
+                        If non-zero and target_instance_count is also non-zero, then cull instances over target count per frame *before* tracking.
+                        (default: 0)
   --tracking.pre_cull_iou_threshold TRACKING.PRE_CULL_IOU_THRESHOLD
-                        If non-zero and pre_cull_to_target also set, then use
-                        IOU threshold to remove overlapping instances over
-                        count *before* tracking. (default: 0)
+                        If non-zero and pre_cull_to_target also set, then use IOU threshold to remove overlapping instances over count *before*
+                        tracking. (default: 0)
   --tracking.post_connect_single_breaks TRACKING.POST_CONNECT_SINGLE_BREAKS
-                        If non-zero and target_instance_count is also non-
-                        zero, then connect track breaks when exactly one track
-                        is lost and exactly one track is spawned in frame.
-                        (default: 0)
+                        If non-zero and target_instance_count is also non-zero, then connect track breaks when exactly one track is lost and exactly
+                        one track is spawned in frame. (default: 0)
   --tracking.clean_instance_count TRACKING.CLEAN_INSTANCE_COUNT
-                        Target number of instances to clean *after* tracking.
-                        (default: 0)
+                        Target number of instances to clean *after* tracking. (default: 0)
   --tracking.clean_iou_threshold TRACKING.CLEAN_IOU_THRESHOLD
-                        IOU to use when culling instances *after* tracking.
-                        (default: 0)
+                        IOU to use when culling instances *after* tracking. (default: 0)
   --tracking.similarity TRACKING.SIMILARITY
                         Options: instance, centroid, iou (default: instance)
   --tracking.match TRACKING.MATCH
                         Options: hungarian, greedy (default: greedy)
+  --tracking.robust TRACKING.ROBUST
+                        Robust quantile of similarity score for instance matching. If equal to 1, keep the max similarity score (non-robust).
+                        (default: 1)
   --tracking.track_window TRACKING.TRACK_WINDOW
                         How many frames back to look for matches (default: 5)
-  --tracking.save_shifted_instances TRACKING.SAVE_SHIFTED_INSTANCES
-                        For optical-flow: Save the shifted instances between
-                        elapsed frames for optimal comparison (default: 0)
   --tracking.min_new_track_points TRACKING.MIN_NEW_TRACK_POINTS
-                        Minimum number of instance points for spawning new
-                        track (default: 0)
+                        Minimum number of instance points for spawning new track (default: 0)
   --tracking.min_match_points TRACKING.MIN_MATCH_POINTS
                         Minimum points for match candidates (default: 0)
   --tracking.img_scale TRACKING.IMG_SCALE
                         For optical-flow: Image scale (default: 1.0)
   --tracking.of_window_size TRACKING.OF_WINDOW_SIZE
-                        For optical-flow: Optical flow window size to consider
-                        at each pyramid (default: 21)
+                        For optical-flow: Optical flow window size to consider at each pyramid (default: 21)
   --tracking.of_max_levels TRACKING.OF_MAX_LEVELS
-                        For optical-flow: Number of pyramid scale levels to
-                        consider (default: 3)
+                        For optical-flow: Number of pyramid scale levels to consider (default: 3)
+  --tracking.save_shifted_instances TRACKING.SAVE_SHIFTED_INSTANCES
+                        If non-zero and tracking.tracker is set to flow, save the shifted instances between elapsed frames (default: 0)
   --tracking.kf_node_indices TRACKING.KF_NODE_INDICES
-                        For Kalman filter: Indices of nodes to track.
-                        (default: )
+                        For Kalman filter: Indices of nodes to track. (default: )
   --tracking.kf_init_frame_count TRACKING.KF_INIT_FRAME_COUNT
-                        For Kalman filter: Number of frames to track with
-                        other tracker. 0 means no Kalman filters will be used.
-                        (default: 0)
+                        For Kalman filter: Number of frames to track with other tracker. 0 means no Kalman filters will be used. (default: 0)
+```
+
+#### Examples:
+
+**1. Simple inference without tracking:**
+
+```none
+sleap-track -m "models/my_model" -o "output_predictions.slp" "input_video.mp4"
+```
+
+**2. Inference with multi-model pipelines (e.g., top-down):**
+
+```none
+sleap-track -m "models/centroid" -m "models/centered_instance" -o "output_predictions.slp" "input_video.mp4"
+```
+
+**3. Inference on suggested frames of a labeling project:**
+
+```none
+sleap-track -m "models/my_model" --only-suggested-frames -o "labels_with_predictions.slp" "labels.v005.slp"
+```
+
+The resulting `labels_with_predictions.slp` can then merged into the base labels project from the SLEAP GUI via **File** --> **Merge into project...**.
+
+**4. Inference with simple tracking:**
+
+```none
+sleap-track -m "models/my_model" --tracking.tracker simple -o "output_predictions.slp" "input_video.mp4"
+```
+
+**5. Inference with max tracks limit:**
+
+```none
+sleap-track -m "models/my_model" --tracking.tracker simplemaxtracks --tracking.max_tracking 1 --tracking.max_tracks 4 -o "output_predictions.slp" "input_video.mp4"
+```
+
+**6. Re-tracking without pose inference:**
+
+```none
+sleap-track --tracking.tracker simplemaxtracks --tracking.max_tracking 1 --tracking.max_tracks 4 -o "retracked.slp" "input_predictions.slp"
+```
+
+**7. Select GPU for pose inference:**
+
+```none
+sleap-track --gpu 1 ...
+```
+
+**8. Select subset of frames to predict on:**
+
+```none
+sleap-track -m "models/my_model" --frames 1000-2000 "input_video.mp4"
 ```
 
 ## Dataset files

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -376,28 +376,39 @@ inference:
   none:
 
   flow:
-    - type: text
-      text: '<b>Pre-tracker data cleaning</b>:'
-    - name: tracking.target_instance_count
-      label: Target Number of Instances Per Frame
-      type: optional_int
-      none_label: No target
-      default_disabled: true
-      range: 1,100
-      default: 1
-    - name: tracking.pre_cull_to_target
-      label: Cull to Target Instance Count
-      type: bool
-      default: false
-    - name: tracking.pre_cull_iou_threshold
-      label: Cull using IoU Threshold
-      type: double
-      default: 0.8
+    # - type: text
+    #   text: '<b>Pre-tracker data cleaning</b>:'
+    # - name: tracking.target_instance_count
+    #   label: Target Number of Instances Per Frame
+    #   type: optional_int
+    #   none_label: No target
+    #   default_disabled: true
+    #   range: 1,100
+    #   default: 1
+    # - name: tracking.pre_cull_to_target
+    #   label: Cull to Target Instance Count
+    #   type: bool
+    #   default: false
+    # - name: tracking.pre_cull_iou_threshold
+    #   label: Cull using IoU Threshold
+    #   type: double
+    #   default: 0.8
     - type: text
       text: '<b>Tracking with optical flow</b>:<br />
       This tracker "shifts" instances from previous frames using optical flow
       before matching instances in each frame to the <i>shifted</i> instances from
       prior frames.'
+    # - name: tracking.max_tracking
+    #   label: Limit max number of tracks
+    #   type: bool
+      default: false
+    - name: tracking.max_tracks
+      label: Max number of tracks
+      type: optional_int
+      none_label: No limit
+      default_disabled: true
+      range: 1,100
+      default: 1
     - name: tracking.similarity
       label: Similarity Method
       type: list
@@ -422,10 +433,10 @@ inference:
       none_label: Use max (non-robust)
       range: 0,1
       default: 0.95
-    - name: tracking.save_shifted_instances
-      label: Save shifted instances
-      type: bool
-      default: false
+    # - name: tracking.save_shifted_instances
+    #   label: Save shifted instances
+    #   type: bool
+    #   default: false
     - type: text
       text: '<b>Kalman filter-based tracking</b>:<br />
       Uses the above tracking options to track instances for an initial
@@ -449,27 +460,38 @@ inference:
       default: false
 
   simple:
-    - type: text
-      text: '<b>Pre-tracker data cleaning</b>:'
-    - name: tracking.target_instance_count
-      label: Target Number of Instances Per Frame
-      type: optional_int
-      none_label: No target
-      default_disabled: true
-      range: 1,100
-      default: 1
-    - name: tracking.pre_cull_to_target
-      label: Cull to Target Instance Count
-      type: bool
-      default: false
-    - name: tracking.pre_cull_iou_threshold
-      label: Cull using IoU Threshold
-      type: double
-      default: 0.8
+    # - type: text
+    #   text: '<b>Pre-tracker data cleaning</b>:'
+    # - name: tracking.target_instance_count
+    #   label: Target Number of Instances Per Frame
+    #   type: optional_int
+    #   none_label: No target
+    #   default_disabled: true
+    #   range: 1,100
+    #   default: 1
+    # - name: tracking.pre_cull_to_target
+    #   label: Cull to Target Instance Count
+    #   type: bool
+    #   default: false
+    # - name: tracking.pre_cull_iou_threshold
+    #   label: Cull using IoU Threshold
+    #   type: double
+    #   default: 0.8
     - type: text
       text: '<b>Tracking</b>:<br />
         This tracker assigns track identities by matching instances from prior
         frames to instances on subsequent frames.'
+    # - name: tracking.max_tracking
+    #   label: Limit max number of tracks
+    #   type: bool
+    #   default: false
+    - name: tracking.max_tracks
+      label: Max number of tracks
+      type: optional_int
+      none_label: No limit
+      default_disabled: true
+      range: 1,100
+      default: 1
     - name: tracking.similarity
       label: Similarity Method
       type: list

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -224,6 +224,7 @@ class InferenceTask:
 
         optional_items_as_nones = (
             "tracking.target_instance_count",
+            "tracking.max_tracks",
             "tracking.kf_init_frame_count",
             "tracking.robust",
             "max_instances",
@@ -233,6 +234,16 @@ class InferenceTask:
             if key in self.inference_params and self.inference_params[key] is None:
                 del self.inference_params[key]
 
+        # Setting max_tracks to True means we want to use the max_tracking mode.
+        if "tracking.max_tracks" in self.inference_params:
+            self.inference_params["tracking.max_tracking"] = True
+
+            # Hacky:  Update the tracker name to include "maxtracks" suffix.
+            if self.inference_params["tracking.tracker"] in ("simple", "flow"):
+                self.inference_params["tracking.tracker"] = (
+                    self.inference_params["tracking.tracker"] + "maxtracks"
+                )
+
         # --tracking.kf_init_frame_count enables the kalman filter tracking
         # so if not set, then remove other (unused) args
         if "tracking.kf_init_frame_count" not in self.inference_params:
@@ -241,6 +252,7 @@ class InferenceTask:
 
         bool_items_as_ints = (
             "tracking.pre_cull_to_target",
+            "tracking.max_tracking",
             "tracking.post_connect_single_breaks",
             "tracking.save_shifted_instances",
         )

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -333,9 +333,6 @@ class Track:
         """
         return attr.asdict(self) == attr.asdict(other)
 
-    def __hash__(self) -> int:
-        return hash(self.spawned_on, self.name)
-
 
 # NOTE:
 # Instance cannot be a slotted class at the moment. This is because it creates

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -333,6 +333,9 @@ class Track:
         """
         return attr.asdict(self) == attr.asdict(other)
 
+    def __hash__(self) -> int:
+        return hash((self.spawned_on, self.name))
+
 
 # NOTE:
 # Instance cannot be a slotted class at the moment. This is because it creates

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -333,9 +333,6 @@ class Track:
         """
         return attr.asdict(self) == attr.asdict(other)
 
-    def __hash__(self) -> int:
-        return hash((self.spawned_on, self.name))
-
 
 # NOTE:
 # Instance cannot be a slotted class at the moment. This is because it creates

--- a/sleap/instance.py
+++ b/sleap/instance.py
@@ -333,6 +333,9 @@ class Track:
         """
         return attr.asdict(self) == attr.asdict(other)
 
+    def __hash__(self) -> int:
+        return hash(self.spawned_on, self.name)
+
 
 # NOTE:
 # Instance cannot be a slotted class at the moment. This is because it creates

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -68,7 +68,7 @@ from sleap.nn.data.pipelines import (
 )
 from sleap.nn.utils import reset_input_layer
 from sleap.io.dataset import Labels
-from sleap.util import frame_list
+from sleap.util import frame_list, make_scoped_dictionary
 from sleap.instance import PredictedInstance, LabeledFrame
 
 from tensorflow.python.framework.convert_to_constants import (
@@ -4773,8 +4773,7 @@ def load_model(
             be performed.
         tracker_window: Number of frames of history to use when tracking. No effect when
             `tracker` is `None`.
-        tracker_max_instances: If not `None`, discard instances beyond this count when
-            tracking. No effect when `tracker` is `None`.
+        tracker_max_instances: If not `None`, create at most this many tracks.
         disable_gpu_preallocation: If `True` (the default), initialize the GPU and
             disable preallocation of memory. This is necessary to prevent freezing on
             some systems with low GPU memory and has negligible impact on performance.
@@ -4863,11 +4862,18 @@ def load_model(
     )
     predictor.verbosity = progress_reporting
     if tracker is not None:
+        use_max_tracker = tracker_max_instances is not None
+        if use_max_tracker and not tracker.endswith("maxtracks"):
+            # Append maxtracks to the tracker name to use the right tracker variants.
+            tracker += "maxtracks"
+            
         predictor.tracker = Tracker.make_tracker_by_name(
             tracker=tracker,
             track_window=tracker_window,
             post_connect_single_breaks=True,
-            clean_instance_count=tracker_max_instances,
+            max_tracking=use_max_tracker,
+            max_tracks=tracker_max_instances,
+            # clean_instance_count=tracker_max_instances,
         )
 
     # Remove temp dirs.
@@ -5335,7 +5341,7 @@ def _make_tracker_from_cli(args: argparse.Namespace) -> Optional[Tracker]:
     Returns:
         An instance of `Tracker` or `None` if tracking method was not specified.
     """
-    policy_args = sleap.util.make_scoped_dictionary(vars(args), exclude_nones=True)
+    policy_args = make_scoped_dictionary(vars(args), exclude_nones=True)
     if "tracking" in policy_args:
         tracker = Tracker.make_tracker_by_name(**policy_args["tracking"])
         return tracker

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4866,7 +4866,7 @@ def load_model(
         if use_max_tracker and not tracker.endswith("maxtracks"):
             # Append maxtracks to the tracker name to use the right tracker variants.
             tracker += "maxtracks"
-            
+
         predictor.tracker = Tracker.make_tracker_by_name(
             tracker=tracker,
             track_window=tracker_window,

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -4824,6 +4824,7 @@ def load_model(
         # Uncompress ZIP packaged models.
         tmp_dirs = []
         for i, model_path in enumerate(model_paths):
+            mp = Path(model_path)
             if model_path.endswith(".zip"):
                 # Create temp dir on demand.
                 tmp_dir = tempfile.TemporaryDirectory()
@@ -4834,7 +4835,12 @@ def load_model(
 
                 # Extract and replace in the list.
                 shutil.unpack_archive(model_path, extract_dir=tmp_dir.name)
-                model_paths[i] = tmp_dir.name
+                unzipped_mp = Path(tmp_dir.name, mp.name).with_suffix("")
+                if Path(unzipped_mp, "best_model.h5").exists():
+                    unzipped_model_path = str(unzipped_mp)
+                else:
+                    unzipped_model_path = str(unzipped_mp.parent)
+                model_paths[i] = unzipped_model_path
 
         return model_paths, tmp_dirs
 

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -414,7 +414,9 @@ class Tracker(BaseTracker):
     matching_function: Callable = greedy_matching
     candidate_maker: object = attr.ib(factory=FlowCandidateMaker)
     track_local_deque: bool = False
-    tracks: Dict[int, Deque[Track]] # Hold tracks, each as a deque with length as track_window
+    tracks: Dict[
+        int, Deque[Track]
+    ]  # Hold tracks, each as a deque with length as track_window
 
     cleaner: Optional[Callable] = None  # TODO: deprecate
     target_instance_count: int = 0
@@ -607,7 +609,7 @@ class Tracker(BaseTracker):
         robust: float = 1.0,
         min_new_track_points: int = 0,
         min_match_points: int = 0,
-        track_loacl_deque: bool = False,
+        track_local_deque: bool = False,
         # Optical flow options
         img_scale: float = 1.0,
         of_window_size: int = 21,

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -413,6 +413,7 @@ class Tracker(BaseTracker):
     similarity_function: Optional[Callable] = instance_similarity
     matching_function: Callable = greedy_matching
     candidate_maker: object = attr.ib(factory=FlowCandidateMaker)
+    tracks: dict() # Hold tracks, each as a deque with length as track_window
 
     cleaner: Optional[Callable] = None  # todo: deprecate
     target_instance_count: int = 0

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -771,6 +771,13 @@ class Tracker(BaseTracker):
             if inst.n_visible_points < self.min_new_track_points:
                 continue
 
+            # Skip if we've reached the maximum number of tracks.
+            if (
+                self.max_tracking
+                and len(self.track_matching_queue_dict) >= self.max_tracks
+            ):
+                break
+
             # Spawn new track.
             new_track = Track(spawned_on=t, name=f"track_{len(self.spawned_tracks)}")
             self.spawned_tracks.append(new_track)

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -413,9 +413,10 @@ class Tracker(BaseTracker):
     similarity_function: Optional[Callable] = instance_similarity
     matching_function: Callable = greedy_matching
     candidate_maker: object = attr.ib(factory=FlowCandidateMaker)
-    tracks: dict()  # Hold tracks, each as a deque with length as track_window
+    track_local_deque: bool = False
+    tracks: Dict[int, Deque[Track]] # Hold tracks, each as a deque with length as track_window
 
-    cleaner: Optional[Callable] = None  # todo: deprecate
+    cleaner: Optional[Callable] = None  # TODO: deprecate
     target_instance_count: int = 0
     pre_cull_function: Optional[Callable] = None
     post_connect_single_breaks: bool = False
@@ -606,6 +607,7 @@ class Tracker(BaseTracker):
         robust: float = 1.0,
         min_new_track_points: int = 0,
         min_match_points: int = 0,
+        track_loacl_deque: bool = False,
         # Optical flow options
         img_scale: float = 1.0,
         of_window_size: int = 21,

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -413,7 +413,7 @@ class Tracker(BaseTracker):
     similarity_function: Optional[Callable] = instance_similarity
     matching_function: Callable = greedy_matching
     candidate_maker: object = attr.ib(factory=FlowCandidateMaker)
-    tracks: dict() # Hold tracks, each as a deque with length as track_window
+    tracks: dict()  # Hold tracks, each as a deque with length as track_window
 
     cleaner: Optional[Callable] = None  # todo: deprecate
     target_instance_count: int = 0

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -747,6 +747,7 @@ class Tracker(BaseTracker):
             cleaner=cleaner,
             pre_cull_function=pre_cull_function,
             max_tracking=max_tracking,
+            max_tracks=max_tracks,
             target_instance_count=target_instance_count,
             post_connect_single_breaks=post_connect_single_breaks,
         )

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -409,14 +409,14 @@ class Tracker(BaseTracker):
             0.95 is a good value.
     """
 
+    track_map: Dict[
+        int, Deque[InstanceType]
+    ]  # Hold tracks, each as a deque with length as track_window
     track_window: int = 5
     similarity_function: Optional[Callable] = instance_similarity
     matching_function: Callable = greedy_matching
     candidate_maker: object = attr.ib(factory=FlowCandidateMaker)
     track_local_deque: bool = False
-    tracks: Dict[
-        int, Deque[Track]
-    ]  # Hold tracks, each as a deque with length as track_window
 
     cleaner: Optional[Callable] = None  # TODO: deprecate
     target_instance_count: int = 0

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -550,14 +550,14 @@ class Tracker(BaseTracker):
 
                 else:
                     t = 0
-
-            if len(self.track_matching_queue) > 0:
-
-                # Default to last timestep + 1 if available.
-                t = self.track_matching_queue[-1].t + 1
-
             else:
-                t = 0
+                if len(self.track_matching_queue) > 0:
+
+                    # Default to last timestep + 1 if available.
+                    t = self.track_matching_queue[-1].t + 1
+
+                else:
+                    t = 0
 
         # Initialize containers for tracked instances at the current timestep.
         tracked_instances = []

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -51,7 +51,8 @@ from sleap.nn.inference import (
     main as sleap_track,
     export_cli as sleap_export,
 )
-from sleap.nn.tracking import FlowCandidateMaker, Tracker
+from sleap.nn.tracking import FlowCandidateMaker, FlowMaxTracksCandidateMaker, Tracker
+from sleap.instance import Track
 
 
 sleap.nn.system.use_cpu_only()

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -1335,7 +1335,8 @@ def test_topdown_id_predictor_save(
 
 
 @pytest.mark.parametrize(
-    "output_path,tracker_method", [("not_default", "flow"), (None, "simple")]
+    "output_path,tracker_method",
+    [("not_default", "flow"), (None, "simple"), (None, "simplemaxtracks")],
 )
 def test_retracking(
     centered_pair_predictions: Labels, tmpdir, output_path, tracker_method
@@ -1350,6 +1351,9 @@ def test_retracking(
     )
     if tracker_method == "flow":
         cmd += " --tracking.save_shifted_instances 1"
+    elif tracker_method == "simplemaxtracks":
+        cmd += " --tracking.max_tracking 1"
+        cmd += " --tracking.max_tracks 2"
     if output_path == "not_default":
         output_path = Path(tmpdir, "tracked_slp.slp")
         cmd += f" --output {output_path}"

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -51,7 +51,12 @@ from sleap.nn.inference import (
     main as sleap_track,
     export_cli as sleap_export,
 )
-from sleap.nn.tracking import FlowCandidateMaker, FlowMaxTracksCandidateMaker, Tracker
+from sleap.nn.tracking import (
+    MatchedFrameInstance,
+    FlowCandidateMaker,
+    FlowMaxTracksCandidateMaker,
+    Tracker,
+)
 from sleap.instance import Track
 
 

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -1,21 +1,23 @@
 import ast
-from typing import cast
-import pytest
-import numpy as np
 import json
-from sleap.io.dataset import Labels
-from sleap.nn.tracking import FlowCandidateMaker, Tracker
-import tensorflow as tf
-import sleap
-from numpy.testing import assert_array_equal, assert_allclose
+import zipfile
 from pathlib import Path
+from typing import cast
+
+import numpy as np
+import pytest
+import tensorflow as tf
 import tensorflow_hub as hub
+from numpy.testing import assert_array_equal, assert_allclose
+
+import sleap
+from sleap.gui.learning import runners
+from sleap.io.dataset import Labels
 from sleap.nn.data.confidence_maps import (
     make_confmaps,
     make_grid_vectors,
     make_multi_confmaps,
 )
-
 from sleap.nn.inference import (
     InferenceLayer,
     InferenceModel,
@@ -49,9 +51,8 @@ from sleap.nn.inference import (
     main as sleap_track,
     export_cli as sleap_export,
 )
+from sleap.nn.tracking import FlowCandidateMaker, Tracker
 
-
-from sleap.gui.learning import runners
 
 sleap.nn.system.use_cpu_only()
 
@@ -830,6 +831,47 @@ def test_topdown_multiclass_predictor_high_threshold(
     labels_pr = predictor.predict(labels_gt)
     assert len(labels_pr) == 1
     assert len(labels_pr[0].instances) == 0
+
+
+def zip_directory_with_itself(src_dir, output_path):
+    """Zip a directory, including the directory itself.
+
+    Args:
+        src_dir: Path to directory to zip.
+        output_path: Path to output zip file.
+    """
+
+    src_path = Path(src_dir)
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        for file_path in src_path.rglob("*"):
+            arcname = src_path.name / file_path.relative_to(src_path)
+            zipf.write(file_path, arcname)
+
+
+def zip_directory_contents(src_dir, output_path):
+    """Zip the contents of a directory, not the directory itself.
+
+    Args:
+        src_dir: Path to directory to zip.
+        output_path: Path to output zip file.
+    """
+
+    src_path = Path(src_dir)
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
+        for file_path in src_path.rglob("*"):
+            arcname = file_path.relative_to(src_path)
+            zipf.write(file_path, arcname)
+
+
+@pytest.mark.parametrize(
+    "zip_func", [zip_directory_with_itself, zip_directory_contents]
+)
+def test_load_model_zipped(tmpdir, min_centroid_model_path, zip_func):
+    mp = Path(min_centroid_model_path)
+    zip_dir = Path(tmpdir, mp.name).with_name(mp.name + ".zip")
+    zip_func(mp, zip_dir)
+
+    predictor = load_model(str(zip_dir))
 
 
 @pytest.mark.parametrize("resize_input_shape", [True, False])

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -1336,7 +1336,12 @@ def test_topdown_id_predictor_save(
 
 @pytest.mark.parametrize(
     "output_path,tracker_method",
-    [("not_default", "flow"), (None, "simple"), (None, "simplemaxtracks")],
+    [
+        ("not_default", "flow"),
+        ("not_default", "flowmaxtracks"),
+        (None, "simple"),
+        (None, "simplemaxtracks"),
+    ],
 )
 def test_retracking(
     centered_pair_predictions: Labels, tmpdir, output_path, tracker_method
@@ -1351,7 +1356,7 @@ def test_retracking(
     )
     if tracker_method == "flow":
         cmd += " --tracking.save_shifted_instances 1"
-    elif tracker_method == "simplemaxtracks":
+    elif tracker_method == "simplemaxtracks" or tracker_method == "flowmaxtracks":
         cmd += " --tracking.max_tracking 1"
         cmd += " --tracking.max_tracks 2"
     if output_path == "not_default":

--- a/tests/nn/test_tracker_components.py
+++ b/tests/nn/test_tracker_components.py
@@ -14,7 +14,7 @@ from sleap.instance import PredictedInstance
 from sleap.skeleton import Skeleton
 
 
-@pytest.mark.parametrize("tracker", ["simple", "flow"])
+@pytest.mark.parametrize("tracker", ["simple", "flow", "simplemaxtracks"])
 @pytest.mark.parametrize("similarity", ["instance", "iou", "centroid"])
 @pytest.mark.parametrize("match", ["greedy", "hungarian"])
 @pytest.mark.parametrize("count", [0, 2])

--- a/tests/nn/test_tracker_components.py
+++ b/tests/nn/test_tracker_components.py
@@ -168,3 +168,202 @@ def test_frame_match_object():
 
     assert matches[1].track == "track b"
     assert matches[1].instance == "instance b"
+
+
+def test_max_tracking():
+    skel = Skeleton.from_names_and_edge_inds(
+        ["A", "B", "C"], edge_inds=[[0, 1], [1, 2]]
+    )
+
+    def make_inst(x, y):
+        pts = np.array([[-0.1, -0.1], [0.0, 0.0], [0.1, 0.1]]) + np.array([[x, y]])
+        return PredictedInstance.from_numpy(pts, [1, 1, 1], 1, skel)
+
+    # Track 2 instances with gap > window size
+    preds = [
+        [
+            make_inst(0, 0),
+            make_inst(0, 1),
+        ],
+        [
+            make_inst(0.1, 0),
+            make_inst(0.1, 1),
+        ],
+        [
+            make_inst(0.2, 0),
+            make_inst(0.2, 1),
+        ],
+        [
+            make_inst(0.3, 0),
+        ],
+        [
+            make_inst(0.4, 0),
+        ],
+        [
+            make_inst(0.5, 0),
+            make_inst(0.5, 1),
+        ],
+        [
+            make_inst(0.6, 0),
+            make_inst(0.6, 1),
+        ],
+    ]
+
+    tracker = Tracker.make_tracker_by_name(
+        tracker="simple",
+        # tracker="simplemaxtracks",
+        match="hungarian",
+        track_window=2,
+        # max_tracks=2,
+        # max_tracking=True,
+    )
+
+    tracked = []
+    for insts in preds:
+        tracked_insts = tracker.track(insts)
+        tracked.append(tracked_insts)
+    all_tracks = list(set([inst.track for frame in tracked for inst in frame]))
+
+    assert len(all_tracks) == 3
+
+    tracker = Tracker.make_tracker_by_name(
+        # tracker="simple",
+        tracker="simplemaxtracks",
+        match="hungarian",
+        track_window=2,
+        max_tracks=2,
+        max_tracking=True,
+    )
+
+    tracked = []
+    for insts in preds:
+        tracked_insts = tracker.track(insts)
+        tracked.append(tracked_insts)
+    all_tracks = list(set([inst.track for frame in tracked for inst in frame]))
+
+    assert len(all_tracks) == 2
+
+    # Test 2 instances with both tracks with gap > window size
+    preds = [
+        [
+            make_inst(0, 0),
+            make_inst(0, 1),
+        ],
+        [
+            make_inst(0.1, 0),
+            make_inst(0.1, 1),
+        ],
+        [
+            make_inst(0.2, 0),
+            make_inst(0.2, 1),
+        ],
+        [],
+        [],
+        [
+            make_inst(0.5, 0),
+            make_inst(0.5, 1),
+        ],
+        [
+            make_inst(0.6, 0),
+            make_inst(0.6, 1),
+        ],
+    ]
+
+    tracker = Tracker.make_tracker_by_name(
+        tracker="simple",
+        # tracker="simplemaxtracks",
+        match="hungarian",
+        track_window=2,
+        # max_tracks=2,
+        # max_tracking=True,
+    )
+
+    tracked = []
+    for insts in preds:
+        tracked_insts = tracker.track(insts)
+        tracked.append(tracked_insts)
+    all_tracks = list(set([inst.track for frame in tracked for inst in frame]))
+
+    assert len(all_tracks) == 4
+
+    tracker = Tracker.make_tracker_by_name(
+        # tracker="simple",
+        tracker="simplemaxtracks",
+        match="hungarian",
+        track_window=2,
+        max_tracks=2,
+        max_tracking=True,
+    )
+
+    tracked = []
+    for insts in preds:
+        tracked_insts = tracker.track(insts)
+        tracked.append(tracked_insts)
+    all_tracks = list(set([inst.track for frame in tracked for inst in frame]))
+
+    assert len(all_tracks) == 2
+
+    # Test having more than 2 detected instances in a frame
+    preds = [
+        [
+            make_inst(0, 0),
+            make_inst(0, 1),
+        ],
+        [
+            make_inst(0.1, 0),
+            make_inst(0.1, 1),
+        ],
+        [
+            make_inst(0.2, 0),
+            make_inst(0.2, 1),
+        ],
+        [
+            make_inst(0.3, 0),
+        ],
+        [
+            make_inst(0.4, 0),
+        ],
+        [
+            make_inst(0.5, 0),
+            make_inst(0.5, 1),
+        ],
+        [
+            make_inst(0.6, 0),
+            make_inst(0.6, 1),
+            make_inst(0.6, 0.5),
+        ],
+    ]
+
+    tracker = Tracker.make_tracker_by_name(
+        tracker="simple",
+        # tracker="simplemaxtracks",
+        match="hungarian",
+        track_window=2,
+        # max_tracks=2,
+        # max_tracking=True,
+    )
+
+    tracked = []
+    for insts in preds:
+        tracked_insts = tracker.track(insts)
+        tracked.append(tracked_insts)
+    all_tracks = list(set([inst.track for frame in tracked for inst in frame]))
+
+    assert len(all_tracks) == 4
+
+    tracker = Tracker.make_tracker_by_name(
+        # tracker="simple",
+        tracker="simplemaxtracks",
+        match="hungarian",
+        track_window=2,
+        max_tracks=2,
+        max_tracking=True,
+    )
+
+    tracked = []
+    for insts in preds:
+        tracked_insts = tracker.track(insts)
+        tracked.append(tracked_insts)
+    all_tracks = list(set([inst.track for frame in tracked for inst in frame]))
+
+    assert len(all_tracks) == 2

--- a/tests/nn/test_tracker_components.py
+++ b/tests/nn/test_tracker_components.py
@@ -170,7 +170,7 @@ def test_frame_match_object():
     assert matches[1].instance == "instance b"
 
 
-def test_max_tracking():
+def make_insts(trx):
     skel = Skeleton.from_names_and_edge_inds(
         ["A", "B", "C"], edge_inds=[[0, 1], [1, 2]]
     )
@@ -179,35 +179,47 @@ def test_max_tracking():
         pts = np.array([[-0.1, -0.1], [0.0, 0.0], [0.1, 0.1]]) + np.array([[x, y]])
         return PredictedInstance.from_numpy(pts, [1, 1, 1], 1, skel)
 
+    insts = []
+    for frame in trx:
+        insts_frame = []
+        for x, y in frame:
+            insts_frame.append(make_inst(x, y))
+        insts.append(insts_frame)
+    return insts
+
+
+def test_max_tracking_large_gap_single_track():
     # Track 2 instances with gap > window size
-    preds = [
+    preds = make_insts(
         [
-            make_inst(0, 0),
-            make_inst(0, 1),
-        ],
-        [
-            make_inst(0.1, 0),
-            make_inst(0.1, 1),
-        ],
-        [
-            make_inst(0.2, 0),
-            make_inst(0.2, 1),
-        ],
-        [
-            make_inst(0.3, 0),
-        ],
-        [
-            make_inst(0.4, 0),
-        ],
-        [
-            make_inst(0.5, 0),
-            make_inst(0.5, 1),
-        ],
-        [
-            make_inst(0.6, 0),
-            make_inst(0.6, 1),
-        ],
-    ]
+            [
+                (0, 0),
+                (0, 1),
+            ],
+            [
+                (0.1, 0),
+                (0.1, 1),
+            ],
+            [
+                (0.2, 0),
+                (0.2, 1),
+            ],
+            [
+                (0.3, 0),
+            ],
+            [
+                (0.4, 0),
+            ],
+            [
+                (0.5, 0),
+                (0.5, 1),
+            ],
+            [
+                (0.6, 0),
+                (0.6, 1),
+            ],
+        ]
+    )
 
     tracker = Tracker.make_tracker_by_name(
         tracker="simple",
@@ -243,31 +255,35 @@ def test_max_tracking():
 
     assert len(all_tracks) == 2
 
+
+def test_max_tracking_small_gap_on_both_tracks():
     # Test 2 instances with both tracks with gap > window size
-    preds = [
+    preds = make_insts(
         [
-            make_inst(0, 0),
-            make_inst(0, 1),
-        ],
-        [
-            make_inst(0.1, 0),
-            make_inst(0.1, 1),
-        ],
-        [
-            make_inst(0.2, 0),
-            make_inst(0.2, 1),
-        ],
-        [],
-        [],
-        [
-            make_inst(0.5, 0),
-            make_inst(0.5, 1),
-        ],
-        [
-            make_inst(0.6, 0),
-            make_inst(0.6, 1),
-        ],
-    ]
+            [
+                (0, 0),
+                (0, 1),
+            ],
+            [
+                (0.1, 0),
+                (0.1, 1),
+            ],
+            [
+                (0.2, 0),
+                (0.2, 1),
+            ],
+            [],
+            [],
+            [
+                (0.5, 0),
+                (0.5, 1),
+            ],
+            [
+                (0.6, 0),
+                (0.6, 1),
+            ],
+        ]
+    )
 
     tracker = Tracker.make_tracker_by_name(
         tracker="simple",
@@ -303,36 +319,40 @@ def test_max_tracking():
 
     assert len(all_tracks) == 2
 
+
+def test_max_tracking_extra_detections():
     # Test having more than 2 detected instances in a frame
-    preds = [
+    preds = make_insts(
         [
-            make_inst(0, 0),
-            make_inst(0, 1),
-        ],
-        [
-            make_inst(0.1, 0),
-            make_inst(0.1, 1),
-        ],
-        [
-            make_inst(0.2, 0),
-            make_inst(0.2, 1),
-        ],
-        [
-            make_inst(0.3, 0),
-        ],
-        [
-            make_inst(0.4, 0),
-        ],
-        [
-            make_inst(0.5, 0),
-            make_inst(0.5, 1),
-        ],
-        [
-            make_inst(0.6, 0),
-            make_inst(0.6, 1),
-            make_inst(0.6, 0.5),
-        ],
-    ]
+            [
+                (0, 0),
+                (0, 1),
+            ],
+            [
+                (0.1, 0),
+                (0.1, 1),
+            ],
+            [
+                (0.2, 0),
+                (0.2, 1),
+            ],
+            [
+                (0.3, 0),
+            ],
+            [
+                (0.4, 0),
+            ],
+            [
+                (0.5, 0),
+                (0.5, 1),
+            ],
+            [
+                (0.6, 0),
+                (0.6, 1),
+                (0.6, 0.5),
+            ],
+        ]
+    )
 
     tracker = Tracker.make_tracker_by_name(
         tracker="simple",

--- a/tests/nn/test_tracker_components.py
+++ b/tests/nn/test_tracker_components.py
@@ -14,7 +14,9 @@ from sleap.instance import PredictedInstance
 from sleap.skeleton import Skeleton
 
 
-@pytest.mark.parametrize("tracker", ["simple", "flow", "simplemaxtracks"])
+@pytest.mark.parametrize(
+    "tracker", ["simple", "flow", "simplemaxtracks", "flowmaxtracks"]
+)
 @pytest.mark.parametrize("similarity", ["instance", "iou", "centroid"])
 @pytest.mark.parametrize("match", ["greedy", "hungarian"])
 @pytest.mark.parametrize("count", [0, 2])

--- a/tests/nn/test_tracking_integration.py
+++ b/tests/nn/test_tracking_integration.py
@@ -116,7 +116,7 @@ def main(f, dir):
         tracker_name, matcher_name, sim_name, max_tracks, max_tracking=False, scale=0
     ):
         if tracker_name == "simplemaxtracks" or tracker_name == "flowmaxtracks":
-            tracker[tracker_name](
+            tracker = tracker[tracker_name](
                 matching_function=matchers[matcher_name],
                 similarity_function=similarities[sim_name],
                 max_tracks=max_tracks,

--- a/tests/nn/test_tracking_integration.py
+++ b/tests/nn/test_tracking_integration.py
@@ -96,6 +96,7 @@ def main(f, dir):
         simple=sleap.nn.tracker.simple.SimpleTracker,
         flow=sleap.nn.tracker.flow.FlowTracker,
         simplemaxtracks=sleap.nn.tracker.SimpleMaxTracker,
+        flowmaxtracks=sleap.nn.tracker.FlowMaxTracker,
     )
     matchers = dict(
         hungarian=sleap.nn.tracker.components.hungarian_matching,
@@ -114,7 +115,7 @@ def main(f, dir):
     def make_tracker(
         tracker_name, matcher_name, sim_name, max_tracks, max_tracking=False, scale=0
     ):
-        if tracker_name == "simplemaxtracks":
+        if tracker_name == "simplemaxtracks" or tracker_name == "flowmaxtracks":
             tracker[tracker_name](
                 matching_function=matchers[matcher_name],
                 similarity_function=similarities[sim_name],
@@ -156,12 +157,24 @@ def main(f, dir):
                             scale=scale,
                         )
                         f(frames, tracker, gt_filename)
+                elif tracker_name == "flowmaxtracks":
+                    # If this tracker supports scale, try multiple scales
+                    for scale in scales:
+                        tracker, gt_filename = make_tracker_and_filename(
+                            tracker_name=tracker_name,
+                            matcher_name=matcher_name,
+                            sim_name=sim_name,
+                            max_tracks=2,
+                            max_tracking=True,
+                            scale=scale,
+                        )
+                        f(frames, tracker, gt_filename)
                 elif tracker_name == "simplemaxtracks":
                     tracker, gt_filename = make_tracker_and_filename(
                         tracker_name=tracker_name,
                         matcher_name=matcher_name,
                         sim_name=sim_name,
-                        max_tracks=5,
+                        max_tracks=2,
                         max_tracking=True,
                         scale=0,
                     )

--- a/tests/nn/test_tracking_integration.py
+++ b/tests/nn/test_tracking_integration.py
@@ -148,7 +148,7 @@ def main(f, dir):
         tracker_name, matcher_name, sim_name, max_tracks, max_tracking=False, scale=0
     ):
         if tracker_name == "simplemaxtracks" or tracker_name == "flowmaxtracks":
-            tracker = tracker[tracker_name](
+            tracker = trackers[tracker_name](
                 matching_function=matchers[matcher_name],
                 similarity_function=similarities[sim_name],
                 max_tracks=max_tracks,

--- a/tests/nn/test_tracking_integration.py
+++ b/tests/nn/test_tracking_integration.py
@@ -95,6 +95,7 @@ def main(f, dir):
     trackers = dict(
         simple=sleap.nn.tracker.simple.SimpleTracker,
         flow=sleap.nn.tracker.flow.FlowTracker,
+        simplemaxtracks=sleap.nn.tracker.SimpleMaxTracker,
     )
     matchers = dict(
         hungarian=sleap.nn.tracker.components.hungarian_matching,
@@ -110,11 +111,21 @@ def main(f, dir):
         0.25,
     )
 
-    def make_tracker(tracker_name, matcher_name, sim_name, scale=0):
-        tracker = trackers[tracker_name](
-            matching_function=matchers[matcher_name],
-            similarity_function=similarities[sim_name],
-        )
+    def make_tracker(
+        tracker_name, matcher_name, sim_name, max_tracks, max_tracking=False, scale=0
+    ):
+        if tracker_name == "simplemaxtracks":
+            tracker[tracker_name](
+                matching_function=matchers[matcher_name],
+                similarity_function=similarities[sim_name],
+                max_tracks=max_tracks,
+                max_tracking=max_tracking,
+            )
+        else:
+            tracker = trackers[tracker_name](
+                matching_function=matchers[matcher_name],
+                similarity_function=similarities[sim_name],
+            )
         if scale:
             tracker.candidate_maker.img_scale = scale
         return tracker
@@ -145,6 +156,16 @@ def main(f, dir):
                             scale=scale,
                         )
                         f(frames, tracker, gt_filename)
+                elif tracker_name == "simplemaxtracks":
+                    tracker, gt_filename = make_tracker_and_filename(
+                        tracker_name=tracker_name,
+                        matcher_name=matcher_name,
+                        sim_name=sim_name,
+                        max_tracks=5,
+                        max_tracking=True,
+                        scale=0,
+                    )
+                    f(frames, tracker, gt_filename)
                 else:
                     tracker, gt_filename = make_tracker_and_filename(
                         tracker_name=tracker_name,

--- a/tests/nn/test_tracking_integration.py
+++ b/tests/nn/test_tracking_integration.py
@@ -3,8 +3,40 @@ import operator
 import os
 import time
 
+import sleap
+from sleap.nn.inference import main as inference_cli
 import sleap.nn.tracker.components
 from sleap.io.dataset import Labels, LabeledFrame
+
+
+def test_simple_tracker(tmpdir, centered_pair_predictions_slp_path):
+    cli = (
+        "--tracking.tracker simple "
+        "--frames 200-300 "
+        f"-o {tmpdir}/simpletracks.slp "
+        f"{centered_pair_predictions_slp_path}"
+    )
+    inference_cli(cli.split(" "))
+
+    labels = sleap.load_file(f"{tmpdir}/simpletracks.slp")
+    assert len(labels.tracks) == 27
+
+
+def test_simplemax_tracker(tmpdir, centered_pair_predictions_slp_path):
+    cli = (
+        "--tracking.tracker simplemaxtracks "
+        "--tracking.max_tracking 1 --tracking.max_tracks 2 "
+        "--frames 200-300 "
+        f"-o {tmpdir}/simplemaxtracks.slp "
+        f"{centered_pair_predictions_slp_path}"
+    )
+    inference_cli(cli.split(" "))
+
+    labels = sleap.load_file(f"{tmpdir}/simplemaxtracks.slp")
+    assert len(labels.tracks) == 2
+
+
+# TODO: Refactor the below things into a real test suite.
 
 
 def make_ground_truth(frames, tracker, gt_filename):


### PR DESCRIPTION
### Description
While performing inference based tracking, the number of tracks that are generated needs to be capped in order to avoid creating multiple irrelevant/redundant tracks. 

We implement a new mode of tracking here to address this by enabling track-local queues to store candidates for matching. This allows for setting the global maximum number of tracks, irrespective of how large the gaps between detections of a track are.

This also exposes that functionality to the `load_model` API, the CLI, and the GUI, where now superseded options such as pre-tracking culling have been removed.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1308

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced maximum tracking and maximum number of tracks options to the `Tracker` class, enhancing its flexibility and functionality.
- New Feature: Added support for these new tracking options in the `load_model` and `_make_tracker_from_cli` functions.
- Test: Expanded test coverage with new test cases for maximum tracking with large gaps, small gaps on both tracks, and extra detections.
- Documentation: Updated CLI documentation to include new tracking options such as `--tracking.max_tracking`, `--tracking.max_tracks`, and `--tracking.robust`.
- Refactor: Adjusted tracker naming conventions based on the presence of `max_tracking` and `max_tracks` parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->