### PR TITLE
Add `RecordingSession`s table to `SessionsDock`

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1178,7 +1178,7 @@ class MainWindow(QMainWindow):
             self.plotFrame()
 
         if _has_topic([UpdateTopic.sessions]):
-            self.sessions_dock.table.model().items = self.labels.sessions
+            self.sessions_dock.sessions_table.model().items = self.labels.sessions
 
         if _has_topic(
             [

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -44,7 +44,6 @@ ensures consistency (e.g.) between color of instances drawn on video
 frame and instances listed in data view table.
 """
 
-
 import os
 import platform
 import random

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1176,6 +1176,9 @@ class MainWindow(QMainWindow):
         ):
             self.plotFrame()
 
+        if _has_topic([UpdateTopic.sessions]):
+            self.sessions_dock.table.model().items = self.labels.sessions
+
         if _has_topic(
             [
                 UpdateTopic.frame,

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1093,6 +1093,7 @@ class MainWindow(QMainWindow):
         has_selected_node = self.state["selected_node"] is not None
         has_selected_edge = self.state["selected_edge"] is not None
         has_selected_video = self.state["selected_video"] is not None
+        has_selected_session = self.state["selected_session"] is not None
         has_video = self.state["video"] is not None
 
         has_frame_range = bool(self.state["has_frame_range"])
@@ -1151,6 +1152,7 @@ class MainWindow(QMainWindow):
         self.suggestions_dock.suggestions_form_widget.buttons[
             "generate_button"
         ].setEnabled(has_videos)
+        self._buttons["remove session"].setEnabled(has_selected_session)
 
         # Update overlays
         self.overlays["track_labels"].visible = (

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -445,7 +445,7 @@ class CommandContext:
         """Shows gui for adding `RecordingSession`s to the project."""
         self.execute(AddSession)
 
-    def removeSessions(self):
+    def removeSelectedSession(self):
         """Removes a session from the project and the sessions dock."""
         self.execute(RemoveSession)
 
@@ -1974,12 +1974,20 @@ class RemoveVideo(EditCommand):
         return True
 
 
+class RemoveSession(EditCommand):
+    topics = [UpdateTopic.sessions]
+
+    @staticmethod
+    def do_action(context: CommandContext, params: dict):
+        current_session = context.state["selected_session"]
+        context.labels.remove_recording_session(current_session)
+
+
 class AddSession(EditCommand):
     topics = [UpdateTopic.sessions]
 
     @staticmethod
     def do_action(context: CommandContext, params: dict):
-
         camera_calibration = params["camera_calibration"]
         session = RecordingSession.load(filename=camera_calibration)
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -82,6 +82,7 @@ class UpdateTopic(Enum):
     frame = 8
     project = 9
     project_instances = 10
+    sessions = 11
 
 
 class AppCommand:
@@ -443,6 +444,10 @@ class CommandContext:
     def addSession(self):
         """Shows gui for adding `RecordingSession`s to the project."""
         self.execute(AddSession)
+
+    def removeSessions(self):
+        """Removes a session from the project and the sessions dock."""
+        self.execute(RemoveSession)
 
     def openSkeletonTemplate(self):
         """Shows gui for loading saved skeleton into project."""
@@ -1700,7 +1705,6 @@ class SelectToFrameGui(NavCommand):
 class GoAdjacentView(NavCommand):
     @classmethod
     def do_action(cls, context: CommandContext, params: dict):
-
         operator = -1 if params["prev_or_next"] == "prev" else 1
 
         labels = context.labels
@@ -1971,7 +1975,7 @@ class RemoveVideo(EditCommand):
 
 
 class AddSession(EditCommand):
-    # topics = [UpdateTopic.session]
+    topics = [UpdateTopic.sessions]
 
     @staticmethod
     def do_action(context: CommandContext, params: dict):

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2004,7 +2004,7 @@ class AddSession(EditCommand):
         if context.state["session"] is None:
             context.state["session"] = session
 
-        # Reset since this action is also linked to a button in the SessionsDock and it 
+        # Reset since this action is also linked to a button in the SessionsDock and it
         # is not visually apparent which session is selected after clicking the button
         context.state["selected_session"] = None
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1980,7 +1980,13 @@ class RemoveSession(EditCommand):
     @staticmethod
     def do_action(context: CommandContext, params: dict):
         current_session = context.state["selected_session"]
-        context.labels.remove_recording_session(current_session)
+        try:
+            context.labels.remove_recording_session(current_session)
+        except Exception as e:
+            raise e
+        finally:
+            # Always set the selected session to None, even if it wasn't removed
+            context.state["selected_session"] = None
 
 
 class AddSession(EditCommand):
@@ -1997,6 +2003,10 @@ class AddSession(EditCommand):
         # Load if no video currently loaded
         if context.state["session"] is None:
             context.state["session"] = session
+
+        # Reset since this action is also linked to a button in the SessionsDock and it 
+        # is not visually apparent which session is selected after clicking the button
+        context.state["selected_session"] = None
 
     @staticmethod
     def ask(context: CommandContext, params: dict) -> bool:

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -32,7 +32,6 @@ from sleap.instance import LabeledFrame, Instance
 from sleap.skeleton import Skeleton
 
 
-# Todo: Vaibhav subclass this to create sessions table model
 class GenericTableModel(QtCore.QAbstractTableModel):
     """
     Generic Qt table model to show a list of properties for some items.
@@ -384,6 +383,17 @@ class GenericTableView(QtWidgets.QTableView):
         if not idx.isValid():
             return None
         return self.model().original_items[idx.row()]
+
+
+class SessionsTableModel(GenericTableModel):
+    properties = ("id", "videos", "cameras")
+
+    def item_to_data(self, obj, item):
+        res = {}
+        res["id"] = hash(item)
+        res["cameras"] = len(getattr(item, "cameras"))
+        res["videos"] = len(getattr(item, "videos"))
+        return res
 
 
 class VideosTableModel(GenericTableModel):

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -32,6 +32,7 @@ from sleap.instance import LabeledFrame, Instance
 from sleap.skeleton import Skeleton
 
 
+# Todo: Vaibhav subclass this to create sessions table model
 class GenericTableModel(QtCore.QAbstractTableModel):
     """
     Generic Qt table model to show a list of properties for some items.
@@ -538,7 +539,6 @@ class SuggestionsTableModel(GenericTableModel):
         if prop != "group":
             super(SuggestionsTableModel, self).sort(column_idx, order)
         else:
-
             if not reverse:
                 # Use group_int (int) instead of group (str).
                 self.beginResetModel()

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -31,6 +31,7 @@ from sleap.gui.dataviews import (
     SkeletonNodesTableModel,
     SuggestionsTableModel,
     VideosTableModel,
+    SessionsTableModel,
 )
 from sleap.gui.dialogs.formbuilder import YamlFormWidget
 from sleap.gui.widgets.views import CollapsibleWidget
@@ -367,7 +368,6 @@ class SkeletonDock(DockWidget):
         vb.addWidget(hbw)
 
         def updatePreviewImage(preview_image_bytes: bytes):
-
             # Decode the preview image
             preview_image = decode_preview_image(preview_image_bytes)
 
@@ -574,11 +574,9 @@ class InstancesDock(DockWidget):
 
 class SessionsDock(DockWidget):
     def __init__(self, main_window: Optional[QMainWindow]):
-        super().__init__(name="Sessions", main_window=main_window, model_type=None)
-
-    def lay_everything_out(self) -> None:
-        triangulation_options = self.create_triangulation_options()
-        self.wgt_layout.addWidget(triangulation_options)
+        super().__init__(
+            name="Sessions", main_window=main_window, model_type=SessionsTableModel
+        )
 
     def create_triangulation_options(self) -> QWidget:
         main_window = self.main_window
@@ -601,3 +599,45 @@ class SessionsDock(DockWidget):
         hbw = QWidget()
         hbw.setLayout(hb)
         return hbw
+
+    def create_models(self) -> SessionsTableModel:
+        main_window = self.main_window
+        self.sessions_model = self.model_type(
+            items=main_window.state["labels"].sessions, context=main_window.commands
+        )
+
+        return self.sessions_model
+
+    def create_tables(self) -> GenericTableView:
+        if self.sessions_model is None:
+            self.create_models()
+
+        self.table = GenericTableView(
+            state=self.main_window.state, row_name="session", model=self.sessions_model
+        )
+        return self.table
+
+    def create_table_edit_buttons(self) -> QWidget:
+        main_window = self.main_window
+
+        hb = QHBoxLayout()
+        self.add_button(hb, "Add Session", lambda x: main_window.commands.addSession())
+        self.add_button(
+            hb, "Remove Session", main_window.commands.deleteSelectedInstance
+        )
+
+        hbw = QWidget()
+        hbw.setLayout(hb)
+        return hbw
+
+    def lay_everything_out(self) -> None:
+        if self.table is None:
+            self.create_tables()
+
+        self.wgt_layout.addWidget(self.table)
+
+        table_edit_buttons = self.create_table_edit_buttons()
+        self.wgt_layout.addWidget(table_edit_buttons)
+
+        triangulation_options = self.create_triangulation_options()
+        self.wgt_layout.addWidget(triangulation_options)

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -638,7 +638,7 @@ class SessionsDock(DockWidget):
         if self.table is None:
             self.create_tables()
 
-        self.wgt_layout.addWidget(self.table)
+        self.wgt_layout.addWidget(self.sessions_table)
 
         table_edit_buttons = self.create_table_edit_buttons()
         self.wgt_layout.addWidget(table_edit_buttons)

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -1,6 +1,6 @@
 """Module for creating dock widgets for the `MainWindow`."""
 
-from typing import Callable, Iterable, List, Optional, Type, Union
+from typing import Callable, Dict, Iterable, List, Optional, Type, Union
 
 from qtpy import QtGui
 from qtpy.QtCore import Qt
@@ -600,21 +600,25 @@ class SessionsDock(DockWidget):
         hbw.setLayout(hb)
         return hbw
 
-    def create_models(self) -> SessionsTableModel:
+    def create_models(self) -> Union[GenericTableModel, Dict[str, GenericTableModel]]:
         main_window = self.main_window
         self.sessions_model = self.model_type(
             items=main_window.state["labels"].sessions, context=main_window.commands
         )
 
-        return self.sessions_model
+        self.model = {"sessions_model": self.sessions_model}
+        return self.model
 
-    def create_tables(self) -> GenericTableView:
+    def create_tables(self) -> Union[GenericTableView, Dict[str, GenericTableView]]:
         if self.sessions_model is None:
             self.create_models()
 
-        self.table = GenericTableView(
-            state=self.main_window.state, row_name="session", model=self.sessions_model
+        main_window = self.main_window
+        self.sessions_table = GenericTableView(
+            state=main_window.state, row_name="session", model=self.sessions_model
         )
+
+        self.table = {"sessions_table": self.sessions_table}
         return self.table
 
     def create_table_edit_buttons(self) -> QWidget:

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -623,7 +623,7 @@ class SessionsDock(DockWidget):
         hb = QHBoxLayout()
         self.add_button(hb, "Add Session", lambda x: main_window.commands.addSession())
         self.add_button(
-            hb, "Remove Session", main_window.commands.deleteSelectedInstance
+            hb, "Remove Session", main_window.commands.removeSelectedSession
         )
 
         hbw = QWidget()

--- a/sleap/io/cameras.py
+++ b/sleap/io/cameras.py
@@ -1,4 +1,5 @@
 """Module for storing information for camera groups."""
+
 import logging
 import tempfile
 from pathlib import Path
@@ -499,7 +500,8 @@ class RecordingSession:
 
         # Ensure the `Camcorder` is in this `RecordingSession`'s `CameraCluster`
         try:
-            assert camcorder in self.camera_cluster
+            for camera in self.camera_cluster.cameras:
+                assert camcorder in self.camera_cluster
         except AssertionError:
             raise ValueError(
                 f"Camcorder {camcorder.name} is not in this RecordingSession's "
@@ -579,6 +581,9 @@ class RecordingSession:
                 videos[cam] = video
 
         return videos
+
+    def __bool__(self):
+        return True
 
     def __attrs_post_init__(self):
         self.camera_cluster.add_session(self)

--- a/sleap/io/cameras.py
+++ b/sleap/io/cameras.py
@@ -500,8 +500,7 @@ class RecordingSession:
 
         # Ensure the `Camcorder` is in this `RecordingSession`'s `CameraCluster`
         try:
-            for camera in self.camera_cluster.cameras:
-                assert camcorder in self.camera_cluster
+            assert camcorder in self.camera_cluster
         except AssertionError:
             raise ValueError(
                 f"Camcorder {camcorder.name} is not in this RecordingSession's "

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -1714,13 +1714,14 @@ class Labels(MutableSequence):
         if video in session.videos:
             session.remove_video(video)
 
-    def remove_session(self, session: RecordingSession):
+    def remove_recording_session(self, session: RecordingSession):
         """Remove a session from self.sessions.
 
         Args:
             session: `RecordingSession` instance
         """
-        self._sessions.remove(session)
+        if session in self._sessions:
+            self._sessions.remove(session)
 
     @classmethod
     def from_json(cls, *args, **kwargs):

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -1714,6 +1714,14 @@ class Labels(MutableSequence):
         if video in session.videos:
             session.remove_video(video)
 
+    def remove_session(self, session: RecordingSession):
+        """Remove a session from self.sessions.
+
+        Args:
+            session: `RecordingSession` instance
+        """
+        self._sessions.remove(session)
+
     @classmethod
     def from_json(cls, *args, **kwargs):
         from sleap.io.format.labels_json import LabelsJsonAdaptor
@@ -2854,7 +2862,6 @@ def find_path_using_paths(missing_path: Text, search_paths: List[Text]) -> Text:
 
     # Look for file with that name in each of the search path directories
     for search_path in search_paths:
-
         if os.path.isfile(search_path):
             path_dir = os.path.dirname(search_path)
         else:

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -5,7 +5,6 @@ from sleap.gui.dataviews import *
 
 
 def test_skeleton_nodes(qtbot, centered_pair_predictions):
-
     table = GenericTableView(
         model=SkeletonNodesTableModel(items=centered_pair_predictions.skeletons[0])
     )
@@ -74,6 +73,19 @@ def test_table_sort(qtbot, centered_pair_predictions):
     assert table.getSelectedRowItem().score == inst.score
 
 
+def test_sessions_table(qtbot, min_session_session):
+    sessions = []
+    sessions.append(min_session_session)
+    table = GenericTableView(
+        row_name="session",
+        is_sortable=True,
+        name_prefix="",
+        model=SessionsTableModel(items=sessions),
+    )
+    table.selectRow(0) 
+    assert table.getSelectedRowItem().cameras == 8
+
+
 def test_table_sort_string(qtbot):
     table_model = GenericTableModel(
         items=[dict(a=1, b=2), dict(a=2, b="")], properties=["a", "b"]
@@ -82,5 +94,7 @@ def test_table_sort_string(qtbot):
     table = GenericTableView(is_sortable=True, model=table_model)
 
     # Make sure we can sort with both numbers and strings (i.e., "")
-    table.model().sort(0)
-    table.model().sort(1)
+    # table.model().sort(0)
+    # table.model().sort(1)
+    table.selectRow(1)
+    assert table.getSelectedRowItem()["a"] == 1

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -1,6 +1,8 @@
 import pytest
 import pytestqt
 
+from sleap.io.video import *
+from sleap.io.cameras import *
 from sleap.gui.dataviews import *
 
 
@@ -82,8 +84,22 @@ def test_sessions_table(qtbot, min_session_session):
         name_prefix="",
         model=SessionsTableModel(items=sessions),
     )
-    table.selectRow(0) 
-    assert table.getSelectedRowItem().cameras == 8
+    table.selectRow(0)
+    assert len(table.getSelectedRowItem().videos) == 0
+    assert len(table.getSelectedRowItem().camera_cluster.cameras) == 8
+    assert len(table.getSelectedRowItem().camera_cluster.sessions) == 1
+
+    video = Video.from_hdf5(filename="test.h5", dataset="box")
+    min_session_session.add_video(
+        video,
+        table.getSelectedRowItem().camera_cluster.cameras[0],
+    )
+
+    # Verify that modification of the recording session is reflected in the recording session stored in the table
+    assert len(table.getSelectedRowItem().videos) == 1
+
+    min_session_session.remove_video(video)
+    assert len(table.getSelectedRowItem().videos) == 0
 
 
 def test_table_sort_string(qtbot):

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -110,7 +110,5 @@ def test_table_sort_string(qtbot):
     table = GenericTableView(is_sortable=True, model=table_model)
 
     # Make sure we can sort with both numbers and strings (i.e., "")
-    # table.model().sort(0)
-    # table.model().sort(1)
-    table.selectRow(1)
-    assert table.getSelectedRowItem()["a"] == 1
+    table.model().sort(0)
+    table.model().sort(1)

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -1,8 +1,3 @@
-import pytest
-import pytestqt
-
-from sleap.io.video import *
-from sleap.io.cameras import *
 from sleap.gui.dataviews import *
 
 
@@ -75,7 +70,7 @@ def test_table_sort(qtbot, centered_pair_predictions):
     assert table.getSelectedRowItem().score == inst.score
 
 
-def test_sessions_table(qtbot, min_session_session):
+def test_sessions_table(qtbot, min_session_session, hdf5_vid):
     sessions = []
     sessions.append(min_session_session)
     table = GenericTableView(
@@ -89,7 +84,7 @@ def test_sessions_table(qtbot, min_session_session):
     assert len(table.getSelectedRowItem().camera_cluster.cameras) == 8
     assert len(table.getSelectedRowItem().camera_cluster.sessions) == 1
 
-    video = Video.from_hdf5(filename="test.h5", dataset="box")
+    video = hdf5_vid
     min_session_session.add_video(
         video,
         table.getSelectedRowItem().camera_cluster.cameras[0],

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -12,8 +12,6 @@ from sleap.gui.widgets.docks import (
     SkeletonDock,
     SessionsDock,
 )
-from sleap.io.cameras import RecordingSession
-
 
 def test_videos_dock(
     qtbot,
@@ -111,29 +109,34 @@ def test_instances_dock(qtbot):
     assert dock.wgt_layout is dock.widget().layout()
 
 
+def test_sessions_dock(qtbot):
+    """Test the `SessionsDock` class."""
+    main_window = MainWindow()
+    dock = SessionsDock(main_window)
+
+    assert dock.name == "Sessions"
+    assert dock.main_window is main_window
+    assert dock.wgt_layout is dock.widget().layout()
+
 def test_sessions_dock_session_table(qtbot, multiview_min_session_labels):
+    """Test the SessionsDock.sessions_table."""
+
+    # Create dock
+    main_window = MainWindow()
+    SessionsDock(main_window)
+
+    # Loading label file
+    main_window.commands.loadLabelsObject(multiview_min_session_labels)
+
+    # Testing if sessions table is loaded correctly
+    sessions = multiview_min_session_labels.sessions
+    main_window.sessions_dock.sessions_table.selectRow(0)
+    assert main_window.sessions_dock.sessions_table.getSelectedRowItem() == sessions[0]
+
+    # Testing if removal of selected session is reflected in sessions dock
+    main_window.state["selected_session"] = sessions[0]
+    main_window._buttons["remove session"].click()
+    
     with pytest.raises(IndexError):
-        """Test the SessionsDock class."""
-
-        # Create dock
-        main_window = MainWindow()
-        dock = SessionsDock(main_window)
-
-        # Testing if dock object loads corretly
-        assert dock.name == "Sessions"
-        assert dock.main_window is main_window
-        assert dock.wgt_layout is dock.widget().layout()
-
-        # Loading label file
-        main_window.commands.loadLabelsObject(multiview_min_session_labels)
-
-        # Testing if sessions table is loaded correctly
-        sessions = multiview_min_session_labels.sessions
-        main_window.sessions_dock.table.selectRow(0)
-        assert main_window.sessions_dock.table.getSelectedRowItem() == sessions[0]
-
-        # Testing if removal of selected session is reflected in sessions dock
-        main_window.state["selected_session"] = sessions[0]
-        main_window._buttons["remove session"].click()
-        # The following line should raise an IndexError since there are no longer any sessions in the table
-        main_window.sessions_dock.table.selectRow(0)
+        # There are no longer any sessions in the table
+        main_window.sessions_dock.sessions_table.selectRow(0)

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -10,7 +10,9 @@ from sleap.gui.widgets.docks import (
     SuggestionsDock,
     VideosDock,
     SkeletonDock,
+    SessionsDock,
 )
+from sleap.io.cameras import RecordingSession
 
 
 def test_videos_dock(
@@ -107,3 +109,31 @@ def test_instances_dock(qtbot):
     assert dock.name == "Instances"
     assert dock.main_window is main_window
     assert dock.wgt_layout is dock.widget().layout()
+
+
+def test_sessions_dock_session_table(qtbot, multiview_min_session_labels):
+    with pytest.raises(IndexError):
+        """Test the SessionsDock class."""
+
+        # Create dock
+        main_window = MainWindow()
+        dock = SessionsDock(main_window)
+
+        # Testing if dock object loads corretly
+        assert dock.name == "Sessions"
+        assert dock.main_window is main_window
+        assert dock.wgt_layout is dock.widget().layout()
+
+        # Loading label file
+        main_window.commands.loadLabelsObject(multiview_min_session_labels)
+
+        # Testing if sessions table is loaded correctly
+        sessions = multiview_min_session_labels.sessions
+        main_window.sessions_dock.table.selectRow(0)
+        assert main_window.sessions_dock.table.getSelectedRowItem() == sessions[0]
+
+        # Testing if removal of selected session is reflected in sessions dock
+        main_window.state["selected_session"] = sessions[0]
+        main_window._buttons["remove session"].click()
+        # The following line should raise an IndexError since there are no longer any sessions in the table
+        main_window.sessions_dock.table.selectRow(0)

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -13,6 +13,7 @@ from sleap.gui.widgets.docks import (
     SessionsDock,
 )
 
+
 def test_videos_dock(
     qtbot,
     centered_pair_predictions: Labels,
@@ -118,6 +119,7 @@ def test_sessions_dock(qtbot):
     assert dock.main_window is main_window
     assert dock.wgt_layout is dock.widget().layout()
 
+
 def test_sessions_dock_session_table(qtbot, multiview_min_session_labels):
     """Test the SessionsDock.sessions_table."""
 
@@ -136,7 +138,7 @@ def test_sessions_dock_session_table(qtbot, multiview_min_session_labels):
     # Testing if removal of selected session is reflected in sessions dock
     main_window.state["selected_session"] = sessions[0]
     main_window._buttons["remove session"].click()
-    
+
     with pytest.raises(IndexError):
         # There are no longer any sessions in the table
         main_window.sessions_dock.sessions_table.selectRow(0)


### PR DESCRIPTION
### Description
The overall goal here is to add a new table  to the [`SessionsDock`](https://github.com/talmolab/sleap/blob/cc78c910129a66951219b4f139effd6c6827b3f0/sleap/gui/widgets/docks.py#L575-L603) that displays all `RecordingSession`s in the `SessionsDock.main_window.label.sessions: List[RecordingSession]` list. The widget should be a table that displays the `RecordingSession`s hash (eventually name), number of `RecordingSession.cameras: List[Camcorder]`, and number of `RecordingSession.videos: List[Video]` (see **Figure 1**). This `SessionsTable` will be used to dynamically populate our `CamerasTable` later on.
- [x] Subclass `GenericTableModel` to create a new model called `SessionsTableModel` with the class attribute `properties = ("id", "videos", "cameras")` (similar to [`VideosTableModel`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/dataviews.py#L388-L392))
- [x] Implement the method `SessionsTableModel.item_to_data(self, obj: List[RecordingSession], item: RecordingSession)` which returns the following dictionary: `{id: item.__hash__(), videos: len(item.videos), cameras: len(item.cameras)}` (similar to [`VideosTableModel.item_to_data`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/dataviews.py#L391-L392))
- [x] Add a `sessions_model_type = SessionsTableModel` attribute to `SessionsDock` (similar to [`SkeletonDock.nodes_model_type`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L217)) and [pass into the `model_type` list for `super().__init__`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L222)
- [x] Add a `SessionsDock.create_models` method (or append to it if it already exists) that sets a `SessionsDock.sessions_model = SessionsDock.sessions_model_type(items=main_window.state["labels"].sessions, context=main_window.commands)` and returns a list of all models created (see [`SkeletonDock.create_models`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L226-L234))
- [x] Add a `SessionsDock.create_tables` method (or append to it if it already exists) that sets a `SessionsDock.sessions_table = GenericTableView(state=..., row_name="session", ...)` and returns a list of all tables created (see [`SkeletonDock.create_tables`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L236-L253))
- [x] Add button to "Add Session" and link it to `CommandContext.add_session(self)`
- [x] Create a command class called `RemoveSession` (similar to [`AddSession`](https://github.com/talmolab/sleap/blob/7f74a8ba75aa2bd9d7cc53a156fcc2efa188607a/sleap/gui/commands.py#L1977-L1991) with only a `do_action` method) that uses  `Labels.remove_recording_session(session: RecordingSession)` (does not exist yet, but it will be named this) to remove the `RecordingSession` from the labels
- [x] Add a method to the command context `CommandContext.remove_session(self, session: RecordingSession)` which takes in a `RecordingSession` to remove and `CommandContext.execute`s the `RemoveSession` class ([similar to `CommandContext.add_session`](https://github.com/talmolab/sleap/blob/7f74a8ba75aa2bd9d7cc53a156fcc2efa188607a/sleap/gui/commands.py#L446) but with an additional argument)
>Note: `CommandContext.execute(command: AppCommand, **kwargs)` passes all keyword arguments into the `command: AppCommand` class as key-value pairs in the `params: dict`
https://github.com/talmolab/sleap/blob/7f74a8ba75aa2bd9d7cc53a156fcc2efa188607a/sleap/gui/commands.py#L242-L244
- [x] Add button to "Remove Session" and link it to `CommandContext.remove_session` (similar to you [add sessions button](https://github.com/vaibhavtrip29/sleap/blob/f4c68acc1925bb8fbaf8f9c451b1ac495c1ebdb4/sleap/gui/widgets/docks.py#L624)). 
- [x] Disable "Remove Session" button when no selected `RecordingSession` (see [comment on `CamerasTable` PR](https://github.com/talmolab/sleap/pull/1671#discussion_r1468061636))
- [x] In the `SessionsDock.lay_everything_out` method, add the `SessionsDock.sessions_table` to the `SessionsDock.wgt_layout: QVBoxLayout` (see the [`InstancesDock.lay_everything_out`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L549-L553)).
- [x] Add a `sessions` option to [`UpdateTopic: Enum`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/commands.py#L70-L82)
- [x] In `MainWindow.on_data_update` add (or append to) the `if _has_topic(UpdateTopic.sessions)` that updates the items to display in the `SessionsTable` (see [`video_dock.table` update](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/app.py#L1172-L1173))

#### Test the `SessionsTable`
Tests for the `SessionsTable` will be added to [`tests/gui/test_dataviews.py`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/tests/gui/test_dataviews.py).
- [ ] Test that the expected `RecordingSession` is returned when we select a specific row of the table (see [existing test for inspiration](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/tests/gui/test_dataviews.py#L53-L55))
- [ ] Test that when we update a `RecordingSession` in `labels.sessions`, the `RecordingSession` in the table is updated as well

#### Test the `SessionsTable` as part of the `SessionsDock`
Tests for the `SessionsDock` will be added to [`tests/gui/widgets/test_docks.py`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/tests/gui/widgets/test_docks.py).
- [ ] Test interactions with table and `GuiState` (see [existing test](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/tests/gui/widgets/test_docks.py#L62-L72))

<image src="https://github.com/talmolab/sleap/assets/38435167/b3eb525f-ba43-4005-8b89-758c89093c87" height="400">

**Figure 1**: Depiction of `SessionsTable` layout.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
    - Added a check for the presence of a selected session in the GUI state.
    - Enabled a button based on the presence of a selected session.
    - Introduced a new `UpdateTopic` enum value for sessions.
    - Added a `removeSelectedSession` method to `AppCommand` for session removal.
    - Updated the `AddSession` class to handle adding sessions and resetting the selected session state.
    - Updated the `SessionsTableModel` class with properties for `id`, `videos`, and `cameras`.
    - Added functionality to `SessionsDock` class for creating models and tables.
- **Bug Fixes**
    - Updated logic in the `find_path_using_paths` function for improved file existence checks.
- **Tests**
    - Added tests for session-related functionality within GUI widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->