### PR TITLE
Bump to 1.4.1a1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,7 +28,7 @@ Please include information about how you installed.
 - OS:
 <!-- [e.g. ubuntu 20.04, macOS 11.0] -->
 - Version(s):
-<!-- e.g. [SLEAP v1.3.3, python 3.8] --->
+<!-- e.g. [SLEAP v1.4.1a1, python 3.8] --->
 - SLEAP installation method (listed [here](https://sleap.ai/installation.html#)):
   - [ ] [Conda from package](https://sleap.ai/installation.html#conda-package)
   - [ ] [Conda from source](https://sleap.ai/installation.html#conda-from-source)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ author = "SLEAP Developers"
 copyright = f"2019–{date.today().year}, Talmo Lab"
 
 # The short X.Y version
-version = "1.3.3"
+version = "1.4.1a1"
 
 # Get the sleap version
 # with open("../sleap/version.py") as f:
@@ -36,7 +36,7 @@ version = "1.3.3"
 #     version = re.search("\d.+(?=['\"])", version_file).group(0)
 
 # Release should be the full branch name
-release = "v1.3.3"
+release = "v1.4.1a1"
 
 html_title = f"SLEAP ({release})"
 html_short_title = "SLEAP"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -232,7 +232,7 @@ Although you do not need Mambaforge installed to perform a `pip install`, we rec
 3. Finally, we can perform the `pip install`:
 
    ```bash
-   pip install sleap[pypi]==1.3.3
+   pip install sleap[pypi]==1.4.1a1
    ```
 
    This works on **any OS except Apple silicon** and on **Google Colab**.

--- a/sleap/version.py
+++ b/sleap/version.py
@@ -12,7 +12,7 @@ Must be a semver string, "aN" should be appended for alpha releases.
 """
 
 
-__version__ = "1.4.1a0"
+__version__ = "1.4.1a1"
 
 
 def versions():


### PR DESCRIPTION
### Description
- Changed the versions in `sleap.version` and documentation on website since changes are  merged to the develop branch and will be visible on sleap.ai/develop which is relevant to the associated pre-release v1.4.1a1.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [X] Documentation Update
- [X] Other (pre-release)

### Does this address any currently open issues?
- Pre-releases [v1.4.1a0](https://github.com/talmolab/sleap/releases/tag/v1.4.1a0) and [v1.4.0a0](https://github.com/talmolab/sleap/releases/tag/v1.4.0a0) did not result in published conda packages since the environment was not able to resolve using the cache.
- #1786 fixed the github workflows. Now we should be able to make pre-release v1.4.1a1 with working conda and pip packages published.

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [X] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [X] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
