### PR TITLE
Fix ubuntu CI import error by adding OpenGL libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,14 +52,14 @@ jobs:
         run: |
           python setup.py bdist_wheel
 
-      # # Upload pip wheel (Ubuntu)
-      # - name: Upload pip wheel (Ubuntu)
-      #   if: matrix.os == 'ubuntu-22.04'
-      #   env:
-      #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      #   shell: bash -l {0}
-      #   run: |
-      #     twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
+      # Upload pip wheel (Ubuntu)
+      - name: Upload pip wheel (Ubuntu)
+        if: matrix.os == 'ubuntu-22.04'
+        env:
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        shell: bash -l {0}
+        run: |
+          twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
 
       # Build conda package (Ubuntu)
       - name: Build conda package (Ubuntu)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,9 @@ jobs:
           conda info
           conda list
 
-      # Build pip wheel (Ubuntu)
-      - name: Build pip wheel (Ubuntu)
-        if: matrix.os == 'ubuntu-22.04'
+      # Build pip wheel (Not Windows)
+      - name: Build pip wheel (Not Windows)
+        if: matrix.os != 'windows-2022'
         shell: bash -l {0}
         run: |
           python setup.py bdist_wheel
@@ -85,9 +85,45 @@ jobs:
           conda build .conda_mac --output-folder build
           echo "BUILD_PATH=$(pwd)/build" >> "$GITHUB_ENV"
 
-      # Test built conda package (Ubuntu and Windows)
-      - name: Test built conda package (Ubuntu and Windows)
-        if: matrix.os != 'macos-14'
+      # Test built conda package (Ubuntu)
+      - name: Test built conda package (Ubuntu)
+        if: matrix.os == 'ubuntu-22.04'
+        shell: bash -l {0}
+        run: |
+          echo "Current build path: $BUILD_PATH"
+          conda deactivate
+    
+          echo "Python executable before activating environment:"
+          which python
+          echo "Python version before activating environment:"
+          python --version
+          echo "Conda info before activating environment:"
+          conda info
+
+          echo "Creating and testing conda environment with sleap package..."
+          sudo apt-get update
+          sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
+          conda create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
+          conda activate sleap_test
+
+          echo "Python executable after activating sleap_test environment:"
+          which python
+          echo "Python version after activating sleap_test environment:"
+          python --version
+          echo "Conda info after activating sleap_test environment:"
+          conda info
+          echo "List of installed conda packages in the sleap_test environment:"
+          conda list
+          echo "List of installed pip packages in the sleap_test environment:"
+          pip list
+    
+          echo "Testing sleap package installation..."
+          sleap_version=$(python -c "import sleap; print(sleap.__version__)")
+          echo "Test completed using sleap version: $sleap_version"
+
+      # Test built conda package (Windows)
+      - name: Test built conda package (Windows)
+        if: matrix.os == 'windows-2022'
         shell: bash -l {0}
         run: |
           echo "Current build path: $BUILD_PATH"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           activate-environment: sleap_ci
           conda-solver: "libmamba"
 
-      - name: Print environment info
+      - name: Print build environment info
         shell: bash -l {0}
         run: |
           which python
@@ -52,14 +52,14 @@ jobs:
         run: |
           python setup.py bdist_wheel
 
-      # Upload pip wheel (Ubuntu)
-      - name: Upload pip wheel (Ubuntu)
-        if: matrix.os == 'ubuntu-22.04'
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        shell: bash -l {0}
-        run: |
-          twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
+      # # Upload pip wheel (Ubuntu)
+      # - name: Upload pip wheel (Ubuntu)
+      #   if: matrix.os == 'ubuntu-22.04'
+      #   env:
+      #     PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+      #   shell: bash -l {0}
+      #   run: |
+      #     twine upload -u __token__ -p "$PYPI_TOKEN" dist/* --non-interactive --skip-existing --disable-progress-bar
 
       # Build conda package (Ubuntu)
       - name: Build conda package (Ubuntu)
@@ -85,95 +85,52 @@ jobs:
           conda build .conda_mac --output-folder build
           echo "BUILD_PATH=$(pwd)/build" >> "$GITHUB_ENV"
 
-      # Test built conda package (Ubuntu)
-      - name: Test built conda package (Ubuntu)
+      # Print build and environment info for each OS after deactiviating build environment
+      - name: Print base environment info
+        shell: bash -l {0}
+        run: |
+          echo "Current build path: $BUILD_PATH"
+          conda deactivate
+    
+          echo "Python executable before activating environment:"
+          which python
+          echo "Python version before activating environment:"
+          python --version
+          echo "Conda info before activating environment:"
+          conda info
+
+      # Install necessary OpenGL packages for Ubuntu only https://github.com/conda-forge/opencv-feedstock/issues/401
+      - name: Install OpenGL libraries on Ubuntu runner
         if: matrix.os == 'ubuntu-22.04'
         shell: bash -l {0}
         run: |
-          echo "Current build path: $BUILD_PATH"
-          conda deactivate
-    
-          echo "Python executable before activating environment:"
-          which python
-          echo "Python version before activating environment:"
-          python --version
-          echo "Conda info before activating environment:"
-          conda info
-
-          echo "Creating and testing conda environment with sleap package..."
           sudo apt-get update
           sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
-          conda create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
-          conda activate sleap_test
 
-          echo "Python executable after activating sleap_test environment:"
-          which python
-          echo "Python version after activating sleap_test environment:"
-          python --version
-          echo "Conda info after activating sleap_test environment:"
-          conda info
-          echo "List of installed conda packages in the sleap_test environment:"
-          conda list
-          echo "List of installed pip packages in the sleap_test environment:"
-          pip list
-    
-          echo "Testing sleap package installation..."
-          sleap_version=$(python -c "import sleap; print(sleap.__version__)")
-          echo "Test completed using sleap version: $sleap_version"
-
-      # Test built conda package (Windows)
-      - name: Test built conda package (Windows)
-        if: matrix.os == 'windows-2022'
+      # Create conda environment using built conda package (Ubuntu and Windows)
+      - name: Create conda environment (Ubuntu and Windows)
+        if: matrix.os != 'macos-14'
         shell: bash -l {0}
         run: |
-          echo "Current build path: $BUILD_PATH"
-          conda deactivate
-    
-          echo "Python executable before activating environment:"
-          which python
-          echo "Python version before activating environment:"
-          python --version
-          echo "Conda info before activating environment:"
-          conda info
-
           echo "Creating and testing conda environment with sleap package..."
           conda create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
-          conda activate sleap_test
 
-          echo "Python executable after activating sleap_test environment:"
-          which python
-          echo "Python version after activating sleap_test environment:"
-          python --version
-          echo "Conda info after activating sleap_test environment:"
-          conda info
-          echo "List of installed conda packages in the sleap_test environment:"
-          conda list
-          echo "List of installed pip packages in the sleap_test environment:"
-          pip list
-    
-          echo "Testing sleap package installation..."
-          sleap_version=$(python -c "import sleap; print(sleap.__version__)")
-          echo "Test completed using sleap version: $sleap_version"
-
-      # Test built conda package (Mac)
-      - name: Test built conda package (Mac)
+      # Create conda environment using built conda package (Mac)
+      # Note channel differences
+      - name: Create conda environment (Mac)
         if: matrix.os == 'macos-14'
         shell: bash -l {0}
         run: |
-          echo "Current build path: $BUILD_PATH"
-          conda deactivate
-    
-          echo "Python executable before activating environment:"
-          which python
-          echo "Python version before activating environment:"
-          python --version
-          echo "Conda info before activating environment:"
-          conda info
-    
           echo "Creating and testing conda environment with sleap package..."
           conda create -y -n sleap_test -c file://$BUILD_PATH -c conda-forge -c anaconda sleap
+
+      # Test conda environment
+      - name: Test conda environment
+        shell: bash -l {0}
+        run: |
+          echo "Activating sleap_test"
           conda activate sleap_test
-    
+
           echo "Python executable after activating sleap_test environment:"
           which python
           echo "Python version after activating sleap_test environment:"

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -91,6 +91,7 @@ jobs:
           # Ubuntu specific values
           - os: ubuntu-22.04
             # Otherwise core dumped in github actions
+            # https://github.com/conda-forge/opencv-feedstock/issues/401#issue-2196393732
             test_args: |
               sudo apt install xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
               sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -128,7 +128,7 @@ jobs:
 
       # Create conda environment using built conda package (Mac)
       # Note channel differences
-      - name: Test built conda package (Mac)
+      - name: Create conda environment (Mac)
         if: matrix.os == 'macos-14'
         shell: bash -l {0}
         run: |

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -124,7 +124,6 @@ jobs:
         run: |
           echo "Creating and testing conda environment with sleap package..."
           conda create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
-          conda activate sleap_test
 
       # Create conda environment using built conda package (Mac)
       # Note channel differences
@@ -134,12 +133,14 @@ jobs:
         run: |
           echo "Creating and testing conda environment with sleap package..."
           conda create -y -n sleap_test -c file://$BUILD_PATH -c conda-forge -c anaconda sleap
-          conda activate sleap_test
 
       # Test conda environment
       - name: Test conda environment
         shell: bash -l {0}
         run: |
+          echo "Activating sleap_test"
+          conda activate sleap_test
+
           echo "Python executable after activating sleap_test environment:"
           which python
           echo "Python version after activating sleap_test environment:"

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -117,8 +117,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
 
-      # Test built conda package (Ubuntu and Windows)
-      - name: Test built conda package (Ubuntu and Windows)
+      # Create conda environment using built conda package (Ubuntu and Windows)
+      - name: Create conda environment (Ubuntu and Windows)
         if: matrix.os != 'macos-14'
         shell: bash -l {0}
         run: |
@@ -126,22 +126,8 @@ jobs:
           conda create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
           conda activate sleap_test
 
-          echo "Python executable after activating sleap_test environment:"
-          which python
-          echo "Python version after activating sleap_test environment:"
-          python --version
-          echo "Conda info after activating sleap_test environment:"
-          conda info
-          echo "List of installed conda packages in the sleap_test environment:"
-          conda list
-          echo "List of installed pip packages in the sleap_test environment:"
-          pip list
-    
-          echo "Testing sleap package installation..."
-          sleap_version=$(python -c "import sleap; print(sleap.__version__)")
-          echo "Test completed using sleap version: $sleap_version"
-
-      # Test built conda package (Mac)
+      # Create conda environment using built conda package (Mac)
+      # Note channel differences
       - name: Test built conda package (Mac)
         if: matrix.os == 'macos-14'
         shell: bash -l {0}
@@ -149,7 +135,11 @@ jobs:
           echo "Creating and testing conda environment with sleap package..."
           conda create -y -n sleap_test -c file://$BUILD_PATH -c conda-forge -c anaconda sleap
           conda activate sleap_test
-    
+
+      # Test conda environment
+      - name: Test conda environment
+        shell: bash -l {0}
+        run: |
           echo "Python executable after activating sleap_test environment:"
           which python
           echo "Python version after activating sleap_test environment:"

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -116,47 +116,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
 
-      # Test built conda package (Ubuntu)
-      - name: Test built conda package (Ubuntu)
-        if: matrix.os == 'ubuntu-22.04'
+      # Test built conda package (Ubuntu and Windows)
+      - name: Test built conda package (Ubuntu and Windows)
+        if: matrix.os != 'macos-14'
         shell: bash -l {0}
         run: |
-          echo "Creating and testing conda environment with sleap package..."
-          sudo apt-get update
-          sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
-          conda create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
-          conda activate sleap_test
-
-          echo "Python executable after activating sleap_test environment:"
-          which python
-          echo "Python version after activating sleap_test environment:"
-          python --version
-          echo "Conda info after activating sleap_test environment:"
-          conda info
-          echo "List of installed conda packages in the sleap_test environment:"
-          conda list
-          echo "List of installed pip packages in the sleap_test environment:"
-          pip list
-    
-          echo "Testing sleap package installation..."
-          sleap_version=$(python -c "import sleap; print(sleap.__version__)")
-          echo "Test completed using sleap version: $sleap_version"
-
-      # Test built conda package (Windows)
-      - name: Test built conda package (Windows)
-        if: matrix.os == 'windows-2022'
-        shell: bash -l {0}
-        run: |
-          echo "Current build path: $BUILD_PATH"
-          conda deactivate
-    
-          echo "Python executable before activating environment:"
-          which python
-          echo "Python version before activating environment:"
-          python --version
-          echo "Conda info before activating environment:"
-          conda info
-
           echo "Creating and testing conda environment with sleap package..."
           conda create -y -n sleap_test -c file://$BUILD_PATH -c sleap/label/dev -c conda-forge -c nvidia -c anaconda sleap
           conda activate sleap_test

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -14,7 +14,7 @@ on:
     branches:
       # - develop
       # - fakebranch
-      - elizabeth/update-python-and-dependencies
+      - elizabeth/fix-ubuntu-CI-ImportError
 
 jobs:
   build:

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -109,6 +109,18 @@ jobs:
           echo "Conda info before activating environment:"
           conda info
 
+      # Install necessary OpenGL packages for Ubuntu only https://github.com/conda-forge/opencv-feedstock/issues/401
+      - name: Install OpenGL libraries on Ubuntu runner
+        shell: bash -l {0}
+        run: |
+          sudo apt-get update
+          sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
+
+      # Test built conda package (Ubuntu)
+      - name: Test built conda package (Ubuntu)
+        if: matrix.os == 'ubuntu-22.04'
+        shell: bash -l {0}
+        run: |
           echo "Creating and testing conda environment with sleap package..."
           sudo apt-get update
           sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -48,7 +48,7 @@ jobs:
           activate-environment: sleap_ci
           conda-solver: "libmamba"
 
-      - name: Print environment info
+      - name: Print build environment info
         shell: bash -l {0}
         run: |
           which python
@@ -95,9 +95,8 @@ jobs:
           conda build .conda_mac --output-folder build
           echo "BUILD_PATH=$(pwd)/build" >> "$GITHUB_ENV"
 
-      # Test built conda package (Ubuntu)
-      - name: Test built conda package (Ubuntu)
-        if: matrix.os == 'ubuntu-22.04'
+      # Print build and environment info for each OS after deactiviating build environment
+      - name: Print base environment info
         shell: bash -l {0}
         run: |
           echo "Current build path: $BUILD_PATH"

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -111,6 +111,7 @@ jobs:
 
       # Install necessary OpenGL packages for Ubuntu only https://github.com/conda-forge/opencv-feedstock/issues/401
       - name: Install OpenGL libraries on Ubuntu runner
+        if: matrix.os == 'ubuntu-22.04'
         shell: bash -l {0}
         run: |
           sudo apt-get update

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -145,16 +145,6 @@ jobs:
         if: matrix.os == 'macos-14'
         shell: bash -l {0}
         run: |
-          echo "Current build path: $BUILD_PATH"
-          conda deactivate
-    
-          echo "Python executable before activating environment:"
-          which python
-          echo "Python version before activating environment:"
-          python --version
-          echo "Conda info before activating environment:"
-          conda info
-    
           echo "Creating and testing conda environment with sleap package..."
           conda create -y -n sleap_test -c file://$BUILD_PATH -c conda-forge -c anaconda sleap
           conda activate sleap_test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         # https://github.com/conda-forge/opencv-feedstock/issues/401#issue-2196393732
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgl1-mesa-glx
+          sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
 
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3.0.3


### PR DESCRIPTION
### Description
Since `qt6-main` was added as a dependency to `opencv` by default, `OpenGL` libraries that come with `qt6-main` need additional libraries to avoid the following error
```
ImportError: libEGL.so.1: cannot open shared object file: No such file or directory
```
The fix is adding the following libraries
```
sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
```
as documented at https://github.com/conda-forge/opencv-feedstock/issues/401. 

- To test the conda packages and pip wheel, these libraries were already added to `build_manual.yml` and `build_ci.yml` respectively. See #1841.
- They are added to the rest of the workflows, `build.yml` and `ci.yml` to test the built conda packages on release, and conda environments. 
- The conda packages are tested in `build_manual.yaml` again.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [X] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#1841 Ubuntu CI failing.

### Outside contributors checklist

- [X] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [X] Add tests that prove your fix is effective or that your feature works
- [X] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
