### PR TITLE
Handle case when no frame selection for trail overlay

### DIFF
--- a/sleap/gui/overlays/tracks.py
+++ b/sleap/gui/overlays/tracks.py
@@ -1,17 +1,16 @@
 """Track trail and track list overlays."""
 
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import attr
+from qtpy import QtCore, QtGui
+
 from sleap.gui.overlays.base import BaseOverlay
+from sleap.gui.widgets.video import QtTextWithBackground
 from sleap.instance import Track
 from sleap.io.dataset import Labels
 from sleap.io.video import Video
 from sleap.prefs import prefs
-from sleap.gui.widgets.video import QtTextWithBackground
-
-import attr
-
-from typing import Iterable, List, Optional, Dict
-
-from qtpy import QtCore, QtGui
 
 
 @attr.s(auto_attribs=True)
@@ -56,7 +55,9 @@ class TrackTrailOverlay(BaseOverlay):
 
         return {"Dark": 0.6, "Normal": 1.0, "Light": 1.25}
 
-    def get_track_trails(self, frame_selection: Iterable["LabeledFrame"]):
+    def get_track_trails(
+        self, frame_selection: Iterable["LabeledFrame"]
+    ) -> Optional[Dict[Track, List[List[Tuple[float, float]]]]]:
         """Get data needed to draw track trail.
 
         Args:
@@ -152,6 +153,8 @@ class TrackTrailOverlay(BaseOverlay):
         frame_selection = self.get_frame_selection(video, frame_idx)
 
         all_track_trails = self.get_track_trails(frame_selection)
+        if all_track_trails is None:
+            return
 
         for track, trails in all_track_trails.items():
             trail_color = tuple(


### PR DESCRIPTION
### Description
If we have a project with no labels in it, then each time we change to a new video, we get the following non-fatal error:
```bash
Traceback (most recent call last):
  File "d:\social-leap-estimates-animal-poses\source\sleap\sleap\gui\app.py", line 1354, in _after_plot_change
    overlay.redraw(self.state["video"], frame_idx)
  File "d:\social-leap-estimates-animal-poses\source\sleap\sleap\gui\overlays\base.py", line 84, in redraw
    self.add_to_scene(video, frame_idx, *args, **kwargs)
  File "d:\social-leap-estimates-animal-poses\source\sleap\sleap\gui\overlays\tracks.py", line 156, in add_to_scene
    for track, trails in all_track_trails.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

This PR returns early if `all_track_trails is None`.

Additionally. this PR also organizes the imports in the tracks.py file.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of track trails to prevent potential errors when no trails are present.

- **Code Quality**
  - Enhanced code readability by reordering import statements and adding type hints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->