### PR TITLE
Fix windows conda package upload and build ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ jobs:
 
       # Login to conda (Windows)
       - name: Login to Anaconda (Windows)
-        if: matrix.os == 'windows-2019'
+        if: matrix.os == 'windows-2022'
         env:
           ANACONDA_LOGIN: ${{ secrets.ANACONDA_LOGIN }}
         shell: powershell
@@ -182,12 +182,12 @@ jobs:
       
       # Upload conda package (Windows)
       - name: Upload conda package (Windows/main)
-        if: matrix.os == 'windows-2019' && !github.event.release.prerelease
+        if: matrix.os == 'windows-2022' && !github.event.release.prerelease
         shell: powershell
         run: |
           anaconda -v upload "build\win-64\*.tar.bz2"
       - name: Upload conda package (Windows/dev)
-        if: matrix.os == 'windows-2019' && github.event.release.prerelease
+        if: matrix.os == 'windows-2022' && github.event.release.prerelease
         shell: powershell
         run: |
           anaconda -v upload "build\win-64\*.tar.bz2" --label dev

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -41,7 +41,6 @@ jobs:
           environment-file: environment_build.yml
           activate-environment: sleap_ci
           conda-solver: "libmamba"
-          # use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
 
       - name: Print build environment info
         shell: bash -l {0}

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -170,14 +170,14 @@ jobs:
       #   run: |
       #     yes 2>/dev/null | anaconda login --username sleap --password "$ANACONDA_LOGIN" || true
       
-      # Login to conda (Windows)
-      - name: Login to Anaconda (Windows)
-        if: matrix.os == 'windows-2022'
-        env:
-          ANACONDA_LOGIN: ${{ secrets.ANACONDA_LOGIN }}
-        shell: powershell
-        run: |
-          echo "yes" | anaconda login --username sleap --password "$env:ANACONDA_LOGIN"
+      # # Login to conda (Windows)
+      # - name: Login to Anaconda (Windows)
+      #   if: matrix.os == 'windows-2022'
+      #   env:
+      #     ANACONDA_LOGIN: ${{ secrets.ANACONDA_LOGIN }}
+      #   shell: powershell
+      #   run: |
+      #     echo "yes" | anaconda login --username sleap --password "$env:ANACONDA_LOGIN"
       
       # # Login to conda (Mac)
       # - name: Login to Anaconda (Mac)
@@ -188,12 +188,12 @@ jobs:
       #   run: |
       #     yes 2>/dev/null | anaconda login --username sleap --password "$ANACONDA_LOGIN" || true
       
-      # Upload conda package (Windows)
-      - name: Upload conda package (Windows/dev)
-        if: matrix.os == 'windows-2022'
-        shell: powershell
-        run: |
-          anaconda -v upload "build\win-64\*.tar.bz2" --label dev
+      # # Upload conda package (Windows)
+      # - name: Upload conda package (Windows/dev)
+      #   if: matrix.os == 'windows-2022'
+      #   shell: powershell
+      #   run: |
+      #     anaconda -v upload "build\win-64\*.tar.bz2" --label dev
       
       # # Upload conda package (Ubuntu)
       # - name: Upload conda package (Ubuntu/dev)
@@ -209,7 +209,7 @@ jobs:
       #   run: |
       #     anaconda -v upload build/osx-arm64/*.tar.bz2 --label dev
       
-      - name: Logout from Anaconda
-        shell: bash -l {0}
-        run: |
-          anaconda logout
+      # - name: Logout from Anaconda
+      #   shell: bash -l {0}
+      #   run: |
+      #     anaconda logout

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -11,8 +11,7 @@ on:
       - '.github/workflows/build_manual.yml'
     branches:
       # - develop
-      # - fakebranch
-      - elizabeth/Fix-windows-build-and-build-CI
+      - fakebranch
 
 jobs:
   build:

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -11,7 +11,8 @@ on:
       - '.github/workflows/build_manual.yml'
     branches:
       # - develop
-      - fakebranch
+      # - fakebranch
+      - elizabeth/Fix-windows-build-and-build-CI
 
 jobs:
   build:
@@ -59,14 +60,14 @@ jobs:
         run: |
           python setup.py bdist_wheel
 
-      # Upload pip wheel (Ubuntu)
-      - name: Upload pip wheel (Ubuntu)
-        if: matrix.os == 'ubuntu-22.04'
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        shell: bash -l {0}
-        run: |
-          twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
+      # # Upload pip wheel (Ubuntu)
+      # - name: Upload pip wheel (Ubuntu)
+      #   if: matrix.os == 'ubuntu-22.04'
+      #   env:
+      #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      #   shell: bash -l {0}
+      #   run: |
+      #     twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
 
       # Build conda package (Ubuntu)
       - name: Build conda package (Ubuntu)
@@ -169,14 +170,14 @@ jobs:
       #   run: |
       #     yes 2>/dev/null | anaconda login --username sleap --password "$ANACONDA_LOGIN" || true
       
-      # # Login to conda (Windows)
-      # - name: Login to Anaconda (Windows)
-      #   if: matrix.os == 'windows-2022'
-      #   env:
-      #     ANACONDA_LOGIN: ${{ secrets.ANACONDA_LOGIN }}
-      #   shell: powershell
-      #   run: |
-      #     echo "yes" | anaconda login --username sleap --password "$env:ANACONDA_LOGIN"
+      # Login to conda (Windows)
+      - name: Login to Anaconda (Windows)
+        if: matrix.os == 'windows-2022'
+        env:
+          ANACONDA_LOGIN: ${{ secrets.ANACONDA_LOGIN }}
+        shell: powershell
+        run: |
+          echo "yes" | anaconda login --username sleap --password "$env:ANACONDA_LOGIN"
       
       # # Login to conda (Mac)
       # - name: Login to Anaconda (Mac)
@@ -187,12 +188,12 @@ jobs:
       #   run: |
       #     yes 2>/dev/null | anaconda login --username sleap --password "$ANACONDA_LOGIN" || true
       
-      # # Upload conda package (Windows)
-      # - name: Upload conda package (Windows/dev)
-      #   if: matrix.os == 'windows-2022'
-      #   shell: powershell
-      #   run: |
-      #     anaconda -v upload "build\win-64\*.tar.bz2" --label dev
+      # Upload conda package (Windows)
+      - name: Upload conda package (Windows/dev)
+        if: matrix.os == 'windows-2022'
+        shell: powershell
+        run: |
+          anaconda -v upload "build\win-64\*.tar.bz2" --label dev
       
       # # Upload conda package (Ubuntu)
       # - name: Upload conda package (Ubuntu/dev)
@@ -208,7 +209,7 @@ jobs:
       #   run: |
       #     anaconda -v upload build/osx-arm64/*.tar.bz2 --label dev
       
-      # - name: Logout from Anaconda
-      #   shell: bash -l {0}
-      #   run: |
-      #     anaconda logout
+      - name: Logout from Anaconda
+        shell: bash -l {0}
+        run: |
+          anaconda logout

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -137,13 +137,13 @@ SLEAP can be installed three different ways: via {ref}`conda package<condapackag
 **Windows** and **Linux**
 
 ```bash
-mamba create -y -n sleap -c conda-forge -c nvidia -c sleap -c anaconda sleap=1.3.3
+mamba create -y -n sleap -c conda-forge -c nvidia -c sleap -c anaconda sleap=1.4.1a1
 ```
 
 **Mac OS X** and **Apple Silicon**
 
 ```bash
-mamba create -y -n sleap -c conda-forge -c anaconda -c sleap sleap=1.3.3
+mamba create -y -n sleap -c conda-forge -c anaconda -c sleap sleap=1.4.1a1
 ```
 
 **This is the recommended installation method**.


### PR DESCRIPTION
### Description
- Using `build_manual.yml` to upload the Windows conda package.
- Changed `windows-2019` to `windows-2022` in `build.yml` upload stages. 
- Removed unnecessary comment from `build_ci.yml` and tested the Build CI.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [X] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- The Windows OS in `build.yml` for the conda upload step was incorrect. This release [v1.4.1a1](https://github.com/talmolab/sleap/releases/tag/v1.4.1a1) built but did not upload the Windows conda package. 
- The Build CI workflow did not work for Windows in this pull request #1791 even though it worked in the previous pull requests ([Build CI Actions](https://github.com/talmolab/sleap/actions/workflows/build_ci.yml)) and only versions were changed in #1791--nothing was changed in the `build_ci.yml` so I am not sure why it even ran. It is running without errors again.

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [X] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [X] Add tests that prove your fix is effective or that your feature works
- [X] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated installation instructions to reflect the new version of SLEAP (1.4.1a1) for Windows, Linux, Mac OS X, and Apple Silicon.

- **Chores**
  - Updated workflow configurations for Windows to use `windows-2022`.
  - Adjusted steps for uploading pip wheels and conda packages based on the operating system in the build workflows.
  - Removed an obsolete commented-out line in the CI build workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->