### PR TITLE
Add `CamerasTable` to `SessionsDock`

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1236,6 +1236,12 @@ class MainWindow(QMainWindow):
         if _has_topic([UpdateTopic.frame, UpdateTopic.project_instances]):
             self.state["last_interacted_frame"] = self.state["labeled_frame"]
 
+        if _has_topic([UpdateTopic.sessions]):
+            self.sessions_dock.table.model().items = self.labels.videos
+
+
+        
+
     def plotFrame(self, *args, **kwargs):
         """Plots (or replots) current frame."""
         if self.state["video"] is None:

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1094,6 +1094,7 @@ class MainWindow(QMainWindow):
         has_selected_edge = self.state["selected_edge"] is not None
         has_selected_video = self.state["selected_video"] is not None
         has_video = self.state["video"] is not None
+        has_selected_camcorder = self.state["selected_camera"] is not None
 
         has_frame_range = bool(self.state["has_frame_range"])
         has_unsaved_changes = bool(self.state["has_changes"])
@@ -1148,6 +1149,7 @@ class MainWindow(QMainWindow):
         self._buttons["show video"].setEnabled(has_selected_video)
         self._buttons["remove video"].setEnabled(has_video)
         self._buttons["delete instance"].setEnabled(has_selected_instance)
+        self._buttons["unlink video"].setEnabled(has_selected_camcorder)
         self.suggestions_dock.suggestions_form_widget.buttons[
             "generate_button"
         ].setEnabled(has_videos)
@@ -1237,7 +1239,7 @@ class MainWindow(QMainWindow):
             self.state["last_interacted_frame"] = self.state["labeled_frame"]
 
         if _has_topic([UpdateTopic.sessions]):
-            self.sessions_dock.table.model().items = self.labels.videos
+            self.sessions_dock.table.model()["camera_table"].items = self.labels.videos
 
 
         

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1244,9 +1244,11 @@ class MainWindow(QMainWindow):
             self.state["last_interacted_frame"] = self.state["labeled_frame"]
 
         if _has_topic([UpdateTopic.sessions]):
-            self.sessions_dock.camera_table.model().items = self.state[
-                "session"  # TODO(LM): Use "selected_session" here
-            ]
+            self.update_cameras_model()
+
+    def update_cameras_model(self):
+        """Update the cameras model with the selected session."""
+        self.sessions_dock.camera_table.model().items = self.state["selected_session"]
 
     def plotFrame(self, *args, **kwargs):
         """Plots (or replots) current frame."""

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1030,7 +1030,7 @@ class MainWindow(QMainWindow):
         """Create dock windows and connect them to GUI."""
 
         self.videos_dock = VideosDock(self)
-        self.sessions_dock = SessionsDock(self)
+        self.sessions_dock = SessionsDock(self, tab_with=self.videos_dock)
         self.skeleton_dock = SkeletonDock(self, tab_with=self.videos_dock)
         self.suggestions_dock = SuggestionsDock(self, tab_with=self.videos_dock)
         self.instances_dock = InstancesDock(self, tab_with=self.videos_dock)

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -145,6 +145,7 @@ class MainWindow(QMainWindow):
         self.state["labeled_frame"] = None
         self.state["last_interacted_frame"] = None
         self.state["filename"] = None
+        self.state["session"] = None
         self.state["show non-visible nodes"] = prefs["show non-visible nodes"]
         self.state["show instances"] = True
         self.state["show labels"] = True
@@ -1095,7 +1096,7 @@ class MainWindow(QMainWindow):
         has_selected_video = self.state["selected_video"] is not None
         has_video = self.state["video"] is not None
         has_selected_camcorder = self.state["selected_camera_table"] is not None
-        
+
         has_frame_range = bool(self.state["has_frame_range"])
         has_unsaved_changes = bool(self.state["has_changes"])
         has_videos = self.labels is not None and len(self.labels.videos) > 0
@@ -1239,10 +1240,9 @@ class MainWindow(QMainWindow):
             self.state["last_interacted_frame"] = self.state["labeled_frame"]
 
         if _has_topic([UpdateTopic.sessions]):
-            self.sessions_dock.table["camera_table"].model().items = self.labels.sessions[0]
-
-
-        
+            self.sessions_dock.table["camera_table"].model().items = self.state[
+                "session"  # TODO(LM): Use "selected_session" here
+            ]
 
     def plotFrame(self, *args, **kwargs):
         """Plots (or replots) current frame."""

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1240,7 +1240,7 @@ class MainWindow(QMainWindow):
             self.state["last_interacted_frame"] = self.state["labeled_frame"]
 
         if _has_topic([UpdateTopic.sessions]):
-            self.sessions_dock.table["camera_table"].model().items = self.state[
+            self.sessions_dock.camera_table.model().items = self.state[
                 "session"  # TODO(LM): Use "selected_session" here
             ]
 

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1095,7 +1095,7 @@ class MainWindow(QMainWindow):
         has_selected_video = self.state["selected_video"] is not None
         has_video = self.state["video"] is not None
         has_selected_camcorder = self.state["selected_camera_table"] is not None
-
+        
         has_frame_range = bool(self.state["has_frame_range"])
         has_unsaved_changes = bool(self.state["has_changes"])
         has_videos = self.labels is not None and len(self.labels.videos) > 0

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1095,7 +1095,7 @@ class MainWindow(QMainWindow):
         has_selected_edge = self.state["selected_edge"] is not None
         has_selected_video = self.state["selected_video"] is not None
         has_video = self.state["video"] is not None
-        has_selected_camcorder = self.state["selected_camera_table"] is not None
+        has_selected_camcorder = self.state["selected_camera"] is not None
 
         has_frame_range = bool(self.state["has_frame_range"])
         has_unsaved_changes = bool(self.state["has_changes"])

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1094,7 +1094,7 @@ class MainWindow(QMainWindow):
         has_selected_edge = self.state["selected_edge"] is not None
         has_selected_video = self.state["selected_video"] is not None
         has_video = self.state["video"] is not None
-        has_selected_camcorder = self.state["selected_camera"] is not None
+        has_selected_camcorder = self.state["selected_camera_table"] is not None
 
         has_frame_range = bool(self.state["has_frame_range"])
         has_unsaved_changes = bool(self.state["has_changes"])
@@ -1239,7 +1239,7 @@ class MainWindow(QMainWindow):
             self.state["last_interacted_frame"] = self.state["labeled_frame"]
 
         if _has_topic([UpdateTopic.sessions]):
-            self.sessions_dock.table.model()["camera_table"].items = self.labels.videos
+            self.sessions_dock.table["camera_table"].model().items = self.labels.sessions[0]
 
 
         

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -655,6 +655,9 @@ class CommandContext:
         """Open the current prerelease version."""
         self.execute(OpenPrereleaseVersion)
 
+    def unlink_video_from_camera(self):
+        """Unlinks video from a camera"""
+        self.execute(UnlinkVideo)
 
 # File Commands
 
@@ -3901,3 +3904,19 @@ def copy_to_clipboard(text: str):
     clipboard = QtWidgets.QApplication.clipboard()
     clipboard.clear(mode=clipboard.Clipboard)
     clipboard.setText(text, mode=clipboard.Clipboard)
+
+class UnlinkVideo(EditCommand):
+    @staticmethod
+    def do_action(context: CommandContext, params: dict):
+        video = params.get("video", None)
+        cam = params.get("Camcoder", None)
+        recording_session = params.get("RecordingSession", None)
+        
+        videos = cam._video_by_session[str(recording_session)]
+
+        videos.remove(video)
+
+        if len(videos) == 0:
+            del str(recording_session)
+        else:
+            cam._video_by_session[str(recording_session)] = videos                

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3923,3 +3923,6 @@ class UnlinkVideo(EditCommand):
 
         if video is not None and recording_session is not None:
             recording_session.remove_video(video)
+
+        # Reset the selected camera
+        context.state["selected_camera"] = None

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3907,14 +3907,14 @@ def copy_to_clipboard(text: str):
     clipboard.setText(text, mode=clipboard.Clipboard)
 
 class UnlinkVideo(EditCommand):
+    topics = [UpdateTopic.sessions]
+    
     @staticmethod
     def do_action(context: CommandContext, params: dict):
         camcorder = context.state["selected_camera_table"]
         recording_session = camcorder.sessions[0] # potentially buggy
 
         video = camcorder.get_video(recording_session)
-
-        print(video)
 
         if video is not None and recording_session is not None:
             recording_session.remove_video(video)

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3911,7 +3911,11 @@ class UnlinkVideo(EditCommand):
     def do_action(context: CommandContext, params: dict):
         video = params.get("selected_camera_table", None)
         recording_session = params.get("RecordingSession", None)
-        recording_session.remove_video(video)
+
+        print(video, recording_session)
+
+        if video is not None and recording_session is not None:
+            recording_session.remove_video(video)
 
 
         

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3915,7 +3915,7 @@ class UnlinkVideo(EditCommand):
 
     @staticmethod
     def do_action(context: CommandContext, params: dict):
-        camcorder = context.state["selected_camera_table"]
+        camcorder = context.state["selected_camera"]
         # TODO(LM): replace with state["selected_session"]
         recording_session = context.state["session"]
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3937,8 +3937,7 @@ class UnlinkVideo(EditCommand):
     @staticmethod
     def do_action(context: CommandContext, params: dict):
         camcorder = context.state["selected_camera"]
-        # TODO(LM): replace with state["selected_session"]
-        recording_session = context.state["session"]
+        recording_session = context.state["selected_session"]
 
         video = camcorder.get_video(recording_session)
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3909,10 +3909,12 @@ def copy_to_clipboard(text: str):
 class UnlinkVideo(EditCommand):
     @staticmethod
     def do_action(context: CommandContext, params: dict):
-        video = params.get("selected_camera_table", None)
-        recording_session = params.get("RecordingSession", None)
+        camcorder = context.state["selected_camera_table"]
+        recording_session = camcorder.sessions[0] # potentially buggy
 
-        print(video, recording_session)
+        video = camcorder.get_video(recording_session)
+
+        print(video)
 
         if video is not None and recording_session is not None:
             recording_session.remove_video(video)

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -660,6 +660,7 @@ class CommandContext:
         """Unlinks video from a camera"""
         self.execute(UnlinkVideo)
 
+
 # File Commands
 
 
@@ -700,8 +701,8 @@ class LoadLabelsObject(AppCommand):
         # Load first video
         if len(labels.videos):
             context.state["video"] = labels.videos[0]
-        
-        context.state["session"] = labels.sessions[0] if len(labels.sessions) else None 
+
+        context.state["session"] = labels.sessions[0] if len(labels.sessions) else None
 
         context.state["project_loaded"] = True
         context.state["has_changes"] = params.get("changed_on_load", False) or (
@@ -3908,19 +3909,17 @@ def copy_to_clipboard(text: str):
     clipboard.clear(mode=clipboard.Clipboard)
     clipboard.setText(text, mode=clipboard.Clipboard)
 
+
 class UnlinkVideo(EditCommand):
     topics = [UpdateTopic.sessions]
-    
+
     @staticmethod
     def do_action(context: CommandContext, params: dict):
         camcorder = context.state["selected_camera_table"]
-        recording_session = camcorder.sessions[0] # potentially buggy
+        # TODO(LM): replace with state["selected_session"]
+        recording_session = context.state["session"]
 
         video = camcorder.get_video(recording_session)
 
         if video is not None and recording_session is not None:
             recording_session.remove_video(video)
-
-
-        
-                 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3909,14 +3909,9 @@ def copy_to_clipboard(text: str):
 class UnlinkVideo(EditCommand):
     @staticmethod
     def do_action(context: CommandContext, params: dict):
-        video = params.get("video", None)
-        cam = params.get("Camcorder", None)
+        video = params.get("selected_camera_table", None)
         recording_session = params.get("RecordingSession", None)
-
-        if video is not None and recording_session is not None \
-            and cam is not None:
-
-            recording_session.remove_video(video)
+        recording_session.remove_video(video)
 
 
         

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -82,6 +82,7 @@ class UpdateTopic(Enum):
     frame = 8
     project = 9
     project_instances = 10
+    sessions = 11
 
 
 class AppCommand:
@@ -3909,14 +3910,14 @@ class UnlinkVideo(EditCommand):
     @staticmethod
     def do_action(context: CommandContext, params: dict):
         video = params.get("video", None)
-        cam = params.get("Camcoder", None)
+        cam = params.get("Camcorder", None)
         recording_session = params.get("RecordingSession", None)
+
+        if video is not None and recording_session is not None \
+            and cam is not None:
+
+            recording_session.remove_video(video)
+
+
         
-        videos = cam._video_by_session[str(recording_session)]
-
-        videos.remove(video)
-
-        if len(videos) == 0:
-            del str(recording_session)
-        else:
-            cam._video_by_session[str(recording_session)] = videos                
+                 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -700,6 +700,8 @@ class LoadLabelsObject(AppCommand):
         # Load first video
         if len(labels.videos):
             context.state["video"] = labels.videos[0]
+        
+        context.state["session"] = labels.sessions[0] if len(labels.sessions) else None 
 
         context.state["project_loaded"] = True
         context.state["has_changes"] = params.get("changed_on_load", False) or (

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -30,6 +30,7 @@ from sleap.gui.color import ColorManager
 from sleap.io.dataset import Labels
 from sleap.instance import LabeledFrame, Instance
 from sleap.skeleton import Skeleton
+from sleap.io.cameras import Camcorder, RecordingSession
 
 
 class GenericTableModel(QtCore.QAbstractTableModel):
@@ -652,3 +653,22 @@ class SkeletonNodeModel(QtCore.QStringListModel):
     def flags(self, index: QtCore.QModelIndex):
         """Overrides Qt method, returns flags (editable etc)."""
         return QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
+    
+class CamerasTableModel(GenericTableModel):
+    """
+    Table model for for multi-view, showing which cameras 
+    are assigned to which videos
+
+    Args: 
+        obj: 'RecordingSession' which has information of cameras 
+              and paired video
+    """
+
+    properties = ("camera, ""video")
+
+    def object_to_items(self, obj: RecordingSession):
+        items = obj.cameras
+        return items
+    
+    def item_to_data(self, obj: RecoderdingSession, item: Camcorder):
+        return {'camera': item.name, 'video': obj.get_video(item)}

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -664,10 +664,10 @@ class CamerasTableModel(GenericTableModel):
               and paired video
     """
 
-    properties = ("camera, ""video")
+    properties = ("camera", "video")
 
     def object_to_items(self, obj: RecordingSession):
-        items = obj.cameras
+        items = obj.linked_cameras()
         return items
     
     def item_to_data(self, obj: RecordingSession, item: Camcorder):

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -666,7 +666,9 @@ class CamerasTableModel(GenericTableModel):
     properties = ("camera", "video")
 
     def object_to_items(self, obj: RecordingSession):
-        return obj.linked_cameras
+        return obj.camera_cluster.cameras
 
     def item_to_data(self, obj: RecordingSession, item: Camcorder):
-        return {"camera": item.name, "video": obj.get_video(item).filename}
+        
+        video = obj.get_video(item)
+        return {"camera": item.name, "video": video.filename if video else ""}

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -663,12 +663,11 @@ class CamerasTableModel(GenericTableModel):
         obj: 'RecordingSession' which has information of cameras 
               and paired video
     """
-
+    
     properties = ("camera", "video")
-
+        
     def object_to_items(self, obj: RecordingSession):
-        items = obj.linked_cameras()
-        return items
+        return obj.linked_cameras
     
     def item_to_data(self, obj: RecordingSession, item: Camcorder):
         return {'camera': item.name, 'video': obj.get_video(item)}

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -653,21 +653,20 @@ class SkeletonNodeModel(QtCore.QStringListModel):
     def flags(self, index: QtCore.QModelIndex):
         """Overrides Qt method, returns flags (editable etc)."""
         return QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsSelectable
-    
-class CamerasTableModel(GenericTableModel):
-    """
-    Table model for for multi-view, showing which cameras 
-    are assigned to which videos
 
-    Args: 
-        obj: 'RecordingSession' which has information of cameras 
+
+class CamerasTableModel(GenericTableModel):
+    """Table model for unlinking `Camcorder`s and `Video`s within a `RecordingSession`.
+
+    Args:
+        obj: 'RecordingSession' which has information of cameras
               and paired video
     """
-    
+
     properties = ("camera", "video")
-        
+
     def object_to_items(self, obj: RecordingSession):
         return obj.linked_cameras
-    
+
     def item_to_data(self, obj: RecordingSession, item: Camcorder):
-        return {'camera': item.name, 'video': obj.get_video(item).filename}
+        return {"camera": item.name, "video": obj.get_video(item).filename}

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -670,5 +670,5 @@ class CamerasTableModel(GenericTableModel):
         items = obj.cameras
         return items
     
-    def item_to_data(self, obj: RecoderdingSession, item: Camcorder):
+    def item_to_data(self, obj: RecordingSession, item: Camcorder):
         return {'camera': item.name, 'video': obj.get_video(item)}

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -679,6 +679,6 @@ class CamerasTableModel(GenericTableModel):
         return obj.camera_cluster.cameras
 
     def item_to_data(self, obj: RecordingSession, item: Camcorder):
-        
+
         video = obj.get_video(item)
         return {"camera": item.name, "video": video.filename if video else ""}

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -670,4 +670,4 @@ class CamerasTableModel(GenericTableModel):
         return obj.linked_cameras
     
     def item_to_data(self, obj: RecordingSession, item: Camcorder):
-        return {'camera': item.name, 'video': obj.get_video(item)}
+        return {'camera': item.name, 'video': obj.get_video(item).filename}

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -31,6 +31,7 @@ from sleap.gui.dataviews import (
     SkeletonNodesTableModel,
     SuggestionsTableModel,
     VideosTableModel,
+    CamerasTableModel,
 )
 from sleap.gui.dialogs.formbuilder import YamlFormWidget
 from sleap.gui.widgets.views import CollapsibleWidget
@@ -574,7 +575,9 @@ class InstancesDock(DockWidget):
 
 class SessionsDock(DockWidget):
     def __init__(self, main_window: Optional[QMainWindow]):
-        super().__init__(name="Sessions", main_window=main_window, model_type=None)
+        self.camera_model_type = CamerasTableModel
+        super().__init__(name="Sessions", main_window=main_window, model_type=[self.camera_model_type])
+        
 
     def lay_everything_out(self) -> None:
         triangulation_options = self.create_triangulation_options()
@@ -601,3 +604,24 @@ class SessionsDock(DockWidget):
         hbw = QWidget()
         hbw.setLayout(hb)
         return hbw
+    
+    def create_models(self) -> GenericTableModel:
+        main_window = self.main_window
+        self.camera_model = self.camera_model_type(
+            items=main_window.state["selected_session"], context=main_window.commands
+        )
+        
+        return [self.camera_model]
+    
+    def create_tables(self) -> GenericTableView:
+        if self.model is None:
+            self.create_models()
+
+        main_window = self.main_window
+        self.camera_table = GenericTableView(
+            state=main_window.state,
+            row_name="camera",
+            model=self.camera_model,
+        )
+
+        return [self.camera_table]

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -629,7 +629,7 @@ class SessionsDock(DockWidget):
         main_window = self.main_window
         self.camera_table = GenericTableView(
             state=main_window.state,
-            row_name="camera_table",
+            row_name="camera",
             model=self.camera_model,
         )
 

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -613,6 +613,10 @@ class SessionsDock(DockWidget):
             hb, "Unlink Video", main_window.commands.unlink_video_from_camera
         )
 
+        hbw = QWidget()
+        hbw.setLayout(hb)
+        return hbw
+
     def create_models(self) -> Union[GenericTableModel, Dict[str, GenericTableModel]]:
         main_window = self.main_window
         self.sessions_model = self.sessions_model_type(

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -639,7 +639,7 @@ class SessionsDock(DockWidget):
         main_window = self.main_window
 
         hb = QHBoxLayout()
-        self.add_button(hb, "Unlink Video", main_window.commands.unlink_video_from_camera())
+        self.add_button(hb, "Unlink Video", main_window.commands.unlink_video_from_camera)
 
         hbw = QWidget()
         hbw.setLayout(hb)

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -574,13 +574,18 @@ class InstancesDock(DockWidget):
 
 
 class SessionsDock(DockWidget):
-    def __init__(self, main_window: Optional[QMainWindow]):
+    def __init__(
+        self,
+        main_window: Optional[QMainWindow],
+        tab_with: Optional[QLayout] = None,
+    ):
         self.sessions_model_type = SessionsTableModel
         self.camera_model_type = CamerasTableModel
         super().__init__(
             name="Sessions",
             main_window=main_window,
             model_type=[self.sessions_model_type, self.camera_model_type],
+            tab_with=tab_with,
         )
 
     def create_triangulation_options(self) -> QWidget:
@@ -673,15 +678,15 @@ class SessionsDock(DockWidget):
         # Add the sessions table to the dock
         self.wgt_layout.addWidget(self.sessions_table)
 
-        video_unlink_button = self.create_video_unlink_button()
-        self.wgt_layout.addWidget(video_unlink_button)
+        table_edit_buttons = self.create_table_edit_buttons()
+        self.wgt_layout.addWidget(table_edit_buttons)
 
         # TODO(LM): Add this to a create method
         # Add the cameras table to the dock
         self.wgt_layout.addWidget(self.camera_table)
 
-        table_edit_buttons = self.create_table_edit_buttons()
-        self.wgt_layout.addWidget(table_edit_buttons)
+        video_unlink_button = self.create_video_unlink_button()
+        self.wgt_layout.addWidget(video_unlink_button)
 
         # Add the triangulation options to the dock
         triangulation_options = self.create_triangulation_options()

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -583,7 +583,8 @@ class SessionsDock(DockWidget):
         if self.table is None:
             self.create_tables()
 
-        self.wgt_layout.addWidget(self.table)
+
+        self.wgt_layout.addWidget(self.camera_table)
 
         video_unlink_button = self.create_video_unlink_button()
         self.wgt_layout.addWidget(video_unlink_button)
@@ -638,7 +639,7 @@ class SessionsDock(DockWidget):
         main_window = self.main_window
 
         hb = QHBoxLayout()
-        self.add_button(hb, "Link Video", main_window.commands.unlink_video_from_camera())
+        self.add_button(hb, "Unlink Video", main_window.commands.unlink_video_from_camera())
 
         hbw = QWidget()
         hbw.setLayout(hb)

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -580,6 +580,14 @@ class SessionsDock(DockWidget):
         
 
     def lay_everything_out(self) -> None:
+        if self.table is None:
+            self.create_tables()
+
+        self.wgt_layout.addWidget(self.table)
+
+        video_unlink_button = self.create_video_unlink_button()
+        self.wgt_layout.addWidget(video_unlink_button)
+
         triangulation_options = self.create_triangulation_options()
         self.wgt_layout.addWidget(triangulation_options)
 
@@ -625,3 +633,13 @@ class SessionsDock(DockWidget):
         )
 
         return [self.camera_table]
+    
+    def create_video_unlink_button(self) -> QWidget:
+        main_window = self.main_window
+
+        hb = QHBoxLayout()
+        self.add_button(hb, "Link Video", main_window.commands.unlink_video_from_camera())
+
+        hbw = QWidget()
+        hbw.setLayout(hb)
+        return hbw

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -651,6 +651,10 @@ class SessionsDock(DockWidget):
             model=self.camera_model,
         )
 
+        self.main_window.state.connect(
+            "selected_session", self.main_window.update_cameras_model
+        )
+
         self.table = {
             "sessions_table": self.sessions_table,
             "camera_table": self.camera_table,

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -620,7 +620,7 @@ class SessionsDock(DockWidget):
             items=main_window.state["selected_session"], context=main_window.commands
         )
         
-        return [self.camera_model]
+        return {"camera_model": self.camera_model}
     
     def create_tables(self) -> GenericTableView:
         if self.model is None:
@@ -629,11 +629,11 @@ class SessionsDock(DockWidget):
         main_window = self.main_window
         self.camera_table = GenericTableView(
             state=main_window.state,
-            row_name="camera",
+            row_name="camera_table",
             model=self.camera_model,
         )
 
-        return [self.camera_table]
+        return {"camera_table": self.camera_table}
     
     def create_video_unlink_button(self) -> QWidget:
         main_window = self.main_window

--- a/sleap/io/cameras.py
+++ b/sleap/io/cameras.py
@@ -42,7 +42,7 @@ class Camcorder:
 
     def get_video(self, session: "RecordingSession") -> Optional[Video]:
         if session not in self._video_by_session:
-            logger.warning(f"{session} not found in {self}.")
+            logger.debug(f"{session} not found in {self}.")
             return None
         return self._video_by_session[session]
 

--- a/sleap/io/cameras.py
+++ b/sleap/io/cameras.py
@@ -462,7 +462,7 @@ class RecordingSession:
             )
 
         if camcorder not in self._video_by_camcorder:
-            logger.warning(
+            logger.debug(
                 f"Camcorder {camcorder.name} is not linked to a video in this "
                 f"RecordingSession."
             )

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -2,6 +2,7 @@ import pytest
 import pytestqt
 
 from sleap.gui.dataviews import *
+from sleap.io.cameras import RecordingSession
 
 
 def test_skeleton_nodes(qtbot, centered_pair_predictions):
@@ -85,14 +86,19 @@ def test_table_sort_string(qtbot):
     table.model().sort(0)
     table.model().sort(1)
 
-def test_camera_table(qtbot):
+def test_camera_table(qtbot, multiview_min_session_labels):
+    table = CamerasTableModel(items=multiview_min_session_labels.sessions[0])
+    
+    assert table.columnCount() == 2
+    assert table.rowCount() == 8
+
     table = GenericTableView(
-        row_name="camera",
+        row_name="instance",
         is_sortable=True,
         name_prefix="",
-        model=CamerasTableModel(),
+        model=CamerasTableModel(items=multiview_min_session_labels.sessions[0]),
     )
 
-    assert table.columnCount() == 2
-
-    assert False
+    table.selectRow(1)
+    assert table.model().data(table.currentIndex()) == "backL"
+    

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -92,6 +92,8 @@ def test_camera_table(qtbot, multiview_min_session_labels):
     assert table.columnCount() == 2
     assert table.rowCount() == 8
 
+    num_rows = table.rowCount()
+
     table = GenericTableView(
         row_name="instance",
         is_sortable=True,
@@ -99,6 +101,29 @@ def test_camera_table(qtbot, multiview_min_session_labels):
         model=CamerasTableModel(items=multiview_min_session_labels.sessions[0]),
     )
 
-    table.selectRow(1)
-    assert table.model().data(table.currentIndex()) == "backL"
+    # Testing if all comcorders are presented in the correct row
+    camcorders = multiview_min_session_labels.sessions[0].linked_cameras
+
+    for i in range(num_rows):
+        table.selectRow(i)
+        assert table.getSelectedRowItem() == camcorders[i]
+        assert table.model().data(table.currentIndex()) == camcorders[i].name
+
+    # Testing if a comcorder change is reflected
+    idxs_to_remove = [1, 2, 7]
+    for idx in idxs_to_remove:
+        multiview_min_session_labels.sessions[0].remove_video(camcorders[idx].get_video(multiview_min_session_labels.sessions[0]))
+
+    removed_camcorder = [cam for i, cam in enumerate(camcorders) if i not in idxs_to_remove]
+
+    for i in range(num_rows-3):
+        table.selectRow(i)
+        assert table.getSelectedRowItem() == camcorders[i]
+        assert table.model().data(table.currentIndex()) == removed_camcorder[i].name
+    
+
+
+
+
+
     

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -92,3 +92,7 @@ def test_camera_table(qtbot):
         name_prefix="",
         model=CamerasTableModel(),
     )
+
+    assert table.columnCount() == 2
+
+    assert False

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -1,8 +1,4 @@
-import pytest
-import pytestqt
-
 from sleap.gui.dataviews import *
-from sleap.io.cameras import RecordingSession
 
 
 def test_skeleton_nodes(qtbot, centered_pair_predictions):

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -84,3 +84,11 @@ def test_table_sort_string(qtbot):
     # Make sure we can sort with both numbers and strings (i.e., "")
     table.model().sort(0)
     table.model().sort(1)
+
+def test_camera_table(qtbot):
+    table = GenericTableView(
+        row_name="camera",
+        is_sortable=True,
+        name_prefix="",
+        model=CamerasTableModel(),
+    )

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -136,7 +136,7 @@ def test_sessions_dock(qtbot, multiview_min_session_labels):
     leftover_camcorder = [cam for i, cam in enumerate(camcorders) if i not in idxs_to_remove]
     
     for cam in to_remove_camcorders:
-        main_window.state["selected_camera_table"] = cam
+        main_window.state["selected_camera"] = cam
         main_window._buttons["unlink video"].click()
 
     

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -1,6 +1,9 @@
 """Module for testing dock widgets for the `MainWindow`."""
 
 from pathlib import Path
+
+import pytest
+
 from sleap import Labels, Video
 from sleap.gui.app import MainWindow
 from sleap.gui.commands import OpenSkeleton

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -10,6 +10,7 @@ from sleap.gui.widgets.docks import (
     SuggestionsDock,
     VideosDock,
     SkeletonDock,
+    SessionsDock, 
 )
 
 
@@ -107,3 +108,25 @@ def test_instances_dock(qtbot):
     assert dock.name == "Instances"
     assert dock.main_window is main_window
     assert dock.wgt_layout is dock.widget().layout()
+
+def test_seesions_dock(gt_bot, multiview_min_session_labels):
+    main_window = MainWindow()
+    dock = SessionsDock(main_window)
+
+    assert dock.name == "Sessions"
+    assert dock.main_window is main_window
+    assert dock.wgt_layout is dock.widget().layout()
+        
+    video_to_remove = multiview_min_session_labels.videos[0]
+    main_window.state["selected_camera_table"] = video_to_remove
+    dock.main_window._buttons["unlink video"].click()
+    assert len(multiview_min_session_labels.videos) == 7
+
+    # video_to_remove = multiview_min_session_labels.videos[1]
+    # main_window.state["selected_camera_table"] = video_to_remove
+    # dock.main_window._buttons["unlink video"].click()
+    # assert len(multiview_min_session_labels.videos) == 6
+
+    # assert (video_to_remove[0] not in labels.videos and video_to_remove[1] not in label.videos)
+
+    # assert main_window.state["video"] == labels.videos[-1]

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -1,10 +1,9 @@
 """Module for testing dock widgets for the `MainWindow`."""
 
 from pathlib import Path
-import pytest
 from sleap import Labels, Video
 from sleap.gui.app import MainWindow
-from sleap.gui.commands import OpenSkeleton, UnlinkVideo
+from sleap.gui.commands import OpenSkeleton
 from sleap.gui.widgets.docks import (
     InstancesDock,
     SuggestionsDock,


### PR DESCRIPTION
### Description
The overall goal is to add `Camcorder`/`Video` assignment table to the `SessionsDock` that is linked to the `SessionsTable` created above. This `CamerasTable` will have two columns. One column will display the `Camcorder.name`s of all `Camcorder`s in the `RecordingSession.cameras: List[Camcorder]` list. The second column will show which `Video`s are assigned to the adjacent `Camcorder.name` by displaying the returned value of `RecordingSession.get_video(Camcorder)` (or `""` if `None`).
- [x] Subclass `GenericTableModel` to create a new model called `CamerasTableModel` with `properties = ("camera", "video")`
- [x] Implement the method `CamerasTableModel.object_to_items(self, obj: RecordingSession)` which returns the list of `Camcorder`s in `obj.cameras: List[Camcorder]`
- [x] Implement the method `CamerasTableModel.item_to_data(self, obj: RecordingSession, item: Camcorder)` which returns the following dictionary: `{camera: item.name, video: obj.get_video(item)}`
- [x] Add a `cameras_model_type = CamerasTableModel` attribute to `SessionsDock` (similar to [`SkeletonDock.nodes_model_type`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L217)) and [pass into the `model_type` list for `super().__init__`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L222)
- [x] Add a `SessionsDock.create_models` method (or append to it if it already exists) that sets a `SessionsDock.cameras_model = SessionsDock.sessions_model_type(items=main_window.state["selected_session"], context=main_window.commands)` and returns a list of all models created (see [`SkeletonDock.create_models`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L226-L234))
- [x] Add a `SessionsDock.create_tables` method (or append to it if it already exists) that sets a `SessionsDock.cameras_table = GenericTableView(state=..., row_name="camera", ...)` and returns a list of all tables created (see [`SkeletonDock.create_tables`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L236-L253))
- [x] Add a command class and `CommandContext.unlink_video_from_camera` method to un-link a `Video` from a `Camcorder`
- [x] Add a button to "Unlink Video" and connect it to the `CommandContext.unlink_video_from_camera` method
- [x] [Disable button to "Unlink Video"](https://github.com/talmolab/sleap/pull/1671#discussion_r1468061636) when there is no selected `Camcorder` for the `CamerasTable`
- [x] In the `SessionsDock.lay_everything_out` method, add the `SessionsDock.cameras_table` to the `SessionsDock.wgt_layout: QVBoxLayout` (see the [`InstancesDock.lay_everything_out`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/widgets/docks.py#L549-L553)).
- [x] Add a `sessions` option to [`UpdateTopic: Enum`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/commands.py#L70-L82) if not already there
- [x] In `MainWindow.on_data_update` add (or append to) the `if _has_topic(UpdateTopic.sessions)` that updates the items to display in the `CamerasTable` (see [`video_dock.table` update](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/sleap/gui/app.py#L1172-L1173))
- [ ] Set the `GuiState` for the `"session"` key to the first `RecordingSession` in `labels.sessions: List[RecordingSession]` when loading a `Labels` project (similar to how we [set the state for `"video"`](https://github.com/talmolab/sleap/blob/548caf5c23b5f84624308af3f15ba6e0ba766f37/sleap/gui/commands.py#L700-L702))

#### Test the `CamerasTable`
Tests for the `CamerasTable` will be added to [`tests/gui/test_dataviews.py`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/tests/gui/test_dataviews.py). These tests will only test the functionality of the table as it's own entity.
- [x] Test that the expected `Camcorder` is returned when we select a specific row of the table (see [existing test for inspiration](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/tests/gui/test_dataviews.py#L53-L55))
- [ ] Test that when we update a `Camcorder` in `labels.sessions`, the `Camcorder` in the table is updated as well (i.e. if we unlink a `Video` from a `Camcorder`, the data in the `Video` cell should be empty)

#### Test the `CamerasTable` as part of the `SessionsDock`
Tests for the `SessionsDock` will be added to [`tests/gui/widgets/test_docks.py`](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/tests/gui/widgets/test_docks.py).
- [x] Test interactions with table and `GuiState` (see [existing test](https://github.com/talmolab/sleap/blob/14b5b782b28bb1d05a65a1f1892b569bfe8ab4e3/tests/gui/widgets/test_docks.py#L62-L72))

<!-- ![image](https://github.com/talmolab/sleap/assets/38435167/2d79f495-1312-4945-8f13-62e4c88101d3)-->

<image src="https://github.com/talmolab/sleap/assets/38435167/2d79f495-1312-4945-8f13-62e4c88101d3" height=400>

**Fig 1**: Depiction of Cameras Table layout.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced session management in the GUI, including state initialization and updates.
	- Added functionality to unlink videos from cameras within sessions.
	- Implemented a new `CamerasTableModel` for managing camera and video pairs in recording sessions.
	- Enhanced `SessionsDock` with new methods and attributes to support camera management and video unlinking.
- **Tests**
	- Updated and added tests for GUI data views and `SessionsDock` functionality, including camera table presentation and video unlinking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->