### PR TITLE
Allow passing in `Labels` to `app.main`

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -176,8 +176,10 @@ class MainWindow(QMainWindow):
             print("Restoring GUI state...")
             self.restoreState(prefs["window state"])
 
-        if labels_path:
+        if labels_path is not None:
             self.commands.loadProjectFile(filename=labels_path)
+        elif labels is not None:
+            self.commands.loadLabelsObject(labels=labels)
         else:
             self.state["project_loaded"] = False
 

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -49,6 +49,8 @@ import os
 import platform
 import random
 import re
+import traceback
+from logging import getLogger
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
 
@@ -83,6 +85,9 @@ from sleap.io.video import available_video_exts
 from sleap.prefs import prefs
 from sleap.skeleton import Skeleton
 from sleap.util import parse_uri_path
+
+
+logger = getLogger(__name__)
 
 
 class MainWindow(QMainWindow):
@@ -1671,7 +1676,12 @@ def main(args: Optional[list] = None, labels: Optional[Labels] = None):
     try:
         sleap.use_cpu_only()
     except RuntimeError:  # Visible devices cannot be modified after being initialized
-        pass
+        logger.warning(
+            "Running processes on the GPU. Restarting your GUI should allow switching "
+            "back to CPU-only mode.\n"
+            "Received the following error when trying to switch back to CPU-only mode:"
+        )
+        traceback.print_exc()
 
     # Print versions.
     print()


### PR DESCRIPTION
### Description
This is more a debugging feature than anything else. A lot of the times when I want to visually inspect a project after making changes to the code, I will end up calling `sleap-label` through it's entry point function `sleap.gui.app.main`. This forces me to save the file and use the path to that file to then open the project in the GUI.

This PR allows developers to 
1. just pass in the `Labels` to visually inspect via `sleap.gui.app.main`
2. create an instance of the GUI after using the GPU

and it also
3. creates the argparser in it's own function

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (flexibility)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Features:**
- Added the ability to pass a pre-loaded `Labels` object to the `MainWindow` constructor, providing more flexibility in initializing the main application window.
- Introduced a new function `create_parser` for creating an argument parser, improving code modularity and readability.

**Improvements:**
- Enhanced the `loadProjectFile` method to accept a `Union[str, Labels]` parameter, allowing for more versatile project file loading.
- Improved error handling when switching to CPU-only mode, increasing application robustness.

**Bug Fixes:**
- Fixed an issue in the `do_action` function where it did not handle the case where `filename` is `None`.
- Corrected the `ask` function to check if the `filename` parameter is an instance of `Labels` before loading the file, preventing potential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->