### PR TITLE
Use positional argument for exception type

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2067,7 +2067,7 @@ class OpenSkeleton(EditCommand):
                 func(*args, **kwargs)
             except Exception as e:
                 tb_str = traceback.format_exception(
-                    etype=type(e), value=e, tb=e.__traceback__
+                    type(e), value=e, tb=e.__traceback__
                 )
                 logger.warning(
                     f"Recieved the following error while replacing skeleton:\n"


### PR DESCRIPTION
### Description
In a downstream branch, we upgrade our EOL `Python 3.7` to a safer `Python 3.10`. But, `traceback.format_exception` has changed it's first positional argument's name from `etype` to `exc` in python 3.7 vs 3.10, relatively.

This PR instead uses just the positional nature of the exception type argument and does not try to pass it in as a keyword argument (to keep compatibility between both Python 3.7 and 3.10).

---

By the way, the open skeleton function gave the same warning on both the develop and downstream branch during L533 of `test_OpenSkeleton`:
https://github.com/talmolab/sleap/blob/8a8ed575cf597f3319e679ab6b43776fef6b3eba/tests/gui/test_commands.py#L527-L534

```
WARNING  sleap.gui.commands:commands.py:2072 Recieved the following error while replacing skeleton:
Traceback (most recent call last):
  File "/Users/liezlmaree/Projects/sleap/sleap/gui/commands.py", line 2067, in try_and_skip_if_error
    func(*args, **kwargs)
  File "/Users/liezlmaree/Projects/sleap/sleap/skeleton.py", line 845, in relabel_node
    self.relabel_nodes({old_name: new_name})
  File "/Users/liezlmaree/Projects/sleap/sleap/skeleton.py", line 863, in relabel_nodes
    raise ValueError("Cannot relabel a node to an existing name.")
ValueError: Cannot relabel a node to an existing name.
```

which seems fine/redundant, but could be something that is avoided with some prepended logic (for another PR).

### Types of changes

- [x] Bugfix (downstream)
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1841 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified error handling in the application without altering functionality, enhancing stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->