### PR TITLE
Add function to create app

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -262,7 +262,6 @@ class MainWindow(QMainWindow):
             event.acceptProposedAction()
 
     def dropEvent(self, event):
-
         # Parse filenames
         filenames = event.mimeData().data("text/uri-list").data().decode()
         filenames = [parse_uri_path(f.strip()) for f in filenames.strip().split("\n")]
@@ -1602,7 +1601,12 @@ class MainWindow(QMainWindow):
         ShortcutDialog().exec_()
 
 
-def create_parser():
+def create_sleap_label_parser():
+    """Creates parser for `sleap-label` command line arguments.
+
+    Returns:
+        argparse.ArgumentParser: The parser.
+    """
 
     import argparse
 
@@ -1645,10 +1649,20 @@ def create_parser():
     return parser
 
 
+def create_app():
+    """Creates Qt application."""
+
+    app = QApplication([])
+    app.setApplicationName(f"SLEAP v{sleap.version.__version__}")
+    app.setWindowIcon(QtGui.QIcon(sleap.util.get_package_file("gui/icon.png")))
+
+    return app
+
+
 def main(args: Optional[list] = None, labels: Optional[Labels] = None):
     """Starts new instance of app."""
 
-    parser = create_parser()
+    parser = create_sleap_label_parser()
     args = parser.parse_args(args)
 
     if args.nonnative:
@@ -1660,9 +1674,7 @@ def main(args: Optional[list] = None, labels: Optional[Labels] = None):
         # https://stackoverflow.com/q/64818879
         os.environ["QT_MAC_WANTS_LAYER"] = "1"
 
-    app = QApplication([])
-    app.setApplicationName(f"SLEAP v{sleap.version.__version__}")
-    app.setWindowIcon(QtGui.QIcon(sleap.util.get_package_file("gui/icon.png")))
+    app = create_app()
 
     window = MainWindow(
         labels_path=args.labels_path,


### PR DESCRIPTION
### Description
When testing things, I often find myself running subsets of sleep.gui.app.main. This PR just breaks up main a little bit and adds a create_app function. Mainly for troubleshooting/testing.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Refactored `sleap/gui/app.py` to improve code readability and maintainability.
  - Introduced a new function `create_app` for creating a Qt application, enhancing modularity.
  - Renamed `create_parser` to `create_sleap_label_parser` for better clarity.
  - Removed the `labels` argument from the `main` function signature to simplify its usage.

**Documentation:**
- Added a docstring to the `create_sleap_label_parser` function to provide more context about its purpose and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->