### PR TITLE
Overwrite the `CameraGroup.optim_points` function

### DIFF
--- a/sleap/io/cameras.py
+++ b/sleap/io/cameras.py
@@ -394,6 +394,35 @@ class CameraCluster(CameraGroup):
 
         return calibration_dict
 
+    # TODO(LM): Remove this function once aniposelib is updated.
+    def optim_points(
+        self,
+        points,
+        p3ds,
+        constraints=[],
+        constraints_weak=[],
+        scale_smooth=4,
+        scale_length=2,
+        scale_length_weak=0.5,
+        reproj_error_threshold=15,
+        reproj_loss="soft_l1",
+        n_deriv_smooth=1,
+        scores=None,
+        verbose=False,
+    ):
+        """Overwrite parent function which does not handle nan values.
+
+        This function is called when we triangulate. The triangulated points are stored
+        in p3ds, but the parent function optimizes the triangulated p3ds to better fit
+        the 2D points. The parent function does not handle nan values (yet), so we need
+        to overwrite it here.
+
+        Reutrns:
+            p3ds: np.ndarray of shape (n_points, 3)
+        """
+
+        return p3ds
+
 
 @define
 class InstanceGroup:


### PR DESCRIPTION
### Description
This PR is a quick fix to the fact that `CameraGroup.optim_points` from the aniposelib library does not handle nan values very well. The `optim_points` function is only called when we have a `Skeleton` with > 20 `Node`s. 

If upon triangulating, the user had some `Point`s set as not visible (there are less than 2 visible labels for the same node), then we would get projections that look like so:
![image](https://github.com/talmolab/sleap/assets/38435167/92410aac-70de-4ba4-a9a2-1b8158a36335)

Overwriting the culprit `CameraGroup.optim_points` to simply pass through the 3D points instead of trying to optimize them yields the desired result:
![image](https://github.com/talmolab/sleap/assets/38435167/f34b5ff6-9642-4722-94f9-a073dda4a708)

And, when we double click, the non-visible node is initialized closeby:
![image](https://github.com/talmolab/sleap/assets/38435167/60ff306d-1148-4187-9f83-4b15f0e06b59)

This PR is just a quick fix to allow people to continue labeling with high-node skeletons until we get a PR (non-existent atm) merged into aniposelib to fix this issue at the source.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
