### PR TITLE
Replace QtDesktop widget in preparation for PySide6

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -171,7 +171,7 @@ class LearningDialog(QtWidgets.QDialog):
 
     def adjust_initial_size(self):
         # Get screen size
-        screen = QtWidgets.QDesktopWidget().screenGeometry()
+        screen = QtGui.QGuiApplication.primaryScreen().availableGeometry()
 
         max_width = 1860
         max_height = 1150

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1,23 +1,20 @@
 """
 Dialogs for running training and/or inference in GUI.
 """
-import cattr
-import os
+import json
 import shutil
-import atexit
 import tempfile
 from pathlib import Path
+from typing import Dict, List, Optional, Text, cast
+
+import cattr
+from qtpy import QtCore, QtGui, QtWidgets
 
 import sleap
 from sleap import Labels, Video
 from sleap.gui.dialogs.filedialog import FileDialog
 from sleap.gui.dialogs.formbuilder import YamlFormWidget
-from sleap.gui.learning import runners, scopedkeydict, configs, datagen, receptivefield
-
-from typing import Dict, List, Text, Optional, cast
-
-from qtpy import QtWidgets, QtCore
-import json
+from sleap.gui.learning import configs, datagen, receptivefield, runners, scopedkeydict
 
 # List of fields which should show list of skeleton nodes
 NODE_LIST_FIELDS = [


### PR DESCRIPTION
### Description
When we migrate to PySide6 in a downstream branch, we will run into the error:
```
AttributeError: module 'qtpy.QtWidgets' has no attribute 'QDesktopWidget'
```
when attempting to open the Training Dialog. 

From [Changes to QWidget](https://doc.qt.io/qt-6/widgets-changes-qt6.html#qdesktopwidget-and-qapplication-desktop):
> QDesktopWidget was already deprecated in Qt 5, and has been removed in Qt 6, together with QApplication::desktop().

Fortunately, we only use `QDesktopWidget` in one place - and it is an easy replacement.

### Types of changes

- [x] Bugfix (downstream)
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1841 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved accuracy in retrieving screen dimensions for better window sizing in multi-monitor setups.

- **Refactor**
	- Enhanced organization of import statements for better code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->