### PR TITLE
Set selected instance to None after removal

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2296,6 +2296,8 @@ class InstanceDeleteCommand(EditCommand):
         lfs_to_remove = []
         for lf, inst in lf_inst_list:
             context.labels.remove_instance(lf, inst, in_transaction=True)
+            if context.state["instance"] == inst:
+                context.state["instance"] = None
             if len(lf.instances) == 0:
                 lfs_to_remove.append(lf)
 
@@ -2533,6 +2535,7 @@ class DeleteSelectedInstance(EditCommand):
             return
 
         context.labels.remove_instance(context.state["labeled_frame"], selected_inst)
+        context.state["instance"] = None
 
 
 class DeleteSelectedInstanceTrack(EditCommand):
@@ -2550,6 +2553,7 @@ class DeleteSelectedInstanceTrack(EditCommand):
 
         track = selected_inst.track
         context.labels.remove_instance(context.state["labeled_frame"], selected_inst)
+        context.state["instance"] = None
 
         if track is not None:
             # remove any instance on this track

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -142,6 +142,7 @@ def test_app_workflow(
     # Select and delete instance
     app.state["instance"] = inst_27_1
     app.commands.deleteSelectedInstance()
+    assert app.state["instance"] is None
 
     assert len(app.state["labeled_frame"].instances) == 1
     assert app.state["labeled_frame"].instances == [inst_27_0]
@@ -179,6 +180,7 @@ def test_app_workflow(
 
     # Delete all instances in track
     app.commands.deleteSelectedInstanceTrack()
+    assert app.state["instance"] is None
 
     assert len(app.state["labeled_frame"].instances) == 0
     app.state["frame_idx"] = 29


### PR DESCRIPTION
### Description
Currently, in the commands where we remove the selected instance from our `Labels` object, we keep the instance in `GuiState["instance"]`.

This doesn't seem like appropriate logic, and it is also leading to some problems for me in:
- #1807

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Correctly reset the application state after instance removal to ensure proper state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->