### PR TITLE
Handle error message edge case when finding yaml paths

### DIFF
--- a/sleap/util.py
+++ b/sleap/util.py
@@ -266,6 +266,8 @@ def get_config_file(
         The full path to the specified config file.
     """
 
+    desired_path = None  # Handle case where get_defaults, but cannot find package_path
+
     if not get_defaults:
         desired_path = os.path.expanduser(
             f"~/.sleap/{sleap_version.__version__}/{shortname}"


### PR DESCRIPTION
### Description
I recently ran into an edge case where a SLEAP-created config file could not be found... the code then raises a `FileNotFoundError` with an informative error message - except it can't actually do this because the error message includes an unbound variable. Whoops.

```python
    f"Cannot locate {shortname} config file at {desired_path} or {package_path}."
UnboundLocalError: local variable 'desired_path' referenced before assignment
```

This PR ropes that variable back into bounds 🤠

```python
    f"Cannot locate {shortname} config file at {desired_path} or {package_path}."
FileNotFoundError: Cannot locate shortcuts.yaml config file at None or /home/talmolab/micromamba/envs/env_2/lib/python3.7/site-packages/sleap/config/shortcuts.yaml.
```

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
