### PR TITLE
Change menu name to match deleting predictions beyond max instance

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -784,9 +784,9 @@ class MainWindow(QMainWindow):
         )
         add_menu_item(
             labelMenu,
-            "delete frame limit predictions",
-            "Delete Predictions beyond Frame Limit...",
-            self.commands.deleteFrameLimitPredictions,
+            "delete max instance predictions",
+            "Delete Predictions beyond Max Instances...",
+            self.commands.deleteInstanceLimitPredictions,
         )
 
         ### Tracks Menu ###

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -490,9 +490,9 @@ class CommandContext:
         """Gui for deleting instances below some score threshold."""
         self.execute(DeleteLowScorePredictions)
 
-    def deleteFrameLimitPredictions(self):
+    def deleteInstanceLimitPredictions(self):
         """Gui for deleting instances beyond some number in each frame."""
-        self.execute(DeleteFrameLimitPredictions)
+        self.execute(DeleteInstanceLimitPredictions)
 
     def completeInstanceNodes(self, instance: Instance):
         """Adds missing nodes to given instance."""
@@ -2438,7 +2438,7 @@ class DeleteLowScorePredictions(InstanceDeleteCommand):
             return super().ask(context, params)
 
 
-class DeleteFrameLimitPredictions(InstanceDeleteCommand):
+class DeleteInstanceLimitPredictions(InstanceDeleteCommand):
     @staticmethod
     def get_frame_instance_list(context: CommandContext, params: dict):
         count_thresh = params["count_threshold"]


### PR DESCRIPTION
### Description
Currently we have a menu option `Delete Predictions beyond Frame Limit...` but it is misleading as it asks for the max instances beyond which the predictions are deleted. Hence changing the menu name to `Delete Predictions beyond Max Instances...` to be clear. 
Also, changed the related function names to reflect the same.

This could potentially clear the confusion related to #1762 

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
