### PR TITLE
Fix drag and drop

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -274,7 +274,7 @@ class MainWindow(QMainWindow):
                 # Load
                 self.commands.openProject(filename=filenames[0], first_open=True)
 
-        elif all([ext.lower() in available_video_exts() for ext in exts]):
+        elif all([ext.lower()[1:] in available_video_exts() for ext in exts]):
             # Import videos
             self.commands.showImportVideos(filenames=filenames)
 


### PR DESCRIPTION
### Description
In #1244, we created a centralized function for querying video extensions, but we're using a notation where there is no `.` character, e.g.:

https://github.com/talmolab/sleap/blob/47f8096d23528b87601519a76f1909906eb8a4dd/sleap/io/video.py#L354

As a result, when checking for the validity of drag and drop inputs, we weren't matching any of the video file types because `Path(...).suffix` returns the extension with the `.`.

This PR fixes that.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
