### PR TITLE
Remove unsupported |= operand to prepare for PySide6

### DIFF
--- a/sleap/gui/dialogs/filedialog.py
+++ b/sleap/gui/dialogs/filedialog.py
@@ -29,7 +29,8 @@ def os_specific_method(func) -> Callable:
 
         if cls.is_non_native:
             kwargs["options"] = kwargs.get("options", 0)
-            kwargs["options"] |= QtWidgets.QFileDialog.DontUseNativeDialog
+            if not kwargs["options"]:
+                kwargs["options"] = QtWidgets.QFileDialog.DontUseNativeDialog
 
         # Make sure we don't send empty options argument
         if "options" in kwargs and not kwargs["options"]:


### PR DESCRIPTION
### Description
In a downstream branch, we get the error:
```
 TypeError: unsupported operand type(s) for |=: 'int' and 'Option'
```

when upgrading to PySide6. 

This PR refactors the offending line to have the same logic, but work for both PySide6 and PySide2. 

### Types of changes

- [x] Bugfix (downstream)
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1841 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of file dialog options to prevent unintended overwriting of user-specified settings when using non-native dialogs. 
	- Ensured that the `DontUseNativeDialog` option is only applied when no other options have been specified. 

These enhancements contribute to a more intuitive and reliable user experience when interacting with file dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->