### PR TITLE
Lower bound albumentation version to handle Nan keypoints

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - conda-forge::scikit-video
     - conda-forge::seaborn
     - conda-forge::qudida
-    - conda-forge::albumentations
+    - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
     - conda-forge::ndx-pose <0.2.0
     - conda-forge::importlib-metadata ==4.11.4
   run:
@@ -89,7 +89,7 @@ requirements:
     - sleap/label/dev::tensorflow ==2.7.0  # TODO: Switch to main label when updated
     - conda-forge::tensorflow-hub <0.14.0  # Causes pynwb conflicts on linux GH-1446
     - conda-forge::qudida
-    - conda-forge::albumentations
+    - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
     - conda-forge::ndx-pose <0.2.0
     - conda-forge::importlib-metadata ==4.11.4
 

--- a/.conda_mac/meta.yaml
+++ b/.conda_mac/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - conda-forge::scikit-video
     - conda-forge::seaborn
     - conda-forge::qudida
-    - conda-forge::albumentations
+    - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
     - conda-forge::ndx-pose <0.2.0
 
   run:
@@ -88,7 +88,7 @@ requirements:
     - conda-forge::seaborn
     # - conda-forge::tensorflow-hub  # pulls in tensorflow cpu from conda-forge
     - conda-forge::qudida
-    - conda-forge::albumentations
+    - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
     - conda-forge::ndx-pose <0.2.0
 
 # test:

--- a/environment.yml
+++ b/environment.yml
@@ -3,50 +3,50 @@
 name: sleap
 
 channels:
-  - conda-forge
-  - nvidia
-  - sleap
-  - anaconda
+    - conda-forge
+    - nvidia
+    - sleap
+    - anaconda
 
 dependencies:
-  # Packages SLEAP uses directly
-  - conda-forge::attrs >=21.2.0
-  - conda-forge::cattrs ==1.1.1
-  - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
-  - conda-forge::jsmin
-  - conda-forge::jsonpickle ==1.2
-  - conda-forge::networkx
-  - anaconda::numpy >=1.19.5,<1.23.0
-  - conda-forge::opencv <4.9.0
-  - conda-forge::h5py <=3.7.0
-  - conda-forge::pandas
-  - conda-forge::pip
-  - conda-forge::pillow #>=8.3.1,<=8.4.0
-  - conda-forge::psutil
-  - conda-forge::pykalman
-  - conda-forge::pyside2 >=5.12 # To ensure application works correctly with QtPy.
-  - conda-forge::python ~=3.7 # Run into _MAX_WINDOWS_WORKERS not found if ==
-  - conda-forge::python-rapidjson
-  - conda-forge::pyyaml
-  - conda-forge::pyzmq
-  - conda-forge::qtpy >=2.0.1
-  - conda-forge::rich
-  - conda-forge::scipy >=1.4.1,<=1.9.0
-  - conda-forge::scikit-image
-  - conda-forge::scikit-learn ==1.0
-  - conda-forge::scikit-video
-  - conda-forge::seaborn
-  - sleap/label/dev::tensorflow ==2.7.0 # TODO: Switch to main label when updated
-  - conda-forge::tensorflow-hub # Pinned in meta.yml, but no problems here... yet
-  - conda-forge::qudida
-  - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
-  - conda-forge::ndx-pose <0.2.0
+    # Packages SLEAP uses directly
+    - conda-forge::attrs >=21.2.0
+    - conda-forge::cattrs ==1.1.1
+    - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
+    - conda-forge::jsmin
+    - conda-forge::jsonpickle ==1.2
+    - conda-forge::networkx
+    - anaconda::numpy >=1.19.5,<1.23.0
+    - conda-forge::opencv <4.9.0
+    - conda-forge::h5py <=3.7.0
+    - conda-forge::pandas
+    - conda-forge::pip
+    - conda-forge::pillow #>=8.3.1,<=8.4.0
+    - conda-forge::psutil
+    - conda-forge::pykalman
+    - conda-forge::pyside2 >=5.12 # To ensure application works correctly with QtPy.
+    - conda-forge::python ~=3.7 # Run into _MAX_WINDOWS_WORKERS not found if ==
+    - conda-forge::python-rapidjson
+    - conda-forge::pyyaml
+    - conda-forge::pyzmq
+    - conda-forge::qtpy >=2.0.1
+    - conda-forge::rich
+    - conda-forge::scipy >=1.4.1,<=1.9.0
+    - conda-forge::scikit-image
+    - conda-forge::scikit-learn ==1.0
+    - conda-forge::scikit-video
+    - conda-forge::seaborn
+    - sleap/label/dev::tensorflow ==2.7.0 # TODO: Switch to main label when updated
+    - conda-forge::tensorflow-hub # Pinned in meta.yml, but no problems here... yet
+    - conda-forge::qudida
+    - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
+    - conda-forge::ndx-pose <0.2.0
 
-  # Packages required by tensorflow to find/use GPUs
-  - conda-forge::cudatoolkit ==11.3.1
-  # "==" results in package not found
-  - conda-forge::cudnn=8.2.1
-  - nvidia::cuda-nvcc=11.3
+    # Packages required by tensorflow to find/use GPUs
+    - conda-forge::cudatoolkit ==11.3.1
+    # "==" results in package not found
+    - conda-forge::cudnn=8.2.1
+    - nvidia::cuda-nvcc=11.3
 
-  - pip:
-      - "--editable=.[conda_dev]"
+    - pip:
+          - "--editable=.[conda_dev]"

--- a/environment.yml
+++ b/environment.yml
@@ -3,50 +3,50 @@
 name: sleap
 
 channels:
-    - conda-forge
-    - nvidia
-    - sleap
-    - anaconda
+  - conda-forge
+  - nvidia
+  - sleap
+  - anaconda
 
 dependencies:
-    # Packages SLEAP uses directly
-    - conda-forge::attrs >=21.2.0
-    - conda-forge::cattrs ==1.1.1
-    - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
-    - conda-forge::jsmin
-    - conda-forge::jsonpickle ==1.2
-    - conda-forge::networkx
-    - anaconda::numpy >=1.19.5,<1.23.0
-    - conda-forge::opencv <4.9.0
-    - conda-forge::h5py <=3.7.0
-    - conda-forge::pandas
-    - conda-forge::pip
-    - conda-forge::pillow #>=8.3.1,<=8.4.0
-    - conda-forge::psutil
-    - conda-forge::pykalman
-    - conda-forge::pyside2 >=5.12  # To ensure application works correctly with QtPy.
-    - conda-forge::python ~=3.7    # Run into _MAX_WINDOWS_WORKERS not found if ==
-    - conda-forge::python-rapidjson
-    - conda-forge::pyyaml
-    - conda-forge::pyzmq
-    - conda-forge::qtpy >=2.0.1
-    - conda-forge::rich
-    - conda-forge::scipy >=1.4.1,<=1.9.0
-    - conda-forge::scikit-image
-    - conda-forge::scikit-learn ==1.0
-    - conda-forge::scikit-video
-    - conda-forge::seaborn
-    - sleap/label/dev::tensorflow ==2.7.0  # TODO: Switch to main label when updated
-    - conda-forge::tensorflow-hub  # Pinned in meta.yml, but no problems here... yet
-    - conda-forge::qudida
-    - conda-forge::albumentations
-    - conda-forge::ndx-pose <0.2.0
+  # Packages SLEAP uses directly
+  - conda-forge::attrs >=21.2.0
+  - conda-forge::cattrs ==1.1.1
+  - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
+  - conda-forge::jsmin
+  - conda-forge::jsonpickle ==1.2
+  - conda-forge::networkx
+  - anaconda::numpy >=1.19.5,<1.23.0
+  - conda-forge::opencv <4.9.0
+  - conda-forge::h5py <=3.7.0
+  - conda-forge::pandas
+  - conda-forge::pip
+  - conda-forge::pillow #>=8.3.1,<=8.4.0
+  - conda-forge::psutil
+  - conda-forge::pykalman
+  - conda-forge::pyside2 >=5.12 # To ensure application works correctly with QtPy.
+  - conda-forge::python ~=3.7 # Run into _MAX_WINDOWS_WORKERS not found if ==
+  - conda-forge::python-rapidjson
+  - conda-forge::pyyaml
+  - conda-forge::pyzmq
+  - conda-forge::qtpy >=2.0.1
+  - conda-forge::rich
+  - conda-forge::scipy >=1.4.1,<=1.9.0
+  - conda-forge::scikit-image
+  - conda-forge::scikit-learn ==1.0
+  - conda-forge::scikit-video
+  - conda-forge::seaborn
+  - sleap/label/dev::tensorflow ==2.7.0 # TODO: Switch to main label when updated
+  - conda-forge::tensorflow-hub # Pinned in meta.yml, but no problems here... yet
+  - conda-forge::qudida
+  - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
+  - conda-forge::ndx-pose <0.2.0
 
-    # Packages required by tensorflow to find/use GPUs
-    - conda-forge::cudatoolkit ==11.3.1
-    # "==" results in package not found
-    - conda-forge::cudnn=8.2.1
-    - nvidia::cuda-nvcc=11.3
+  # Packages required by tensorflow to find/use GPUs
+  - conda-forge::cudatoolkit ==11.3.1
+  # "==" results in package not found
+  - conda-forge::cudnn=8.2.1
+  - nvidia::cuda-nvcc=11.3
 
-    - pip:  
-        - "--editable=.[conda_dev]"
+  - pip:
+      - "--editable=.[conda_dev]"

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -3,42 +3,42 @@
 name: sleap
 
 channels:
-    - conda-forge
-    - anaconda
+  - conda-forge
+  - anaconda
 
 dependencies:
-    # Packages SLEAP uses directly
-    - conda-forge::attrs >=21.2.0
-    - conda-forge::importlib-metadata <7.1.0
-    - conda-forge::cattrs ==1.1.1
-    - conda-forge::h5py
-    - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
-    - conda-forge::jsmin
-    - conda-forge::jsonpickle ==1.2
-    - conda-forge::keras <2.10.0,>=2.9.0rc0  # Required by tensorflow-macos
-    - conda-forge::networkx <3.3
-    - anaconda::numpy >=1.19.5,<1.23.0
-    - conda-forge::opencv
-    - conda-forge::pandas
-    - conda-forge::pip
-    - conda-forge::pillow
-    - conda-forge::psutil
-    - conda-forge::pykalman
-    - conda-forge::pyside2 >=5.12  # To ensure application works correctly with QtPy.
-    - conda-forge::python  ~=3.9
-    - conda-forge::python-rapidjson
-    - conda-forge::pyyaml
-    - conda-forge::pyzmq
-    - conda-forge::qtpy >=2.0.1
-    - conda-forge::rich
-    - conda-forge::scipy >=1.4.1,<=1.9.0
-    - conda-forge::scikit-image
-    - conda-forge::scikit-learn ==1.0
-    - conda-forge::scikit-video
-    - conda-forge::seaborn
-    # - conda-forge::tensorflow-hub  # pulls in tensorflow cpu from conda-forge
-    - conda-forge::qudida
-    - conda-forge::albumentations
-    - conda-forge::ndx-pose <0.2.0
-    - pip:
-        - "--editable=.[conda_dev]"
+  # Packages SLEAP uses directly
+  - conda-forge::attrs >=21.2.0
+  - conda-forge::importlib-metadata <7.1.0
+  - conda-forge::cattrs ==1.1.1
+  - conda-forge::h5py
+  - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
+  - conda-forge::jsmin
+  - conda-forge::jsonpickle ==1.2
+  - conda-forge::keras <2.10.0,>=2.9.0rc0 # Required by tensorflow-macos
+  - conda-forge::networkx <3.3
+  - anaconda::numpy >=1.19.5,<1.23.0
+  - conda-forge::opencv
+  - conda-forge::pandas
+  - conda-forge::pip
+  - conda-forge::pillow
+  - conda-forge::psutil
+  - conda-forge::pykalman
+  - conda-forge::pyside2 >=5.12 # To ensure application works correctly with QtPy.
+  - conda-forge::python  ~=3.9
+  - conda-forge::python-rapidjson
+  - conda-forge::pyyaml
+  - conda-forge::pyzmq
+  - conda-forge::qtpy >=2.0.1
+  - conda-forge::rich
+  - conda-forge::scipy >=1.4.1,<=1.9.0
+  - conda-forge::scikit-image
+  - conda-forge::scikit-learn ==1.0
+  - conda-forge::scikit-video
+  - conda-forge::seaborn
+  # - conda-forge::tensorflow-hub  # pulls in tensorflow cpu from conda-forge
+  - conda-forge::qudida
+  - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
+  - conda-forge::ndx-pose <0.2.0
+  - pip:
+      - "--editable=.[conda_dev]"

--- a/environment_mac.yml
+++ b/environment_mac.yml
@@ -3,42 +3,42 @@
 name: sleap
 
 channels:
-  - conda-forge
-  - anaconda
+    - conda-forge
+    - anaconda
 
 dependencies:
-  # Packages SLEAP uses directly
-  - conda-forge::attrs >=21.2.0
-  - conda-forge::importlib-metadata <7.1.0
-  - conda-forge::cattrs ==1.1.1
-  - conda-forge::h5py
-  - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
-  - conda-forge::jsmin
-  - conda-forge::jsonpickle ==1.2
-  - conda-forge::keras <2.10.0,>=2.9.0rc0 # Required by tensorflow-macos
-  - conda-forge::networkx <3.3
-  - anaconda::numpy >=1.19.5,<1.23.0
-  - conda-forge::opencv
-  - conda-forge::pandas
-  - conda-forge::pip
-  - conda-forge::pillow
-  - conda-forge::psutil
-  - conda-forge::pykalman
-  - conda-forge::pyside2 >=5.12 # To ensure application works correctly with QtPy.
-  - conda-forge::python  ~=3.9
-  - conda-forge::python-rapidjson
-  - conda-forge::pyyaml
-  - conda-forge::pyzmq
-  - conda-forge::qtpy >=2.0.1
-  - conda-forge::rich
-  - conda-forge::scipy >=1.4.1,<=1.9.0
-  - conda-forge::scikit-image
-  - conda-forge::scikit-learn ==1.0
-  - conda-forge::scikit-video
-  - conda-forge::seaborn
-  # - conda-forge::tensorflow-hub  # pulls in tensorflow cpu from conda-forge
-  - conda-forge::qudida
-  - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
-  - conda-forge::ndx-pose <0.2.0
-  - pip:
-      - "--editable=.[conda_dev]"
+    # Packages SLEAP uses directly
+    - conda-forge::attrs >=21.2.0
+    - conda-forge::importlib-metadata <7.1.0
+    - conda-forge::cattrs ==1.1.1
+    - conda-forge::h5py
+    - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
+    - conda-forge::jsmin
+    - conda-forge::jsonpickle ==1.2
+    - conda-forge::keras <2.10.0,>=2.9.0rc0 # Required by tensorflow-macos
+    - conda-forge::networkx <3.3
+    - anaconda::numpy >=1.19.5,<1.23.0
+    - conda-forge::opencv
+    - conda-forge::pandas
+    - conda-forge::pip
+    - conda-forge::pillow
+    - conda-forge::psutil
+    - conda-forge::pykalman
+    - conda-forge::pyside2 >=5.12 # To ensure application works correctly with QtPy.
+    - conda-forge::python  ~=3.9
+    - conda-forge::python-rapidjson
+    - conda-forge::pyyaml
+    - conda-forge::pyzmq
+    - conda-forge::qtpy >=2.0.1
+    - conda-forge::rich
+    - conda-forge::scipy >=1.4.1,<=1.9.0
+    - conda-forge::scikit-image
+    - conda-forge::scikit-learn ==1.0
+    - conda-forge::scikit-video
+    - conda-forge::seaborn
+    # - conda-forge::tensorflow-hub  # pulls in tensorflow cpu from conda-forge
+    - conda-forge::qudida
+    - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
+    - conda-forge::ndx-pose <0.2.0
+    - pip:
+          - "--editable=.[conda_dev]"

--- a/environment_no_cuda.yml
+++ b/environment_no_cuda.yml
@@ -5,43 +5,43 @@
 name: sleap_ci
 
 channels:
-  - conda-forge
-  - sleap
-  - anaconda
+    - conda-forge
+    - sleap
+    - anaconda
 
 dependencies:
-  # Packages SLEAP uses directly
-  - conda-forge::attrs >=21.2.0
-  - conda-forge::cattrs ==1.1.1
-  - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
-  - conda-forge::jsmin
-  - conda-forge::jsonpickle ==1.2
-  - conda-forge::networkx
-  - anaconda::numpy >=1.19.5,<1.23.0
-  - conda-forge::opencv <4.9.0
-  - conda-forge::pandas
-  - conda-forge::pip
-  - conda-forge::pillow #>=8.3.1,<=8.4.0
-  - conda-forge::psutil
-  - conda-forge::pykalman
-  - conda-forge::pyside2 >=5.12 # To ensure application works correctly with QtPy.
-  - conda-forge::python ~=3.7 # Run into _MAX_WINDOWS_WORKERS not found if ==
-  - conda-forge::python-rapidjson
-  - conda-forge::pyyaml
-  - conda-forge::pyzmq
-  - conda-forge::qtpy >=2.0.1
-  - conda-forge::rich
-  - conda-forge::scipy >=1.4.1,<=1.9.0
-  - conda-forge::scikit-image
-  - conda-forge::scikit-learn ==1.0
-  - conda-forge::scikit-video
-  - conda-forge::seaborn
-  # - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10
-  - sleap/label/dev::tensorflow ==2.7.0
-  - conda-forge::tensorflow-hub
-  - conda-forge::qudida
-  - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
-  - conda-forge::ndx-pose <0.2.0
+    # Packages SLEAP uses directly
+    - conda-forge::attrs >=21.2.0
+    - conda-forge::cattrs ==1.1.1
+    - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
+    - conda-forge::jsmin
+    - conda-forge::jsonpickle ==1.2
+    - conda-forge::networkx
+    - anaconda::numpy >=1.19.5,<1.23.0
+    - conda-forge::opencv <4.9.0
+    - conda-forge::pandas
+    - conda-forge::pip
+    - conda-forge::pillow #>=8.3.1,<=8.4.0
+    - conda-forge::psutil
+    - conda-forge::pykalman
+    - conda-forge::pyside2 >=5.12 # To ensure application works correctly with QtPy.
+    - conda-forge::python ~=3.7 # Run into _MAX_WINDOWS_WORKERS not found if ==
+    - conda-forge::python-rapidjson
+    - conda-forge::pyyaml
+    - conda-forge::pyzmq
+    - conda-forge::qtpy >=2.0.1
+    - conda-forge::rich
+    - conda-forge::scipy >=1.4.1,<=1.9.0
+    - conda-forge::scikit-image
+    - conda-forge::scikit-learn ==1.0
+    - conda-forge::scikit-video
+    - conda-forge::seaborn
+    # - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10
+    - sleap/label/dev::tensorflow ==2.7.0
+    - conda-forge::tensorflow-hub
+    - conda-forge::qudida
+    - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
+    - conda-forge::ndx-pose <0.2.0
 
-  - pip:
-      - "--editable=.[conda_dev]"
+    - pip:
+          - "--editable=.[conda_dev]"

--- a/environment_no_cuda.yml
+++ b/environment_no_cuda.yml
@@ -1,47 +1,47 @@
 # Use this environment file if your computer does not have a nvidia GPU and runs Windows
-# or Linux. This environment file has exactly the same dependencies listed as 
-# environment.yaml, minus the packages required by tensorflow to find/use GPUs. 
+# or Linux. This environment file has exactly the same dependencies listed as
+# environment.yaml, minus the packages required by tensorflow to find/use GPUs.
 
 name: sleap_ci
 
 channels:
-    - conda-forge
-    - sleap
-    - anaconda
+  - conda-forge
+  - sleap
+  - anaconda
 
 dependencies:
-    # Packages SLEAP uses directly
-    - conda-forge::attrs >=21.2.0
-    - conda-forge::cattrs ==1.1.1
-    - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
-    - conda-forge::jsmin
-    - conda-forge::jsonpickle ==1.2
-    - conda-forge::networkx
-    - anaconda::numpy >=1.19.5,<1.23.0
-    - conda-forge::opencv <4.9.0
-    - conda-forge::pandas
-    - conda-forge::pip
-    - conda-forge::pillow #>=8.3.1,<=8.4.0
-    - conda-forge::psutil
-    - conda-forge::pykalman
-    - conda-forge::pyside2 >=5.12  # To ensure application works correctly with QtPy.
-    - conda-forge::python ~=3.7    # Run into _MAX_WINDOWS_WORKERS not found if ==
-    - conda-forge::python-rapidjson
-    - conda-forge::pyyaml
-    - conda-forge::pyzmq
-    - conda-forge::qtpy >=2.0.1
-    - conda-forge::rich
-    - conda-forge::scipy >=1.4.1,<=1.9.0
-    - conda-forge::scikit-image
-    - conda-forge::scikit-learn ==1.0
-    - conda-forge::scikit-video
-    - conda-forge::seaborn
-    # - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10
-    - sleap/label/dev::tensorflow ==2.7.0
-    - conda-forge::tensorflow-hub
-    - conda-forge::qudida
-    - conda-forge::albumentations
-    - conda-forge::ndx-pose <0.2.0
+  # Packages SLEAP uses directly
+  - conda-forge::attrs >=21.2.0
+  - conda-forge::cattrs ==1.1.1
+  - conda-forge::imageio-ffmpeg # Required for imageio to read/write videos with ffmpeg
+  - conda-forge::jsmin
+  - conda-forge::jsonpickle ==1.2
+  - conda-forge::networkx
+  - anaconda::numpy >=1.19.5,<1.23.0
+  - conda-forge::opencv <4.9.0
+  - conda-forge::pandas
+  - conda-forge::pip
+  - conda-forge::pillow #>=8.3.1,<=8.4.0
+  - conda-forge::psutil
+  - conda-forge::pykalman
+  - conda-forge::pyside2 >=5.12 # To ensure application works correctly with QtPy.
+  - conda-forge::python ~=3.7 # Run into _MAX_WINDOWS_WORKERS not found if ==
+  - conda-forge::python-rapidjson
+  - conda-forge::pyyaml
+  - conda-forge::pyzmq
+  - conda-forge::qtpy >=2.0.1
+  - conda-forge::rich
+  - conda-forge::scipy >=1.4.1,<=1.9.0
+  - conda-forge::scikit-image
+  - conda-forge::scikit-learn ==1.0
+  - conda-forge::scikit-video
+  - conda-forge::seaborn
+  # - sleap::tensorflow >=2.6.3,<2.11  # No windows GPU support for >2.10
+  - sleap/label/dev::tensorflow ==2.7.0
+  - conda-forge::tensorflow-hub
+  - conda-forge::qudida
+  - conda-forge::albumentations >=1.4.15 # Handle Nan keypoints
+  - conda-forge::ndx-pose <0.2.0
 
-    - pip:  
-        - "--editable=.[conda_dev]"
+  - pip:
+      - "--editable=.[conda_dev]"

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -36,7 +36,7 @@ seaborn
 tensorflow>=2.6.3,<2.9; platform_machine != 'arm64'
 # tensorflow ==2.7.4; platform_machine != 'arm64'
 tensorflow-hub<=0.14.0
-albumentations
+albumentations>=1.4.15 # Handle Nan keypoints
 ndx-pose<0.2.0
 # These dependencies are untested since we do not offer a wheel for apple silicon atm.
 tensorflow-macos==2.9.2; sys_platform == 'darwin' and platform_machine == 'arm64'


### PR DESCRIPTION
### Description
In some of our now-older environments, we were getting this error while try to run training:
```
  File "/Users/liezlmaree/micromamba/envs/sleap_py310/lib/python3.10/site-packages/albumentations/core/keypoints_utils.py", line 228, in convert_keypoint_to_albumentations
    keypoint = (int(x), int(y), angle_to_2pi_range(a), s, *tail)

ValueError: cannot convert float NaN to integer
```
. This is with `albumentations==1.4.14`.

We no longer get this error when running `albumenation==1.4.15` as the `conver_keypoint_to_albumentations` function was replaced with `convert_keypoints_to_albumentations` (plural) and does not try to `int(Nan)` for our `Nan` keypoints.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
