### PR TITLE
(3a -> 3) Debug missing `PredictedInstance`s (not displaying in GUI)

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2928,6 +2928,26 @@ class AddInstance(EditCommand):
         if context.state["labeled_frame"] not in context.labels.labels:
             context.labels.append(context.state["labeled_frame"])
 
+        # Also add the instance to the frame group if it exists
+        video = context.state["video"]
+        session = context.labels.get_session(video=video)
+        if session is None:
+            return
+
+        frame_idx = context.state["frame_idx"]
+        frame_group = session.frame_groups.get(frame_idx, None)
+        if frame_group is None:
+            return
+
+        instance_group = frame_group.get_instance_group(instance=from_predicted)
+        if instance_group is None:
+            return
+
+        camera = session.get_camera(video=video)
+        frame_group.add_instance(
+            instance=new_instance, camera=camera, instance_group=instance_group
+        )
+
     @staticmethod
     def create_new_instance(
         context: CommandContext,

--- a/sleap/io/cameras.py
+++ b/sleap/io/cameras.py
@@ -1666,15 +1666,15 @@ class FrameGroup:
     ):
         """Add an (existing) `Instance` to the `FrameGroup`.
 
-        If no `InstanceGroup` is provided, then check the `Instance` is already in an
+        If no `InstanceGroup` is provided, then require the `Instance` is already in an
         `InstanceGroup` contained in the `FrameGroup`. Otherwise, add the `Instance` to
-        the `InstanceGroup` and `FrameGroup`.
+        the both the `FrameGroup` and provided `InstanceGroup`.
 
         Args:
             instance: `Instance` to add to the `FrameGroup`.
             camera: `Camcorder` to link the `Instance` to.
             instance_group: `InstanceGroup` to add the `Instance` to. If None, then
-                check the `Instance` is already in an `InstanceGroup`.
+                require the `Instance` is already in `FrameGroup.instance_groups`.
 
         Raises:
             ValueError: If the `InstanceGroup` is not in the `FrameGroup`.
@@ -1721,9 +1721,9 @@ class FrameGroup:
         instance_group = self.get_instance_group(instance=instance)
 
         if instance_group is None:
-            logger.warning(
-                f"Instance {instance} not found in this FrameGroup.instance_groups: "
-                f"{self.instance_groups}."
+            logger.debug(
+                f"Instance to remove {instance} not found in this "
+                f"FrameGroup.instance_groups: {self.instance_groups}."
             )
             return
 
@@ -1973,6 +1973,9 @@ class FrameGroup:
 
         # Add the `Instance` to the `FrameGroup`
         self._instances_by_cam[camera].add(instance)
+
+        # Add the `Instance` to the `RecordingSession`'s `Labels` (and `LabeledFrame`)
+        self.session.labels.add_instance(frame=labeled_frame, instance=instance)
 
     def create_and_add_missing_instances(self, instance_group: InstanceGroup):
         """Add missing instances to `FrameGroup` from `InstanceGroup`s.

--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -62,7 +62,7 @@ import h5py as h5
 import numpy as np
 import datetime
 from sklearn.model_selection import train_test_split
-from sleap.io.cameras import RecordingSession
+from sleap.io.cameras import FrameGroup, RecordingSession
 
 try:
     from typing import ForwardRef
@@ -1405,10 +1405,40 @@ class Labels(MutableSequence):
     def remove_instance(
         self, frame: LabeledFrame, instance: Instance, in_transaction: bool = False
     ):
-        """Remove instance from frame, updating track occupancy."""
+        """Remove instance from frame, updating track occupancy and `FrameGroup`."""
+
         frame.instances.remove(instance)
         if not in_transaction:
             self._cache.remove_instance(frame, instance)
+
+        # Also remove instance from `InstanceGroup` if any
+        session = self.get_session(frame.video)
+        if session is None:
+            return  # No session, so no `FrameGroup` to update
+        frame_group: FrameGroup = session.frame_groups.get(frame.frame_idx, None)
+        if frame_group is None:
+            return  # No `FrameGroup` for this frame
+        video = frame.video
+        camera = session.get_camera(video=video)
+        if camera is None:
+            return  # No camera, so no `InstanceGroup` to update
+
+        # If `Instance.from_predicted`, then replace with `PredictedInstance`
+        instance_group = frame_group.get_instance_group(instance=instance)
+        replace_instance = (instance.from_predicted is not None) and (
+            instance_group is not None
+        )
+
+        # Add the new instance to the `FrameGroup` and replace the old one
+        if replace_instance:
+            frame_group.add_instance(
+                instance=instance.from_predicted,
+                camera=camera,
+                instance_group=instance_group,
+            )
+        # Otherwise just remove the instance
+        else:
+            frame_group.remove_instance(instance=instance)
 
     def add_instance(self, frame: LabeledFrame, instance: Instance):
         """Add instance to frame, updating track occupancy."""


### PR DESCRIPTION
### Description
`TriangulateSession` calls `frame_group.upsert_points` which should create `PredictedInstance`s for any `Camcorder`s that do not already have an assigned `Instance` (or `PredictedIntance`). However, after triangulating, the `PredictedInstance`s were not being displayed in the GUI - even though the containing `InstanceGroup` appeared to have been filled in with `PredictedInstance`s for each "missing" view.

This PR does 3 things:
1. adds the filler `PredictedInstance`s to the `LabeledFrame`
2. replaces `PredictedInstance`s with `Instance`s (when creating an `Instance` from a `PredictedInstance`)
3. replaces `Instance` with `PredictedInstance` (when removing an `Instance` that ha an associated `PredictedInstance`)

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for adding and removing instances in frame groups, ensuring better data management and user interaction within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->