### PR TITLE
Add imageio dependencies for pypi wheel

### DIFF
--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -6,6 +6,8 @@
 # These are also distributed through conda and not pip installed when using conda.
 attrs>=21.2.0,<=21.4.0
 cattrs==1.1.1
+imageio
+imageio-ffmpeg
 # certifi>=2017.4.17,<=2021.10.8
 jsmin
 jsonpickle==1.2


### PR DESCRIPTION
### Description
In #1943, we added missing `imageio-ffmpeg` dependencies for the conda package.

The PR adds the missing `imageio-ffmpeg` dependencies for the PyPI wheels. This was already don in #1841 separately, but should be applied to all branches that it affects (i.e. also develop).

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [x] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1943 
- #1841

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for image and video processing capabilities through the addition of new dependencies.
- **Chores**
	- Updated project requirements to include `imageio` and `imageio-ffmpeg`, ensuring enhanced multimedia content handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->