### PR TITLE
PR2: Add new preference and `AnnoucementChecker` class

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -152,6 +152,7 @@ class MainWindow(QMainWindow):
         self.state["share usage data"] = prefs["share usage data"]
         self.state["skeleton_preview_image"] = None
         self.state["skeleton_description"] = "No skeleton loaded yet"
+        self.state["announcement last seen date"] = prefs["announcement last seen date"]
         if no_usage_data:
             self.state["share usage data"] = False
         self.state["clipboard_track"] = None
@@ -215,6 +216,7 @@ class MainWindow(QMainWindow):
         prefs["color predicted"] = self.state["color predicted"]
         prefs["trail shade"] = self.state["trail_shade"]
         prefs["share usage data"] = self.state["share usage data"]
+        prefs["announcement last seen date"] = self.state["announcement last seen date"]
 
         # Save preferences.
         prefs.save()

--- a/sleap/gui/web.py
+++ b/sleap/gui/web.py
@@ -3,7 +3,9 @@
 import attr
 import pandas as pd
 import requests
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
+from sleap import prefs
+from datetime import date
 
 
 REPO_ID = "talmolab/sleap"
@@ -144,6 +146,29 @@ class ReleaseChecker:
             "Check the page online for a full listing: "
             f"https://github.com/{self.repo_id}"
         )
+
+
+@attr.s(auto_attribs=True)
+class AnnouncementChecker:
+    """Checker for new announcements on the releases page of sleap."""
+
+    def check_for_new_announcements(self) -> bool:
+        """Check for new announcements on the releases page not seen by user."""
+        if date.today().strftime("%Y%m%d") > prefs.prefs["announcement last seen date"]:
+            return True
+        return False
+
+    def get_latest_announcement(self) -> Optional[date]:
+        """Return latest announcement date if available."""
+        if self.check_for_new_announcements():
+            return date.today().strftime("%Y%m%d")
+        return None
+    
+    def update_announcement_last_seen(self):
+        """Update the last seen date of announcement in preferences."""
+        latest_announcement_date = self.get_latest_announcement()
+        if latest_announcement_date is not None:
+            prefs.prefs["announcement last seen date"] = latest_announcement_date
 
 
 def get_analytics_data() -> Dict[str, Any]:

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -5,6 +5,7 @@ Importing this module creates `prefs`, instance of `Preferences` class.
 """
 
 from sleap import util
+from datetime import date
 
 
 class Preferences(object):
@@ -28,6 +29,7 @@ class Preferences(object):
         "node label size": 12,
         "show non-visible nodes": True,
         "share usage data": True,
+        "announcement last seen date": date.today().strftime("%Y%m%d")
     }
     _filename = "preferences.yaml"
 


### PR DESCRIPTION
### Description
Adding the appropriate preferences for the date of the last seen announcement and updating the `app.py` class to update the preference of saving the last seen announcement date. Further, creating a class `AnnouncementChecker` in `web.py` to check and update the announcement date when a new one is published.

This is the second PR of the stack that solves the discussion #1492 

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
