### PR TITLE
Add message if drag drop fails

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -278,6 +278,12 @@ class MainWindow(QMainWindow):
             # Import videos
             self.commands.showImportVideos(filenames=filenames)
 
+        else:
+            raise TypeError(
+                f"Invalid file type(s) dropped: {', '.join(exts)} \n"
+                f"Expected formats: .slp, .{', .'.join(available_video_exts())}"
+            )
+
     @property
     def labels(self) -> Labels:
         return self.state["labels"]

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -281,7 +281,7 @@ class MainWindow(QMainWindow):
         else:
             raise TypeError(
                 f"Invalid file type(s) dropped: {', '.join(exts)} \n"
-                f"Expected formats: .slp, .{', .'.join(available_video_exts())}"
+                f"Supported formats: .slp, .{', .'.join(available_video_exts())}"
             )
 
     @property

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -274,7 +274,7 @@ class MainWindow(QMainWindow):
                 # Load
                 self.commands.openProject(filename=filenames[0], first_open=True)
 
-        elif all([ext.lower() in available_video_exts() for ext in exts]):
+        elif all([ext.lower()[1:] in available_video_exts() for ext in exts]):
             # Import videos
             self.commands.showImportVideos(filenames=filenames)
 


### PR DESCRIPTION
### Description
I also noticed that the drag and drop was not working (rather than fix it like @talmo in #1449), I was like "Man I could have sworn that was a feature we had". Part of this was because I checked the terminal and did not see any feedback to what might be happening.

This PR adds that bit of feedback - incase the feature breaks in the future or just in general if a user drops an unsupported file:

```python
TypeError: Invalid file type(s) dropped: .yaml, .sh
Expected formats: .slp, .mp4, .avi, .mov, .mj2, .mkv, .h5, .hdf5, .slp, .npy, .npz, .jpg, .jpeg, .png, .tif, .tiff, .json, .yaml
```

P.S. I suppose here we could have allowed the `.yaml` to be loaded, but we use an `all` conditional, so.... Out of the scope of this PR.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (raise error)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
