### PR TITLE
Fix skeleton table coloring bug

### DIFF
--- a/sleap/gui/color.py
+++ b/sleap/gui/color.py
@@ -283,7 +283,7 @@ class ColorManager:
 
             return (128, 128, 128)
 
-        if self.distinctly_color == "instance_groups":
+        if self.distinctly_color == "instance_groups" and parent_instance:
 
             if parent_frame is None and parent_instance:
                 parent_frame = parent_instance.frame


### PR DESCRIPTION
### Description
In #1760, we added an option to distincly color by instance group. However, the `Node` items in the `SkeletonDock` was getting caught in this case and being colored the `ColorManager.uncolored_prediction_color` (see below). This PR adds a simple check that the `parent_instance is not None` in addition to `ColorManager.distinctly_color == "instance_groups"`.

![image](https://github.com/talmolab/sleap/assets/38435167/7a81f6e1-1db7-4990-92be-04ad221793c9)

https://github.com/talmolab/sleap/blob/93e38f2229c2ebff9139951c5b07cc726c5d66ea/sleap/gui/color.py#L270-L301

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
