### PR TITLE
Fix out of bounds albumentations issues and update dependencies

### DIFF
--- a/.conda/bld.bat
+++ b/.conda/bld.bat
@@ -7,7 +7,7 @@ set PIP_IGNORE_INSTALLED=False
 
 @REM Install the pip dependencies. Note: Using urls to wheels might be better: 
 @REM https://docs.conda.io/projects/conda-build/en/stable/user-guide/wheel-files.html)
-pip install --no-cache-dir -r .\requirements.txt --no-binary qudida,albumentations
+pip install --no-cache-dir -r .\requirements.txt
 
 @REM Install sleap itself. This does not install the requirements, but will list which 
 @REM requirements are missing (see "install_requires") when user attempts to install.

--- a/.conda/build.sh
+++ b/.conda/build.sh
@@ -7,7 +7,7 @@ export PIP_IGNORE_INSTALLED=False
 
 # Install the pip dependencies. Note: Using urls to wheels might be better: 
 # https://docs.conda.io/projects/conda-build/en/stable/user-guide/wheel-files.html)
-pip install --no-cache-dir -r ./requirements.txt --no-binary qudida,albumentations
+pip install --no-cache-dir -r ./requirements.txt
 
 
 # Install sleap itself. This does not install the requirements, but will list which 

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -52,6 +52,9 @@ requirements:
     - conda-forge::scikit-learn ==1.0
     - conda-forge::scikit-video
     - conda-forge::seaborn
+    - conda-forge::qudida
+    - conda-forge::albumentations
+    - conda-forge::ndx-pose
   run:
     - conda-forge::python ==3.7.12  # Run into _MAX_WINDOWS_WORKERS not found if <
     - conda-forge::attrs ==21.4.0
@@ -82,6 +85,9 @@ requirements:
     - conda-forge::seaborn
     - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10, sleap channel has 2.6.3
     - conda-forge::tensorflow-hub <0.14.0  # Causes pynwb conflicts on linux GH-1446
+    - conda-forge::qudida
+    - conda-forge::albumentations
+    - conda-forge::ndx-pose
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -36,15 +36,15 @@ dependencies:
     - conda-forge::seaborn
     - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10
     - conda-forge::tensorflow-hub  # Pinned in meta.yml, but no problems here... yet
+    - conda-forge::qudida
+    - conda-forge::albumentations
+    - conda-forge::ndx-pose
 
     # Packages required by tensorflow to find/use GPUs
     - conda-forge::cudatoolkit ==11.3.1
     # "==" results in package not found
     - conda-forge::cudnn=8.2.1
     - nvidia::cuda-nvcc=11.3
-    - conda-forge::qudida
-    - conda-forge::albumentations
-    - conda-forge::ndx-pose
 
     - pip:  
         - "--editable=.[conda_dev]"

--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,9 @@ dependencies:
     # "==" results in package not found
     - conda-forge::cudnn=8.2.1
     - nvidia::cuda-nvcc=11.3
+    - conda-forge::qudida
+    - conda-forge::albumentations
 
     - pip:  
         - "--editable=.[conda_dev]"
-        - "--no-binary qudida,albumentations"
+        # - "--no-binary qudida,albumentations"

--- a/environment.yml
+++ b/environment.yml
@@ -44,6 +44,7 @@ dependencies:
     - nvidia::cuda-nvcc=11.3
     - conda-forge::qudida
     - conda-forge::albumentations
+    - conda-forge::ndx-pose
 
     - pip:  
         - "--editable=.[conda_dev]"

--- a/environment.yml
+++ b/environment.yml
@@ -48,4 +48,3 @@ dependencies:
 
     - pip:  
         - "--editable=.[conda_dev]"
-        # - "--no-binary qudida,albumentations"

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -35,6 +35,8 @@ dependencies:
     - conda-forge::scikit-video
     - conda-forge::seaborn
     - conda-forge::tensorflow-hub
+    - conda-forge::qudida
+    - conda-forge::albumentations
+    - conda-forge::ndx-pose
     - pip:
         - "--editable=.[conda_dev]"
-        - "--no-binary qudida,albumentations"

--- a/environment_no_cuda.yml
+++ b/environment_no_cuda.yml
@@ -43,4 +43,3 @@ dependencies:
 
     - pip:  
         - "--editable=.[conda_dev]"
-        # - "--no-binary qudida,albumentations"

--- a/environment_no_cuda.yml
+++ b/environment_no_cuda.yml
@@ -37,7 +37,10 @@ dependencies:
     - conda-forge::seaborn
     - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10
     - conda-forge::tensorflow-hub
+    - conda-forge::qudida
+    - conda-forge::albumentations
+    - conda-forge::ndx-pose
 
     - pip:  
         - "--editable=.[conda_dev]"
-        - "--no-binary qudida,albumentations"
+        # - "--no-binary qudida,albumentations"

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -36,7 +36,8 @@ tensorflow-hub<=0.14.0
 # These dependencies are untested since we do not offer a wheel for apple silicon atm.
 tensorflow-macos==2.9.2; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-albumentations # added 03212024
+albumentations
+ndx-pose
 
 # Dependencies of dependencies
 # google-auth 2.23.0 has requirement urllib3<2.0

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -33,11 +33,11 @@ scikit-video
 seaborn
 tensorflow>=2.6.3,<2.9; platform_machine != 'arm64'
 tensorflow-hub<=0.14.0
+albumentations
+ndx-pose
 # These dependencies are untested since we do not offer a wheel for apple silicon atm.
 tensorflow-macos==2.9.2; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'
-albumentations
-ndx-pose
 
 # Dependencies of dependencies
 # google-auth 2.23.0 has requirement urllib3<2.0

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -3,7 +3,7 @@
 # setup.py, the packages in requirements.txt will also be installed when running 
 # pip install sleap[pypi].
 
-# These are also distrubuted through conda and not pip installed when using conda.
+# These are also distributed through conda and not pip installed when using conda.
 attrs>=21.2.0,<=21.4.0
 cattrs==1.1.1
 # certifi>=2017.4.17,<=2021.10.8
@@ -11,7 +11,7 @@ jsmin
 jsonpickle==1.2
 networkx
 numpy>=1.19.5,<1.23.0
-opencv-python>=4.2.0,<=4.6.0
+opencv-python>=4.2.0,<=4.7.0
 pandas
 pillow>=8.3.1,<=8.4.0
 psutil
@@ -36,6 +36,7 @@ tensorflow-hub<=0.14.0
 # These dependencies are untested since we do not offer a wheel for apple silicon atm.
 tensorflow-macos==2.9.2; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'
+albumentations # added 03212024
 
 # Dependencies of dependencies
 # google-auth 2.23.0 has requirement urllib3<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 # No conda packages for these
 imgstore<0.3.0  # 0.3.3 results in https://github.com/O365/python-o365/issues/591
-ndx-pose
+# ndx-pose
 nixio>=1.5.3  # Constrain put on by @jgrewe from G-Node
 qimage2ndarray  # ==1.9.0
 segmentation-models
@@ -13,4 +13,4 @@ tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64
 h5py<3.2; sys_platform == 'win32'  # Newer versions result in error above, linking issue in Linux
 pynwb>=2.3.3  # 2.0.0 required by ndx-pose, 2.3.3 fixes importlib-metadata incompatibility
 
-albumentations
+# albumentations

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 
 # No conda packages for these
 imgstore<0.3.0  # 0.3.3 results in https://github.com/O365/python-o365/issues/591
-# ndx-pose
 nixio>=1.5.3  # Constrain put on by @jgrewe from G-Node
 qimage2ndarray  # ==1.9.0
 segmentation-models
@@ -12,5 +11,3 @@ tensorflow-metal==0.5.0; sys_platform == 'darwin' and platform_machine == 'arm64
 # Conda installing results in https://github.com/h5py/h5py/issues/2037
 h5py<3.2; sys_platform == 'win32'  # Newer versions result in error above, linking issue in Linux
 pynwb>=2.3.3  # 2.0.0 required by ndx-pose, 2.3.3 fixes importlib-metadata incompatibility
-
-# albumentations

--- a/sleap/nn/data/augmentation.py
+++ b/sleap/nn/data/augmentation.py
@@ -195,7 +195,7 @@ class AlbumentationsAugmenter:
 
         return cls(
             augmenter=A.Compose(
-                aug_stack, keypoint_params=A.KeypointParams(format="xy")
+                aug_stack, keypoint_params=A.KeypointParams(format="xy", remove_invisible=False)
             ),
             image_key=image_key,
             instances_key=instances_key,

--- a/sleap/nn/data/augmentation.py
+++ b/sleap/nn/data/augmentation.py
@@ -195,7 +195,8 @@ class AlbumentationsAugmenter:
 
         return cls(
             augmenter=A.Compose(
-                aug_stack, keypoint_params=A.KeypointParams(format="xy", remove_invisible=False)
+                aug_stack,
+                keypoint_params=A.KeypointParams(format="xy", remove_invisible=False),
             ),
             image_key=image_key,
             instances_key=instances_key,

--- a/tests/nn/data/test_augmentation.py
+++ b/tests/nn/data/test_augmentation.py
@@ -164,8 +164,9 @@ def test_augmentation_edges(min_labels):
     ds = augmenter.transform_dataset(ds)
 
     example = next(iter(ds))
-
+    # TODO: check for correctness
     assert example["instances"].shape == (3, 2, 2)
+
 
 
 def test_random_cropper(min_labels):

--- a/tests/nn/data/test_augmentation.py
+++ b/tests/nn/data/test_augmentation.py
@@ -55,12 +55,17 @@ def augmenter(augmentation_config):
     return augmentation.AlbumentationsAugmenter.from_config(augmentation_config)
 
 # Test class instantiation and augmentation
-@pytest.mark.parametrize("dummy_instances_data", [
-    pytest.param("dummy_instances_data_zeros", id="zeros"),
-    pytest.param("dummy_instances_data_nans", id="nans"),
-    pytest.param("dummy_instances_data_mixed", id="mixed"),
-])
-def test_albumentations_augmenter(dummy_image_data, dummy_instances_data, augmenter, dummy_dataset):
+@pytest.mark.parametrize(
+    "dummy_instances_data",
+    [
+        pytest.param("dummy_instances_data_zeros", id="zeros"),
+        pytest.param("dummy_instances_data_nans", id="nans"),
+        pytest.param("dummy_instances_data_mixed", id="mixed"),
+    ],
+)
+def test_albumentations_augmenter(
+    dummy_image_data, dummy_instances_data, augmenter, dummy_dataset
+):
     # Apply augmentation
     augmented_dataset = augmenter.transform_dataset(dummy_dataset)
 
@@ -130,7 +135,10 @@ def test_augmentation_with_no_instances(min_labels):
 
 def test_augmentation_edges(min_labels):
     # Tests 1722
-    # FAILED tests/nn/data/test_augmentation.py::test_augmentation_edges - tensorflow.python.framework.errors_impl.InvalidArgumentError: ValueError: Expected x for keypoint (384.0, 384.0, 0.0, 0.0) to be in the range [0.0, 384], got 384.0.
+    # FAILED tests/nn/data/test_augmentation.py::test_augmentation_edges - 
+    # tensorflow.python.framework.errors_impl.InvalidArgumentError: ValueError: 
+    # Expected x for keypoint (384.0, 384.0, 0.0, 0.0) to be in the range [0.0, 384], 
+    # got 384.0.
     height, width = min_labels[0].video.shape[1:3]
     min_labels[0].instances.append(
         sleap.Instance.from_numpy(

--- a/tests/nn/data/test_augmentation.py
+++ b/tests/nn/data/test_augmentation.py
@@ -12,27 +12,33 @@ from sleap.nn.data import augmentation
 
 @pytest.fixture
 def dummy_instances_data_nans():
-    return np.full((2, 2), np.nan, dtype=np.float32)  # All NaNs
+    return np.full((2, 2), np.nan, dtype=np.float32)
+
 
 @pytest.fixture
 def dummy_instances_data_mixed():
     return np.array([[0.1, np.nan], [0.0, 0.8]], dtype=np.float32)
 
+
 @pytest.fixture
 def dummy_image_data():
     return np.zeros((100, 100, 3), dtype=np.uint8)
+
 
 @pytest.fixture
 def dummy_instances_data_zeros():
     return np.zeros((2, 2), dtype=np.float32)
 
+
 @pytest.fixture
 def rotation_min_angle():
     return 90
 
+
 @pytest.fixture
 def rotation_max_angle():
     return 90
+
 
 @pytest.fixture
 def augmentation_config(rotation_min_angle, rotation_max_angle):
@@ -42,6 +48,7 @@ def augmentation_config(rotation_min_angle, rotation_max_angle):
         rotation_max_angle=rotation_max_angle
     )
 
+
 @pytest.fixture
 def dummy_dataset(dummy_image_data, dummy_instances_data_zeros):
     dataset = tf.data.Dataset.from_tensor_slices({
@@ -50,9 +57,11 @@ def dummy_dataset(dummy_image_data, dummy_instances_data_zeros):
     })
     return dataset
 
+
 @pytest.fixture
 def augmenter(augmentation_config):
     return augmentation.AlbumentationsAugmenter.from_config(augmentation_config)
+
 
 # Test class instantiation and augmentation
 @pytest.mark.parametrize(

--- a/tests/nn/data/test_augmentation.py
+++ b/tests/nn/data/test_augmentation.py
@@ -45,16 +45,15 @@ def augmentation_config(rotation_min_angle, rotation_max_angle):
     return augmentation.AugmentationConfig(
         rotate=True,
         rotation_min_angle=rotation_min_angle,
-        rotation_max_angle=rotation_max_angle
+        rotation_max_angle=rotation_max_angle,
     )
 
 
 @pytest.fixture
 def dummy_dataset(dummy_image_data, dummy_instances_data_zeros):
-    dataset = tf.data.Dataset.from_tensor_slices({
-        "image": [dummy_image_data],
-        "instances": [dummy_instances_data_zeros]
-    })
+    dataset = tf.data.Dataset.from_tensor_slices(
+        {"image": [dummy_image_data], "instances": [dummy_instances_data_zeros]}
+    )
     return dataset
 
 
@@ -166,7 +165,6 @@ def test_augmentation_edges(min_labels):
     example = next(iter(ds))
     # TODO: check for correctness
     assert example["instances"].shape == (3, 2, 2)
-
 
 
 def test_random_cropper(min_labels):

--- a/tests/nn/data/test_augmentation.py
+++ b/tests/nn/data/test_augmentation.py
@@ -144,10 +144,6 @@ def test_augmentation_with_no_instances(min_labels):
 
 def test_augmentation_edges(min_labels):
     # Tests 1722
-    # FAILED tests/nn/data/test_augmentation.py::test_augmentation_edges - 
-    # tensorflow.python.framework.errors_impl.InvalidArgumentError: ValueError: 
-    # Expected x for keypoint (384.0, 384.0, 0.0, 0.0) to be in the range [0.0, 384], 
-    # got 384.0.
     height, width = min_labels[0].video.shape[1:3]
     min_labels[0].instances.append(
         sleap.Instance.from_numpy(


### PR DESCRIPTION
### Description
- Use conda to install albumentations and qudida instead of pip in pypi build
- Fix `open-cv` version in pypi build
- Do no discard out-of-bound points in augmenter

### Types of changes

- [X] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#1722 , #1719 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced new dependencies `qudida`, `albumentations`, and `ndx-pose` to enhance functionality.
    - Added support for more robust data augmentation techniques in neural network training.
- **Bug Fixes**
    - Updated `opencv-python` version constraint to ensure compatibility.
- **Tests**
    - Implemented new tests for data augmentation edge cases and configuration-based augmentations.
- **Chores**
    - Updated and streamlined dependency lists across different environment setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->