### PR TITLE
Use | instead of + in key commands

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1373,7 +1373,7 @@ class MainWindow(QMainWindow):
             6: Qt.Key_7,
             7: Qt.Key_8,
             8: Qt.Key_9,
-            9: Qt.Key_0
+            9: Qt.Key_0,
         }
         for track_ind, track in enumerate(self.labels.tracks):
             key_command = ""

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -757,12 +757,12 @@ class MainWindow(QMainWindow):
         labelMenu.addAction(
             "Copy Instance",
             self.commands.copyInstance,
-            Qt.CTRL + Qt.Key_C,
+            Qt.CTRL | Qt.Key_C,
         )
         labelMenu.addAction(
             "Paste Instance",
             self.commands.pasteInstance,
-            Qt.CTRL + Qt.Key_V,
+            Qt.CTRL | Qt.Key_V,
         )
 
         labelMenu.addSeparator()
@@ -856,12 +856,12 @@ class MainWindow(QMainWindow):
         tracksMenu.addAction(
             "Copy Instance Track",
             self.commands.copyInstanceTrack,
-            Qt.CTRL + Qt.SHIFT + Qt.Key_C,
+            Qt.CTRL | Qt.SHIFT | Qt.Key_C,
         )
         tracksMenu.addAction(
             "Paste Instance Track",
             self.commands.pasteInstanceTrack,
-            Qt.CTRL + Qt.SHIFT + Qt.Key_V,
+            Qt.CTRL | Qt.SHIFT | Qt.Key_V,
         )
 
         tracksMenu.addSeparator()
@@ -1361,10 +1361,24 @@ class MainWindow(QMainWindow):
         """Updates track menu options."""
         self.track_menu.clear()
         self.delete_tracks_menu.clear()
+
+        # Create a dictionary mapping track indices to Qt.Key values
+        key_mapping = {
+            0: Qt.Key_1,
+            1: Qt.Key_2,
+            2: Qt.Key_3,
+            3: Qt.Key_4,
+            4: Qt.Key_5,
+            5: Qt.Key_6,
+            6: Qt.Key_7,
+            7: Qt.Key_8,
+            8: Qt.Key_9,
+            9: Qt.Key_0
+        }
         for track_ind, track in enumerate(self.labels.tracks):
             key_command = ""
             if track_ind < 9:
-                key_command = Qt.CTRL + Qt.Key_0 + self.labels.tracks.index(track) + 1
+                key_command = Qt.CTRL | key_mapping[track_ind]
             self.track_menu.addAction(
                 f"{track.name}",
                 lambda x=track: self.commands.setInstanceTrack(x),
@@ -1374,7 +1388,7 @@ class MainWindow(QMainWindow):
                 f"{track.name}", lambda x=track: self.commands.deleteTrack(x)
             )
         self.track_menu.addAction(
-            "New Track", self.commands.addTrack, Qt.CTRL + Qt.Key_0
+            "New Track", self.commands.addTrack, Qt.CTRL | Qt.Key_0
         )
 
     def _update_seekbar_marks(self):


### PR DESCRIPTION
### Description
In our attempts to migrate to PySide6 in a downstream branch, we are getting the following error:
```
    key_command = Qt.CTRL + Qt.Key_0 + self.labels.tracks.index(track) + 1
TypeError: unsupported operand type(s) for +: 'PySide6.QtCore.QKeyCombination' and 'int'
```
and the following warning:
```
UserWarning: 
The "+" operator is deprecated in Qt For Python 6.0 .
Please use "|" instead.
```
.

This PR refactors for PySide6 by using the `|` operator instead of the depreciated `+` operator when combining keys (which is also supported by PySide2).

### Types of changes

- [x] Bugfix (downstream)
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1841

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved keyboard shortcut definitions for actions like copying and pasting instances and managing track actions.
	- Introduced a new, structured key mapping for track indices to enhance shortcut assignment clarity. 

- **Bug Fixes**
	- Enhanced clarity and correctness in keyboard shortcut logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->