### PR TITLE
Do not always color skeletons table black

### DIFF
--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -413,13 +413,6 @@ class SkeletonNodesTableModel(GenericTableModel):
         elif key == "symmetry":
             self.context.setNodeSymmetry(skeleton=self.obj, node=item, symmetry=value)
 
-    def get_item_color(self, item: Any, key: str):
-        if self.skeleton:
-            color = self.context.app.color_manager.get_item_color(
-                item, parent_skeleton=self.skeleton
-            )
-            return QtGui.QColor(*color)
-
 
 class SkeletonEdgesTableModel(GenericTableModel):
     """Table model for skeleton edges."""
@@ -435,14 +428,6 @@ class SkeletonEdgesTableModel(GenericTableModel):
                 for edge in skeleton.edges
             ]
         return items
-
-    def get_item_color(self, item: Any, key: str):
-        if self.skeleton:
-            edge_pair = (item["source"], item["destination"])
-            color = self.context.app.color_manager.get_item_color(
-                edge_pair, parent_skeleton=self.skeleton
-            )
-            return QtGui.QColor(*color)
 
 
 class LabeledFrameTableModel(GenericTableModel):


### PR DESCRIPTION
### Description
Previously, our logic for coloring the items in the skeletons table had morphed unnoticed overtime from the initial feature ([Apply node/edge color to skeleton tables.](https://github.com/talmolab/sleap/commit/8c8c97846aafb6cb3f7e6b75a0a0c0dd9fb2bb3c)) and eventually resulted in it always being colored black.

In this PR, we simply remove the `SkeletonEdgesTableModel.get_item_color` and `SkeletonNodesTableModel.get_item_color` methods which defaults to the Qt coloring (that is used for our other tables).

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1865

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed outdated methods for item color retrieval, improving overall application stability and reducing potential errors related to color management.

- **Refactor**
	- Streamlined color handling logic by eliminating redundant methods, paving the way for future enhancements in item visualization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->