### PR TITLE
Allow zoom with trackpad

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -254,7 +254,6 @@ class MainWindow(QMainWindow):
             event.acceptProposedAction()
 
     def dropEvent(self, event):
-
         # Parse filenames
         filenames = event.mimeData().data("text/uri-list").data().decode()
         filenames = [parse_uri_path(f.strip()) for f in filenames.strip().split("\n")]

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -141,7 +141,6 @@ class LoadImageWorker(QtCore.QObject):
         self.load_queue = []
 
         try:
-
             t0 = time.time()
 
             # Get image data
@@ -998,7 +997,6 @@ class GraphicsView(QGraphicsView):
         self._down_pos = event.pos()
         # behavior depends on which button is pressed
         if event.button() == Qt.LeftButton:
-
             if event.modifiers() == Qt.NoModifier:
                 if self.click_mode == "area":
                     self.setDragMode(QGraphicsView.RubberBandDrag)
@@ -1026,7 +1024,6 @@ class GraphicsView(QGraphicsView):
         # check if mouse moved during click
         has_moved = event.pos() != self._down_pos
         if event.button() == Qt.LeftButton:
-
             if self.in_zoom:
                 self.in_zoom = False
                 zoom_rect = self.scene.selectionArea().boundingRect()
@@ -1059,7 +1056,6 @@ class GraphicsView(QGraphicsView):
             # pass along event
             self.leftMouseButtonReleased.emit(scenePos.x(), scenePos.y())
         elif event.button() == Qt.RightButton:
-
             self.setDragMode(QGraphicsView.NoDrag)
             self.rightMouseButtonReleased.emit(scenePos.x(), scenePos.y())
 
@@ -1135,7 +1131,6 @@ class GraphicsView(QGraphicsView):
         """Custom event handler, clears zoom."""
         scenePos = self.mapToScene(event.pos())
         if event.button() == Qt.LeftButton:
-
             if event.modifiers() == Qt.AltModifier:
                 if self.canZoom:
                     self.clearZoom()
@@ -1149,11 +1144,11 @@ class GraphicsView(QGraphicsView):
     def wheelEvent(self, event):
         """Custom event handler. Zoom in/out based on scroll wheel change."""
         # zoom on wheel when no mouse buttons are pressed
-        if event.buttons() == Qt.NoButton:
+        if event.modifiers() != Qt.AltModifier:
             angle = event.angleDelta().y()
             factor = 1.1 if angle > 0 else 0.9
 
-            self.zoomFactor = max(factor * self.zoomFactor, 1)
+            self.zoomFactor = max(min(factor * self.zoomFactor, 8), 0.2)
             self.updateViewer()
 
         # Trigger wheelEvent for all child elements. This is a bit of a hack.
@@ -1586,6 +1581,7 @@ class QtNode(QGraphicsEllipseItem):
 
     def wheelEvent(self, event):
         """Custom event handler for mouse scroll wheel."""
+
         if self.dragParent:
             angle = event.delta() / 20 + self.parentObject().rotation()
             self.parentObject().setRotation(angle)
@@ -1665,7 +1661,6 @@ class QtEdge(QGraphicsPolygonItem):
         polygon = QPolygonF()
 
         if self.player.state.get("edge style", default="").lower() == "wedge":
-
             r = self.src.visible_radius / 2.0
 
             norm_a = line.normalVector()
@@ -1850,7 +1845,7 @@ class QtInstance(QGraphicsObject):
         self.track_label.setHtml(instance_label_text)
 
         # Add nodes
-        for (node, point) in self.instance.nodes_points:
+        for node, point in self.instance.nodes_points:
             if point.visible or self.show_non_visible:
                 node_item = QtNode(
                     parent=self,
@@ -1865,7 +1860,7 @@ class QtInstance(QGraphicsObject):
                 self.nodes[node.name] = node_item
 
         # Add edges
-        for (src, dst) in self.skeleton.edge_names:
+        for src, dst in self.skeleton.edge_names:
             # Make sure that both nodes are present in this instance before drawing edge
             if src in self.nodes and dst in self.nodes:
                 edge_item = QtEdge(
@@ -2363,7 +2358,6 @@ def plot_instances(scene, frame_idx, labels, video=None, fixed=True):
 
 
 if __name__ == "__main__":
-
     import argparse
 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
### Description
This PR allows zooming with the trackpad on a laptop. Zooming with the trackpad actually passes a MouseButton into the events.buttons(), so previously this was being passed over in the wheelEvent. 

Now, we just check that the event modifier is not the Alt key (which is the only other action that uses the wheelEvent - for rotating an instance about a node).

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1528

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated event handlers and function calls in `sleap/gui/widgets/video.py` for improved code readability and maintainability.
- Style: Removed unnecessary empty lines and if conditions in `sleap/gui/widgets/video.py` to streamline the code.
- New Feature: Adjusted zoom behavior in `sleap/gui/widgets/video.py` for a more intuitive user experience.
- Chore: Minor graphical element manipulations in `sleap/gui/widgets/video.py` for better UI consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->