### PR TITLE
Set `LD_LIBRARY_PATH` on `mamba activate`

### DIFF
--- a/.conda/README.md
+++ b/.conda/README.md
@@ -3,7 +3,7 @@ This folder defines the conda package build for Linux and Windows. There are run
 To build, first go to the base repo directory and install the build environment:
 
 ```
-conda env create -f environment_build.yml -n sleap_build && conda activate sleap_build
+mamba env create -f environment_build.yml -n sleap_build && conda activate sleap_build
 ```
 
 And finally, run the build command pointing to this directory:
@@ -15,7 +15,7 @@ conda build .conda --output-folder build -c conda-forge -c nvidia -c https://con
 To install the local package:
 
 ```
-conda create -n sleap_0 -c conda-forge -c nvidia -c ./build -c https://conda.anaconda.org/sleap/ -c anaconda sleap=x.x.x
+mamba create -n sleap_0 -c conda-forge -c nvidia -c ./build -c https://conda.anaconda.org/sleap/ -c anaconda sleap=x.x.x
 ```
 
 replacing x.x.x with the version of SLEAP that you just built.

--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -13,3 +13,11 @@ pip install --no-cache-dir -r ./requirements.txt
 # Install sleap itself. This does not install the requirements, but will list which 
 # requirements are missing (see "install_requires") when user attempts to install.
 python setup.py install --single-version-externally-managed --record=record.txt
+
+# Copy the activate scripts to $PREFIX/etc/conda/activate.d.
+# This will allow them to be run on environment activation.
+export CHANGE=activate
+
+mkdir -p "${PREFIX}/etc/conda/${CHANGE}.d"
+ls "${RECIPE_DIR}"
+cp "${RECIPE_DIR}/${PKG_NAME}_${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"

--- a/.conda/sleap_activate.sh
+++ b/.conda/sleap_activate.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Help CUDA find GPUs!
+export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -349,6 +349,31 @@ pip install tensorflow==2.6.3
 ```
 ````
 
+````{note}
+If you are on Linux, have a NVIDIA GPU, and are having trouble utilizing your GPU:
+
+```bash
+W tensorflow/stream_executor/platform/default/dso_loader.cc:64 Could not load dynamic 
+library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object 
+file: No such file or directory
+```
+
+then activate the environment:
+
+```bash
+mamba activate sleap
+```
+
+and run the commands:
+```bash
+mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+echo '#!/bin/sh' >> $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
+echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
+source $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
+```
+These commands only need to be run once and will subsequently run autimatically upon activating your `sleap` environment.
+````
+
 ## Upgrading and uninstalling
 
 We **strongly recommend** installing SLEAP in a fresh environment when updating. This is because dependency versions might change, and depending on the state of your previous environment, directly updating might break compatibility with some of them.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -367,11 +367,11 @@ mamba activate sleap
 and run the commands:
 ```bash
 mkdir -p $CONDA_PREFIX/etc/conda/activate.d
-echo '#!/bin/sh' >> $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
-echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
-source $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
+echo '#!/bin/sh' >> $CONDA_PREFIX/etc/conda/activate.d/sleap_activate.sh
+echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/sleap_activate.sh
+source $CONDA_PREFIX/etc/conda/activate.d/sleap_activate.sh
 ```
-These commands only need to be run once and will subsequently run autimatically upon activating your `sleap` environment.
+These commands only need to be run once and will subsequently run automatically upon activating your `sleap` environment.
 ````
 
 ## Upgrading and uninstalling

--- a/environment.yml
+++ b/environment.yml
@@ -46,16 +46,4 @@ dependencies:
 
     - pip:  
         - "--editable=.[conda_dev]"
-
-# If you are on Linux, have a NVIDIA GPU, and are getting the warning:
-
-# W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic 
-# library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object 
-# file: No such file or directory
-
-# then activate the environment and run the commands:
-
-# mkdir -p $CONDA_PREFIX/etc/conda/activate.d
-# echo '#!/bin/sh' >> $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
-# echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
-# source $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
+        

--- a/environment.yml
+++ b/environment.yml
@@ -46,3 +46,16 @@ dependencies:
 
     - pip:  
         - "--editable=.[conda_dev]"
+
+# If you are on Linux, have a NVIDIA GPU, and are getting the warning:
+
+# W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic 
+# library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object 
+# file: No such file or directory
+
+# then activate the environment and run the commands:
+
+# mkdir -p $CONDA_PREFIX/etc/conda/activate.d
+# echo '#!/bin/sh' >> $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
+# echo 'export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH' >> $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh
+# source $CONDA_PREFIX/etc/conda/activate.d/libcudart_activate.sh


### PR DESCRIPTION
### Description
Some Linux users have been unable to utilize the GPU. Modifying some installation instructions from `tensorflow`, this PR sets the `LD_LIBRARY+PATH` on `mamba activate` (if installing SLEAP via the conda package) and gives instructions for setting the `LD_LIBRARY_PATH` manually (once and then automated on `mamba activate`) for conda from source.

Related:
- #1390

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [x] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1476

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Switched from `conda` to `mamba` for package management, improving the speed and reliability of environment creation and package installation.
- Bug Fix: Added a shell script that sets the `LD_LIBRARY_PATH` for Linux users with NVIDIA GPUs, resolving issues with GPU utilization.
- Documentation: Updated the installation instructions in `installation.md` to reflect the switch to `mamba` and added guidance for Linux users with NVIDIA GPUs on how to set up their environment correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->