### PR TITLE
(3d -> 3c) Add method for multi instance products

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3422,6 +3422,9 @@ class TriangulateSession(EditCommand):
         video = params.get("video", None) or context.state["video"]
         session = params.get("session", None) or context.labels.get_session(video)
         instances = params["instances"]
+        session = cast(RecordingSession, session)  # Could be None if no labels or video
+
+        # Get best instance grouping and reprojected coords
         instances_and_reprojected_coords = (
             TriangulateSession.get_instance_grouping_and_reprojected_coords(
                 session=session, instance_hypotheses=instances
@@ -3818,7 +3821,7 @@ class TriangulateSession(EditCommand):
     def _get_instance_grouping(
         instances: Dict[int, Dict[Camcorder, List[Instance]]],
         reprojection_error_per_frame: Dict[int, float],
-    ) -> Tuple[int, Dict[Camcorder, List[Instance]]]:
+    ) -> Tuple[Dict[Camcorder, List[Instance]], int]:
         """Get instance grouping with lowest reprojection error.
 
         Args:

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3422,9 +3422,16 @@ class TriangulateSession(EditCommand):
         video = params.get("video", None) or context.state["video"]
         session = params.get("session", None) or context.labels.get_session(video)
         instances = params["instances"]
+        instances_and_reprojected_coords = (
+            TriangulateSession.get_instance_grouping_and_reprojected_coords(
+                session=session, instance_hypotheses=instances
+            )
+        )
 
         # Update instances
-        TriangulateSession.update_instances(session=session, instances=instances)
+        TriangulateSession.update_instances(
+            instances_and_coords=instances_and_reprojected_coords
+        )
 
     @classmethod
     def ask(cls, context: CommandContext, params: dict) -> bool:
@@ -3480,7 +3487,6 @@ class TriangulateSession(EditCommand):
         if session is None or instance is None:
             return
 
-        track = instance.track  # TODO(LM): Replace with InstanceGroup
         cams_to_include = params.get("cams_to_include", None) or session.linked_cameras
 
         # If not enough `Camcorder`s available/specified, then return
@@ -3492,13 +3498,12 @@ class TriangulateSession(EditCommand):
         ):
             return False
 
-        # Get all instances accross views at this frame index
+        # Get all instances products accross views at this frame index
         instances = TriangulateSession.get_and_verify_enough_instances(
             context=context,
             session=session,
-            frame_inds=[frame_idx],
+            frame_idx=frame_idx,
             cams_to_include=cams_to_include,
-            track=track,
             show_dialog=show_dialog,
         )
 
@@ -3514,19 +3519,18 @@ class TriangulateSession(EditCommand):
     @staticmethod
     def get_and_verify_enough_instances(
         session: RecordingSession,
-        frame_inds: List[int],
+        frame_idx: int,
         context: Optional[CommandContext] = None,
         cams_to_include: Optional[List[Camcorder]] = None,
-        track: Union[Track, int] = -1,
         show_dialog: bool = True,
     ) -> Union[Dict[int, Dict[Camcorder, List[Instance]]], bool]:
-        """Get all instances accross views at this frame index.
+        """Get all instances accross views at this frame index (and products of instances).
 
         If not enough `Instance`s are available at this frame index, then return False.
 
         Args:
             session: The `RecordingSession` containing the `Camcorder`s.
-            frame_inds: List of frame indices to get instances from (0-indexed).
+            frame_idx: Frame index to get instances from (0-indexed).
             context: The optional command context used to display a dialog.
             cams_to_include: List of `Camcorder`s to include. Default is all.
             track: `Track` object used to find instances accross views. Default is -1
@@ -3534,20 +3538,18 @@ class TriangulateSession(EditCommand):
             show_dialog: If True, then show a warning dialog. Default is True.
 
         Returns:
-            Dict with frame identifier keys (does not necessarily need to be the frame
-            index) and values of another inner dict with `Camcorder` keys and
-            `List[Instance]` values if enough instances are found, False otherwise.
+            Dict with frame identifier keys (not the frame index) and values of another
+            inner dict with `Camcorder` keys and `List[Instance]` values if enough
+            instances are found, False otherwise.
         """
 
         try:
             instances: Dict[
                 int, Dict[Camcorder, List[Instance]]
-            ] = TriangulateSession.get_instances_across_views_multiple_frames(
+            ] = TriangulateSession.get_products_of_instances(
                 session=session,
-                frame_inds=frame_inds,
+                frame_idx=frame_idx,
                 cams_to_include=cams_to_include,
-                track=track,
-                require_multiple_views=True,
             )
             return instances
         except ValueError:
@@ -3752,20 +3754,91 @@ class TriangulateSession(EditCommand):
         return views
 
     @staticmethod
-    def get_instance_grouping(
+    def get_instance_grouping_and_reprojected_coords(
+        session: RecordingSession,
+        instance_hypotheses: Dict[int, Dict[Camcorder, List[Instance]]],
+    ):
+        """Get instance grouping and reprojected coords with lowest reprojection error.
+
+        Triangulation of all possible groupings needs to be performed... Thus, we return
+        the best grouping's triangulation in this step to then be used when updating the
+        instance.
+
+        Args:
+            session: The `RecordingSession` containing the `Camcorder`s.
+            instance_hypotheses: Dict with frame identifier keys (not the frame index)
+                and values of another inner dict with `Camcorder` keys and
+                `List[Instance]` values.
+
+
+        Returns:
+            best_instances_and_reprojected_coords: Dict with `Camcorder` keys with
+                `Tuple[Instance, np.ndarray]` values.
+        """
+
+        # Calculate reprojection error for each instance grouping
+        (
+            reprojection_error_per_frame,
+            instances_and_coords,
+        ) = TriangulateSession.calculate_error_per_frame(
+            session=session,
+            instances=instance_hypotheses,
+        )
+
+        # Just for type hinting
+        reprojection_error_per_frame = cast(
+            Dict[int, float], reprojection_error_per_frame
+        )
+        instances_and_coords = cast(
+            Dict[int, Dict[Camcorder, Iterator[Tuple[Instance, np.ndarray]]]],
+            instances_and_coords,
+        )
+
+        # Get instance grouping with lowest reprojection error
+        best_instances, frame_id_min_error = TriangulateSession._get_instance_grouping(
+            instances=instance_hypotheses,
+            reprojection_error_per_frame=reprojection_error_per_frame,
+        )
+
+        # Just for type hinting
+        best_instances = cast(Dict[Camcorder, List[Instance]], best_instances)
+        instances_and_coords = cast(
+            Dict[int, Dict[Camcorder, Iterator[Tuple[Instance, np.ndarray]]]],
+            instances_and_coords,
+        )
+
+        # Get the best reprojection
+        best_instances_and_reprojected_coords: Dict[
+            Camcorder, Iterator[Tuple[Instance, np.ndarray]]
+        ] = instances_and_coords[frame_id_min_error]
+
+        return best_instances_and_reprojected_coords
+
+    @staticmethod
+    def _get_instance_grouping(
         instances: Dict[int, Dict[Camcorder, List[Instance]]],
         reprojection_error_per_frame: Dict[int, float],
-    ) -> Dict[int, Dict[Camcorder, List[Instance]]]:
-        """Get instance grouping for triangulation."""
+    ) -> Tuple[int, Dict[Camcorder, List[Instance]]]:
+        """Get instance grouping with lowest reprojection error.
 
-        frame_with_min_error = min(
+        Args:
+            instances: Dict with frame identifier keys (not the frame index) and values
+                of another inner dict with `Camcorder` keys and `List[Instance]` values.
+            reprojection_error_per_frame: Dict with frame identifier keys (not the frame
+                index) and values of reprojection error for the frame.
+
+        Returns:
+            best_instances: Dict with `Camcorder` keys and `List[Instance]` values.
+            frame_id_min_error: The frame identifier with the lowest reprojection
+        """
+
+        frame_id_min_error = min(
             reprojection_error_per_frame, key=reprojection_error_per_frame.get
         )
 
-        best_instances = instances[frame_with_min_error]
-        best_instances_correct_format = {frame_with_min_error: best_instances}
+        best_instances = instances[frame_id_min_error]
 
-        return best_instances_correct_format
+        return best_instances, frame_id_min_error
 
     @staticmethod
     def _calculate_reprojection_error(
@@ -3773,8 +3846,11 @@ class TriangulateSession(EditCommand):
         instances: Dict[int, Dict[Camcorder, List[Instance]]],
         per_instance: bool = False,
         per_view: bool = False,
-    ) -> Union[
-        Dict[int, float], Dict[int, Dict[Camcorder, List[Tuple[Instance, float]]]]
+    ) -> Tuple[
+        Union[
+            Dict[int, float], Dict[int, Dict[Camcorder, List[Tuple[Instance, float]]]]
+        ],
+        Dict[int, Dict[Camcorder, Iterator[Tuple[Instance, np.ndarray]]]],
     ]:
         """Calculate reprojection error per frame or per instance.
 
@@ -3790,10 +3866,15 @@ class TriangulateSession(EditCommand):
                 `Tuple[Tuple[str, str], float]` values. If per_instance is True, then that takes precendence.
 
         Returns:
-            Dict with frame identifier keys (not the frame index) and values of another
-            inner dict with `Camcorder` keys and `List[Tuple[Instance, float]]` values
-            if per_instance is True, otherwise a dict with frame identifier keys and
-            values of reprojection error for the frame.
+            reprojection_per_frame: Dict with frame identifier keys (not the frame index) and values of another
+                inner dict with `Camcorder` keys and `List[Tuple[Instance, float]]` values
+                if per_instance is True, otherwise a dict with frame identifier keys and
+                values of reprojection error for the frame.
+            instances_and_coords: Dict with frame identifier keys (not the frame index)
+                and values of another inner dict with `Camcorder` keys and
+                `Iterator[Tuple[Instance, np.ndarray]]` values that contain the instance
+                and the reprojected coordinates.
+
         """
 
         reprojection_error_per_frame = {}
@@ -3831,75 +3912,126 @@ class TriangulateSession(EditCommand):
 
             reprojection_error_per_frame[frame_id] = frame_error
 
-        return reprojection_error_per_frame
+        return reprojection_error_per_frame, instances_and_coords
 
     @staticmethod
     def calculate_error_per_instance(
         session: RecordingSession, instances: Dict[int, Dict[Camcorder, List[Instance]]]
-    ) -> Dict[int, float]:
-        """Calculate reprojection error per instance."""
+    ) -> Tuple[
+        Dict[int, Dict[Camcorder, List[Tuple[Instance, float]]]],
+        Dict[int, Dict[Camcorder, Iterator[Tuple[Instance, np.ndarray]]]],
+    ]:
+        """Calculate reprojection error per instance.
 
-        reprojection_error_per_instance = (
-            TriangulateSession._calculate_reprojection_error(
-                session=session, instances=instances, per_instance=True
-            )
+        Args:
+            session: The `RecordingSession` containing the `Camcorder`s.
+            instances: Dict with frame identifier keys (not the frame index) and values
+                of another inner dict with `Camcorder` keys and `List[Instance]` values.
+
+        Returns:
+            reprojection_error_per_instance: Dict with frame identifier keys (not the
+                frame index) and values of another inner dict with `Camcorder` keys and
+                `List[Tuple[Instance, float]]` values.
+            instances_and_coords: Dict with frame identifier keys (not the frame index)
+                and values of another inner dict with `Camcorder` keys and
+                `Iterator[Tuple[Instance, np.ndarray]]` values that contain the instance
+                and the reprojected coordinates.
+        """
+
+        (
+            reprojection_error_per_instance,
+            instances_and_coords,
+        ) = TriangulateSession._calculate_reprojection_error(
+            session=session, instances=instances, per_instance=True
         )
 
-        return reprojection_error_per_instance
+        return reprojection_error_per_instance, instances_and_coords
 
     @staticmethod
     def calculate_error_per_view(
         session: RecordingSession, instances: Dict[int, Dict[Camcorder, List[Instance]]]
-    ) -> Dict[int, float]:
-        """Calculate reprojection error per instance."""
+    ) -> Tuple[
+        Dict[int, Dict[Camcorder, float]],
+        Dict[int, Dict[Camcorder, Iterator[Tuple[Instance, np.ndarray]]]],
+    ]:
+        """Calculate reprojection error per instance.
 
-        reprojection_error_per_view = TriangulateSession._calculate_reprojection_error(
+        Args:
+            session: The `RecordingSession` containing the `Camcorder`s.
+            instances: Dict with frame identifier keys (not the frame index) and values
+                of another inner dict with `Camcorder` keys and `List[Instance]` values.
+
+        Returns:
+            reprojection_error_per_view: Dict with frame identifier keys (not the frame
+                index) and values of another inner dict with `Camcorder` keys and
+                `float` values.
+            instances_and_coords: Dict with frame identifier keys (not the frame index)
+                and values of another inner dict with `Camcorder` keys and
+                `Iterator[Tuple[Instance, np.ndarray]]` values that contain the instance
+                and the reprojected coordinates.
+        """
+
+        (
+            reprojection_error_per_view,
+            instances_and_coords,
+        ) = TriangulateSession._calculate_reprojection_error(
             session=session, instances=instances, per_view=True
         )
 
-        return reprojection_error_per_view
+        return reprojection_error_per_view, instances_and_coords
 
     @staticmethod
     def calculate_error_per_frame(
         session: RecordingSession, instances: Dict[int, Dict[Camcorder, List[Instance]]]
-    ) -> Dict[int, float]:
-        """Calculate reprojection error per frame."""
+    ) -> Tuple[
+        Dict[int, float],
+        Dict[int, Dict[Camcorder, Iterator[Tuple[Instance, np.ndarray]]]],
+    ]:
+        """Calculate reprojection error per frame.
 
-        reprojection_error_per_frame = TriangulateSession._calculate_reprojection_error(
+        Args:
+            session: The `RecordingSession` containing the `Camcorder`s.
+            instances: Dict with frame identifier keys (not the frame index) and values
+                of another inner dict with `Camcorder` keys and `List[Instance]` values.
+
+        Returns:
+            reprojection_error_per_frame: Dict with frame identifier keys (not the frame
+                index) and values of reprojection error for the frame.
+            instances_and_coords: Dict with frame identifier keys (not the frame index)
+                and values of another inner dict with `Camcorder` keys and
+                `Iterator[Tuple[Instance, np.ndarray]]` values that contain the instance
+                and the reprojected coordinates.
+        """
+
+        (
+            reprojection_error_per_frame,
+            instances_and_coords,
+        ) = TriangulateSession._calculate_reprojection_error(
             session=session, instances=instances, per_instance=False
         )
 
-        return reprojection_error_per_frame
+        return reprojection_error_per_frame, instances_and_coords
 
     @staticmethod
     def get_products_of_instances(
-        selected_instance: Instance,
         session: RecordingSession,
         frame_idx: int,
         cams_to_include: Optional[List[Camcorder]] = None,
     ) -> Dict[int, Dict[Camcorder, List[Instance]]]:
-        """Get all (single-instance) possible products of instances across views.
+        """Get all (multi-instance) possible products of instances across views.
 
         Args:
-            selected_instance: The `Instance` to add to  permutations of instances in
-                views other than that of the `selected_instance`.
             session: The `RecordingSession` containing the `Camcorder`s.
             frame_idx: Frame index to get instances from (0-indexed).
             cams_to_include: List of `Camcorder`s to include. Default is all.
             require_multiple_views: If True, then raise and error if one or less views
                 or instances are found.
 
-        Raises:
-            ValueError if one or less views or instances are found.
-
         Returns:
             Dict with frame identifier keys (not the frame index) and values of another
             inner dict with `Camcorder` keys and `List[Instance]` values. Each
-            `List[Instance]` is of length 1.
+            `List[Instance]` is of length "max number of instances in frame set".
         """
-
-        cam_selected = session.get_camera(selected_instance.video)
-        cam_selected = cast(Camcorder, cam_selected)  # Could be None if not in session
 
         # Get all instances accross views at this frame index, then remove selected
         instances: Dict[
@@ -3912,16 +4044,19 @@ class TriangulateSession(EditCommand):
             require_multiple_views=True,
         )
 
+        # Get the skeleton from an example instance
+        skeleton = next(iter(instances.values()))[0].skeleton
+
         # Find max number of instances in other views
         max_num_instances = max([len(instances) for instances in instances.values()])
 
         # Create a dummy instance of all nan values
         dummy_instance = Instance.from_numpy(
             np.full(
-                shape=(len(selected_instance.skeleton.nodes), 2),
+                shape=(len(skeleton.nodes), 2),
                 fill_value=np.nan,
             ),
-            skeleton=selected_instance.skeleton,
+            skeleton=skeleton,
         )
 
         # Get permutations of instances from other views
@@ -4187,6 +4322,8 @@ class TriangulateSession(EditCommand):
                 insts_coords_in_frame: np.ndarray = insts_coords_list[frame_idx][
                     cam_idx
                 ]  # len(T) of N x 2
+
+                # TODO(LM): I think we will need a reconsumable iterator here.
                 insts_and_coords_in_frame[cam]: Tuple[Instance, np.ndarray] = zip(
                     instances_in_frame_ordered,
                     insts_coords_in_frame,
@@ -4222,7 +4359,7 @@ class TriangulateSession(EditCommand):
             session=session, instances=instances
         )
 
-        # Group together instances (the reordered by cam) and the reprojected coords.
+        # Reorder instances (by cam) and the reprojected coords.
         instances_and_coords: Dict[
             int, Dict[Camcorder, Iterator[Tuple[Instance, np.ndarray]]]
         ] = TriangulateSession.group_instances_and_coords(
@@ -4235,31 +4372,23 @@ class TriangulateSession(EditCommand):
 
     @staticmethod
     def update_instances(
-        session, instances: Dict[int, Dict[Camcorder, List[Instance]]]
+        instances_and_coords: Dict[Camcorder, Iterator[Tuple[Instance, np.ndarray]]]
     ):
-        """Triangulate, reproject, and update coordinates of `Instances`.
+        """Update coordinates of `Instances`.
 
         Args:
-            session: The `RecordingSession` containing the `Camcorder`s.
-            instances: Dict with frame identifier keys (does not necessarily need to be
-                the frame index) and values of another inner dict with `Camcorder` keys
-                and `List[Instance]` values.
+            instances_and_coords: Dict with `Camcorder` keys and
+                `Iterator[Tuple[Instance, np.ndarray]]` values containing the Instance
+                and it's reprojected coordinates.
 
         Returns:
             None
         """
 
-        # Triangulate and reproject instance coordinates.
-        instances_and_coords = TriangulateSession.calculate_reprojected_points(
-            session=session, instances=instances
-        )
-
-        # TODO(LM): Since we only use the values here, is a dictionary overkill?
         # Update the instance coordinates.
-        for instances_in_frame in instances_and_coords.values():
-            for instances_in_view in instances_in_frame.values():
-                for inst, inst_coord in instances_in_view:
-                    inst.update_points(points=inst_coord, exclude_complete=True)
+        for instances_in_view in instances_and_coords.values():
+            for inst, inst_coord in instances_in_view:
+                inst.update_points(points=inst_coord, exclude_complete=True)
 
 
 def open_website(url: str):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1339,13 +1339,13 @@ def test_triangulate_session_get_products_of_instances(
 
     views = TriangulateSession.get_all_views_at_frame(session, lf.frame_idx)
     max_num_instances_in_view = max([len(instances) for instances in views.values()])
-    assert len(instances) == max_num_instances_in_view ** (len(views) - 1)
+    assert len(instances) == max_num_instances_in_view ** len(views)
 
     for frame_id in instances:
         instances_in_frame = instances[frame_id]
         for cam in instances_in_frame:
             instances_in_view = instances_in_frame[cam]
-            assert len(instances_in_view) == 1
+            assert len(instances_in_view) == max_num_instances_in_view
             for inst in instances_in_view:
                 try:
                     assert inst.frame_idx == selected_instance.frame_idx
@@ -1408,10 +1408,16 @@ def test_triangulate_session_get_instance_grouping(
     assert len(best_instances) == 1
     for frame_id, instances_in_frame in best_instances.items():
         for cam, instances_in_view in instances_in_frame.items():
+            tracks_in_view = set(
+                [
+                    inst.track if inst is not None else "None"
+                    for inst in instances_in_view
+                ]
+            )
+            assert len(tracks_in_view) == len(instances_in_view)
             for inst in instances_in_view:
                 try:
                     assert inst.frame_idx == selected_instance.frame_idx
-                    assert inst.track == selected_instance.track
                 except:
                     assert inst.frame is None
                     assert inst.track is None

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -31,11 +31,11 @@ from sleap.io.pathutils import fix_path_separator
 from sleap.io.video import Video
 from sleap.util import get_package_file
 
-# # These imports cause trouble when running `pytest.main()` from within the file
-# # Comment out to debug tests file via VSCode's "Debug Python File"
-# from tests.info.test_h5 import extract_meta_hdf5
-# from tests.io.test_formats import read_nix_meta
-# from tests.io.test_video import assert_video_params
+# These imports cause trouble when running `pytest.main()` from within the file
+# Comment out to debug tests file via VSCode's "Debug Python File"
+from tests.info.test_h5 import extract_meta_hdf5
+from tests.io.test_formats import read_nix_meta
+from tests.io.test_video import assert_video_params
 
 
 def test_delete_user_dialog(centered_pair_predictions):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -31,11 +31,11 @@ from sleap.io.pathutils import fix_path_separator
 from sleap.io.video import Video
 from sleap.util import get_package_file
 
-# These imports cause trouble when running `pytest.main()` from within the file
-# Comment out to debug tests file via VSCode's "Debug Python File"
-from tests.info.test_h5 import extract_meta_hdf5
-from tests.io.test_formats import read_nix_meta
-from tests.io.test_video import assert_video_params
+# # These imports cause trouble when running `pytest.main()` from within the file
+# # Comment out to debug tests file via VSCode's "Debug Python File"
+# from tests.info.test_h5 import extract_meta_hdf5
+# from tests.io.test_formats import read_nix_meta
+# from tests.io.test_video import assert_video_params
 
 
 def test_delete_user_dialog(centered_pair_predictions):
@@ -1063,32 +1063,29 @@ def test_triangulate_session_get_and_verify_enough_instances(
     labels = multiview_min_session_labels
     session = labels.sessions[0]
     lf = labels.labeled_frames[0]
-    track = labels.tracks[1]
 
     # Test with no cams_to_include, expect views from all linked cameras
     instances = TriangulateSession.get_and_verify_enough_instances(
-        session=session, frame_inds=[lf.frame_idx], track=track
+        session=session, frame_idx=lf.frame_idx
     )
-    instances_in_frame = instances[lf.frame_idx]
+    instances_in_frame = instances[0]
     assert (
-        len(instances_in_frame) == 6
-    )  # Some views don't have an instance at this track
+        len(instances_in_frame) == 8
+    )  # All views should have same number of instances (padded with dummy instance(s))
     for cam in session.linked_cameras:
         if cam.name in ["side", "sideL"]:  # The views that don't have an instance
             continue
         instances_in_view = instances_in_frame[cam]
         for inst in instances_in_view:
             assert inst.frame_idx == lf.frame_idx
-            assert inst.track == track
             assert inst.video == session[cam]
 
     # Test with cams_to_include, expect views from only those cameras
     cams_to_include = session.linked_cameras[-2:]
     instances = TriangulateSession.get_and_verify_enough_instances(
         session=session,
-        frame_inds=[lf.frame_idx],
+        frame_idx=lf.frame_idx,
         cams_to_include=cams_to_include,
-        track=track,
     )
     instances_in_frame = instances[lf.frame_idx]
     assert len(instances_in_frame) == len(cams_to_include)
@@ -1096,21 +1093,24 @@ def test_triangulate_session_get_and_verify_enough_instances(
         instances_in_view = instances_in_frame[cam]
         for inst in instances_in_view:
             assert inst.frame_idx == lf.frame_idx
-            assert inst.track == track
             assert inst.video == session[cam]
 
     # Test with not enough instances, expect views from only those cameras
     cams_to_include = session.linked_cameras[0:2]
+    cam = cams_to_include[0]
+    video = session[cam]
+    lfs = labels.find(video, lf.frame_idx)
+    lf = lfs[0]
+    lf.instances = []
     instances = TriangulateSession.get_and_verify_enough_instances(
         session=session,
-        frame_inds=[lf.frame_idx],
+        frame_idx=lf.frame_idx,
         cams_to_include=cams_to_include,
-        track=None,
     )
     assert isinstance(instances, bool)
     assert not instances
     messages = "".join([rec.message for rec in caplog.records])
-    assert "One or less instances found for frame" in messages
+    assert "No Instances found for" in messages
 
 
 def test_triangulate_session_verify_enough_views(
@@ -1259,7 +1259,9 @@ def test_triangulate_session_update_instances(multiview_min_session_labels: Labe
 
     # Just run for code coverage testing, do not test output here (race condition)
     # (see "functional core, imperative shell" pattern)
-    TriangulateSession.update_instances(session=session, instances=instances)
+    TriangulateSession.update_instances(
+        instances_and_coords=instances_and_coordinates[0]
+    )
 
 
 def test_triangulate_session_do_action(multiview_min_session_labels: Labels):
@@ -1332,7 +1334,6 @@ def test_triangulate_session_get_products_of_instances(
     selected_instance = lf.instances[0]
 
     instances = TriangulateSession.get_products_of_instances(
-        selected_instance=selected_instance,
         session=session,
         frame_idx=lf.frame_idx,
     )
@@ -1363,15 +1364,16 @@ def test_triangulate_session_calculate_error_per_frame(
     labels = multiview_min_session_labels
     session = labels.sessions[0]
     lf = labels.labeled_frames[0]
-    selected_instance = lf.instances[0]
 
     instances = TriangulateSession.get_products_of_instances(
-        selected_instance=selected_instance,
         session=session,
         frame_idx=lf.frame_idx,
     )
 
-    reprojection_error_per_frame = TriangulateSession.calculate_error_per_frame(
+    (
+        reprojection_error_per_frame,
+        instances_and_coords,
+    ) = TriangulateSession.calculate_error_per_frame(
         session=session, instances=instances
     )
 
@@ -1383,7 +1385,7 @@ def test_triangulate_session_calculate_error_per_frame(
 def test_triangulate_session_get_instance_grouping(
     multiview_min_session_labels: Labels,
 ):
-    """Test `TriangulateSession.get_instance_grouping`."""
+    """Test `TriangulateSession._get_instance_grouping`."""
 
     labels = multiview_min_session_labels
     session = labels.sessions[0]
@@ -1391,33 +1393,29 @@ def test_triangulate_session_get_instance_grouping(
     selected_instance = lf.instances[0]
 
     instances = TriangulateSession.get_products_of_instances(
-        selected_instance=selected_instance,
         session=session,
         frame_idx=lf.frame_idx,
     )
 
-    reprojection_error_per_frame = TriangulateSession.calculate_error_per_frame(
+    (
+        reprojection_error_per_frame,
+        instances_and_coords,
+    ) = TriangulateSession.calculate_error_per_frame(
         session=session, instances=instances
     )
 
-    best_instances: Dict[
-        int, Dict[Camcorder, Instance]
-    ] = TriangulateSession.get_instance_grouping(
+    best_instances, frame_id_min_error = TriangulateSession._get_instance_grouping(
         instances=instances, reprojection_error_per_frame=reprojection_error_per_frame
     )
-    assert len(best_instances) == 1
-    for frame_id, instances_in_frame in best_instances.items():
-        for cam, instances_in_view in instances_in_frame.items():
-            tracks_in_view = set(
-                [
-                    inst.track if inst is not None else "None"
-                    for inst in instances_in_view
-                ]
-            )
-            assert len(tracks_in_view) == len(instances_in_view)
-            for inst in instances_in_view:
-                try:
-                    assert inst.frame_idx == selected_instance.frame_idx
-                except:
-                    assert inst.frame is None
-                    assert inst.track is None
+    assert len(best_instances) == len(session.camera_cluster)
+    for instances_in_view in best_instances.values():
+        tracks_in_view = set(
+            [inst.track if inst is not None else "None" for inst in instances_in_view]
+        )
+        assert len(tracks_in_view) == len(instances_in_view)
+        for inst in instances_in_view:
+            try:
+                assert inst.frame_idx == selected_instance.frame_idx
+            except:
+                assert inst.frame is None
+                assert inst.track is None


### PR DESCRIPTION
### Description
This method adapts the instance grouping to consider mutliple instances per frame instead of just a single instance per frame.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
