### PR TITLE
All instances are always selectable

### DIFF
--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -1787,7 +1787,7 @@ class QtInstance(QGraphicsObject):
         color = color_manager.get_item_color(self.instance)
 
         self.show_non_visible = show_non_visible
-        self.selectable = not self.predicted or color_manager.color_predicted
+        self.selectable = True
         self.markerRadius = markerRadius
         self.nodeLabelSize = nodeLabelSize
 


### PR DESCRIPTION
### Description
Predicted instances were not selectable if they were not colored. This fix allows all instances to always be selectable by the user. 

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [x] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the logic for video selection to ensure the selectable attribute is always set to true, enhancing user interaction with predicted videos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->