### PR TITLE
(4b -> 4) Automatically add videos when “Add Recording Session”

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -357,10 +357,10 @@ class MainWindow(QMainWindow):
         self.state.connect(
             "video",
             callbacks=[
+                update_session,  # Important to update session before other callbacks
                 switch_frame,
                 lambda x: self._update_seekbar_marks(),
                 update_frame_chunk_suggestions,
-                update_session,
             ],
         )
 
@@ -1416,6 +1416,11 @@ class MainWindow(QMainWindow):
                 self.statusBar().setStyleSheet("color: red")
             else:
                 self.statusBar().setStyleSheet("color: black")
+
+            if self.state["session"] is not None and current_video is not None:
+                camera = self.state["session"].get_camera(video=self.state["video"])
+                if camera is not None:
+                    message += f"{spacer}Camera: {camera.name}"
 
         self.statusBar().showMessage(message)
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2037,7 +2037,6 @@ class AddSession(EditCommand):
         video_paths = []
         for camera_name in camera_names:
             camera_folder = parent_dir / camera_name
-            
 
             # Skip if camera folder does not exist
             if not camera_folder.exists():
@@ -2046,7 +2045,11 @@ class AddSession(EditCommand):
             # Append all videos in camera folder
             video_path = None
             for file in camera_folder.iterdir():
-                if str(file).endswith(".mp4") or str(file).endswith(".avi") or str(file).endswith(".mov"):
+                if (
+                    str(file).endswith(".mp4")
+                    or str(file).endswith(".avi")
+                    or str(file).endswith(".mov")
+                ):
                     video_path = camera_folder / file
                     video_paths.append(str(video_path))
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2025,6 +2025,32 @@ class AddSession(EditCommand):
         # Reset since this action is also linked to a button in the SessionsDock and it
         # is not visually apparent which session is selected after clicking the button
         context.state["selected_session"] = None
+        
+        # Find parent of calibration file
+        parent_dir = os.path.dirname(camera_calibration)
+        
+        # Use camcorder names in session to find camera folders
+        cameras = session.camera_cluster.cameras
+        camera_names = [camera.name for camera in cameras]
+        
+        # Find videos inside camera folders
+        video_paths = []
+        for camera_name in camera_names:
+            camera_folder = os.path.join(parent_dir, camera_name)
+            
+            # Skip if camera folder does not exist
+            if (not os.path.exists(camera_folder)):
+                continue
+            
+            # Append all videos in camera folder
+            video_path = None;
+            for file in os.listdir(camera_folder):
+                if file.endswith(".mp4"): 
+                    video_path = os.path.join(camera_folder, file)
+                    video_paths.append(video_path)
+        
+        # Show import video dialog if any videos are found
+        ImportVideos().ask(filenames=[video_paths])
 
     @staticmethod
     def ask(context: CommandContext, params: dict) -> bool:

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2037,6 +2037,7 @@ class AddSession(EditCommand):
         video_paths = []
         for camera_name in camera_names:
             camera_folder = parent_dir / camera_name
+            print(camera_folder)
             
             # Skip if camera folder does not exist
             if (not camera_folder.exists()):
@@ -2050,7 +2051,8 @@ class AddSession(EditCommand):
                     video_paths.append(video_path)
         
         # Show import video dialog if any videos are found
-        ImportVideos().ask(filenames=[video_paths])
+        if (len(video_paths) > 0):
+            ImportVideos().ask(filenames=[video_paths])
 
     @staticmethod
     def ask(context: CommandContext, params: dict) -> bool:

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2027,8 +2027,8 @@ class AddSession(EditCommand):
         context.state["selected_session"] = None
         
         # Find parent of calibration file
-        parent_dir = os.path.dirname(camera_calibration)
-        
+        calibration_path = Path(camera_calibration)
+        parent_dir = calibration_path.parent        
         # Use camcorder names in session to find camera folders
         cameras = session.camera_cluster.cameras
         camera_names = [camera.name for camera in cameras]
@@ -2036,17 +2036,17 @@ class AddSession(EditCommand):
         # Find videos inside camera folders
         video_paths = []
         for camera_name in camera_names:
-            camera_folder = os.path.join(parent_dir, camera_name)
+            camera_folder = parent_dir / camera_name
             
             # Skip if camera folder does not exist
-            if (not os.path.exists(camera_folder)):
+            if (not camera_folder.exists()):
                 continue
             
             # Append all videos in camera folder
             video_path = None;
-            for file in os.listdir(camera_folder):
+            for file in camera_folder.iterdir():
                 if file.endswith(".mp4"): 
-                    video_path = os.path.join(camera_folder, file)
+                    video_path = camera_folder / file
                     video_paths.append(video_path)
         
         # Show import video dialog if any videos are found

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2037,7 +2037,7 @@ class AddSession(EditCommand):
         video_paths = []
         for camera_name in camera_names:
             camera_folder = parent_dir / camera_name
-            print(camera_folder)
+            
 
             # Skip if camera folder does not exist
             if not camera_folder.exists():
@@ -2046,13 +2046,13 @@ class AddSession(EditCommand):
             # Append all videos in camera folder
             video_path = None
             for file in camera_folder.iterdir():
-                if file.endswith(".mp4"):
+                if str(file).endswith(".mp4") or str(file).endswith(".avi") or str(file).endswith(".mov"):
                     video_path = camera_folder / file
-                    video_paths.append(video_path)
+                    video_paths.append(str(video_path))
 
         # Show import video dialog if any videos are found
         if len(video_paths) > 0:
-            ImportVideos().ask(filenames=[video_paths])
+            context.showImportVideos(filenames=video_paths)
 
     @staticmethod
     def ask(context: CommandContext, params: dict) -> bool:

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2025,33 +2025,33 @@ class AddSession(EditCommand):
         # Reset since this action is also linked to a button in the SessionsDock and it
         # is not visually apparent which session is selected after clicking the button
         context.state["selected_session"] = None
-        
+
         # Find parent of calibration file
         calibration_path = Path(camera_calibration)
-        parent_dir = calibration_path.parent        
+        parent_dir = calibration_path.parent
         # Use camcorder names in session to find camera folders
         cameras = session.camera_cluster.cameras
         camera_names = [camera.name for camera in cameras]
-        
+
         # Find videos inside camera folders
         video_paths = []
         for camera_name in camera_names:
             camera_folder = parent_dir / camera_name
             print(camera_folder)
-            
+
             # Skip if camera folder does not exist
-            if (not camera_folder.exists()):
+            if not camera_folder.exists():
                 continue
-            
+
             # Append all videos in camera folder
-            video_path = None;
+            video_path = None
             for file in camera_folder.iterdir():
-                if file.endswith(".mp4"): 
+                if file.endswith(".mp4"):
                     video_path = camera_folder / file
                     video_paths.append(video_path)
-        
+
         # Show import video dialog if any videos are found
-        if (len(video_paths) > 0):
+        if len(video_paths) > 0:
             ImportVideos().ask(filenames=[video_paths])
 
     @staticmethod

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2049,6 +2049,7 @@ class AddSession(EditCommand):
                     str(file).endswith(".mp4")
                     or str(file).endswith(".avi")
                     or str(file).endswith(".mov")
+                    or str(file).endswith(".mkv")
                 ):
                     video_path = camera_folder / file
                     video_paths.append(str(video_path))

--- a/tests/fixtures/cameras.py
+++ b/tests/fixtures/cameras.py
@@ -1,5 +1,9 @@
 """Camera fixtures for pytest."""
 
+import shutil
+import toml
+from pathlib import Path
+
 import pytest
 
 from sleap.io.cameras import CameraCluster, RecordingSession
@@ -18,3 +22,35 @@ def min_session_camera_cluster(min_session_calibration_toml_path):
 @pytest.fixture
 def min_session_session(min_session_calibration_toml_path):
     return RecordingSession.load(min_session_calibration_toml_path)
+
+
+@pytest.fixture
+def min_session_directory(tmpdir, min_session_calibration_toml_path):
+    # Create a new RecordingSession object
+    camera_calibration_path = min_session_calibration_toml_path
+
+    # Create temporary directory with the structured video files
+    temp_dir = tmpdir.mkdir("recording_session")
+
+    # Copy and paste the calibration toml
+    shutil.copy(camera_calibration_path, temp_dir)
+
+    # Create directories for each camera
+    calibration_data = toml.load(camera_calibration_path)
+    camera_dnames = [
+        value["name"] for value in calibration_data.values() if "name" in value
+    ]
+
+    for cam_name in camera_dnames:
+        cam_dir = Path(temp_dir, cam_name)
+        cam_dir.mkdir()
+
+    # Copy and paste the videos in the directories (only min_session_[camera_name].mp4)
+    videos_dir = Path("tests/data/videos")
+    for file in videos_dir.iterdir():
+        if file.suffix == ".mp4" and "min_session" in file.stem:
+            camera_fname = file.stem.split("_")[2]
+            if camera_fname in camera_dnames:
+                shutil.copy(file, Path(temp_dir, camera_fname))
+
+    return temp_dir

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -3,6 +3,8 @@ import sys
 import time
 from pathlib import Path, PurePath
 from typing import List
+import tempfile
+import pathlib
 
 import numpy as np
 import pytest
@@ -1451,3 +1453,20 @@ def test_DeleteInstanceGroup(multiview_min_session_frame_groups: Labels):
     # Check InstanceGroup.instances
     assert len(instance_group_0.instances) == 8
     assert len(instance_group_1.instances) == 6
+
+def test_automatic_addition_videos(min_session_calibration_toml_path):
+    """Test if the automatic addition of videos works."""
+    # Create a new RecordingSession object
+    camera_calibration_path = min_session_calibration_toml_path
+    
+    # Create temporary directory with the structured video files
+    test_path = Path(camera_calibration_path)
+    data_path = test_path.parent.parent.parent
+    
+    # Copy and paste the videos and the toml_path
+    
+    # Create a new Label()
+    
+    # Create and add a new RecordingSession object
+    
+    # Check if the videos were added to the Label object

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1454,19 +1454,66 @@ def test_DeleteInstanceGroup(multiview_min_session_frame_groups: Labels):
     assert len(instance_group_0.instances) == 8
     assert len(instance_group_1.instances) == 6
 
+
 def test_automatic_addition_videos(min_session_calibration_toml_path):
     """Test if the automatic addition of videos works."""
     # Create a new RecordingSession object
     camera_calibration_path = min_session_calibration_toml_path
-    
+
     # Create temporary directory with the structured video files
     test_path = Path(camera_calibration_path)
-    data_path = test_path.parent.parent.parent
-    
-    # Copy and paste the videos and the toml_path
-    
+    data_path = test_path.parent.parent.parent  # tests/data/cameras
+
+    with tempfile.TemporaryDirectory(dir=data_path) as temp_dir:
+        # Copy and paste the videos and the toml_path
+        shutil.copy(camera_calibration_path, temp_dir)
+        files_in_directory = [
+            file for file in Path(temp_dir).iterdir() if file.is_file()
+        ]
+        assert len(files_in_directory) == 1
+
+        # Create directories for each camera
+        directory_names = [
+            "back",
+            "backL",
+            "mid",
+            "midL",
+            "side",
+            "sideL",
+            "top",
+            "topL",
+        ]
+
+        for directory_name in directory_names:
+            new_dir = Path(temp_dir, directory_name)
+            new_dir.mkdir()
+
+        assert len([file for file in Path(temp_dir).iterdir() if file.is_dir()]) == 8
+
+        # Copy and paste the videos in the directories (only min_session_[camera_name].mp4)
+        test_directory = test_path.parent.parent.parent
+        test_directory = Path(test_directory, "videos")
+        for file in test_directory.iterdir():
+            if file.suffix == ".mp4" and "min_session" in file.stem:
+                camera_name = file.stem.split("_")[2]
+                if camera_name in directory_names:
+                    shutil.copy(file, Path(temp_dir, camera_name))
+
+        # Check if the videos were added to the temporary directory under each camera directory
+        for directory_name in directory_names:
+            assert (
+                len(
+                    [
+                        file
+                        for file in Path(temp_dir, directory_name).iterdir()
+                        if file.is_file()
+                    ]
+                )
+                == 1
+            )
+
     # Create a new Label()
-    
+
     # Create and add a new RecordingSession object
-    
+
     # Check if the videos were added to the Label object

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1511,8 +1511,13 @@ def test_automatic_addition_videos(min_session_calibration_toml_path):
                 == 1
             )
 
-    # Create a new Label()
+    # Create a new Label() object
+    labels = Labels()
+    context = CommandContext.from_labels(labels)
+    camera_calibration_path = min_session_calibration_toml_path
 
     # Create and add a new RecordingSession object
+    params = {"camera_calibration": camera_calibration_path}
+    AddSession.do_action(context, params)
 
-    # Check if the videos were added to the Label object
+    # Check if the videos were asked to be added to the Label object``


### PR DESCRIPTION
### Description
Whenever a user uploads a recording session toml file, the GUI will automatically add videos of the recording session and will link the videos to the corresponding cameras. 

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [x] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [x] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [x] Add tests that prove your fix is effective or that your feature works
- [x] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
