### PR TITLE
Allow using DummyVideo when restructuring

### DIFF
--- a/sleap/io/video.py
+++ b/sleap/io/video.py
@@ -1547,12 +1547,16 @@ class Video:
 
         # Use from_filename to fixup the video path and determine backend
         def fixup_video(x: dict, cl: Video):
-            backend_dict = x.pop("backend")
+            backend_dict: dict = x.pop("backend")
+
+            # If the backend is a DummyVideo
+            if backend_dict.get("dummy", False):
+                return cl(backend=cl.make_specific_backend(DummyVideo, backend_dict))
+
             filename = backend_dict.pop("filename", None) or backend_dict.pop(
                 "file", None
             )
-
-            return Video.from_filename(filename, **backend_dict)
+            return cl.from_filename(filename, **backend_dict)
 
         vid_cattr = cattr.Converter()
         vid_cattr.register_structure_hook(Video, fixup_video)


### PR DESCRIPTION
### Description
While refactoring in preparation for new dependencies in #1905, we accidentally removed support for loading `DummyVideos` - which is quite useful for debugging user data (especially if they have large videos that we don't necessarily need and perhaps they don't necessarily want to share).

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
