### PR TITLE
Fix zmq inference

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -608,7 +608,8 @@ def run_gui_training(
         zmq_ports = dict()
         zmq_ports["controller_port"] = inference_params.get("controller_port", 9000)
         zmq_ports["publish_port"] = inference_params.get("publish_port", 9001)
-        # open training monitor window
+
+        # Open training monitor window
         win = LossViewer(zmq_ports=zmq_ports)
 
         # Reassign the values in the inference parameters in case the ports were changed

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -605,12 +605,9 @@ def run_gui_training(
         from sleap.gui.widgets.monitor import LossViewer
         from sleap.gui.widgets.imagedir import QtImageDirectoryWidget
 
-        if all(key in inference_params for key in ["controller_port", "publish_port"]):
-            zmq_ports = {
-                "controller_port": inference_params["controller_port"],
-                "publish_port": inference_params["publish_port"],
-            }
-
+        zmq_ports = dict()
+        zmq_ports["controller_port"] = inference_params.get("controller_port", 9000)
+        zmq_ports["publish_port"] = inference_params.get("publish_port", 9001)
         # open training monitor window
         win = LossViewer(zmq_ports=zmq_ports)
 

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -316,26 +316,24 @@ class LossViewer(QtWidgets.QMainWindow):
 
         def find_free_port(port: int, zmq_context: zmq.Context):
             """Find free port to bind to.
-            
+
             Args:
                 port: The port to start searching from.
                 zmq_context: The ZMQ context to use.
-            
+
             Returns:
                 The free port.
             """
             attempts = 0
             max_attempts = 10
-            while not is_port_free(
-                port=port, zmq_context=zmq_context
-            ):
+            while not is_port_free(port=port, zmq_context=zmq_context):
                 if attempts >= max_attempts:
                     raise OSError(
                         f"Could not find free port after {max_attempts} attempts."
                     )
                 port = select_zmq_port(zmq_context=self.ctx)
                 attempts += 1
-            
+
             return port
 
         # Find a free port and bind to it.

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -328,8 +328,10 @@ class LossViewer(QtWidgets.QMainWindow):
             max_attempts = 10
             while not is_port_free(port=port, zmq_context=zmq_context):
                 if attempts >= max_attempts:
-                    raise OSError(
-                        f"Could not find free port after {max_attempts} attempts."
+                    raise RuntimeError(
+                        f"Could not find free port to display training progress after "
+                        f"{max_attempts} attempts. Please check your network settings "
+                        "or use the CLI `sleap-train` command."
                     )
                 port = select_zmq_port(zmq_context=self.ctx)
                 attempts += 1

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -322,9 +322,15 @@ class LossViewer(QtWidgets.QMainWindow):
         self.sub.subscribe("")
 
         # Find a free port to bind to.
+        attempts = 0
+        max_attempts = 10
         while not is_port_free(
             port=self.zmq_ports["publish_port"], zmq_context=self.ctx
         ):
+            if attempts >= max_attempts:
+                raise ValueError(
+                    f"Could not find free port after {max_attempts} attempts."
+                )
             self.zmq_ports["publish_port"] = select_zmq_port(zmq_context=self.ctx)
         publish_address = "tcp://127.0.0.1:" + str(self.zmq_ports["publish_port"])
 

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -314,19 +314,19 @@ class LossViewer(QtWidgets.QMainWindow):
         self.ctx = zmq.Context() if zmq_context is None else zmq_context
 
         # Default publish and control address
-        controller_address = "tcp://127.0.0.1:9000"
-        publish_address = "tcp://127.0.0.1:9001"
+        controller_address = f"tcp://127.0.0.1:{self.zmq_ports['controller_port']}"
+        publish_address = f"tcp://127.0.0.1:{self.zmq_ports['publish_port']}"
 
         # Progress monitoring, SUBSCRIBER
         self.sub = self.ctx.socket(zmq.SUB)
         self.sub.subscribe("")
 
-        if self.zmq_ports:
-            while not is_port_free(
-                port=self.zmq_ports["publish_port"], zmq_context=self.ctx
-            ):
-                self.zmq_ports["publish_port"] = select_zmq_port(zmq_context=self.ctx)
-            publish_address = "tcp://127.0.0.1:" + str(self.zmq_ports["publish_port"])
+        # Find a free port to bind to.
+        while not is_port_free(
+            port=self.zmq_ports["publish_port"], zmq_context=self.ctx
+        ):
+            self.zmq_ports["publish_port"] = select_zmq_port(zmq_context=self.ctx)
+        publish_address = "tcp://127.0.0.1:" + str(self.zmq_ports["publish_port"])
 
         # Port is free, so bind to it.
         self.sub.bind(publish_address)

--- a/tests/gui/test_monitor.py
+++ b/tests/gui/test_monitor.py
@@ -64,9 +64,3 @@ def test_monitor_release(qtbot, min_centroid_model_path):
     assert win3.zmq_ports["publish_port"] == publish_port
 
     win3.close()
-
-
-if __name__ == "__main__":
-    import pytest
-
-    pytest.main([f"{__file__}::test_monitor_release"])

--- a/tests/gui/test_monitor.py
+++ b/tests/gui/test_monitor.py
@@ -1,4 +1,3 @@
-from turtle import title
 from sleap.gui.widgets.monitor import LossViewer
 from sleap import TrainingJobConfig
 
@@ -12,6 +11,9 @@ def test_monitor_release(qtbot, min_centroid_model_path):
     win.reset(what="Model Type", config=config)
     assert win.config.optimization.early_stopping.plateau_patience == 10
 
+    # Ensure zmq port is set correctly
+    assert win.zmq_ports["controller_port"] == 9000
+    assert win.zmq_ports["publish_port"] == 9001
     # Ensure all lines of update_runtime() are run error-free
     win.is_running = True
     win.t0 = 0
@@ -33,8 +35,12 @@ def test_monitor_release(qtbot, min_centroid_model_path):
     win.close()
 
     # Make sure the first monitor released its zmq socket
-    win2 = LossViewer()
+    controller_port = 9191
+    zmq_ports = dict(controller_port=controller_port)
+    win2 = LossViewer(zmq_ports=zmq_ports)
     win2.show()
+    assert win2.zmq_ports["controller_port"] == controller_port
+    assert win2.zmq_ports["publish_port"] == 9001
 
     # Make sure batches to show field is working correction
 
@@ -47,3 +53,20 @@ def test_monitor_release(qtbot, min_centroid_model_path):
     assert win2.batches_to_show == 200
 
     win2.close()
+
+    # Ensure zmq port is set correctly
+    controller_port = 9191
+    publish_port = 9101
+    zmq_ports = dict(controller_port=controller_port, publish_port=publish_port)
+    win3 = LossViewer(zmq_ports=zmq_ports)
+    win3.show()
+    assert win3.zmq_ports["controller_port"] == controller_port
+    assert win3.zmq_ports["publish_port"] == publish_port
+
+    win3.close()
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([f"{__file__}::test_monitor_release"])


### PR DESCRIPTION
### Description
After the changes added in:
- #1780

when running inference, the zmq ports are not on the inference GUI and so were not being passed into the `LossViewer`. Because of this, when trying to run inference, we would get this error:
```bash
Traceback (most recent call last):
  File "d:\social-leap-estimates-animal-poses\source\sleap\sleap\gui\learning\dialog.py", line 731, in run
    items_for_inference=items_for_inference,
  File "d:\social-leap-estimates-animal-poses\source\sleap\sleap\gui\learning\runners.py", line 559, in run_learning_pipeline
    save_viz=save_viz,
  File "d:\social-leap-estimates-animal-poses\source\sleap\sleap\gui\learning\runners.py", line 618, in run_gui_training
    inference_params["controller_port"] = win.zmq_ports["controller_port"]
TypeError: 'NoneType' object is not subscriptable
```

This PR does not add the ZMQ ports to the inference GUI, but instead makes changes so that even if ZMQ  ports were not found in the GUI params, default values will be used.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved setup for ZMQ ports in `MonitorWidget`, including default port handling and dynamic free port allocation.
  - Enhanced error handling for ZMQ port setup, ensuring robustness when free ports are unavailable.

- **Tests**
  - Added tests to verify correct ZMQ port settings and behavior in `LossViewer` instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->