### PR TITLE
View Hyperparameter nonetype fix

### DIFF
--- a/sleap/gui/dialogs/metrics.py
+++ b/sleap/gui/dialogs/metrics.py
@@ -120,10 +120,11 @@ class MetricsTableDialog(QtWidgets.QWidget):
         if cfg_info is None:
             cfg_info = self.table_view.getSelectedRowItem()
 
+        cfg_getter = self._cfg_getter
         key = cfg_info.path
         if key not in model_detail_widgets:
             model_detail_widgets[key] = TrainingEditorWidget.from_trained_config(
-                cfg_info
+                cfg_info, cfg_getter
             )
 
         model_detail_widgets[key].show()

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1114,8 +1114,12 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         self.setLayout(layout)
 
     @classmethod
-    def from_trained_config(cls, cfg_info: configs.ConfigFileInfo):
-        widget = cls(require_trained=True, head=cfg_info.head_name)
+    def from_trained_config(
+        cls, cfg_info: configs.ConfigFileInfo, cfg_getter: configs.TrainingConfigsGetter
+    ):
+        widget = cls(
+            require_trained=True, head=cfg_info.head_name, cfg_getter=cfg_getter
+        )
         widget.acceptSelectedConfigInfo(cfg_info)
         widget.setWindowTitle(cfg_info.path_dir)
         return widget


### PR DESCRIPTION
### Description
Previously, while trying to view the hyperparameters of trained models, the window did not open and threw a `NoneType` error. This was due to the `cfg_getter` that was not passed from the `metrics.py` to the `dialogs.py` in order to fetch the configs file to read the hyperparameters. Hence, passing the `cfg_getter` to avoid the `NoneType` error.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
