### PR TITLE
Elizabeth/set kalman filter args equal to max tracking args

### DIFF
--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -946,11 +946,17 @@ class Tracker(BaseTracker):
             pre_cull_function=pre_cull_function,
             max_tracking=max_tracking,
             max_tracks=max_tracks,
-            target_instance_count=target_instance_count,
+            target_instance_count=target_instance_count, # TODO: deprecate target_instance_count
             post_connect_single_breaks=post_connect_single_breaks,
         )
 
-        if target_instance_count and kf_init_frame_count:
+        # Kalman filter requires deprecated target_instance_count
+        if (max_tracks or target_instance_count) and kf_init_frame_count:
+            if not target_instance_count:
+                # If target_instance_count is not set, use max_tracks instead
+                # target_instance_count not available in the GUI
+                target_instance_count = max_tracks
+
             kalman_obj = KalmanTracker.make_tracker(
                 init_tracker=tracker_obj,
                 init_frame_count=kf_init_frame_count,
@@ -960,8 +966,8 @@ class Tracker(BaseTracker):
             )
 
             return kalman_obj
-        elif kf_init_frame_count and not target_instance_count:
-            raise ValueError("Kalman filter requires target instance count.")
+        elif kf_init_frame_count and not (max_tracks or target_instance_count):
+            raise ValueError("Kalman filter requires max tracks or target instance count.")
         else:
             return tracker_obj
 

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -1381,6 +1381,8 @@ class KalmanTracker(BaseTracker):
         if init_tracker.pre_cull_function is None:
             init_tracker.pre_cull_function = cull_function
 
+        print(f"Using {init_tracker.get_name()} to track {init_frame_count} frames for Kalman filters.")
+
         return cls(
             init_tracker=init_tracker,
             kalman_tracker=kalman_tracker,
@@ -1433,7 +1435,7 @@ class KalmanTracker(BaseTracker):
                 # Initialize the Kalman filters
                 self.kalman_tracker.init_filters(self.init_set.instances)
 
-                # print(f"Kalman filters initialized (frame {t})")
+                print(f"Kalman filters initialized (frame {t})")
 
                 # Clear the data used to init filters, so that if the filters
                 # stop tracking and we need to re-init, we won't re-use the

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -926,6 +926,7 @@ class Tracker(BaseTracker):
 
         pre_cull_function = None
         if target_instance_count and pre_cull_to_target:
+            # Right now this is not accessible from the GUI
 
             def pre_cull_function(inst_list):
                 cull_frame_instances(

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -1398,6 +1398,7 @@ class KalmanTracker(BaseTracker):
         untracked_instances: List[InstanceType],
         img: Optional[np.ndarray] = None,
         t: int = None,
+        **kwargs,
     ) -> List[InstanceType]:
         """Tracks individual frame, using Kalman filters if possible."""
 

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -824,8 +824,13 @@ class Tracker(BaseTracker):
             #         "tracking."
             #     )
             self.cleaner.run(frames)
-        elif self.target_instance_count and self.post_connect_single_breaks:
+        elif (self.target_instance_count or self.max_tracks) and self.post_connect_single_breaks:
+            if not self.target_instance_count:
+                # If target_instance_count is not set, use max_tracks instead
+                # target_instance_count not available in the GUI
+                self.target_instance_count = self.max_tracks
             connect_single_track_breaks(frames, self.target_instance_count)
+            print("Connecting single track breaks.")
 
     def get_name(self):
         tracker_name = self.candidate_maker.__class__.__name__

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -855,7 +855,7 @@ class Tracker(BaseTracker):
         of_max_levels: int = 3,
         save_shifted_instances: bool = False,
         # Pre-tracking options to cull instances
-        target_instance_count: int = 0,
+        target_instance_count: int = 0, # TODO: deprecate target_instance_count
         pre_cull_to_target: bool = False,
         pre_cull_iou_threshold: Optional[float] = None,
         # Post-tracking options to connect broken tracks

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -574,7 +574,7 @@ class Tracker(BaseTracker):
     max_tracking: bool = False  # To enable maximum tracking.
 
     cleaner: Optional[Callable] = None  # TODO: deprecate
-    target_instance_count: int = 0
+    target_instance_count: int = 0 # TODO: deprecate
     pre_cull_function: Optional[Callable] = None
     post_connect_single_breaks: bool = False
     robust_best_instance: float = 1.0


### PR DESCRIPTION
# Description

## Replicating the Error

- `target_instance_count` not present in GUI but is present as argument in `make_tracker_by_name` https://github.com/talmolab/sleap/blob/1339f0d2c71c1e600f071321034582ac5f89019d/sleap/nn/tracking.py#L836-L872
    
```bash
Software versions:
SLEAP: 1.4.1a2
TensorFlow: 2.9.2
Numpy: 1.22.4
Python: 3.9.20
OS: macOS-14.5-arm64-arm-64bit
.
.
.
Using already trained model for centroid: /Users/elizabethberrigan/repos/sleap/tests/data/models/minimal_instance.UNet.centroid/training_config.json
Using already trained model for centered_instance: /Users/elizabethberrigan/repos/sleap/tests/data/models/minimal_instance.UNet.centered_instance/training_config.json
Command line call:
sleap-track /Users/elizabethberrigan/repos/sleap/tests/data/tracks/clip.2node.slp --only-labeled-frames -m /Users/elizabethberrigan/repos/sleap/tests/data/models/minimal_instance.UNet.centroid/training_config.json -m /Users/elizabethberrigan/repos/sleap/tests/data/models/minimal_instance.UNet.centered_instance/training_config.json --batch_size 4 --tracking.tracker flow --tracking.similarity instance --tracking.match greedy --tracking.track_window 5 --tracking.kf_init_frame_count 10 --tracking.kf_node_indices 0,1,2 --tracking.post_connect_single_breaks 1 --controller_port 9000 --publish_port 9001 -o /Users/elizabethberrigan/repos/sleap/tests/data/tracks/predictions/clip.2node.slp.241003_221743.predictions.slp --verbosity json --no-empty-frames

Started inference at: 2024-10-03 22:17:47.149775
Args:
{
│   'data_path': '/Users/elizabethberrigan/repos/sleap/tests/data/tracks/clip.2node.slp',
│   'models': [
│   │   '/Users/elizabethberrigan/repos/sleap/tests/data/models/minimal_instance.UNet.centroid/training_config.json',
│   │   '/Users/elizabethberrigan/repos/sleap/tests/data/models/minimal_instance.UNet.centered_instance/training_config.json'
│   ],
│   'frames': '',
│   'only_labeled_frames': True,
│   'only_suggested_frames': False,
Traceback (most recent call last):
  File "/Users/elizabethberrigan/miniforge3/envs/sleap_v1.4.1a2/bin/sleap-track", line 33, in <module>
    sys.exit(load_entry_point('sleap==1.4.1a2', 'console_scripts', 'sleap-track')())
  File "/Users/elizabethberrigan/miniforge3/envs/sleap_v1.4.1a2/lib/python3.9/site-packages/sleap/nn/inference.py", line 5467, in main
    tracker = _make_tracker_from_cli(args)
  File "/Users/elizabethberrigan/miniforge3/envs/sleap_v1.4.1a2/lib/python3.9/site-packages/sleap/nn/inference.py", line 5401, in _make_tracker_from_cli
    tracker = Tracker.make_tracker_by_name(**policy_args["tracking"])
  File "/Users/elizabethberrigan/miniforge3/envs/sleap_v1.4.1a2/lib/python3.9/site-packages/sleap/nn/tracking.py", line 916, in make_tracker_by_name
    raise ValueError("Kalman filter requires target instance count.")
ValueError: Kalman filter requires target instance count.
│   'output': '/Users/elizabethberrigan/repos/sleap/tests/data/tracks/predictions/clip.2node.slp.241003_221743.predictions.slp',
│   'no_empty_frames': True,
│   'verbosity': 'json',
│   'video.dataset': None,
│   'video.input_format': 'channels_last',
│   'video.index': '',
│   'cpu': False,
Process return code: 1

```

- Same error when `max_tracking` is set
    
    ```bash
    (sleap_v1.4.1a2) C:\repos\sleap>sleap-label
    Saving config: C:\Users\eb/.sleap/1.4.1a2/preferences.yaml
    
    Software versions:
    SLEAP: 1.4.1a2
    TensorFlow: 2.7.0
    Numpy: 1.21.6
    Python: 3.7.12
    OS: Windows-10-10.0.22621-SP0
    .
    .
    .
    
    Using already trained model for centroid: C:/repos/sleap/tests/data/models/minimal_instance.UNet.centroid/training_config.json
    Using already trained model for centered_instance: C:/repos/sleap/tests/data/models/minimal_instance.UNet.centered_instance/training_config.json
    Command line call:
    sleap-track C:/repos/sleap/tests/data/tracks/clip.2node.slp --video.index 0 --frames 1499 -m C:/repos/sleap/tests/data/models/minimal_instance.UNet.centroid/training_config.json -m C:/repos/sleap/tests/data/models/minimal_instance.UNet.centered_instance/training_config.json --batch_size 4 --tracking.tracker flowmaxtracks --max_instances 2 --tracking.max_tracks 2 --tracking.similarity instance --tracking.match greedy --tracking.track_window 5 --tracking.kf_init_frame_count 10 --tracking.kf_node_indices 0,1 --tracking.post_connect_single_breaks 1 --controller_port 9000 --publish_port 9001 --tracking.max_tracking 1 -o C:/repos/sleap/tests/data/tracks\predictions\clip.2node.slp.241004_091302.predictions.slp --verbosity json --no-empty-frames
    
    Started inference at: 2024-10-04 09:13:06.788183
    Args:
    {
        'data_path': 'C:/repos/sleap/tests/data/tracks/clip.2node.slp',
        'models': [
            'C:/repos/sleap/tests/data/models/minimal_instance.UNet.centroid/training_config.json',
            'C:/repos/sleap/tests/data/models/minimal_instance.UNet.centered_instance/training_config.json'
        ],
        'frames': '1499',
        'only_labeled_frames': False,
        'only_suggested_frames': False,
        'output': 'C:/repos/sleap/tests/data/tracks\\predictions\\clip.2node.slp.241004_091302.predictions.slp',
        'no_empty_frames': True,
        'verbosity': 'json',
        'video.dataset': None,
        'video.input_format': 'channels_last',
        'video.index': '0',
        'cpu': False,
        'first_gpu': False,
        'last_gpu': False,
        'gpu': 'auto',
        'max_edge_length_ratio': 0.25,
        'dist_penalty_weight': 1.0,
        'batch_size': 4,
        'open_in_gui': False,
        'peak_threshold': 0.2,
        'max_instances': 2,
        'tracking.tracker': 'flowmaxtracks',
        'tracking.max_tracking': True,
        'tracking.max_tracks': 2,
        'tracking.target_instance_count': None,
        'tracking.pre_cull_to_target': None,
        'tracking.pre_cull_iou_threshold': None,
        'tracking.post_connect_single_breaks': 1,
        'tracking.clean_instance_count': None,
        'tracking.clean_iou_threshold': None,
        'tracking.similarity': 'instance',
        'tracking.match': 'greedy',
        'tracking.robust': None,
        'tracking.track_window': 5,
        'tracking.min_new_track_points': None,
    Traceback (most recent call last):
      File "C:\Users\eb\Miniforge3\envs\sleap_v1.4.1a2\Scripts\sleap-track-script.py", line 33, in <module>
        sys.exit(load_entry_point('sleap==1.4.1a2', 'console_scripts', 'sleap-track')())
      File "C:\Users\eb\Miniforge3\envs\sleap_v1.4.1a2\lib\site-packages\sleap\nn\inference.py", line 5467, in main
        tracker = _make_tracker_from_cli(args)
      File "C:\Users\eb\Miniforge3\envs\sleap_v1.4.1a2\lib\site-packages\sleap\nn\inference.py", line 5401, in _make_tracker_from_cli
        tracker = Tracker.make_tracker_by_name(**policy_args["tracking"])
      File "C:\Users\eb\Miniforge3\envs\sleap_v1.4.1a2\lib\site-packages\sleap\nn\tracking.py", line 916, in make_tracker_by_name
        raise ValueError("Kalman filter requires target instance count.")
    ValueError: Kalman filter requires target instance count.
        'tracking.min_match_points': None,
        'tracking.img_scale': None,
        'tracking.of_window_size': None,
        'tracking.of_max_levels': None,
        'tracking.save_shifted_instances': None,
        'tracking.kf_node_indices': [0, 1],
        'tracking.kf_init_frame_count': 10
    Process return code: 1
    ```


## Tracing the Error

- `Tracker.make_tracker_by_name` *does* take `target_instance_count` as an argument and it is set to `0` by default.
- `kf_init_frame_count` is set to `10` while `target_instance_count` remains `0`, producing the error  "Kalman filter requires target instance count." https://github.com/talmolab/sleap/blob/1339f0d2c71c1e600f071321034582ac5f89019d/sleap/nn/tracking.py#L957-L958
    - We want it to run these lines instead, which requires `target_instance_count` and `kf_init_frame_count` https://github.com/talmolab/sleap/blob/1339f0d2c71c1e600f071321034582ac5f89019d/sleap/nn/tracking.py#L947-L954
- Called here (args parsed from CLI): https://github.com/talmolab/sleap/blob/1339f0d2c71c1e600f071321034582ac5f89019d/sleap/nn/tracking.py#L1564-L1570
- presence of `max_tracking` does change the tracker candidate. Is this a problem?? Will CLI behavior be different than GUI behavior?

- *Related*: If we want to cull, we need to add `pre_cull_to_target` option to the GUI. Right now, nothing will lead to the pre-cull function through the GUI https://github.com/talmolab/sleap/blob/1339f0d2c71c1e600f071321034582ac5f89019d/sleap/nn/tracking.py#L922-L930

### Types of changes

- [X] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
https://github.com/talmolab/sleap/pull/1447
#1583, #1980 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
