### PR TITLE
Fix ubuntu and mac conda builds

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -91,6 +91,8 @@ requirements:
     - conda-forge::ndx-pose
     - conda-forge::importlib-metadata ==4.11.4
 
+# This no longer works so we have moved it to the build workflow
+# https://github.com/talmolab/sleap/pull/1744
 # test:
 #   imports:
 #     - sleap

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -91,6 +91,6 @@ requirements:
     - conda-forge::ndx-pose
     - conda-forge::importlib-metadata ==4.11.4
 
-test:
-  imports:
-    - sleap
+# test:
+#   imports:
+#     - sleap

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -108,9 +108,13 @@ jobs:
         run: |
           echo "Build path is: $BUILD_PATH"
           conda deactivate
+          echo $(conda info)
+          echo "Testing conda package with numpy"
+          mamba create -y -n numpy_test numpy
+          echo "Testing conda package with sleap"
           mamba create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
           conda activate sleap_test
-          echo conda list
+          echo $(conda list)
           python -c "import sleap; print(sleap.__version__)"
           echo "Test completed using sleap version: $(python -c 'import sleap; print(sleap.__version__)')"
 

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -83,17 +83,19 @@ jobs:
         shell: bash -l {0}
         run: |
           conda build .conda --output-folder build
+          echo "Listing contents of the build directory:"
+          ls -l $(pwd)/build
           echo "BUILD_PATH=$(pwd)/build" >> $GITHUB_ENV
           echo "Build path set for Ubuntu: $BUILD_PATH"
 
-      # Build conda package (Windows)
-      - name: Build conda package (Windows)
-        if: matrix.os == 'windows-2022'
-        shell: powershell
-        run: |
-          conda build .conda --output-folder build
-          echo "BUILD_PATH=$(pwd -PathType Unix)/build" >> $GITHUB_ENV
-          echo "Build path set for Windows: $BUILD_PATH"
+      # # Build conda package (Windows) 
+      # - name: Build conda package (Windows)
+      #   if: matrix.os == 'windows-2022'
+      #   shell: powershell
+      #   run: |
+      #     conda build .conda --output-folder build
+      #     echo "BUILD_PATH=%(pwd)/build%"   
+
 
       # Build conda package (Mac)
       - name: Build conda package (Mac)
@@ -101,6 +103,8 @@ jobs:
         shell: bash -l {0}
         run: |
           conda build .conda_mac --output-folder build
+          echo "Listing contents of the build directory:"
+          ls -l $(pwd)/build
           echo "BUILD_PATH=$(pwd)/build" >> $GITHUB_ENV
           echo "Build path set for Mac: $BUILD_PATH"
 

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -78,24 +78,21 @@ jobs:
           twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
 
       # Build conda package (Ubuntu)
+      # echo "{environment_variable_name}={value}" >> "$GITHUB_ENV"
       - name: Build conda package (Ubuntu)
         if: matrix.os == 'ubuntu-22.04'
         shell: bash -l {0}
         run: |
           conda build .conda --output-folder build
-          echo "Listing contents of the build directory:"
-          ls -l $(pwd)/build
-          echo "BUILD_PATH=$(pwd)/build" >> $GITHUB_ENV
-          echo "Build path set for Ubuntu: $BUILD_PATH"
+          echo "BUILD_PATH=$(pwd)/build" >> "$GITHUB_ENV"
 
-      # # Build conda package (Windows) 
-      # - name: Build conda package (Windows)
-      #   if: matrix.os == 'windows-2022'
-      #   shell: powershell
-      #   run: |
-      #     conda build .conda --output-folder build
-      #     echo "BUILD_PATH=%(pwd)/build%"   
-
+      # Build conda package (Windows) 
+      - name: Build conda package (Windows)
+        if: matrix.os == 'windows-2022'
+        shell: powershell
+        run: |
+          conda build .conda --output-folder build
+          echo "BUILD_PATH=$(pwd)/build" >> "$env:GITHUB_ENV"
 
       # Build conda package (Mac)
       - name: Build conda package (Mac)
@@ -103,17 +100,15 @@ jobs:
         shell: bash -l {0}
         run: |
           conda build .conda_mac --output-folder build
-          echo "Listing contents of the build directory:"
-          ls -l $(pwd)/build
-          echo "BUILD_PATH=$(pwd)/build" >> $GITHUB_ENV
-          echo "Build path set for Mac: $BUILD_PATH"
+          echo "BUILD_PATH=$(pwd)/build" >> "$GITHUB_ENV"
 
       # Test
       - name: Test built conda package
         shell: bash -l {0}
         run: |
+          echo "$BUILD_PATH"
           conda deactivate
-          mamba create -y -n sleap_test -c conda-forge -c nvidia -c file://$BUILD_PATH -c sleap/label/dev -c anaconda sleap
+          mamba create -y -n sleap_test -c sleap/label/dev -c conda-forge -c nvidia -c file://$BUILD_PATH -c anaconda sleap
           conda activate sleap_test
           python -c "import sleap; print(sleap.__version__)"
           echo "Test completed using sleap version: $(python -c 'import sleap; print(sleap.__version__)')"

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -83,6 +83,8 @@ jobs:
         shell: bash -l {0}
         run: |
           conda build .conda --output-folder build
+          echo "BUILD_PATH=$(pwd)/build" >> $GITHUB_ENV
+          echo "Build path set for Ubuntu: $BUILD_PATH"
 
       # Build conda package (Windows)
       - name: Build conda package (Windows)
@@ -90,6 +92,8 @@ jobs:
         shell: powershell
         run: |
           conda build .conda --output-folder build
+          echo "BUILD_PATH=$(pwd -PathType Unix)/build" >> $GITHUB_ENV
+          echo "Build path set for Windows: $BUILD_PATH"
 
       # Build conda package (Mac)
       - name: Build conda package (Mac)
@@ -97,15 +101,18 @@ jobs:
         shell: bash -l {0}
         run: |
           conda build .conda_mac --output-folder build
+          echo "BUILD_PATH=$(pwd)/build" >> $GITHUB_ENV
+          echo "Build path set for Mac: $BUILD_PATH"
 
       # Test
       - name: Test built conda package
         shell: bash -l {0}
         run: |
           conda deactivate
-          mamba create -y -n sleap_test -c conda-forge -c nvidia -c file://$(pwd)/build -c sleap/label/dev -c anaconda sleap
+          mamba create -y -n sleap_test -c conda-forge -c nvidia -c file://$BUILD_PATH -c sleap/label/dev -c anaconda sleap
           conda activate sleap_test
           python -c "import sleap; print(sleap.__version__)"
+          echo "Test completed using sleap version: $(python -c 'import sleap; print(sleap.__version__)')"
 
       # # Login to conda (Ubuntu)
       # - name: Login to Anaconda (Ubuntu)

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -106,10 +106,11 @@ jobs:
       - name: Test built conda package
         shell: bash -l {0}
         run: |
-          echo "$BUILD_PATH"
+          echo "Build path is: $BUILD_PATH"
           conda deactivate
           mamba create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
           conda activate sleap_test
+          echo conda list
           python -c "import sleap; print(sleap.__version__)"
           echo "Test completed using sleap version: $(python -c 'import sleap; print(sleap.__version__)')"
 

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           echo "$BUILD_PATH"
           conda deactivate
-          mamba create -y -n sleap_test -c sleap/label/dev -c conda-forge -c nvidia -c file://$BUILD_PATH -c anaconda sleap
+          mamba create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
           conda activate sleap_test
           python -c "import sleap; print(sleap.__version__)"
           echo "Test completed using sleap version: $(python -c 'import sleap; print(sleap.__version__)')"

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -109,10 +109,8 @@ jobs:
           echo "Build path is: $BUILD_PATH"
           conda deactivate
           echo $(conda info)
-          echo "Testing conda package with numpy"
-          mamba create -y -n numpy_test numpy
           echo "Testing conda package with sleap"
-          mamba create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
+          conda create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
           conda activate sleap_test
           echo $(conda list)
           python -c "import sleap; print(sleap.__version__)"

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -92,7 +92,7 @@ jobs:
         shell: powershell
         run: |
           conda build .conda --output-folder build
-          echo "BUILD_PATH=$(pwd)/build" >> "$env:GITHUB_ENV"
+          echo "BUILD_PATH=$\(pwd)\build" >> "$env:GITHUB_ENV"
 
       # Build conda package (Mac)
       - name: Build conda package (Mac)

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -92,7 +92,7 @@ jobs:
         shell: powershell
         run: |
           conda build .conda --output-folder build
-          echo "BUILD_PATH=$\(pwd)\build" >> "$env:GITHUB_ENV"
+          echo "BUILD_PATH=\$(pwd)\build" >> "$env:GITHUB_ENV"
 
       # Build conda package (Mac)
       - name: Build conda package (Mac)

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -11,8 +11,8 @@ on:
       - '.github/workflows/build_manual.yml'
     branches:
       # - develop
-      - fakebranch
-      # - talmo/fix-mac-v140
+      # - fakebranch
+      - elizabeth/Fix-ubuntu-conda-build
 
 jobs:
   build:
@@ -97,6 +97,15 @@ jobs:
         shell: bash -l {0}
         run: |
           conda build .conda_mac --output-folder build
+
+      # Test
+      - name: Test built conda package
+        shell: bash -l {0}
+        run: |
+          conda deactivate
+          mamba create -y -n sleap_test -c conda-forge -c nvidia -c file://$(pwd)/build -c sleap/label/dev -c anaconda sleap
+          conda activate sleap_test
+          python -c "import sleap; print(sleap.__version__)"
 
       # # Login to conda (Ubuntu)
       # - name: Login to Anaconda (Ubuntu)


### PR DESCRIPTION
### Description
Follow-up to #1734 where Ubuntu conda package takes forever to build in the CI and fails to import SLEAP and is not working for Macs.

Note: Ubuntu conda package does build locally without issues
 

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [X] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [X] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
    - Updated build configurations and paths for multiple operating systems.
    - Added a test for the conda package in the build process.
    - Modified testing configuration to disable importing `sleap`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->