### PR TITLE
Menu option to open preferences directory and update to util functions to pathlib

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -520,7 +520,7 @@ class MainWindow(QMainWindow):
         add_menu_item(
             fileMenu,
             "open preference directory",
-            "Open preference directory...",
+            "Open Preferences Directory...",
             self.openPrefs,
         )
 

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -53,6 +53,8 @@ import traceback
 from logging import getLogger
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
+import sys
+import subprocess
 
 from qtpy import QtCore, QtGui
 from qtpy.QtCore import QEvent, Qt
@@ -84,7 +86,7 @@ from sleap.io.dataset import Labels
 from sleap.io.video import available_video_exts
 from sleap.prefs import prefs
 from sleap.skeleton import Skeleton
-from sleap.util import parse_uri_path
+from sleap.util import parse_uri_path, get_config_file
 
 
 logger = getLogger(__name__)
@@ -513,6 +515,13 @@ class MainWindow(QMainWindow):
         fileMenu.addSeparator()
         add_menu_item(
             fileMenu, "reset prefs", "Reset preferences to defaults...", self.resetPrefs
+        )
+
+        add_menu_item(
+            fileMenu,
+            "open preference directory",
+            "Open preference directory...",
+            self.openPrefs,
         )
 
         fileMenu.addSeparator()
@@ -1329,6 +1338,20 @@ class MainWindow(QMainWindow):
             "Note: Some preferences may not take effect until application is restarted."
         )
         msg.exec_()
+
+    def openPrefs(self):
+        """Open preference file directory"""
+        pref_path = get_config_file("preferences.yaml")
+        # Make sure the pref_path is a directory rather than a file
+        if pref_path.is_file():
+            pref_path = pref_path.parent
+        # Open the file explorer at the folder containing the preferences.yaml file
+        if sys.platform == "win32":
+            subprocess.Popen(["explorer", str(pref_path)])
+        elif sys.platform == "darwin":
+            subprocess.Popen(["open", str(pref_path)])
+        else:
+            subprocess.Popen(["xdg-open", str(pref_path)])
 
     def _update_track_menu(self):
         """Updates track menu options."""

--- a/sleap/util.py
+++ b/sleap/util.py
@@ -270,30 +270,20 @@ def get_config_file(
         The full path to the specified config file.
     """
 
-    desired_path = None  # Handle case where get_defaults, but cannot find package_path
+    desired_path = Path.home() / f".sleap/{sleap_version.__version__}/{shortname}"
 
-    if not get_defaults:
-        desired_path = os.path.expanduser(
-            f"~/.sleap/{sleap_version.__version__}/{shortname}"
-        )
+    # Make sure there's a ~/.sleap/<version>/ directory to store user version of the config file.
+    desired_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Make sure there's a ~/.sleap/<version>/ directory to store user version of the
-        # config file.
-        try:
-            os.makedirs(os.path.expanduser(f"~/.sleap/{sleap_version.__version__}"))
-        except FileExistsError:
-            pass
+    # If we don't care whether the file exists, just return the path
+    if ignore_file_not_found:
+        return desired_path
 
-        # If we don't care whether the file exists, just return the path
-        if ignore_file_not_found:
-            return desired_path
-
-    # If we do care whether the file exists, check the package version of the
-    # config file if we can't find the user version.
-
-    if get_defaults or not os.path.exists(desired_path):
+    # If we do care whether the file exists, check the package version of the config file if we can't find the user version.
+    if get_defaults or not desired_path.exists():
         package_path = get_package_file(f"config/{shortname}")
-        if not os.path.exists(package_path):
+        package_path = Path(package_path)
+        if not package_path.exists():
             raise FileNotFoundError(
                 f"Cannot locate {shortname} config file at {desired_path} or {package_path}."
             )


### PR DESCRIPTION
### Description
Right now, users are finding it a bit difficult to find the `preferences.yaml` file that stores the user preferences. Hence, adding a menu option to open the File Explorer (Windows)/Finder (MacOS)/Linux at the `preferences.yaml` directory.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [x] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to open the preference file directory from the app menu. This feature is accessible via a new menu item and works across different platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->