### PR TITLE
Update python versions and dependencies

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -20,8 +20,10 @@ build:
 
 requirements:
   host:
-    - conda-forge::python ==3.7.12  # Run into _MAX_WINDOWS_WORKERS not found if <
-    - numpy >=1.19.5,<1.23.0  # Linux likes anaconda, windows likes conda-forge
+    # - conda-forge::python ==3.7.12  # Run into _MAX_WINDOWS_WORKERS not found if <
+    - conda-forge::python >=3.9.0,<3.10.0
+    # - numpy >=1.19.5,<1.23.0  # Linux likes anaconda, windows likes conda-forge
+    - numpy >=1.21.6 # SciPy 1.11 requires numpy >=1.21.6
     - conda-forge::cudatoolkit ==11.3.1
     - conda-forge::cudnn=8.2.1
     - nvidia::cuda-nvcc=11.3
@@ -41,13 +43,15 @@ requirements:
     - conda-forge::pillow >=8.3.2
     - conda-forge::psutil
     - conda-forge::pykalman
-    - conda-forge::pyside2 >=5.12,<5.14
+    # - conda-forge::pyside2 >=5.12,<5.14  # To ensure works correctly with QtPy.
+    - conda-forge::pyside6 >5.15 # >5.15 is compatible with Python 3.9
     - conda-forge::python-rapidjson
     - conda-forge::pyyaml
     - conda-forge::pyzmq
     - conda-forge::qtpy >=2.0.1
     - conda-forge::rich
-    - conda-forge::scipy >=1.4.1,<=1.9.0
+    # - conda-forge::scipy >=1.4.1,<=1.9.0
+    - conda-forge::scipy >=1.11 # Python 3.9 requires scipy >=1.11
     - conda-forge::scikit-image
     - conda-forge::scikit-learn ==1.0
     - conda-forge::scikit-video
@@ -57,7 +61,10 @@ requirements:
     - conda-forge::ndx-pose
     - conda-forge::importlib-metadata ==4.11.4
   run:
-    - conda-forge::python ==3.7.12  # Run into _MAX_WINDOWS_WORKERS not found if <
+    # - conda-forge::python ==3.7.12  # Run into _MAX_WINDOWS_WORKERS not found if <
+    - conda-forge::python >=3.9.0,<3.10.0
+    # - numpy >=1.19.5,<1.23.0  # Linux likes anaconda, windows likes conda-forge
+    - numpy >=1.21.6 # SciPy 1.11 requires numpy >=1.21.6
     - conda-forge::attrs ==21.4.0
     - conda-forge::cattrs ==1.1.1
     - conda-forge::cudatoolkit ==11.3.1
@@ -67,19 +74,20 @@ requirements:
     - conda-forge::jsmin
     - conda-forge::jsonpickle ==1.2
     - conda-forge::networkx
-    - numpy >=1.19.5,<1.23.0  # Linux likes anaconda, windows likes conda-forge
     - conda-forge::opencv <4.9.0
     - conda-forge::pandas
     - conda-forge::pillow >=8.3.2
     - conda-forge::psutil
     - conda-forge::pykalman
-    - conda-forge::pyside2 >=5.12,<5.14  # To ensure works correctly with QtPy.
+    # - conda-forge::pyside2 >=5.12,<5.14  # To ensure works correctly with QtPy.
+    - conda-forge::pyside6 >5.15 # >5.15 is compatible with Python 3.9
     - conda-forge::python-rapidjson
     - conda-forge::pyyaml
     - conda-forge::pyzmq
     - conda-forge::qtpy >=2.0.1
     - conda-forge::rich
-    - conda-forge::scipy >=1.4.1,<=1.9.0
+    # - conda-forge::scipy >=1.4.1,<=1.9.0
+    - conda-forge::scipy >=1.11 # Python 3.9 requires scipy >=1.11
     - conda-forge::scikit-image
     - conda-forge::scikit-learn ==1.0
     - conda-forge::scikit-video

--- a/.conda_mac/meta.yaml
+++ b/.conda_mac/meta.yaml
@@ -23,7 +23,7 @@ source:
 
 requirements:
   host:  
-    - conda-forge::python >=3.12.0,<3.13.0
+    - conda-forge::python >=3.11.0,<3.12.0
     - anaconda::numpy >=1.19.5,<1.23.0
     - conda-forge::setuptools
     - conda-forge::packaging
@@ -59,7 +59,7 @@ requirements:
     - conda-forge::ndx-pose
 
   run:
-    - conda-forge::python >=3.12.0,<3.13.0
+    - conda-forge::python >=3.11.0,<3.12.0
     - conda-forge::attrs >=21.2.0
     - conda-forge::cattrs ==1.1.1
     - conda-forge::h5py

--- a/.conda_mac/meta.yaml
+++ b/.conda_mac/meta.yaml
@@ -23,7 +23,8 @@ source:
 
 requirements:
   host:  
-    - conda-forge::python >=3.10.0,<3.11.0
+    # - conda-forge::python >=3.10.0,<3.11.0
+    - conda-forge::python >=3.11.0,<3.12.0
     - anaconda::numpy >=1.19.5,<1.23.0
     - conda-forge::setuptools
     - conda-forge::packaging
@@ -49,7 +50,8 @@ requirements:
     - conda-forge::pyzmq
     - conda-forge::qtpy >=2.0.1
     - conda-forge::rich
-    - conda-forge::scipy >=1.4.1,<=1.9.0
+    # - conda-forge::scipy >=1.4.1,<=1.9.0
+    -  conda-forge::scipy >=1.11.1
     - conda-forge::scikit-image
     - conda-forge::scikit-learn ==1.0
     - conda-forge::scikit-video
@@ -59,7 +61,8 @@ requirements:
     - conda-forge::ndx-pose
 
   run:
-    - conda-forge::python >=3.10.0,<3.11.0
+    # - conda-forge::python >=3.10.0,<3.11.0
+    - conda-forge::python >=3.11.0,<3.12.0
     - conda-forge::attrs >=21.2.0
     - conda-forge::cattrs ==1.1.1
     - conda-forge::h5py
@@ -79,7 +82,8 @@ requirements:
     - conda-forge::pyzmq
     - conda-forge::qtpy >=2.0.1
     - conda-forge::rich
-    - conda-forge::scipy >=1.4.1,<=1.9.0
+    # - conda-forge::scipy >=1.4.1,<=1.9.0
+    -  conda-forge::scipy >=1.11.1
     - conda-forge::scikit-image
     - conda-forge::scikit-learn ==1.0
     - conda-forge::scikit-video

--- a/.conda_mac/meta.yaml
+++ b/.conda_mac/meta.yaml
@@ -23,7 +23,7 @@ source:
 
 requirements:
   host:  
-    - conda-forge::python >=3.11.0,<3.12.0
+    - conda-forge::python >=3.10.0,<3.11.0
     - anaconda::numpy >=1.19.5,<1.23.0
     - conda-forge::setuptools
     - conda-forge::packaging
@@ -59,7 +59,7 @@ requirements:
     - conda-forge::ndx-pose
 
   run:
-    - conda-forge::python >=3.11.0,<3.12.0
+    - conda-forge::python >=3.10.0,<3.11.0
     - conda-forge::attrs >=21.2.0
     - conda-forge::cattrs ==1.1.1
     - conda-forge::h5py

--- a/.conda_mac/meta.yaml
+++ b/.conda_mac/meta.yaml
@@ -23,7 +23,7 @@ source:
 
 requirements:
   host:  
-    - conda-forge::python >=3.9.0, <3.10.0
+    - conda-forge::python >=3.12.0,<3.13.0
     - anaconda::numpy >=1.19.5,<1.23.0
     - conda-forge::setuptools
     - conda-forge::packaging
@@ -59,7 +59,7 @@ requirements:
     - conda-forge::ndx-pose
 
   run:
-    - conda-forge::python >=3.9.0, <3.10.0
+    - conda-forge::python >=3.12.0,<3.13.0
     - conda-forge::attrs >=21.2.0
     - conda-forge::cattrs ==1.1.1
     - conda-forge::h5py


### PR DESCRIPTION
### Description
- The conda package for Windows and Linux currently uses Python 3.7.12 which is at its end-of-life. We would like to use the latest Python version possible for our conda build.
- TensorFlow 2.7.0 is the current working version of TensorFlow in SLEAP for Windows and Linux. TensorFlow 2.7.0 is compatible with Python 3.7 - 3.9. 
- We are currently using PySide 2 in both the Windows/Linux and Mac conda packages. We would like to upgrade this to PySide 6. 
- PySide 6 is dependent on SciPy which is dependent on numpy. 
- The Mac conda package used `tensorflow-macos==2.9.2`, is compatible with Python 3.12.
- We will update the PyPI build dependencies as well. 

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [X] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- The Mac GUI is breaking in the latest pre-release #1803, #1802. 
- This is following up many dependency updates in pre-release [v1.4.1a1](https://github.com/talmolab/sleap/releases/tag/v1.4.1a1).

### Outside contributors checklist

- [X] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [X] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
