### PR TITLE
Scale new instances to new frame size

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2989,28 +2989,28 @@ class AddInstance(EditCommand):
 
         has_missing_nodes = False
 
-        #calculate scale factor for getting new x and y values
-        old_size_width =  copy_instance.frame.video.shape[2]
-        old_size_height =  copy_instance.frame.video.shape[1]
-        new_size_width =  new_instance.frame.video.shape[2]
-        new_size_height =  new_instance.frame.video.shape[1]
+        # Calculate scale factor for getting new x and y values.
+        old_size_width = copy_instance.frame.video.shape[2]
+        old_size_height = copy_instance.frame.video.shape[1]
+        new_size_width = new_instance.frame.video.shape[2]
+        new_size_height = new_instance.frame.video.shape[1]
         scale_width = new_size_width / old_size_width
         scale_height = new_size_height / old_size_height
 
-        # go through each node in skeleton
+        # Go through each node in skeleton.
         for node in context.state["skeleton"].node_names:
-            # if we're copying from a skeleton that has this node
+            # If we're copying from a skeleton that has this node.
             if node in copy_instance and not copy_instance[node].isnan():
-                # Ensure x, y inside current frame, then copy x, y, and visible
-                # we don't want to copy a PredictedPoint or score attribute
-                x_old = copy_instance[node].x 
-                y_old = copy_instance[node].y 
+                # Ensure x, y inside current frame, then copy x, y, and visible.
+                # We don't want to copy a PredictedPoint or score attribute.
+                x_old = copy_instance[node].x
+                y_old = copy_instance[node].y
                 x_new = x_old * scale_width
                 y_new = y_old * scale_height
 
                 new_instance[node] = Point(
-                    x = x_new,
-                    y = y_new,
+                    x=x_new,
+                    y=y_new,
                     visible=copy_instance[node].visible,
                     complete=mark_complete,
                 )


### PR DESCRIPTION
### Description
Fixed the updated x and y values when copying an instance across frames so that the new x and y values are still within the boundaries of the new frame.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1551

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

New Feature:
- Enhanced video frame resizing in the SLEAP GUI. The update ensures that when the size of a video frame changes, the coordinates of visible nodes are accurately scaled to fit within the new frame size. This improvement maintains the correct positioning of nodes, providing a more accurate and consistent user experience during video analysis.

Documentation:
- Added a new entry for Lili Karashchuk with email lili.karashchuk@alleninstitute.org and affiliation with the Allen Institute of Neural Dynamics.

Refactor:
- Modified the `read_frames` function in `deeplabcut.py` to improve efficiency and track information.

Bug Fix:
- Fixed a spelling error in the `summary()` function of `nn/system.py`.

Style:
- Updated the encoding process in the `to_hdf5` function of `video.py` to optimize storage of video frames in the HDF5 file.

Test:
- Modified the test case `test_import_labels_from_dlc_folder()` in `test_commands.py` to assert the correct number of tracks in the `labels` object.

Chores:
- Updated dependencies to the latest versions.

Note: The changes in `tests/io/test_formats.py` and `sleap/gui/commands.py` are not categorized as they do not fall under any of the specified categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->