### PR TITLE
Remove `imageio` pin

### DIFF
--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -25,7 +25,6 @@ pyyaml
 pyzmq
 qtpy>=2.0.1
 rich==10.16.1
-imageio<=2.15.0
 imgaug==0.4.0
 scipy>=1.4.1,<=1.9.0
 scikit-image


### PR DESCRIPTION
### Description
In an effort to get `sleap-io` and `sleap` in the same environment, we would like the dependencies to line up. This PR remove the pin from `imagio`.
> `imageio` is a dependency of a dependency and [not directly used in the `sleap` source code](https://github.com/search?q=repo%3Atalmolab%2Fsleap+imageio&type=code)

In fact, this PR removes listing `imageio` as a dependency at all - although it is still pulled in as a dependency of a dependency.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (dependencies)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Chore: Updated dependencies in `pypi_requirements.txt`. Removed the `imageio` package ~and added the `imgaug` package with a specific version constraint. Also, updated the version constraint for the `scipy` package.~ These changes are part of ongoing efforts to keep our software up-to-date and secure. Please update your environment accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->