### PR TITLE
(4b -> 4) Display the left-ellipsis for Video filename in UnlinkedVideosTable and CamerasTable

### DIFF
--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -668,11 +668,13 @@ class SessionsDock(DockWidget):
             state=main_window.state,
             row_name="camera",
             model=self.camera_model,
+            ellipsis_left=True,
         )
         self.unlinked_videos_table = GenericTableView(
             state=main_window.state,
             row_name="unlinked_video",
             model=self.unlinked_videos_model,
+            ellipsis_left=True,
         )
 
         self.main_window.state.connect(


### PR DESCRIPTION
### Description
Set the `ellipsis_left` keyword argument to `True` when creating UnlinkedVideosTable and CamerasTable in `docks.py`. This way, the filename column in the UnlinkedVideosTable and the video column in CamerasTable will be ellipsis left. This will display the name of the video file instead of the start of the path in both tables. 

Now the tables look like this: 

![스크린샷 2024-04-19 123344](https://github.com/talmolab/sleap/assets/114635820/bdcb477c-c878-4b1f-8be4-68bfb75597ef)

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [x] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [x] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [x] Add tests that prove your fix is effective or that your feature works
- [x] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced table views for cameras and unlinked videos to include left ellipsis for better text overflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->