### PR TITLE
Temp mutliview-branch fix to add frame to Instance (when using Labels.add_instance)

### DIFF
--- a/sleap/io/dataset.py
+++ b/sleap/io/dataset.py
@@ -1483,6 +1483,10 @@ class Labels(MutableSequence):
 
         # Add instance and track to labels
         frame.instances.append(instance)
+
+        # TODO: Do NOT merge into develop, this next line is handled by InstancesList
+        instance.frame = frame  # Needed to add instance to instance group
+
         if (instance.track is not None) and (instance.track not in self.tracks):
             self.add_track(video=frame.video, track=instance.track)
 


### PR DESCRIPTION
### Description
One of the multiview branch beta testers has reported that they are unable to add an `Instance` to an instance group without 

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
