### PR TITLE
Add version restrictions to tensorflow for pypi

### DIFF
--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -32,7 +32,7 @@ scikit-image
 scikit-learn ==1.0.*
 scikit-video
 seaborn
-tensorflow>=2.6.3,<2.11; sys_platform == "win32" and platform_machine != 'arm64'
+tensorflow>=2.6.3,<2.9; sys_platform == "win32"
 tensorflow>=2.6.3,<=2.11; sys_platform != "win32" and platform_machine != 'arm64'
 tensorflow-hub<=0.14.0
 # These dependencies are untested since we do not offer a wheel for apple silicon atm.

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -31,5 +31,7 @@ scikit-image
 scikit-learn ==1.0.*
 scikit-video
 seaborn
-tensorflow
+tensorflow>=2.6.3,<2.9.0; platform_machine != 'arm64'
 tensorflow-hub
+tensorflow-macos==2.9.2; sys_platform == 'darwin' and platform_machine == 'arm64'
+tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -40,6 +40,8 @@ tensorflow-macos==2.9.2; sys_platform == 'darwin' and platform_machine == 'arm64
 tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 
 # Dependencies of dependencies
+# google-auth 2.23.0 has requirement urllib3<2.0
+urllib3<2.0  # Not a 'noticed' runtime-dependency
 # tensorboard 2.11.2 has requirement protobuf<4,>=3.9.2
 # tensorflow 2.11.0 has requirement protobuf<3.20,>=3.9.2
-protobuf<3.20
+protobuf<3.20  # Makes GUI work in windows

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -12,7 +12,6 @@ jsonpickle==1.2
 networkx
 numpy>=1.19.5,<1.23.0
 opencv-python>=4.2.0,<=4.6.0
-# opencv-python-headless>=4.2.0.34,<=4.5.5.62
 pandas
 pillow>=8.3.1,<=8.4.0
 psutil
@@ -34,6 +33,7 @@ seaborn
 tensorflow>=2.6.3,<2.11; sys_platform == "win32" and platform_machine != 'arm64'
 tensorflow>=2.6.3,<=2.11; sys_platform != "win32" and platform_machine != 'arm64'
 tensorflow-hub<=0.14.0
+# These dependencies are untested since we do not offer a wheel for apple silicon atm.
 tensorflow-macos==2.9.2; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -32,8 +32,7 @@ scikit-image
 scikit-learn ==1.0.*
 scikit-video
 seaborn
-tensorflow>=2.6.3,<2.9; sys_platform == "win32"
-tensorflow>=2.6.3,<=2.11; sys_platform != "win32" and platform_machine != 'arm64'
+tensorflow>=2.6.3,<2.9; platform_machine != 'arm64'
 tensorflow-hub<=0.14.0
 # These dependencies are untested since we do not offer a wheel for apple silicon atm.
 tensorflow-macos==2.9.2; sys_platform == 'darwin' and platform_machine == 'arm64'

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -18,7 +18,9 @@ psutil
 pykalman==0.9.5
 PySide2>=5.13.2,<=5.14.1; platform_machine != 'arm64'
 PySide6; sys_platform == 'darwin' and platform_machine == 'arm64'
-python-rapidjson
+# Otherwise error: Microsoft Visual C++ 14.0 is required. 
+python-rapidjson <=1.10; sys_platform == 'win32'
+python-rapidjson; sys_platform != 'win32'
 pyyaml
 pyzmq
 qtpy>=2.0.1

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -31,7 +31,13 @@ scikit-image
 scikit-learn ==1.0.*
 scikit-video
 seaborn
-tensorflow>=2.6.3,<2.9.0; platform_machine != 'arm64'
-tensorflow-hub
+tensorflow>=2.6.3,<2.11; sys_platform == "win32" and platform_machine != 'arm64'
+tensorflow>=2.6.3,<=2.11; sys_platform != "win32" and platform_machine != 'arm64'
+tensorflow-hub<=0.14.0
 tensorflow-macos==2.9.2; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+
+# Dependencies of dependencies
+# tensorboard 2.11.2 has requirement protobuf<4,>=3.9.2
+# tensorflow 2.11.0 has requirement protobuf<3.20,>=3.9.2
+protobuf<3.20


### PR DESCRIPTION
### Description
Add version restrictions to tensorflow for pypi extra. While the conda packages for 1.3.2 were not affected (since `tensorflow` is pulled in from anaconda), the PyPI only package installed via `pip install sleap[pypi]` had conflicts between the version of `tensorflow` and the version of `keras`. 

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1495
- #1483

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the project's dependencies in `requirements.txt` to ensure compatibility across different platforms and machine types. 
- Bug Fix: Added specific version constraints for `python-rapidjson` to address a Microsoft Visual C++ requirement error on Windows.
- New Feature: Introduced support for TensorFlow on Apple Silicon machines by adding `tensorflow-macos` and `tensorflow-metal` dependencies.
- Chore: Added and updated version constraints for several dependencies including `tensorflow`, `tensorflow-hub`, `urllib3`, `google-auth`, and `protobuf` to maintain compatibility and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->