### PR TITLE
Adding ragged metadata to `info.json`

### DIFF
--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -1142,6 +1142,7 @@ class InferenceModel(tf.keras.Model):
 
         info["frozen_model_inputs"] = frozen_func.inputs
         info["frozen_model_outputs"] = frozen_func.outputs
+        info["unragged_outputs"] = unrag_outputs
 
         with (Path(save_path) / "info.json").open("w") as fp:
             json.dump(


### PR DESCRIPTION
### Description
To have information if the output tensors in the frozen graph file that is generated is either ragged or not, `unragged_outputs` is added to the `info.json` file that is generated as part of the model export.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
