### PR TITLE
Install ffmpeg on macos and Ubuntu runners when testing PyPI wheel

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -110,6 +110,7 @@ jobs:
             test_args: |
               brew install ffmpeg
               which ffmpeg
+              pytest --durations=-1 tests/
 
           
 

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -98,6 +98,8 @@ jobs:
               sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
               sudo Xvfb :1 -screen 0 1024x768x24 </dev/null &
               export DISPLAY=":1"
+              conda install conda-forge::ffmpeg
+              echo which ffmpeg
               pytest tests -k 'not exclude_from_linux_pip_test'
           # Windows specific values
           - os: windows-2022

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -99,7 +99,7 @@ jobs:
               sudo Xvfb :1 -screen 0 1024x768x24 </dev/null &
               export DISPLAY=":1"
               conda install conda-forge::ffmpeg
-              echo which ffmpeg
+              which ffmpeg
               pytest tests -k 'not exclude_from_linux_pip_test'
           # Windows specific values
           - os: windows-2022
@@ -110,7 +110,7 @@ jobs:
           - os: macos-14
             test_args: |
               conda install conda-forge::ffmpeg
-              echo which ffmpeg
+              which ffmpeg
 
           
 

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -92,6 +92,8 @@ jobs:
           - os: ubuntu-22.04
             # Otherwise core dumped in github actions
             # https://github.com/conda-forge/opencv-feedstock/issues/401#issue-2196393732
+            # Need ffmpeg since linux imageio-ffmpeg does not contain the binary executable of ffmpeg 
+            # https://pypi.org/project/imageio-ffmpeg/0.5.1/#modal-close
             test_args: |
               sudo apt install xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
               sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -102,6 +102,15 @@ jobs:
           # Windows specific values
           - os: windows-2022
             venv_cmd: .\venv\Scripts\activate
+          # MacOS specific values
+          # Need ffmpeg since linux imageio-ffmpeg does not contain the binary executable of ffmpeg 
+          # https://pypi.org/project/imageio-ffmpeg/0.5.1/#modal-close
+          - os: macos-14
+            test_args: |
+              conda install conda-forge::ffmpeg
+              echo which ffmpeg
+
+          
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -83,10 +83,17 @@ jobs:
           - test_args: pytest --durations=-1 tests/
           - condarc: .conda/condarc.yaml
           - pyver: "3.10"
+          # MacOS specific values
+          # Need ffmpeg since linux imageio-ffmpeg does not contain the binary executable of ffmpeg 
+          # https://pypi.org/project/imageio-ffmpeg/0.5.1/#modal-close
           # Use special condarc if macos
           - os: "macos-14"
             condarc: .conda_mac/condarc.yaml
             pyver: "3.10"
+            test_args: |
+              brew install ffmpeg
+              which ffmpeg
+              pytest --durations=-1 tests/
           # Ubuntu specific values
           - os: ubuntu-22.04
             # Otherwise core dumped in github actions
@@ -103,14 +110,6 @@ jobs:
           # Windows specific values
           - os: windows-2022
             venv_cmd: .\venv\Scripts\activate
-          # MacOS specific values
-          # Need ffmpeg since linux imageio-ffmpeg does not contain the binary executable of ffmpeg 
-          # https://pypi.org/project/imageio-ffmpeg/0.5.1/#modal-close
-          - os: macos-14
-            test_args: |
-              brew install ffmpeg
-              which ffmpeg
-              pytest --durations=-1 tests/
 
           
 

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -94,11 +94,10 @@ jobs:
             # Need ffmpeg since linux imageio-ffmpeg does not contain the binary executable of ffmpeg 
             # https://pypi.org/project/imageio-ffmpeg/0.5.1/#modal-close
             test_args: |
-              sudo apt install xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+              sudo apt install ffmpeg xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
               sudo apt-get install libglapi-mesa libegl-mesa0 libegl1 libopengl0 libgl1-mesa-glx
               sudo Xvfb :1 -screen 0 1024x768x24 </dev/null &
               export DISPLAY=":1"
-              conda install conda-forge::ffmpeg
               which ffmpeg
               pytest tests -k 'not exclude_from_linux_pip_test'
           # Windows specific values
@@ -109,7 +108,7 @@ jobs:
           # https://pypi.org/project/imageio-ffmpeg/0.5.1/#modal-close
           - os: macos-14
             test_args: |
-              conda install conda-forge::ffmpeg
+              brew install ffmpeg
               which ffmpeg
 
           


### PR DESCRIPTION
### Description
- `imagio-ffmpeg` platform-specific wheels are only available for Windows and macos but excluding Silicon macs!
    
    [imageio-ffmpeg PyPI documentation](https://pypi.org/project/imageio-ffmpeg/0.5.1/#modal-close)
    
    “”””Note that the platform-specific wheels contain the binary executable of ffmpeg, which makes this package around 60 MiB in size. I guess that’s the cost for being able to read/write video files.
    
    For Linux users: the above is not the case when installing via your Linux package manager (if that is possible), because this package would simply depend on ffmpeg in that case”””

- This causes the following tests to fail when running `build_ci` on the silicon macs and ubuntu runners which tests the built SLEAP PyPI wheel:
```
FAILED tests/io/test_videowriter.py::test_imageio_video_writer_avi - RuntimeError: No ffmpeg exe could be found. Install ffmpeg on your system, or set the IMAGEIO_FFMPEG_EXE environment variable.
FAILED tests/io/test_videowriter.py::test_imageio_video_writer_odd_size - RuntimeError: No ffmpeg exe could be found. Install ffmpeg on your system, or set the IMAGEIO_FFMPEG_EXE environment variable.
```
- This does not happen for our CI tests, which test the `conda` environments across OS's because `imagio-ffmpeg` installed via [conda-forge](https://anaconda.org/conda-forge/imageio-ffmpeg) pulls in the correct `conda` install of `ffmpeg` while resolving the environment. This should is also the case for our built `conda` packages.
      - versions from latest environments in actions listed here per OS:
      - Ubuntu: `ffmpeg  7.0.2 gpl_h226ea3b_102    conda-forge`, `imageio-ffmpeg 0.5.1 pyhd8ed1ab_0 conda-forge`
      - macos-14: `ffmpeg 6.1.2 gpl_h3ef3969_102 conda-forge`, `imageio-ffmpeg 0.5.1 pyhd8ed1ab_0 conda-forge`
      - Windows: `ffmpeg 6.1.2 gpl_h9cf63cc_102 conda-forge`, `imageio-ffmpeg 0.5.1  pyhd8ed1ab_0 conda-forge`

- This issue for the PyPI runners can be remedied by installing `ffmpeg` as part of the github action workflow.
     - Update: We no longer get the errors in the build CI (no upload) runner after these changes.
- [Anaconda documentation for ffmpeg conda package](https://anaconda.org/conda-forge/ffmpeg)

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [X] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
GA workflows failing for ubuntu and silicon mac runners #1923. 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
