### PR TITLE
Test wheel on macos python 3.10 using build_ci

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -70,8 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-2022"]
-        # os: ["ubuntu-22.04", "windows-2022", "macos-14"]  # removing macos-14 for now since the setup-python action only support py>=3.10, which is breaking this CI.
+        os: ["ubuntu-22.04", "windows-2022", "macos-14"]
         # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrixinclude
         include:
           # Default values

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -13,8 +13,7 @@ on:
       - '.github/workflows/build_manual.yml'
     branches:
       # - develop
-      # - fakebranch
-      - elizabeth/fix-ubuntu-CI-ImportError
+      - fakebranch
 
 jobs:
   build:

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -32,7 +32,7 @@ tensorflow==2.9.2; platform_machine != 'arm64'
 tensorflow-hub
 albumentations
 ndx-pose
-# These dependencies are untested since we do not offer a wheel for apple silicon atm.
+# Silicon Mac specific packages
 tensorflow-macos >=2.10.0,<2.13.0; sys_platform == 'darwin' and platform_machine == 'arm64'
 tensorflow-metal; sys_platform == 'darwin' and platform_machine == 'arm64'
 


### PR DESCRIPTION
### Description
- setup-python action only supports py>=3.10, which was breaking the CI for macos.
- Now that we have python 3.10 in the runners and as the preferred python for pip packages, we should be able to test all operating systems with the SLEAP PyPI wheel. 
- macos-14 has been added to the matrix of OS's to test SLEAP the PyPI wheel.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [X] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
