### PR TITLE
Resolve copy prior frame issue to take latest available user instance…

### DIFF
--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -18,7 +18,7 @@ from sleap.gui.commands import (
     SaveProjectAs,
     get_new_version_filename,
 )
-from sleap.instance import Instance, LabeledFrame
+from sleap.instance import Instance, LabeledFrame, Point
 from sleap.io.convert import default_analysis_filename
 from sleap.io.dataset import Labels
 from sleap.io.format.adaptor import Adaptor
@@ -616,13 +616,15 @@ def test_CopyInstance(min_tracks_2node_labels: Labels):
     assert context.state["clipboard_instance"] == instance
 
 
-def test_CopyPriorFrame(centered_pair_predictions: Labels):
+def test_CopyPriorFramePreviousUser(centered_pair_predictions: Labels):
+    """Test that we copy prior user frame when available."""
     context = CommandContext.from_labels(centered_pair_predictions)
     context.state["labeled_frame"] = centered_pair_predictions.find(
         centered_pair_predictions.videos[0], frame_idx=124
     )[0]
     context.state["video"] = centered_pair_predictions.videos[0]
     context.state["frame_idx"] = 124
+    context.state["skeleton"] = centered_pair_predictions.skeleton
 
     # No user instances in current frame, only predicted
     assert len(context.state["labeled_frame"].user_instances) == 0
@@ -641,18 +643,124 @@ def test_CopyPriorFrame(centered_pair_predictions: Labels):
 
     skeleton = centered_pair_predictions.skeleton
     user_inst = Instance(
-        skeleton=skeleton, points={node: Point(1, 1) for node in skeleton.nodes}
+        skeleton=skeleton,
+        points={node: Point(1, 1) for node in skeleton.nodes},
+        frame=prev_frame,
     )
     prev_instances.append(user_inst)
 
+    # Confirm there is one user instance in previous frame
+    assert len(prev_frame.user_instances) == 1
+
     context.newInstance(init_method="prior_frame")
 
-    # Confirm we only added one user instance
-    assert len(context.state["labeled_frame"].user_instances) == 1
+    # Confirm that the newly added user instance is the same as the sole user instance in the previous frame
+    newly_added_instance = context.state["labeled_frame"].user_instances[0]
+    assert newly_added_instance.video == user_inst.video
+    assert newly_added_instance.points == user_inst.points
+    assert newly_added_instance.track == user_inst.track
+
+
+def test_CopyPriorFramePreviousUser2(centered_pair_predictions: Labels):
+    """Test that we copy user instance in previous frame when the current frame has no instances."""
+    context = CommandContext.from_labels(centered_pair_predictions)
+    context.state["labeled_frame"] = centered_pair_predictions.find(
+        centered_pair_predictions.videos[0], frame_idx=124
+    )[0]
+    context.state["labeled_frame"].instances = []
+    context.state["video"] = centered_pair_predictions.videos[0]
+    context.state["frame_idx"] = 124
+    context.state["skeleton"] = centered_pair_predictions.skeleton
+
+    # No instances in current frame
+    assert len(context.state["labeled_frame"].instances) == 0
+
+    # Get previous frame
+    prev_idx = 123
+    prev_frame = context.labels.find(context.state["video"], prev_idx, return_new=True)[
+        0
+    ]
+    prev_instances = prev_frame.instances
+
+    # Confirm that previous frame has 2 predicted instances
+    assert len(prev_frame.user_instances) == 0
+    assert len(prev_frame.predicted_instances) == 2
+
+    # Add user instance to previous frame
+    skeleton = centered_pair_predictions.skeleton
+    user_inst = Instance(
+        skeleton=skeleton,
+        points={node: Point(1, 1) for node in skeleton.nodes},
+        frame=context.state["labeled_frame"],
+    )
+    prev_instances.insert(0, user_inst)
+
+    # Confirm addition of user instance in previous frame
+    assert len(prev_frame.user_instances) == 1
+
+    context.newInstance(init_method="best")
+
+    # Confirm that user instance in current frame is the same as the user instance in previous frame
+    current_user_instance = context.state["labeled_frame"].user_instances[0]
+    assert current_user_instance.video == user_inst.video
+    assert current_user_instance.points == user_inst.points
+    assert current_user_instance.track == user_inst.track
+
+
+def test_CopyPriorFrameCurrentUser(centered_pair_predictions: Labels):
+    """Test that we copy user instance in current frame when the current frame has >= amount of instances
+    as the previous frame."""
+    context = CommandContext.from_labels(centered_pair_predictions)
+    context.state["labeled_frame"] = centered_pair_predictions.find(
+        centered_pair_predictions.videos[0], frame_idx=124
+    )[0]
+    context.state["video"] = centered_pair_predictions.videos[0]
+    context.state["frame_idx"] = 124
+    context.state["skeleton"] = centered_pair_predictions.skeleton
+
+    # No user instances in current frame, only predicted
+    assert len(context.state["labeled_frame"].user_instances) == 0
     assert len(context.state["labeled_frame"].predicted_instances) == 2
 
-    # Confirm that the user instance added is the last one from previous frame
-    assert context.state["labeled_frame"].user_instances[0] == user_inst
+    # Get previous frame
+    prev_idx = 123
+    prev_frame = context.labels.find(context.state["video"], prev_idx, return_new=True)[
+        0
+    ]
+    prev_instances = prev_frame.instances
+
+    # Confirm that previous frame has same amount of instances as current frame and has no user instances
+    assert len(prev_frame.user_instances) == 0
+    assert len(prev_frame.predicted_instances) == 2
+
+    # Add user instance to current frame
+    skeleton = centered_pair_predictions.skeleton
+    user_inst = Instance(
+        skeleton=skeleton,
+        points={node: Point(1, 1) for node in skeleton.nodes},
+        frame=context.state["labeled_frame"],
+    )
+    context.state["labeled_frame"].instances.insert(0, user_inst)
+
+    # Confirm addition of user instance in current frame
+    assert len(context.state["labeled_frame"].user_instances) == 1
+
+    # Confirm that current frame has more instances than previous frame
+    assert len(context.state["labeled_frame"].instances) > len(prev_frame.instances)
+
+    # Remove tracks from all instances so that unused_predictions is empty
+    for inst in context.state["labeled_frame"].instances:
+        inst.track = None
+        inst.from_predicted = inst
+
+    context.newInstance(init_method="best")
+
+    # Confirm that both user instances in the current frame are the same
+    previous_user_instance = context.state["labeled_frame"].user_instances[0]
+    newly_added_instance = context.state["labeled_frame"].user_instances[1]
+    assert newly_added_instance.video == previous_user_instance.video
+    assert newly_added_instance.points == previous_user_instance.points
+    assert newly_added_instance.track == previous_user_instance.track
 
 
 def test_PasteInstance(min_tracks_2node_labels: Labels):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -617,10 +617,6 @@ def test_CopyInstance(min_tracks_2node_labels: Labels):
 
 
 def test_CopyPriorFrame(centered_pair_predictions: Labels):
-    # make the frame idx 124 so that the previous frame has two predicted and then add a user instance to the previous
-    # then run addInstance on the current frame and assert that the added instance is the user instance we added
-
-    # Test labels.numpy prefers user instances
     context = CommandContext.from_labels(centered_pair_predictions)
     context.state["labeled_frame"] = centered_pair_predictions.find(
         centered_pair_predictions.videos[0], frame_idx=124
@@ -632,8 +628,8 @@ def test_CopyPriorFrame(centered_pair_predictions: Labels):
     assert len(context.state["labeled_frame"].user_instances) == 0
     assert len(context.state["labeled_frame"].predicted_instances) == 2
 
-    prev_idx = AddInstance.get_previous_frame_index(context)
-    assert prev_idx is not None
+    # Modify previous frame to have a user instance
+    prev_idx = 123
     prev_frame = context.labels.find(context.state["video"], prev_idx, return_new=True)[
         0
     ]
@@ -643,6 +639,7 @@ def test_CopyPriorFrame(centered_pair_predictions: Labels):
     assert len(prev_frame.user_instances) == 0
     assert len(prev_frame.predicted_instances) == 2
 
+    skeleton = centered_pair_predictions.skeleton
     user_inst = Instance(
         skeleton=skeleton, points={node: Point(1, 1) for node in skeleton.nodes}
     )


### PR DESCRIPTION
… in prior frame rather than take the last instance in previous frame

### Description
Instead of returning the copy_instance, first check if the copy_instance is a predicted instance in which case check the previous frame to see if it has any user instances. If so, set copy_instance to the last user instance in the previous frame.

### Types of changes

- [X] Bugfix
- [ ] New feature
- [X] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]
https://github.com/talmolab/sleap/issues/1065

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the logic for selecting instances to copy from, ensuring accurate handling of predicted and user instances.
- **Tests**
  - Added a new test `test_CopyPriorFrame` to validate the behavior of adding a user instance based on the previous frame's data.
- **Documentation**
  - Updated the declarations of exported or public entities for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->