### PR TITLE
Handle skeleton deserialization internally

### DIFF
--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -6,23 +6,23 @@ is to provide a common interface for defining the parts of the animal,
 their connection to each other, and needed meta-data.
 """
 
-import attr
-import cattr
-import numpy as np
-import jsonpickle
-import json
-import h5py
 import copy
-
+import json
 import operator
 from enum import Enum
 from itertools import count
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, Text
+from typing import Any, Dict, Iterable, List, Optional, Text, Tuple, Union
 
+import attr
+import cattr
+import h5py
+import jsonpickle
 import networkx as nx
+import numpy as np
 from networkx.readwrite import json_graph
 from scipy.io import loadmat
 
+from sleap.util import decode_preview_image
 
 NodeRef = Union[str, "Node"]
 H5FileRef = Union[str, h5py.File]

--- a/sleap/util.py
+++ b/sleap/util.py
@@ -377,16 +377,23 @@ def parse_uri_path(uri: str) -> str:
     return Path(url2pathname(urlparse(unquote(uri)).path)).as_posix()
 
 
-def decode_preview_image(img_b64: bytes) -> Image:
+def decode_preview_image(
+    img_b64: bytes, return_bytes: bool = False
+) -> Union[Image.Image, bytes]:
     """Decode a skeleton preview image byte string representation to a `PIL.Image`
 
     Args:
         img_b64: a byte string representation of a skeleton preview image
+        return_bytes: whether to return the decoded image as bytes
 
     Returns:
-        A PIL.Image of the skeleton preview
+        Either a PIL.Image of the skeleton preview image or the decoded image as bytes
+        (if `return_bytes` is True).
     """
     bytes = base64.b64decode(img_b64)
+    if return_bytes:
+        return bytes
+
     buffer = BytesIO(bytes)
     img = Image.open(buffer)
     return img

--- a/sleap/util.py
+++ b/sleap/util.py
@@ -11,7 +11,7 @@ import shutil
 from collections import defaultdict
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Dict, Hashable, Iterable, List, Optional
+from typing import Any, Dict, Hashable, Iterable, List, Optional, Union
 from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
@@ -26,6 +26,7 @@ try:
     from importlib.resources import files  # New in 3.9+
 except ImportError:
     from importlib_resources import files  # TODO(LM): Upgrade to importlib.resources.
+
 from PIL import Image
 
 import sleap.version as sleap_version


### PR DESCRIPTION
### Description
It has become apparent that it will be safer for us to handle (de)serialization of our data structures internally rather than relying on external libraries such as `cattr` and `jsonpickle` to do this for us. Without constraining these (de)serialization dependencies (which may also cause other upgrade/dependency constraints elsewhere), we cannot expect that the format of (de)serialization will be backwards compatible within (even the same!) version of SLEAP (albeit installed at different times).

Keeping with the theme above, this PR is the first of many that starts migrating (de)serialization to internal SLEAP code. In this PR, we add a function to replace `jsonpickle.decode` which is intended to be used on `jsonpickle.encode`d `Skeleton`s.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1841
- #1918
- #1934

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
