### PR TITLE
Remove python version from website build yml

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,7 +8,7 @@ on:
       # 'main' triggers updates to 'sleap.ai', all others to 'sleap.ai/develop'
       - main
       - develop
-      - liezl/update-intallation-docs-1.4.1 # again!
+      - liezl/remove-python-version-from-website-build-yml
     paths:
       - "docs/**"
       - "README.rst"
@@ -26,7 +26,6 @@ jobs:
         # https://github.com/conda-incubator/setup-miniconda
         uses: conda-incubator/setup-miniconda@v3.0.3
         with:
-          python-version: 3.7
           environment-file: environment_no_cuda.yml
           activate-environment: sleap_ci
       - name: Print environment info


### PR DESCRIPTION
### Description
Remove the python-version constraint on the website.yml file (python version comes from environment yml) - also a blocker when the environment yaml specifies a different python range.

### Types of changes
- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [x] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #1989

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
