### PR TITLE
Add id property to RecordingSession

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -327,7 +327,18 @@ class MainWindow(QMainWindow):
         self.setCentralWidget(self.player)
 
         def switch_frame(video):
-            """Jump to last labeled frame"""
+            """Maintain the same frame index if available.
+
+            If the video is shorter than the current frame index, find the last labeled
+            frame. If no labeled frame is found, set the frame index to 0.
+            """
+
+            # If the new video is long enough, stay on the current frame index
+            current_frame_idx = self.state["frame_idx"]
+            if video.num_frames > current_frame_idx:
+                return
+
+            # If the new video is not long enough, find last labeled frame or set to 0
             last_label = self.labels.find_last(video)
             if last_label is not None:
                 self.state["frame_idx"] = last_label.frame_idx

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -387,11 +387,11 @@ class GenericTableView(QtWidgets.QTableView):
 
 
 class SessionsTableModel(GenericTableModel):
-    properties = ("id", "videos", "cameras")
+    properties = ("index", "videos", "cameras")
 
-    def item_to_data(self, obj, item):
+    def item_to_data(self, obj, item: RecordingSession):
         res = {}
-        res["id"] = hash(item)
+        res["index"] = item.id
         res["cameras"] = len(getattr(item, "cameras"))
         res["videos"] = len(getattr(item, "videos"))
         return res

--- a/sleap/io/cameras.py
+++ b/sleap/io/cameras.py
@@ -1014,6 +1014,14 @@ class RecordingSession:
     _excluded_views: Optional[Tuple[str]] = field(default=None)
 
     @property
+    def id(self) -> str:
+        """Unique identifier for the `RecordingSession`."""
+        if self.labels is not None and self in self.labels.sessions:
+            return self.labels.sessions.index(self)
+        else:
+            return hash(self)
+
+    @property
     def videos(self) -> List[Video]:
         """List of `Video`s."""
 

--- a/tests/io/test_cameras.py
+++ b/tests/io/test_cameras.py
@@ -275,6 +275,11 @@ def test_recording_session(
     session_3 = sessions_cattr.structure(session_dict_2, RecordingSession)
     compare_sessions(session_2, session_3)
 
+    # Test id
+    assert session.id == hash(session)
+    labels.add_session(session)
+    assert session.id == labels.sessions.index(session)
+
 
 def test_recording_session_get_videos_from_selected_cameras(
     multiview_min_session_labels: Labels,


### PR DESCRIPTION
### Description
Previously, we used the hash of a RecordingSession as an ID in the Sessions Table. This PR adds a RecordingSession.id property that uses the index of the RecordingSession in the list of Labels.sessions if it exists (or reverts to the hash value).

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
