### PR TITLE
(3c -> 3b) Add method to test instance grouping

### DIFF
--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1368,7 +1368,7 @@ def test_triangulate_session_get_permutations_of_instances(
                 assert inst.video == session[cam]
 
 
-def test_triangulate_session_calculate_reprojection_per_frame(
+def test_triangulate_session_calculate_error_per_frame(
     multiview_min_session_labels: Labels,
 ):
     """Test `TriangulateSession.get_permutations_of_instances`."""
@@ -1384,7 +1384,7 @@ def test_triangulate_session_calculate_reprojection_per_frame(
         frame_idx=lf.frame_idx,
     )
 
-    reprojection_error_per_frame = TriangulateSession.calculate_reprojection_per_frame(
+    reprojection_error_per_frame = TriangulateSession.calculate_error_per_frame(
         session=session, instances=instances
     )
 
@@ -1409,7 +1409,7 @@ def test_triangulate_session_get_instance_grouping(
         frame_idx=lf.frame_idx,
     )
 
-    reprojection_error_per_frame = TriangulateSession.calculate_reprojection_per_frame(
+    reprojection_error_per_frame = TriangulateSession.calculate_error_per_frame(
         session=session, instances=instances
     )
 

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1358,14 +1358,14 @@ def test_triangulate_session_get_products_of_instances(
 def test_triangulate_session_calculate_error_per_frame(
     multiview_min_session_labels: Labels,
 ):
-    """Test `TriangulateSession.get_permutations_of_instances`."""
+    """Test `TriangulateSession.calculate_error_per_frame`."""
 
     labels = multiview_min_session_labels
     session = labels.sessions[0]
     lf = labels.labeled_frames[0]
     selected_instance = lf.instances[0]
 
-    instances = TriangulateSession.get_permutations_of_instances(
+    instances = TriangulateSession.get_products_of_instances(
         selected_instance=selected_instance,
         session=session,
         frame_idx=lf.frame_idx,
@@ -1383,14 +1383,14 @@ def test_triangulate_session_calculate_error_per_frame(
 def test_triangulate_session_get_instance_grouping(
     multiview_min_session_labels: Labels,
 ):
-    """Test `TriangulateSession.get_permutations_of_instances`."""
+    """Test `TriangulateSession.get_instance_grouping`."""
 
     labels = multiview_min_session_labels
     session = labels.sessions[0]
     lf = labels.labeled_frames[0]
     selected_instance = lf.instances[0]
 
-    instances = TriangulateSession.get_permutations_of_instances(
+    instances = TriangulateSession.get_products_of_instances(
         selected_instance=selected_instance,
         session=session,
         frame_idx=lf.frame_idx,

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1409,9 +1409,9 @@ def test_triangulate_session_get_instance_grouping(
     for frame_id, instances_in_frame in best_instances.items():
         for cam, instances_in_view in instances_in_frame.items():
             for inst in instances_in_view:
-                assert inst.frame_idx == selected_instance.frame_idx
-                assert inst.track == selected_instance.track
-
-
-if __name__ == "__main__":
-    pytest.main([f"{__file__}::test_triangulate_session_get_instance_grouping"])
+                try:
+                    assert inst.frame_idx == selected_instance.frame_idx
+                    assert inst.track == selected_instance.track
+                except:
+                    assert inst.frame is None
+                    assert inst.track is None

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1063,32 +1063,29 @@ def test_triangulate_session_get_and_verify_enough_instances(
     labels = multiview_min_session_labels
     session = labels.sessions[0]
     lf = labels.labeled_frames[0]
-    track = labels.tracks[1]
 
     # Test with no cams_to_include, expect views from all linked cameras
     instances = TriangulateSession.get_and_verify_enough_instances(
-        session=session, frame_inds=[lf.frame_idx], track=track
+        session=session, frame_idx=lf.frame_idx
     )
-    instances_in_frame = instances[lf.frame_idx]
+    instances_in_frame = instances[0]
     assert (
-        len(instances_in_frame) == 6
-    )  # Some views don't have an instance at this track
+        len(instances_in_frame) == 8
+    )  # All views should have same number of instances (padded with dummy instance(s))
     for cam in session.linked_cameras:
         if cam.name in ["side", "sideL"]:  # The views that don't have an instance
             continue
         instances_in_view = instances_in_frame[cam]
         for inst in instances_in_view:
             assert inst.frame_idx == lf.frame_idx
-            assert inst.track == track
             assert inst.video == session[cam]
 
     # Test with cams_to_include, expect views from only those cameras
     cams_to_include = session.linked_cameras[-2:]
     instances = TriangulateSession.get_and_verify_enough_instances(
         session=session,
-        frame_inds=[lf.frame_idx],
+        frame_idx=lf.frame_idx,
         cams_to_include=cams_to_include,
-        track=track,
     )
     instances_in_frame = instances[lf.frame_idx]
     assert len(instances_in_frame) == len(cams_to_include)
@@ -1096,21 +1093,24 @@ def test_triangulate_session_get_and_verify_enough_instances(
         instances_in_view = instances_in_frame[cam]
         for inst in instances_in_view:
             assert inst.frame_idx == lf.frame_idx
-            assert inst.track == track
             assert inst.video == session[cam]
 
     # Test with not enough instances, expect views from only those cameras
     cams_to_include = session.linked_cameras[0:2]
+    cam = cams_to_include[0]
+    video = session[cam]
+    lfs = labels.find(video, lf.frame_idx)
+    lf = lfs[0]
+    lf.instances = []
     instances = TriangulateSession.get_and_verify_enough_instances(
         session=session,
-        frame_inds=[lf.frame_idx],
+        frame_idx=lf.frame_idx,
         cams_to_include=cams_to_include,
-        track=None,
     )
     assert isinstance(instances, bool)
     assert not instances
     messages = "".join([rec.message for rec in caplog.records])
-    assert "One or less instances found for frame" in messages
+    assert "No Instances found for" in messages
 
 
 def test_triangulate_session_verify_enough_views(
@@ -1259,7 +1259,9 @@ def test_triangulate_session_update_instances(multiview_min_session_labels: Labe
 
     # Just run for code coverage testing, do not test output here (race condition)
     # (see "functional core, imperative shell" pattern)
-    TriangulateSession.update_instances(session=session, instances=instances)
+    TriangulateSession.update_instances(
+        instances_and_coords=instances_and_coordinates[0]
+    )
 
 
 def test_triangulate_session_do_action(multiview_min_session_labels: Labels):
@@ -1332,20 +1334,19 @@ def test_triangulate_session_get_products_of_instances(
     selected_instance = lf.instances[0]
 
     instances = TriangulateSession.get_products_of_instances(
-        selected_instance=selected_instance,
         session=session,
         frame_idx=lf.frame_idx,
     )
 
     views = TriangulateSession.get_all_views_at_frame(session, lf.frame_idx)
     max_num_instances_in_view = max([len(instances) for instances in views.values()])
-    assert len(instances) == max_num_instances_in_view ** (len(views) - 1)
+    assert len(instances) == max_num_instances_in_view ** len(views)
 
     for frame_id in instances:
         instances_in_frame = instances[frame_id]
         for cam in instances_in_frame:
             instances_in_view = instances_in_frame[cam]
-            assert len(instances_in_view) == 1
+            assert len(instances_in_view) == max_num_instances_in_view
             for inst in instances_in_view:
                 try:
                     assert inst.frame_idx == selected_instance.frame_idx
@@ -1363,15 +1364,16 @@ def test_triangulate_session_calculate_error_per_frame(
     labels = multiview_min_session_labels
     session = labels.sessions[0]
     lf = labels.labeled_frames[0]
-    selected_instance = lf.instances[0]
 
     instances = TriangulateSession.get_products_of_instances(
-        selected_instance=selected_instance,
         session=session,
         frame_idx=lf.frame_idx,
     )
 
-    reprojection_error_per_frame = TriangulateSession.calculate_error_per_frame(
+    (
+        reprojection_error_per_frame,
+        instances_and_coords,
+    ) = TriangulateSession.calculate_error_per_frame(
         session=session, instances=instances
     )
 
@@ -1383,7 +1385,7 @@ def test_triangulate_session_calculate_error_per_frame(
 def test_triangulate_session_get_instance_grouping(
     multiview_min_session_labels: Labels,
 ):
-    """Test `TriangulateSession.get_instance_grouping`."""
+    """Test `TriangulateSession._get_instance_grouping`."""
 
     labels = multiview_min_session_labels
     session = labels.sessions[0]
@@ -1391,27 +1393,29 @@ def test_triangulate_session_get_instance_grouping(
     selected_instance = lf.instances[0]
 
     instances = TriangulateSession.get_products_of_instances(
-        selected_instance=selected_instance,
         session=session,
         frame_idx=lf.frame_idx,
     )
 
-    reprojection_error_per_frame = TriangulateSession.calculate_error_per_frame(
+    (
+        reprojection_error_per_frame,
+        instances_and_coords,
+    ) = TriangulateSession.calculate_error_per_frame(
         session=session, instances=instances
     )
 
-    best_instances: Dict[
-        int, Dict[Camcorder, Instance]
-    ] = TriangulateSession.get_instance_grouping(
+    best_instances, frame_id_min_error = TriangulateSession._get_instance_grouping(
         instances=instances, reprojection_error_per_frame=reprojection_error_per_frame
     )
-    assert len(best_instances) == 1
-    for frame_id, instances_in_frame in best_instances.items():
-        for cam, instances_in_view in instances_in_frame.items():
-            for inst in instances_in_view:
-                try:
-                    assert inst.frame_idx == selected_instance.frame_idx
-                    assert inst.track == selected_instance.track
-                except:
-                    assert inst.frame is None
-                    assert inst.track is None
+    assert len(best_instances) == len(session.camera_cluster)
+    for instances_in_view in best_instances.values():
+        tracks_in_view = set(
+            [inst.track if inst is not None else "None" for inst in instances_in_view]
+        )
+        assert len(tracks_in_view) == len(instances_in_view)
+        for inst in instances_in_view:
+            try:
+                assert inst.frame_idx == selected_instance.frame_idx
+            except:
+                assert inst.frame is None
+                assert inst.track is None


### PR DESCRIPTION
### Description
This PR adds a method to test and retrieve the "correct" instance grouping. Here "correct" means the instance grouping with the lowest total reprojection error across all frames.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new methods for grouping instances and calculating reprojection error in the GUI.

- **Tests**
  - Added tests to ensure the accuracy and reliability of new triangulation and reprojection functionalities.
 
<!-- end of auto-generated comment: release notes by coderabbit.ai -->