### PR TITLE
Option for Max Stride to be 128

### DIFF
--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -44,7 +44,7 @@ model:
     label: Max Stride
     name: model.backbone.hourglass.max_stride
     type: list
-    options: 1,2,4,8,16,32,64
+    options: 1,2,4,8,16,32,64,128
   # - default: 4
   #   help: Determines the number of upsampling blocks in the network.
   #   label: Output Stride
@@ -81,7 +81,7 @@ model:
     label: Max Stride
     name: model.backbone.leap.max_stride
     type: list
-    options: 2,4,8,16,32,64
+    options: 2,4,8,16,32,64,128
   # - default: 1
   #   help: Determines the number of upsampling blocks in the network.
   #   label: Output Stride
@@ -190,7 +190,7 @@ model:
     label: Max Stride
     name: model.backbone.resnet.max_stride
     type: list
-    options: 2,4,8,16,32,64
+    options: 2,4,8,16,32,64,128
   # - default: 4
   #   help: Stride of the final output. If the upsampling branch is not defined, the
   #     output stride is controlled via dilated convolutions or reduced pooling in the
@@ -250,7 +250,7 @@ model:
     label: Max Stride
     name: model.backbone.unet.max_stride
     type: list
-    options: 2,4,8,16,32,64
+    options: 2,4,8,16,32,64,128
   # - default: 1
   #   help: Determines the number of upsampling blocks in the network.
   #   label: Output Stride


### PR DESCRIPTION
### Description
A user requested an option for the max stride to be able to be set to 128
### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1940

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded the selectable options for the `Max Stride` parameter in multiple model configurations, including `hourglass`, `leap`, `resnet`, and `unet`, now allowing for a value of `128`.
  
This enhancement provides users with greater flexibility in model configuration and performance tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->