### PR TITLE
Add ZMQ support via GUI and CLI

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -212,6 +212,19 @@ training:
   type: list
 
 - type: text
+  text: '<b>ZMQ Options</b>'
+
+- name: controller_port
+  label: Controller Port
+  type: int
+  default: 9000 
+
+- name: publish_port
+  label: Publish Port
+  type: int
+  default: 9001
+
+- type: text
   text: '<b>Output Options</b>'
 
 - default: ''

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -218,11 +218,13 @@ training:
   label: Controller Port
   type: int
   default: 9000 
+  range: 1024,65535
 
 - name: publish_port
   label: Publish Port
   type: int
   default: 9001
+  range: 1024,65535
 
 - type: text
   text: '<b>Output Options</b>'

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -603,12 +603,16 @@ def run_gui_training(
 
         if all(key in inference_params for key in ["controller_port", "publish_port"]):
             zmq_ports = {
-                "controller_address": inference_params["controller_port"],
-                "publisher_address": inference_params["publish_port"],
+                "controller_port": inference_params["controller_port"],
+                "publish_port": inference_params["publish_port"],
             }
 
         # open training monitor window
         win = LossViewer(zmq_ports=zmq_ports)
+
+        # Reassign the values in the inference parameters in case the ports were changed
+        inference_params["controller_port"] = win.zmq_ports["controller_port"]
+        inference_params["publish_port"] = win.zmq_ports["publish_port"]
         win.resize(600, 400)
         win.show()
 

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -550,6 +550,7 @@ def run_learning_pipeline(
             labels_filename=labels_filename,
             labels=labels,
             config_info_list=config_info_list,
+            inference_params=inference_params,
             gui=True,
             save_viz=save_viz,
         )
@@ -577,6 +578,7 @@ def run_gui_training(
     labels_filename: str,
     labels: Labels,
     config_info_list: List[ConfigFileInfo],
+    inference_params: Dict[str, Any],
     gui: bool = True,
     save_viz: bool = False,
 ) -> Dict[Text, Text]:
@@ -594,13 +596,19 @@ def run_gui_training(
     """
 
     trained_job_paths = dict()
-
+    zmq_ports = None
     if gui:
         from sleap.gui.widgets.monitor import LossViewer
         from sleap.gui.widgets.imagedir import QtImageDirectoryWidget
 
+        if all(key in inference_params for key in ["controller_port", "publish_port"]):
+            zmq_ports = {
+                "controller_address": inference_params["controller_port"],
+                "publisher_address": inference_params["publish_port"],
+            }
+
         # open training monitor window
-        win = LossViewer()
+        win = LossViewer(zmq_ports=zmq_ports)
         win.resize(600, 400)
         win.show()
 
@@ -664,6 +672,7 @@ def run_gui_training(
             # Run training
             trained_job_path, ret = train_subprocess(
                 job_config=job,
+                inference_params=inference_params,
                 labels_filename=labels_filename,
                 video_paths=video_path_list,
                 waiting_callback=waiting,
@@ -806,6 +815,7 @@ def run_gui_inference(
 def train_subprocess(
     job_config: TrainingJobConfig,
     labels_filename: str,
+    inference_params: Dict[str, Any],
     video_paths: Optional[List[Text]] = None,
     waiting_callback: Optional[Callable] = None,
     save_viz: bool = False,
@@ -829,6 +839,10 @@ def train_subprocess(
             training_job_path,
             labels_filename,
             "--zmq",
+            "--controller_port",
+            str(inference_params["controller_port"]),
+            "--publish_port",
+            str(inference_params["publish_port"]),
         ]
 
         if save_viz:

--- a/sleap/gui/utils.py
+++ b/sleap/gui/utils.py
@@ -1,0 +1,28 @@
+"""Generic module containing utilities used for the GUI."""
+
+import zmq
+from typing import Optional
+
+
+def is_port_free(port: int, zmq_context: Optional[zmq.Context] = None) -> bool:
+    """Checks if a port is free."""
+    ctx = zmq.Context.instance() if zmq_context is None else zmq_context
+    socket = ctx.socket(zmq.REP)
+    address = f"tcp://127.0.0.1:{port}"
+    try:
+        socket.bind(address)
+        socket.unbind(address)
+        return True
+    except zmq.error.ZMQError:
+        return False
+    finally:
+        socket.close()
+
+
+def select_zmq_port(zmq_context: Optional[zmq.Context] = None) -> int:
+    """Select a port that is free to connect within the given context."""
+    ctx = zmq.Context.instance() if zmq_context is None else zmq_context
+    socket = ctx.socket(zmq.REP)
+    port = socket.bind_to_random_port("tcp://127.0.0.1")
+    socket.close()
+    return port

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -3,6 +3,7 @@
 import numpy as np
 from time import perf_counter
 from sleap.nn.config.training_job import TrainingJobConfig
+from sleap.gui.utils import is_port_free, select_zmq_port
 import zmq
 import jsonpickle
 import logging
@@ -10,7 +11,6 @@ from typing import Optional, Dict
 from qtpy import QtCore, QtWidgets, QtGui
 from qtpy.QtCharts import QtCharts
 import attr
-from sleap.nn import training
 
 
 logger = logging.getLogger(__name__)
@@ -313,12 +313,10 @@ class LossViewer(QtWidgets.QMainWindow):
         self.sub = self.ctx.socket(zmq.SUB)
         self.sub.subscribe("")
 
-        if self.zmq_ports and not training.is_port_free(
+        if self.zmq_ports and not is_port_free(
             port=self.zmq_ports["publish_port"], zmq_context=self.ctx
         ):
-            self.zmq_ports["publish_port"] = training.select_zmq_port(
-                zmq_context=self.ctx
-            )
+            self.zmq_ports["publish_port"] = select_zmq_port(zmq_context=self.ctx)
             publish_address = "tcp://127.0.0.1:" + str(self.zmq_ports["publish_port"])
 
         self.sub.bind(publish_address)
@@ -328,10 +326,10 @@ class LossViewer(QtWidgets.QMainWindow):
         if self.show_controller:
             self.zmq_ctrl = self.ctx.socket(zmq.PUB)
 
-            if self.zmq_ports and not training.is_port_free(
+            if self.zmq_ports and not is_port_free(
                 port=self.zmq_ports["controller_port"], zmq_context=self.ctx
             ):
-                self.zmq_ports["controller_port"] = training.select_zmq_port(
+                self.zmq_ports["controller_port"] = select_zmq_port(
                     zmq_context=self.ctx
                 )
                 controller_address = "tcp://127.0.0.1:" + str(

--- a/sleap/nn/inference.py
+++ b/sleap/nn/inference.py
@@ -1142,6 +1142,7 @@ class InferenceModel(tf.keras.Model):
 
         info["frozen_model_inputs"] = frozen_func.inputs
         info["frozen_model_outputs"] = frozen_func.outputs
+        info["unragged_outputs"] = unrag_outputs
 
         with (Path(save_path) / "info.json").open("w") as fp:
             json.dump(

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -403,7 +403,7 @@ def is_port_free(port: int, zmq_context: Optional[zmq.Context] = None) -> bool:
         socket.bind(address)
         socket.unbind(address)
         return True
-    except zmq.ZMQError:
+    except zmq.error.ZMQError:
         return False
     finally:
         socket.close()

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1873,6 +1873,18 @@ def create_trainer_using_cli(args: Optional[List] = None):
         ),
     )
     parser.add_argument(
+        "--publish_port",
+        type=int,
+        default=9001,
+        help="Port to set up the publish address while using ZMQ, defaults to 9001.",
+    )
+    parser.add_argument(
+        "--controller_port",
+        type=int,
+        default=9000,
+        help="Port to set up the controller address while using ZMQ, defaults to 9000.",
+    )
+    parser.add_argument(
         "--run_name",
         default="",
         help="Run name to use when saving file, overrides other run name settings.",
@@ -1926,6 +1938,10 @@ def create_trainer_using_cli(args: Optional[List] = None):
     job_config.outputs.tensorboard.write_logs |= args.tensorboard
     job_config.outputs.zmq.publish_updates |= args.zmq
     job_config.outputs.zmq.subscribe_to_controller |= args.zmq
+    job_config.outputs.zmq.controller_address = "tcp://127.0.0.1:" + str(
+        args.controller_port
+    )
+    job_config.outputs.zmq.publish_address = "tcp://127.0.0.1:" + str(args.publish_port)
     if args.run_name != "":
         job_config.outputs.run_name = args.run_name
     if args.prefix != "":

--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -11,7 +11,6 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from time import time
 from typing import Callable, List, Optional, Text, TypeVar, Union
-import zmq
 
 import attr
 import cattr
@@ -392,30 +391,6 @@ def setup_new_run_folder(
         run_path = config.run_path
 
     return run_path
-
-
-def is_port_free(port: int, zmq_context: Optional[zmq.Context] = None) -> bool:
-    """Checks if a port is free."""
-    ctx = zmq.Context.instance() if zmq_context is None else zmq_context
-    socket = ctx.socket(zmq.REP)
-    address = f"tcp://127.0.0.1:{port}"
-    try:
-        socket.bind(address)
-        socket.unbind(address)
-        return True
-    except zmq.error.ZMQError:
-        return False
-    finally:
-        socket.close()
-
-
-def select_zmq_port(zmq_context: Optional[zmq.Context] = None) -> int:
-    """Select a port that is free to connect within the given context."""
-    ctx = zmq.Context.instance() if zmq_context is None else zmq_context
-    socket = ctx.socket(zmq.REP)
-    port = socket.bind_to_random_port("tcp://127.0.0.1")
-    socket.close()
-    return port
 
 
 def setup_zmq_callbacks(zmq_config: ZMQConfig) -> List[tf.keras.callbacks.Callback]:


### PR DESCRIPTION
### Description
Adding ZMQ port options in the GUI and CLI for having ease of specifying the ports. Previously, if a port was occupied users had to change it each time by manually editing the training config each time. 
This feature saves time by specifying the ports in the GUI.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
