### PR TITLE
Link videos to camera when add session

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2136,6 +2136,12 @@ class LinkVideoToSession(EditCommand):
         recording_session = params["session"] or context.state["selected_session"]
         camcorder = params["camera"] or context.state["selected_camera"]
 
+        if camcorder is None:
+            raise ValueError("No camera selected.")
+
+        if recording_session is None:
+            raise ValueError("No session selected.")
+
         if camcorder.get_video(recording_session) is None:
             recording_session.add_video(video=video, camcorder=camcorder)
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -54,7 +54,7 @@ from sleap.gui.dialogs.missingfiles import MissingFilesDialog
 from sleap.gui.state import GuiState
 from sleap.gui.suggestions import VideoFrameSuggestions
 from sleap.instance import Instance, LabeledFrame, Point, PredictedInstance, Track
-from sleap.io.cameras import FrameGroup, InstanceGroup, RecordingSession
+from sleap.io.cameras import Camcorder, FrameGroup, InstanceGroup, RecordingSession
 from sleap.io.convert import default_analysis_filename
 from sleap.io.dataset import Labels
 from sleap.io.format.adaptor import Adaptor
@@ -454,7 +454,7 @@ class CommandContext:
         self,
         video: Optional[Video] = None,
         session: Optional[RecordingSession] = None,
-        camera: Optional[str] = None,
+        camera: Optional[Camcorder] = None,
     ):
         """Links a video to a `RecordingSession`."""
         self.execute(LinkVideoToSession, video=video, session=session, camera=camera)

--- a/sleap/io/cameras.py
+++ b/sleap/io/cameras.py
@@ -1159,6 +1159,12 @@ class RecordingSession:
                 f"{self.camera_cluster}."
             )
 
+        # Ensure the `Video` is a `Video` object
+        if not isinstance(video, Video):
+            raise ValueError(
+                f"Expected a `Video` object, but got {type(video)} instead."
+            )
+
         # Add session-to-videos (1-to-many) map to `CameraCluster`
         if self not in self.camera_cluster._videos_by_session:
             self.camera_cluster.add_session(self)


### PR DESCRIPTION
### Description
In #1788, we added the ability to automatically add videos when adding a recording session (given that the videos and calibration.toml were in the expected sleap-anipose directory structure). This PR extends this functionality to automatically link videos to cameras as well.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
