### PR TITLE
Create and assign instance group with Shift + `num` in (`n_instance_groups`, `9`]

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -189,6 +189,15 @@ class MainWindow(QMainWindow):
         else:
             self.state["project_loaded"] = False
 
+    def create_and_assign_instance_group(self):
+        """Creates a new instance group and assigns the selected instance."""
+        instance = self.state["instance"]
+        self.commands.addInstanceGroup()  # Create a new instance group
+        if instance is not None:
+            new_group = self.state["session"].frame_groups
+            [self.state["frame_idx"]].instance_groups[-1]
+            self.commands.setInstanceGroup(instance_group=new_group)
+
     def setWindowTitle(self, value):
         """Sets window title (if value is not None)."""
         if value is not None:
@@ -835,6 +844,12 @@ class MainWindow(QMainWindow):
         self.inst_groups_menu = sessionsMenu.addMenu("Set Instance Group")
         self.inst_groups_delete_menu = sessionsMenu.addMenu("Delete Instance Group")
         self.state.connect("frame_idx", self._update_sessions_menu)
+
+        self.inst_groups_menu.addAction(
+            "New Instance Group and Assign (Shift + 0)",
+            self.create_and_assign_instance_group,
+            Qt.SHIFT + Qt.Key_0
+        )
 
         ### Tracks Menu ###
 


### PR DESCRIPTION
### Description
When the user clicks Shift + 0 keyboard shortcut, it should both create a new instance group and assign the selected instance if any.

### Types of changes

- [ ] Bugfix
- [x ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
