### PR TITLE
Sort encoded `Skeleton` dictionary for backwards compatibility 

### DIFF
--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -18,7 +18,6 @@ from typing import Any, Dict, Iterable, List, Optional, Text, Tuple, Union
 import attr
 import cattr
 import h5py
-import jsonpickle
 import networkx as nx
 import numpy as np
 from networkx.readwrite import json_graph
@@ -1496,7 +1495,7 @@ class Skeleton:
         Returns:
             A string containing the JSON representation of the skeleton.
         """
-        jsonpickle.set_encoder_options("simplejson", sort_keys=True, indent=4)
+
         if node_to_idx is not None:
             # Map Nodes to int
             indexed_node_graph = nx.relabel_nodes(G=self._graph, mapping=node_to_idx)

--- a/sleap/skeleton.py
+++ b/sleap/skeleton.py
@@ -421,10 +421,29 @@ class SkeletonEncoder:
         Returns:
             json_str: The JSON string representation of the data.
         """
+
+        # This is required for backwards compatibility with SLEAP <=1.3.4
+        sorted_data = cls._recursively_sort_dict(data)
+
         encoder = cls()
-        encoded_data = encoder._encode(data)
+        encoded_data = encoder._encode(sorted_data)
         json_str = json.dumps(encoded_data)
         return json_str
+
+    @staticmethod
+    def _recursively_sort_dict(dictionary: Dict[str, Any]) -> Dict[str, Any]:
+        """Recursively sorts the dictionary by keys."""
+        sorted_dict = dict(sorted(dictionary.items()))
+        for key, value in sorted_dict.items():
+            if isinstance(value, dict):
+                sorted_dict[key] = SkeletonEncoder._recursively_sort_dict(value)
+            elif isinstance(value, list):
+                for i, item in enumerate(value):
+                    if isinstance(item, dict):
+                        sorted_dict[key][i] = SkeletonEncoder._recursively_sort_dict(
+                            item
+                        )
+        return sorted_dict
 
     def _encode(self, obj: Any) -> Any:
         """Recursively encodes the input object.

--- a/tests/test_skeleton.py
+++ b/tests/test_skeleton.py
@@ -45,6 +45,18 @@ def test_decoded_encoded_Skeleton(skeleton_fixture_name, request):
     # Encode the graph as a json string to test .encode method
     encoded_json_str = SkeletonEncoder.encode(graph)
 
+    # Assert that the encoded json has keys in sorted order (backwards compatibility)
+    encoded_dict = json.loads(encoded_json_str)
+    sorted_keys = sorted(encoded_dict.keys())
+    assert list(encoded_dict.keys()) == sorted_keys
+    for key, value in encoded_dict.items():
+        if isinstance(value, dict):
+            assert list(value.keys()) == sorted(value.keys())
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, dict):
+                    assert list(item.keys()) == sorted(item.keys())
+
     # Get the skeleton from the encoded json string
     decoded_skeleton = Skeleton.from_json(encoded_json_str)
 


### PR DESCRIPTION
### Description
In #1970, we created our own `SkeletonEncoder` class to move away from using `jsonpickle.encode`. And, while the `SkeletonEncoder` paired with the `SkeletonDecoder` works perfectly fine, we get some strange behavior when trying to load `Skeleton` jsons across versions of SLEAP (that still use `jsonpickle.decode`).

The only difference seemed to be the ordering of the keys in the dictionaries; thus, this PR sorts the `Skeleton` dictionaries before encoding them - which has proven to do the trick with some manual testing across versions.


#### Unsorted skeleton (breaks backwards compatibility)

```js
{"directed": true, "multigraph": true, "graph": {"name": "Skeleton-0", "num_edges_inserted": 46}, "nodes": [{"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["head", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["thorax", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["abdomen", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["wingL", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["wingR", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["forelegL4", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["forelegR4", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["midlegL4", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["midlegR4", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["hindlegL4", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["hindlegR4", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["eyeL", 1.0]}}}, {"id": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["eyeR", 1.0]}}}], "links": [{"edge_insert_idx": 44, "type": {"py/reduce": [{"py/type": "sleap.skeleton.EdgeType"}, {"py/tuple": [1]}]}, "source": {"py/id": 1}, "target": {"py/id": 12}, "key": 0}, {"edge_insert_idx": 45, "type": {"py/id": 14}, "source": {"py/id": 1}, "target": {"py/id": 13}, "key": 0}, {"edge_insert_idx": 34, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 1}, "key": 0}, {"edge_insert_idx": 35, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 3}, "key": 0}, {"edge_insert_idx": 36, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 4}, "key": 0}, {"edge_insert_idx": 37, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 5}, "key": 0}, {"edge_insert_idx": 38, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 6}, "key": 0}, {"edge_insert_idx": 39, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 7}, "key": 0}, {"edge_insert_idx": 40, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 8}, "key": 0}, {"edge_insert_idx": 41, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 9}, "key": 0}, {"edge_insert_idx": 42, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 10}, "key": 0}, {"edge_insert_idx": 43, "type": {"py/id": 14}, "source": {"py/id": 2}, "target": {"py/id": 11}, "key": 0}]}

```

#### Sorted skeleton (backwards compatible)

```js
{"directed": true, "graph": {"name": "Skeleton-0", "num_edges_inserted": 46}, "links": [{"edge_insert_idx": 44, "key": 0, "source": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["head", 1.0]}}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["eyeL", 1.0]}}, "type": {"py/reduce": [{"py/type": "sleap.skeleton.EdgeType"}, {"py/tuple": [1]}]}}, {"edge_insert_idx": 45, "key": 0, "source": {"py/id": 1}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["eyeR", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 34, "key": 0, "source": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["thorax", 1.0]}}, "target": {"py/id": 1}, "type": {"py/id": 3}}, {"edge_insert_idx": 35, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["abdomen", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 36, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["wingL", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 37, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["wingR", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 38, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["forelegL4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 39, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["forelegR4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 40, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["midlegL4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 41, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["midlegR4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 42, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["hindlegL4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 43, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["hindlegR4", 1.0]}}, "type": {"py/id": 3}}], "multigraph": true, "nodes": [{"id": {"py/id": 1}}, {"id": {"py/id": 5}}, {"id": {"py/id": 6}}, {"id": {"py/id": 7}}, {"id": {"py/id": 8}}, {"id": {"py/id": 9}}, {"id": {"py/id": 10}}, {"id": {"py/id": 11}}, {"id": {"py/id": 12}}, {"id": {"py/id": 13}}, {"id": {"py/id": 14}}, {"id": {"py/id": 2}}, {"id": {"py/id": 4}}]}
```

#### v1.3.3 Skeleton

```js
{"directed": true, "graph": {"name": "Skeleton-0", "num_edges_inserted": 46}, "links": [{"edge_insert_idx": 44, "key": 0, "source": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["head", 1.0]}}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["eyeL", 1.0]}}, "type": {"py/reduce": [{"py/type": "sleap.skeleton.EdgeType"}, {"py/tuple": [1]}]}}, {"edge_insert_idx": 45, "key": 0, "source": {"py/id": 1}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["eyeR", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 34, "key": 0, "source": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["thorax", 1.0]}}, "target": {"py/id": 1}, "type": {"py/id": 3}}, {"edge_insert_idx": 35, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["abdomen", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 36, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["wingL", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 37, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["wingR", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 38, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["forelegL4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 39, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["forelegR4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 40, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["midlegL4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 41, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["midlegR4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 42, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["hindlegL4", 1.0]}}, "type": {"py/id": 3}}, {"edge_insert_idx": 43, "key": 0, "source": {"py/id": 5}, "target": {"py/object": "sleap.skeleton.Node", "py/state": {"py/tuple": ["hindlegR4", 1.0]}}, "type": {"py/id": 3}}], "multigraph": true, "nodes": [{"id": {"py/id": 1}}, {"id": {"py/id": 5}}, {"id": {"py/id": 6}}, {"id": {"py/id": 7}}, {"id": {"py/id": 8}}, {"id": {"py/id": 9}}, {"id": {"py/id": 10}}, {"id": {"py/id": 11}}, {"id": {"py/id": 12}}, {"id": {"py/id": 13}}, {"id": {"py/id": 14}}, {"id": {"py/id": 2}}, {"id": {"py/id": 4}}]}
```


### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1972
- #1970 
- #1961 
- #1841

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to sort dictionary keys recursively during the encoding process for improved data consistency.
- **Bug Fixes**
	- Enhanced the encoding process to ensure compatibility with earlier versions of the SLEAP framework.
- **Tests**
	- Added assertions to verify that encoded JSON keys are sorted, improving robustness and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->