### PR TITLE
Refactor `skeleton.to_json` to serialize skeleton object without jsonpickle

### DIFF
--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1050,14 +1050,8 @@ class Skeleton:
                     # in legacy SLEAP.
                     "edge_insert_idx": edge_ind,
                     "key": 0,  # Always 0.
-                    "source": {
-                        "py/object": "sleap.skeleton.Node",
-                        "py/state": {"py/tuple": [source.name, source.weight]},
-                    },
-                    "target": {
-                        "py/object": "sleap.skeleton.Node",
-                        "py/state": {"py/tuple": [target.name, target.weight]},
-                    },
+                    "source": {"py/id": self.nodes.index(node)},
+                    "target": {"py/id": self.nodes.index(node)},
                     "type": edge_type,
                 }
             )

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -999,6 +999,7 @@ class Skeleton:
         Returns:
             A string containing the JSON representation of the skeleton.
         """
+        # TODO: Replace jsonpickle with a custom encoder from sleap-io.
         jsonpickle.set_encoder_options("simplejson", sort_keys=True, indent=4)
         if node_to_idx is not None:
             indexed_node_graph = nx.relabel_nodes(

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1078,14 +1078,14 @@ class Skeleton:
             else:
                 edge_type = {"py/id": 2}
 
-            src, dst = tuple(symmetry.nodes)
-            print(f"src: {src}")
-            print(f"dst: {dst}")
+            symmetry_src, symmetry_dst = symmetry
+            print(f"src: {symmetry_src}")
+            print(f"dst: {symmetry_dst}")
             edges_dicts.append(
                 {
                     "key": 0,
-                    "source": {"py/id": node_to_id[src]},
-                    "target": {"py/id": node_to_id[dst]},
+                    "source": {"py/id": node_to_id[symmetry_src]},
+                    "target": {"py/id": node_to_id[symmetry_dst]},
                     "type": edge_type,
                 }
             )

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1097,7 +1097,7 @@ class Skeleton:
                     {
                         "id": {
                             "py/object": "sleap.skeleton.Node",
-                            "py/state": {"name": node.name, "weight": node.weight},
+                            "py/state": {"py/tuple": [node.name, node.weight]},
                         }
                     }
                     for node in self.nodes
@@ -1118,7 +1118,7 @@ class Skeleton:
                     {
                         "id": {
                             "py/object": "sleap.skeleton.Node",
-                            "py/state": {"name": node.name, "weight": node.weight},
+                            "py/state": {"py/tuple": [node.name, node.weight]},
                         }
                     }
                     for node in self.nodes

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1082,15 +1082,16 @@ class Skeleton:
                     "type": edge_type,
                 }
             )
-
+        # Create graph field
+        graph = {
+            "name": self.name,
+            "num_edges_inserted": len(self.edges),
+        }
         # Create skeleton dict.
         if self.is_template:
             skeleton_dict = {
                 "directed": True,
-                "graph": {
-                    "name": self.name,
-                    "num_edges_inserted": len(self.edges),
-                },
+                "nx_graph": graph, 
                 "links": edges_dicts,
                 "multigraph": True,
                 # In the order in Skeleton.nodes and must match up with nodes_dicts.
@@ -1101,14 +1102,16 @@ class Skeleton:
         else:
             skeleton_dict ={
                     "directed": True,
-                    "graph": {
-                        "name": self.name,
-                        "num_edges_inserted": len(self.edges),
-                    },
+                    "nx_graph": graph,
                     "links": edges_dicts,
                     "multigraph": True,
                     # In the order in Skeleton.nodes and must match up with nodes_dicts.
                     "nodes": [{"id": {"py/id": node_to_id[node]}} for node in self.nodes],}
+            
+        print(f'skeleton_dict: {skeleton_dict}')
+        json_str = json.dumps(skeleton_dict)
+        print(f'json_str: {json_str}')
+        return json_str
 
         # jsonpickle.set_encoder_options("simplejson", sort_keys=True, indent=4)
         # if node_to_idx is not None:

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1005,13 +1005,17 @@ class Skeleton:
         nodes_dicts = []
         node_to_id = {}
         for node in self.nodes:
+            print(f'node: {node}')
             if node not in node_to_id:
                 node_to_id[node] = node_to_idx[node] if node_to_idx is not None else len(node_to_id)
                 nodes_dicts.append({"name": node.name, "weight": 1.0})
+                print(f'node_to_id: {node_to_id}')
+                print(f'nodes_dicts: {nodes_dicts}')
         
         # Create a dictionary to store edge data
         edges_dicts = []
         for edge_ind, edge in enumerate(self.edges):
+            print(f'edge: {edge}')
             if edge_ind == 0:
                 edge_type = {
                     "py/reduce": [
@@ -1019,19 +1023,20 @@ class Skeleton:
                         {"py/tuple": [1]},  # 1 = real edge, 2 = symmetry edge
                     ]
                 }
+                print(f'edge_type: {edge_type}')
             else:
                 edge_type = {"py/id": 1}
-
+                print(f'edge_type: {edge_type}')
             edges_dicts.append(
                 {
                     "edge_insert_idx": edge_ind,
                     "key": 0,  # Always 0.
-                    "source": node_to_id[edge.source],
-                    "target": node_to_id[edge.destination],
+                    "source": node_to_id[edge[0]],
+                    "target": node_to_id[edge[1]],
                     "type": edge_type,
                 }
             )
-
+            print(f'edges_dicts: {edges_dicts}')
         # Build links dicts for symmetry edges.
         for symmetry_ind, symmetry in enumerate(self.symmetries):
             if symmetry_ind == 0:

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -987,9 +987,9 @@ class Skeleton:
         """Convert the :class:`Skeleton` to a JSON representation.
 
         Args:
-            node_to_idx: optional dict which maps :class:`Nodes`to index
+            node_to_idx: optional dict which maps :class:`Nodes` to index
                 in some list. This is used when saving
-                :class:`Labels`where we want to serialize the
+                :class:`Labels` where we want to serialize the
                 :class:`Nodes` outside the :class:`Skeleton` object.
                 If given, then we replace each :class:`Node` with
                 specified index before converting :class:`Skeleton`.

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1050,8 +1050,8 @@ class Skeleton:
                     # in legacy SLEAP.
                     "edge_insert_idx": edge_ind,
                     "key": 0,  # Always 0.
-                    "source": {"py/id": self.nodes.index(node)},
-                    "target": {"py/id": self.nodes.index(node)},
+                    "source": {"py/id": self.nodes.index(source)},
+                    "target": {"py/id": self.nodes.index(target)},
                     "type": edge_type,
                 }
             )

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1004,7 +1004,7 @@ class Skeleton:
         node_to_id = {}
         for node in self.nodes:
             if node not in node_to_id:
-                print(f'node: {node}')
+                print(f"node: {node}")
                 # Note: This ID is not the same as the node index in the skeleton in
                 # legacy SLEAP, but we do not retain this information in the labels, so
                 # IDs will be different.
@@ -1014,15 +1014,15 @@ class Skeleton:
                 #
                 # TODO: Store legacy metadata in labels to get byte-level compatibility?
                 node_to_id[node] = len(node_to_id)
-                print(f'node_to_id: {node_to_id}')
+                print(f"node_to_id: {node_to_id}")
                 nodes_dicts.append({"name": node.name, "weight": 1.0})
-        print(f'nodes_dicts: {nodes_dicts}')
+        print(f"nodes_dicts: {nodes_dicts}")
 
         # Build links dicts for normal edges.
         edges_dicts = []
         for edge_ind, edge in enumerate(self.edges):
-            print(f'edge_ind: {edge_ind}')
-            print(f'edge: {edge}')
+            print(f"edge_ind: {edge_ind}")
+            print(f"edge: {edge}")
             if edge_ind == 0:
                 edge_type = {
                     "py/reduce": [
@@ -1030,38 +1030,44 @@ class Skeleton:
                         {"py/tuple": [1]},  # 1 = real edge, 2 = symmetry edge
                     ]
                 }
-                print(f'edge_type: {edge_type}')
+                print(f"edge_type: {edge_type}")
             else:
                 edge_type = {"py/id": 1}
-                print(f'edge_type: {edge_type}')
+                print(f"edge_type: {edge_type}")
 
             # Edges are stored as a list of tuples of nodes
-            # The source and target are the nodes in the tuple (edge) are the first and 
+            # The source and target are the nodes in the tuple (edge) are the first and
             # second nodes respectively
             source = edge[0]
-            print(f'source: {source}')
-            print(f'node_to_id[source]: {node_to_id[source]}')
+            print(f"source: {source}")
+            print(f"node_to_id[source]: {node_to_id[source]}")
             target = edge[1]
-            print(f'target: {target}')
-            print(f'node_to_id[target]: {node_to_id[target]}')
+            print(f"target: {target}")
+            print(f"node_to_id[target]: {node_to_id[target]}")
             edges_dicts.append(
                 {
                     # Note: Insert idx is not the same as the edge index in the skeleton
                     # in legacy SLEAP.
                     "edge_insert_idx": edge_ind,
                     "key": 0,  # Always 0.
-                    "source": {"py/object": "sleap.skeleton.Node", "py/state": {"name": source.name, "weight": 1.0}},
-                    "target": {"py/object": "sleap.skeleton.Node", "py/state": {"name": target.name, "weight": 1.0}},
+                    "source": {
+                        "py/object": "sleap.skeleton.Node",
+                        "py/state": {"name": source.name, "weight": 1.0},
+                    },
+                    "target": {
+                        "py/object": "sleap.skeleton.Node",
+                        "py/state": {"name": target.name, "weight": 1.0},
+                    },
                     # "target": {"py/id": node_to_id[target]},
                     "type": edge_type,
                 }
             )
-        print(f'edges_dicts: {edges_dicts}')
+        print(f"edges_dicts: {edges_dicts}")
 
         # Build links dicts for symmetry edges.
         for symmetry_ind, symmetry in enumerate(self.symmetries):
-            print(f'symmetry_ind: {symmetry_ind}')
-            print(f'symmetry: {symmetry}')
+            print(f"symmetry_ind: {symmetry_ind}")
+            print(f"symmetry: {symmetry}")
             if symmetry_ind == 0:
                 edge_type = {
                     "py/reduce": [
@@ -1073,8 +1079,8 @@ class Skeleton:
                 edge_type = {"py/id": 2}
 
             src, dst = tuple(symmetry.nodes)
-            print(f'src: {src}')
-            print(f'dst: {dst}')
+            print(f"src: {src}")
+            print(f"dst: {dst}")
             edges_dicts.append(
                 {
                     "key": 0,

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1093,29 +1093,44 @@ class Skeleton:
             # Template skeletons have additional fields
             nx_graph = {
                 "directed": True,
-                "graph": graph, 
+                "graph": graph,
+                "nodes": [
+                    {
+                        "id": {
+                            "py/object": "sleap.skeleton.Node",
+                            "py/state": {"name": node.name, "weight": node.weight},
+                        }
+                    }
+                    for node in self.nodes
+                ],
                 "links": edges_dicts,
                 "multigraph": True,
-                # In the order in Skeleton.nodes and must match up with nodes_dicts.
-                "nodes": [{"id": {"py/id": node_to_id[node]}} for node in self.nodes],
             }
             skeleton_dict = {
                 "description": self.description,
-                "nx_graph": nx_graph, 
+                "nx_graph": nx_graph,
                 "preview_image": self.preview_image,
             }
         else:
-            skeleton_dict ={
-                    "directed": True,
-                    "graph": graph,
-                    "links": edges_dicts,
-                    "multigraph": True,
-                    # In the order in Skeleton.nodes and must match up with nodes_dicts.
-                    "nodes": [{"id": {"py/id": node_to_id[node]}} for node in self.nodes],}
-            
-        print(f'skeleton_dict: {skeleton_dict}')
-        json_str = json.dumps(skeleton_dict)
-        print(f'json_str: {json_str}')
+            skeleton_dict = {
+                "directed": True,
+                "graph": graph,
+                "nodes": [
+                    {
+                        "id": {
+                            "py/object": "sleap.skeleton.Node",
+                            "py/state": {"name": node.name, "weight": node.weight},
+                        }
+                    }
+                    for node in self.nodes
+                ],
+                "links": edges_dicts,
+                "multigraph": True,
+            }
+
+        print(f"skeleton_dict: {skeleton_dict}")
+        json_str = json.dumps(skeleton_dict, indent=4, sort_keys=True)
+        print(f"json_str: {json_str}")
         return json_str
 
         # jsonpickle.set_encoder_options("simplejson", sort_keys=True, indent=4)

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -987,7 +987,7 @@ class Skeleton:
         """Convert the :class:`Skeleton` to a JSON representation.
 
         Args:
-            node_to_idx: optional dict which maps :class:`Nodes`to index
+            node_to_idx: optional dict which maps :class:`Node`s to index
                 in some list. This is used when saving
                 :class:`Labels`where we want to serialize the
                 :class:`Nodes` outside the :class:`Skeleton` object.
@@ -1050,8 +1050,9 @@ class Skeleton:
                     # in legacy SLEAP.
                     "edge_insert_idx": edge_ind,
                     "key": 0,  # Always 0.
-                    "source": {"py/id": node_to_id[source]},
-                    "target": {"py/id": node_to_id[target]},
+                    "source": {"py/object": "sleap.skeleton.Node", "py/state": {"name": source.name, "weight": 1.0}},
+                    "target": {"py/object": "sleap.skeleton.Node", "py/state": {"name": target.name, "weight": 1.0}},
+                    # "target": {"py/id": node_to_id[target]},
                     "type": edge_type,
                 }
             )
@@ -1087,22 +1088,26 @@ class Skeleton:
             "name": self.name,
             "num_edges_inserted": len(self.edges),
         }
-        # Create skeleton dict.
+        # Create skeleton dict
         if self.is_template:
-            skeleton_dict = {
+            # Template skeletons have additional fields
+            nx_graph = {
                 "directed": True,
-                "nx_graph": graph, 
+                "graph": graph, 
                 "links": edges_dicts,
                 "multigraph": True,
                 # In the order in Skeleton.nodes and must match up with nodes_dicts.
                 "nodes": [{"id": {"py/id": node_to_id[node]}} for node in self.nodes],
+            }
+            skeleton_dict = {
                 "description": self.description,
+                "nx_graph": nx_graph, 
                 "preview_image": self.preview_image,
             }
         else:
             skeleton_dict ={
                     "directed": True,
-                    "nx_graph": graph,
+                    "graph": graph,
                     "links": edges_dicts,
                     "multigraph": True,
                     # In the order in Skeleton.nodes and must match up with nodes_dicts.

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1052,13 +1052,12 @@ class Skeleton:
                     "key": 0,  # Always 0.
                     "source": {
                         "py/object": "sleap.skeleton.Node",
-                        "py/state": {"name": source.name, "weight": 1.0},
+                        "py/state": {"py/tuple": [source.name, source.weight]},
                     },
                     "target": {
                         "py/object": "sleap.skeleton.Node",
-                        "py/state": {"name": target.name, "weight": 1.0},
+                        "py/state": {"py/tuple": [target.name, target.weight]},
                     },
-                    # "target": {"py/id": node_to_id[target]},
                     "type": edge_type,
                 }
             )

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -999,35 +999,17 @@ class Skeleton:
         Returns:
             A string containing the JSON representation of the skeleton.
         """
-        # TODO: Replace jsonpickle with a custom encoder from sleap-io.
-
-        if node_to_idx is not None:
-            indexed_node_graph = nx.relabel_nodes(
-                G=self._graph, mapping=node_to_idx
-            )  # map nodes to int
-        else:
-            indexed_node_graph = self._graph
-
+        # Logic taken from github.com/talmolab/sleap-io/io/slp.py::serialize_skeletons
+        # https://github.com/talmolab/sleap-io/blob/main/sleap_io/io/slp.py#L606
         # Create a dictionary to store node data
-        # Taken from sleap-io: https://github.com/talmolab/sleap-io/blob/2bc3d5210c46bdb25413d25970c4bdc7adb6e8cc/sleap_io/io/slp.py#L633C1-L644C71
         nodes_dicts = []
         node_to_id = {}
         for node in self.nodes:
             if node not in node_to_id:
-                # Note: This ID is not the same as the node index in the skeleton in
-                # legacy SLEAP, but we do not retain this information in the labels, so
-                # IDs will be different.
-                #
-                # The weight is also kept fixed here, but technically this is not
-                # modified or used in legacy SLEAP either.
-                #
-                # TODO: Store legacy metadata in labels to get byte-level compatibility?
-                node_to_id[node] = len(node_to_id)
+                node_to_id[node] = node_to_idx[node] if node_to_idx is not None else len(node_to_id)
                 nodes_dicts.append({"name": node.name, "weight": 1.0})
         
         # Create a dictionary to store edge data
-        # Taken from sleap-io: https://github.com/talmolab/sleap-io/blob/2bc3d5210c46bdb25413d25970c4bdc7adb6e8cc/sleap_io/io/slp.py#L649-L693
-        # Build links dicts for normal edges.
         edges_dicts = []
         for edge_ind, edge in enumerate(self.edges):
             if edge_ind == 0:

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -987,7 +987,7 @@ class Skeleton:
         """Convert the :class:`Skeleton` to a JSON representation.
 
         Args:
-            node_to_idx: optional dict which maps :class:`Node`sto index
+            node_to_idx: optional dict which maps :class:`Nodes`to index
                 in some list. This is used when saving
                 :class:`Labels`where we want to serialize the
                 :class:`Nodes` outside the :class:`Skeleton` object.

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -1024,8 +1024,6 @@ class Skeleton:
 
             edges_dicts.append(
                 {
-                    # Note: Insert idx is not the same as the edge index in the skeleton
-                    # in legacy SLEAP.
                     "edge_insert_idx": edge_ind,
                     "key": 0,  # Always 0.
                     "source": node_to_id[edge.source],
@@ -1057,21 +1055,25 @@ class Skeleton:
             )
 
         # Create skeleton dict.
-        # Taken from sleap-io: https://github.com/talmolab/sleap-io/blob/2bc3d5210c46bdb25413d25970c4bdc7adb6e8cc/sleap_io/io/slp.py#L695C1-L708C10
-        skeleton_dicts = []
-        skeleton_dicts.append(
-            {
-                "directed": True,
-                "graph": {
-                    "name": self.name,
-                    "num_edges_inserted": len(self.edges),
-                },
-                "links": edges_dicts,
-                "multigraph": True,
-                # In the order in Skeleton.nodes and must match up with nodes_dicts.
-                "nodes": [{"id": node_to_id[node]} for node in self.nodes],
-            }
-        )
+        skeleton_dict = {
+            "directed": True,
+            "graph": {
+                "name": self.name,
+                "num_edges_inserted": len(self.edges),
+            },
+            "links": edges_dicts,
+            "multigraph": True,
+            # In the order in Skeleton.nodes and must match up with nodes_dicts.
+            "nodes": [{"id": node_to_id[node]} for node in self.nodes],
+        }
+
+        # Convert the skeleton dict to a JSON string using the standard json module
+        json_str = json.dumps(skeleton_dict, indent=4, sort_keys=True)
+
+        return json_str
+
+
+        
         # jsonpickle.set_encoder_options("simplejson", sort_keys=True, indent=4)
         # if node_to_idx is not None:
         #     indexed_node_graph = nx.relabel_nodes(

--- a/test_Skeleton_to_json.v006.ipynb
+++ b/test_Skeleton_to_json.v006.ipynb
@@ -1,0 +1,313 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sleap\n",
+    "\n",
+    "import json\n",
+    "import jsonpickle\n",
+    "import attrs\n",
+    "\n",
+    "from sleap.skeleton import Skeleton\n",
+    "from typing import List, Dict, Any, Tuple, Union, Optional\n",
+    "from networkx.readwrite import json_graph\n",
+    "from sleap.io.dataset import Labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sleap: 1.4.1a2\n",
+      "jsonpickle: 1.2\n",
+      "attrs: 24.2.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"sleap: {sleap.__version__}\")\n",
+    "print(f\"jsonpickle: {jsonpickle.__version__}\")\n",
+    "print(f\"attrs: {attrs.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# tuples vs. dicts\n",
+    "# saving to individual skeleton JSON files\n",
+    "# input Skeleton from labels file \n",
+    "# from_json_data get rid of cattrs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# old code from SLEAP\n",
+    "    # def to_json(self, node_to_idx: Optional[Dict[Node, int]] = None) -> str:\n",
+    "    #     \"\"\"Convert the :class:`Skeleton` to a JSON representation.\n",
+    "\n",
+    "    #     Args:\n",
+    "    #         node_to_idx: optional dict which maps :class:`Nodes`to index\n",
+    "    #             in some list. This is used when saving\n",
+    "    #             :class:`Labels`where we want to serialize the\n",
+    "    #             :class:`Nodes` outside the :class:`Skeleton` object.\n",
+    "    #             If given, then we replace each :class:`Node` with\n",
+    "    #             specified index before converting :class:`Skeleton`.\n",
+    "    #             Otherwise, we convert :class:`Node` objects with the rest of\n",
+    "    #             the :class:`Skeleton`.\n",
+    "\n",
+    "    #     Returns:\n",
+    "    #         A string containing the JSON representation of the skeleton.\n",
+    "    #     \"\"\"\n",
+    "    #     jsonpickle.set_encoder_options(\"simplejson\", sort_keys=True, indent=4)\n",
+    "    #     if node_to_idx is not None:\n",
+    "    #         indexed_node_graph = nx.relabel_nodes(\n",
+    "    #             G=self._graph, mapping=node_to_idx\n",
+    "    #         )  # map nodes to int\n",
+    "    #     else:\n",
+    "    #         indexed_node_graph = self._graph\n",
+    "\n",
+    "    #     # Encode to JSON\n",
+    "    #     graph = json_graph.node_link_data(indexed_node_graph)\n",
+    "\n",
+    "    #     # SLEAP v1.3.0 added `description` and `preview_image` to `Skeleton`, but saving\n",
+    "    #     # these fields breaks data format compatibility. Currently, these are only\n",
+    "    #     # added in our custom template skeletons. To ensure backwards data format\n",
+    "    #     # compatibilty of user data, we only save these fields if they are not None.\n",
+    "    #     if self.is_template:\n",
+    "    #         data = {\n",
+    "    #             \"nx_graph\": graph,\n",
+    "    #             \"description\": self.description,\n",
+    "    #             \"preview_image\": self.preview_image,\n",
+    "    #         }\n",
+    "    #     else:\n",
+    "    #         data = graph\n",
+    "\n",
+    "    #     json_str = jsonpickle.encode(data)\n",
+    "\n",
+    "    #     return json_str"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # Test Skeleton from labels file made with sleap-io\n",
+    "\n",
+    "# labels_path = r\"C:\\repos\\sleap-io\\minimal_instance_from_sio.slp\"\n",
+    "\n",
+    "# # Load labels\n",
+    "# labels = sleap.load_file(labels_path)\n",
+    "\n",
+    "# labels.skeletons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "test_skeleton: Skeleton(description=None, nodes=[A, B], edges=[A->B], symmetries=[])\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Test with labels\n",
+    "\n",
+    "# Load the labels\n",
+    "test_labels = sleap.load_file(r'tests\\data\\slp_hdf5\\minimal_instance.slp')\n",
+    "\n",
+    "# Get the first skeleton\n",
+    "test_skeleton = test_labels.skeletons[0]\n",
+    "\n",
+    "# Print the skeleton\n",
+    "print(f'test_skeleton: {test_skeleton}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "node: Node(name='A', weight=1.0)\n",
+      "node_to_id: {Node(name='A', weight=1.0): 0}\n",
+      "node: Node(name='B', weight=1.0)\n",
+      "node_to_id: {Node(name='A', weight=1.0): 0, Node(name='B', weight=1.0): 1}\n",
+      "nodes_dicts: [{'name': 'A', 'weight': 1.0}, {'name': 'B', 'weight': 1.0}]\n",
+      "edge_ind: 0\n",
+      "edge: (Node(name='A', weight=1.0), Node(name='B', weight=1.0))\n",
+      "edge_type: {'py/reduce': [{'py/type': 'sleap.skeleton.EdgeType'}, {'py/tuple': [1]}]}\n",
+      "source: Node(name='A', weight=1.0)\n",
+      "node_to_id[source]: 0\n",
+      "target: Node(name='B', weight=1.0)\n",
+      "node_to_id[target]: 1\n",
+      "edges_dicts: [{'edge_insert_idx': 0, 'key': 0, 'source': {'py/object': 'sleap.skeleton.Node', 'py/state': {'name': 'A', 'weight': 1.0}}, 'target': {'py/object': 'sleap.skeleton.Node', 'py/state': {'name': 'B', 'weight': 1.0}}, 'type': {'py/reduce': [{'py/type': 'sleap.skeleton.EdgeType'}, {'py/tuple': [1]}]}}]\n",
+      "skeleton_dict: {'directed': True, 'graph': {'name': 'Skeleton-0', 'num_edges_inserted': 1}, 'links': [{'edge_insert_idx': 0, 'key': 0, 'source': {'py/object': 'sleap.skeleton.Node', 'py/state': {'name': 'A', 'weight': 1.0}}, 'target': {'py/object': 'sleap.skeleton.Node', 'py/state': {'name': 'B', 'weight': 1.0}}, 'type': {'py/reduce': [{'py/type': 'sleap.skeleton.EdgeType'}, {'py/tuple': [1]}]}}], 'multigraph': True, 'nodes': [{'id': {'py/id': 0}}, {'id': {'py/id': 1}}]}\n",
+      "json_str: {\"directed\": true, \"graph\": {\"name\": \"Skeleton-0\", \"num_edges_inserted\": 1}, \"links\": [{\"edge_insert_idx\": 0, \"key\": 0, \"source\": {\"py/object\": \"sleap.skeleton.Node\", \"py/state\": {\"name\": \"A\", \"weight\": 1.0}}, \"target\": {\"py/object\": \"sleap.skeleton.Node\", \"py/state\": {\"name\": \"B\", \"weight\": 1.0}}, \"type\": {\"py/reduce\": [{\"py/type\": \"sleap.skeleton.EdgeType\"}, {\"py/tuple\": [1]}]}}], \"multigraph\": true, \"nodes\": [{\"id\": {\"py/id\": 0}}, {\"id\": {\"py/id\": 1}}]}\n",
+      "test_skeleton_json: {\"directed\": true, \"graph\": {\"name\": \"Skeleton-0\", \"num_edges_inserted\": 1}, \"links\": [{\"edge_insert_idx\": 0, \"key\": 0, \"source\": {\"py/object\": \"sleap.skeleton.Node\", \"py/state\": {\"name\": \"A\", \"weight\": 1.0}}, \"target\": {\"py/object\": \"sleap.skeleton.Node\", \"py/state\": {\"name\": \"B\", \"weight\": 1.0}}, \"type\": {\"py/reduce\": [{\"py/type\": \"sleap.skeleton.EdgeType\"}, {\"py/tuple\": [1]}]}}], \"multigraph\": true, \"nodes\": [{\"id\": {\"py/id\": 0}}, {\"id\": {\"py/id\": 1}}]}\n",
+      "Wrote test_skeleton_json to file\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Save to json using the old to_json method (deprecated)\n",
+    "test_skeleton_json = test_skeleton.to_json()\n",
+    "print(f'test_skeleton_json: {test_skeleton_json}')\n",
+    "\n",
+    "# Save json string to file\n",
+    "with open(r'test_skeleton_serialization.json', 'w') as f:\n",
+    "    f.write(test_skeleton_json)\n",
+    "    print(f'Wrote test_skeleton_json to file')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "unhashable type: 'dict'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m~\\AppData\\Local\\Temp\\ipykernel_21480\\3098081962.py\u001b[0m in \u001b[0;36m<module>\u001b[1;34m\u001b[0m\n\u001b[0;32m      1\u001b[0m \u001b[1;31m# Load the json file\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m----> 2\u001b[1;33m \u001b[0mtest_skeleton_from_json\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mSkeleton\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mfrom_json\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtest_skeleton_json\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34mf'test_skeleton_from_json: {test_skeleton_from_json}'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mc:\\repos\\sleap\\sleap\\skeleton.py\u001b[0m in \u001b[0;36mfrom_json\u001b[1;34m(cls, json_str, idx_to_node)\u001b[0m\n\u001b[0;32m   1193\u001b[0m         \u001b[0mdicts\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mjsonpickle\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdecode\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mjson_str\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1194\u001b[0m         \u001b[0mnx_graph\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mdicts\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"nx_graph\"\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mdicts\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m-> 1195\u001b[1;33m         \u001b[0mgraph\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mjson_graph\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mnode_link_graph\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mnx_graph\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m   1196\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m   1197\u001b[0m         \u001b[1;31m# Replace graph node indices with corresponding nodes from node_map\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mc:\\miniforge3\\envs\\sleap_dev_latest\\lib\\site-packages\\networkx\\readwrite\\json_graph\\node_link.py\u001b[0m in \u001b[0;36mnode_link_graph\u001b[1;34m(data, directed, multigraph, attrs)\u001b[0m\n\u001b[0;32m    167\u001b[0m         \u001b[0mnode\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mto_tuple\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0md\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mget\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mname\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mnext\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mc\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    168\u001b[0m         \u001b[0mnodedata\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m{\u001b[0m\u001b[0mstr\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mk\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m \u001b[0mv\u001b[0m \u001b[1;32mfor\u001b[0m \u001b[0mk\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mv\u001b[0m \u001b[1;32min\u001b[0m \u001b[0md\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mif\u001b[0m \u001b[0mk\u001b[0m \u001b[1;33m!=\u001b[0m \u001b[0mname\u001b[0m\u001b[1;33m}\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 169\u001b[1;33m         \u001b[0mgraph\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0madd_node\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mnode\u001b[0m\u001b[1;33m,\u001b[0m \u001b[1;33m**\u001b[0m\u001b[0mnodedata\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    170\u001b[0m     \u001b[1;32mfor\u001b[0m \u001b[0md\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mdata\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0mlinks\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    171\u001b[0m         \u001b[0msrc\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mtuple\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0md\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0msource\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0md\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0msource\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mlist\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32melse\u001b[0m \u001b[0md\u001b[0m\u001b[1;33m[\u001b[0m\u001b[0msource\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;32mc:\\miniforge3\\envs\\sleap_dev_latest\\lib\\site-packages\\networkx\\classes\\digraph.py\u001b[0m in \u001b[0;36madd_node\u001b[1;34m(self, node_for_adding, **attr)\u001b[0m\n\u001b[0;32m    416\u001b[0m         \u001b[0mdoesn\u001b[0m\u001b[0;31m'\u001b[0m\u001b[0mt\u001b[0m \u001b[0mchange\u001b[0m \u001b[0mon\u001b[0m \u001b[0mmutables\u001b[0m\u001b[1;33m.\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    417\u001b[0m         \"\"\"\n\u001b[1;32m--> 418\u001b[1;33m         \u001b[1;32mif\u001b[0m \u001b[0mnode_for_adding\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0m_succ\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    419\u001b[0m             \u001b[1;32mif\u001b[0m \u001b[0mnode_for_adding\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    420\u001b[0m                 \u001b[1;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m\"None cannot be a node\"\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
+      "\u001b[1;31mTypeError\u001b[0m: unhashable type: 'dict'"
+     ]
+    }
+   ],
+   "source": [
+    "# Load the json file\n",
+    "test_skeleton_from_json = Skeleton.from_json(test_skeleton_json)\n",
+    "print(f'test_skeleton_from_json: {test_skeleton_from_json}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # Read json file from sleap-io\n",
+    "# sleap_io_json_path = r\"C:\\repos\\sleap-io\\skeletons.json\"\n",
+    "\n",
+    "# with open(sleap_io_json_path, 'r') as f:\n",
+    "#     sleap_io_json = f.read()\n",
+    "\n",
+    "# sleap_io_json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Skeleton(name='Skeleton-0', description='None', nodes=['A', 'B'], edges=[('A', 'B')], symmetries=[])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load skeleton from json made with dev branch\n",
+    "skeleton_from_dev_path = r\"skeleton_from_labels_dev_branch.json\"\n",
+    "skeleton_from_dev = Skeleton.load_json(skeleton_from_dev_path)\n",
+    "\n",
+    "skeleton_from_dev"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Skeleton(name='Skeleton-0', description='None', nodes=['A', 'B'], edges=[('A', 'B')], symmetries=[])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Load skeleton from json made with code changes\n",
+    "skeleton_from_code_changes_path = r\"test_skeleton_serialization.json\"\n",
+    "skeleton_from_code_changes = Skeleton.load_json(skeleton_from_code_changes_path)\n",
+    "\n",
+    "skeleton_from_code_changes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "sleap_dev_1.4.1a2",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### Description
- We are seeing issues with `skeleton.json` where `jsonpickle` is encoding the skeleton graph dictionary in a way that breaks backwards compatibility, specifically:
     - """The change in attrs version used by jsonpickle to write/read the skeleton.json is causing problems, namely, attrs >=22.2.0 returns the object state as a dictionary instead of a tuple. This results in incompatibilities when attempting to deserialize skeleton.json files (w/ an older attrs <22.2.0) that were serialized with attrs >=22.2.0. Based on the discussion in https://github.com/python-attrs/attrs/pull/1085 it sounds like attrs ==22.2.0 was unable to deserialize pickled data from attrs <22.2.0, and attrs ==23.1.0 (>=23.1.0?) at least fixes backwards compatibility. The long-term plan for attrs (discussed in https://github.com/python-attrs/attrs/issues/1091) is to remove support for deserializing tuples after giving everyone a few versions of attrs to convert their data over to a dictionary serialization.""" from #1918 .
     - https://github.com/talmolab/sleap/blob/1370782877edc10346023fecbaf502e5bf3ce006/sleap/skeleton.py#L986-L1028
- The solution is to move away from `jsonpickle` and manually serialize our skeleton objects to json strings.
- We can re-use code written in `sleap-io` to do this
     - https://github.com/talmolab/sleap-io/blob/2bc3d5210c46bdb25413d25970c4bdc7adb6e8cc/sleap_io/io/slp.py#L606-L710
- Tests will be added to make sure the new serialized skeletons can be used as expected
     - https://github.com/talmolab/sleap/blob/1370782877edc10346023fecbaf502e5bf3ce006/sleap/skeleton.py#L1057 
### Types of changes

- [ ] Bugfix
- [ ] New feature
- [X] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1918 
- #1841

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Added a TODO comment for future enhancement regarding JSON encoding in the Skeleton class.
- **New Features**
	- Improved the `to_json` method for the Skeleton class, enhancing the serialization of skeleton data with a more structured representation of nodes and edges.
	- Introduced a new Jupyter notebook for testing the conversion of skeleton data to JSON format, demonstrating serialization and deserialization processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->