### PR TITLE
Fix typo to allow rendering videos with mp4

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1335,7 +1335,7 @@ class ExportLabeledClip(AppCommand):
             context.app,
             caption="Save Video As...",
             dir=default_out_filename,
-            filter="Video (*.avi *mp4)",
+            filter="Video (*.avi *.mp4)",
         )
 
         # Check if user hit cancel


### PR DESCRIPTION
### Description
Oh no, there was a 4-year long typo in which we intended to support rendering videos in the mp4 format, but actually only made it seem like we supported the avi format.

### Before this PR
<img width="300" alt="image" src="https://github.com/user-attachments/assets/759a40ca-804b-49fa-a913-d7965198681f">

#### After this PR
<img width="300" alt="image" src="https://github.com/user-attachments/assets/6031699e-69ba-47aa-9075-c50234b7b2df">


### Types of changes

- [x] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
