### PR TITLE
Always reproject non-visible nodes

### DIFF
--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -1566,7 +1566,8 @@ class QtNode(QGraphicsEllipseItem):
             # Disable contextual menu for right clicks on node
             self.player.is_menu_enabled = False
 
-            self.point.complete = True  # FIXME: move to command
+            # For triangulation, we want non-visible nodes to always be updated
+            self.point.complete = self.point.visible  # FIXME: move to command
             self.updatePoint(user_change=True)
         elif event.button() == Qt.MidButton:
             pass

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -1555,6 +1555,7 @@ class QtNode(QGraphicsEllipseItem):
                 super(QtNode, self).mousePressEvent(event)
                 self.updatePoint()
 
+            # Note that the setter for complete will not allow complete if not visible
             self.point.complete = complete  # FIXME: move to command
 
         elif event.button() == Qt.RightButton:
@@ -1563,11 +1564,9 @@ class QtNode(QGraphicsEllipseItem):
 
             # Right-click to toggle node as missing from this instance
             self.toggleVisibility()
+
             # Disable contextual menu for right clicks on node
             self.player.is_menu_enabled = False
-
-            # For triangulation, we want non-visible nodes to always be updated
-            self.point.complete = self.point.visible  # FIXME: move to command
             self.updatePoint(user_change=True)
         elif event.button() == Qt.MidButton:
             pass

--- a/tests/test_point_array.py
+++ b/tests/test_point_array.py
@@ -32,19 +32,60 @@ def test_point(p1):
         p1.score = 30.0
         assert p1.score == 30.0
 
+    # Check complete does not change visibility when visible
+    visible = True
+    p1.visible = visible
+    p1.complete = False
+    assert p1.complete == False
+    assert p1.visible == visible
+    p1.complete = True
+    assert p1.complete == True
+    assert p1.visible == visible
+
+    # Check that complete cannot be set to True if not visible
+    visible = False
+    p1.visible = visible
+    p1.complete = False
+    assert p1.complete == False
+    assert p1.visible == visible
+    p1.complete = True
+    assert p1.complete == False
+    assert p1.visible == visible
+
+    # Check visibility also changes complete
+    p1.visible = False
+    assert p1.visible == False
+    assert p1.complete == False
+    p1.visible = True
+    assert p1.visible == True
+    assert p1.complete == True
+
 
 def test_constructor():
     p = Point(x=1.0, y=2.0, visible=False, complete=True)
     assert p.x == 1.0
     assert p.y == 2.0
     assert p.visible == False
-    assert p.complete == True
+    assert p.complete == False  # If a point is not visible, it is not complete
 
     p = PredictedPoint(x=1.0, y=2.0, visible=False, complete=True, score=0.3)
     assert p.x == 1.0
     assert p.y == 2.0
     assert p.visible == False
-    assert p.complete == True
+    assert p.complete == False  # If a point is not visible, it is not complete
+    assert p.score == 0.3
+
+    p = Point(x=1.0, y=2.0, visible=True, complete=False)
+    assert p.x == 1.0
+    assert p.y == 2.0
+    assert p.visible == True
+    assert p.complete == False  # A point can be visible but not complete
+
+    p = PredictedPoint(x=1.0, y=2.0, visible=True, complete=False, score=0.3)
+    assert p.x == 1.0
+    assert p.y == 2.0
+    assert p.visible == True
+    assert p.complete == False  # A point can be visible but not complete
     assert p.score == 0.3
 
 


### PR DESCRIPTION
### Description
Previously, we set a point to complete if the user had clicked on that point (to set back to incomplete, the user would need to Ctrl + click on the node). However, we desire non-visible nodes to always be updated when triangulating. The current logic uses the `Point.complete` attribute to determine whether or not to (re)project a node - this is the only functional thing `Point.complete` is currently being used for.

This PR...

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
