### PR TITLE
Add gui dropdown to set instance to instance group

### DIFF
--- a/sleap/gui/dropdown.py
+++ b/sleap/gui/dropdown.py
@@ -1,0 +1,56 @@
+from PyQt5.QtWidgets import QMainWindow, QAction, QApplication, QKeySequence
+import sys
+
+class Commands:
+    def __init__(self):
+        # simulate instance to group assignments for simplicity
+        self.instance_groups = {}
+
+    def assignInstanceToGroup(self, instance_id, group):
+        # assign the instance to the selected group
+        self.instance_groups[instance_id] = group
+        print(f"Assigned Instance {instance_id} to Group {group}")
+
+class CommandContext:
+    def __init__(self, commands):
+        self.commands = commands
+        self.current_instance = "Instance1"  # placeholder for currently selected instance
+
+    def executeAssignToGroup(self, group):
+        self.commands.assignInstanceToGroup(self.current_instance, group)
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.commands = Commands()
+        self.command_context = CommandContext(self.commands)
+        self.initUI()
+
+    def initUI(self):
+        menuBar = self.menuBar()
+        tracksMenu = menuBar.addMenu("Tracks")
+        self.addInstanceGroupAssignmentMenu(menuBar)
+        self.setWindowTitle('Main Application Window')
+        self.setGeometry(300, 300, 250, 150)
+        self.show()
+
+    def addInstanceGroupAssignmentMenu(self, menuBar):
+        instanceGroupMenu = menuBar.addMenu("Assign Instance to Group")
+        instanceGroupMenu.setToolTipsVisible(True)
+
+        # example groups
+        instance_groups = ["Group A", "Group B", "Group C"]
+        # hotkeys for each group assignment
+        hotkeys = ["Ctrl+Shift+A", "Ctrl+Shift+B", "Ctrl+Shift+C"]
+        
+        for group, hotkey in zip(instance_groups, hotkeys):
+            action = QAction(f"Assign to {group}", instanceGroupMenu)
+            action.setShortcut(QKeySequence(hotkey))
+            # using CommandContext to execute the command
+            action.triggered.connect(lambda checked, g=group: self.command_context.executeAssignToGroup(g))
+            instanceGroupMenu.addAction(action)
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    ex = MainWindow()
+    sys.exit(app.exec_())


### PR DESCRIPTION
Added a file called dropdown.py where an instance is set to an instance group. 
Added a new CommandContext class to show the context in which commands are executed
Updated the Commands class to use a dictionary that simulates the assignment of instances to groups (for now)
Added hotkeys for easier use.
GUI trigger commands through the CommandContext
Used lambda function within the loop to ensure that the correct group is assigned when the action is triggered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new version of OpenCV (`opencv-contrib-python<4.7.0`) across various environments for improved compatibility.
  - Added keyboard shortcuts for easier navigation and instance grouping in the GUI.
  - Enhanced GUI with a new `SessionsDock` for managing recording sessions and camera links.
  - Implemented functionality to manage sessions, cameras, and videos within the application.
  - Added new plotting and updating functionalities for frames and views in the GUI.
  - Introduced methods for triangulating and reprojecting instances within sessions.
  
- **Bug Fixes**
  - Corrected typos and improved logic in handling video points completeness.

- **Documentation**
  - Updated installation instructions to include steps for handling specific OpenCV versions.

- **Tests**
  - Enhanced testing for new GUI components, camera handling, and dataset management functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->