### PR TITLE
Fix package export

### DIFF
--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -1450,7 +1450,9 @@ class Video:
                 for i in range(len(frame_numbers)):
                     frames.append(encode(frame_data[i]))
 
-                max_frame_size = max([len(x) for x in frames])
+                max_frame_size = (
+                    max([len(x) if len(x) else 0 for x in frames]) if len(frames) else 0
+                )
 
                 dset = f.create_dataset(
                     dataset + "/video",


### PR DESCRIPTION
### Description
In #1559, we switched up the format to use zero-padded, constant length byte strings for embedded PNG encoded images for .pkg.slp files.

Right now this throws an error when we export from labels that have videos without any labeled frames, as is common when generating splits or when there are only predictions in a given video (but not user labels).

This PR fixes that by checking for zero length videos during export.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty frames in video processing to ensure accurate frame size calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->