### PR TITLE
Use `tf.math.mod` instead of `%`

### DIFF
--- a/sleap/nn/peak_finding.py
+++ b/sleap/nn/peak_finding.py
@@ -221,7 +221,7 @@ def find_global_peaks_rough(
     channels = tf.cast(tf.shape(cms)[-1], tf.int64)
     total_peaks = tf.cast(tf.shape(argmax_cols)[0], tf.int64)
     sample_subs = tf.range(total_peaks, dtype=tf.int64) // channels
-    channel_subs = tf.range(total_peaks, dtype=tf.int64) % channels
+    channel_subs = tf.math.mod(tf.range(total_peaks, dtype=tf.int64), channels)
 
     # Gather subscripts.
     peak_subs = tf.stack([sample_subs, argmax_rows, argmax_cols, channel_subs], axis=1)


### PR DESCRIPTION
### Description
In a downstream branch that uses `tensorflow ==2.9.2`, I ran into this issue during inference:
```
    File "d:\social-leap-estimates-animal-poses\source\sleap\sleap\nn\peak_finding.py", line 224, in find_global_peaks_rough
      channel_subs = tf.range(total_peaks, dtype=tf.int64) % channels
Node: 'mod'

2 root error(s) found.
  (0) UNKNOWN:  JIT compilation failed.
         [[{{node mod}}]]
         [[top_down_inference_model/find_instance_peaks_1/RaggedFromValueRowIds_1/RowPartitionFromValueRowIds/assert_less/Assert/AssertGuard/pivot_f/_177/_415]]
  (1) UNKNOWN:  JIT compilation failed.
         [[{{node mod}}]]
```

In this PR, we replace python's `%` with `tf.math.mod` which seems to play nicer.

### Types of changes

- [x] Bugfix (downstream)
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1841 
- #1721
- [Bonsai-SLEAP "JIT compilation failed." error after installation #1532](https://github.com/orgs/bonsai-rx/discussions/1532)

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
