### PR TITLE
Add 1000 and 2500 as trail length viewing options

### DIFF
--- a/sleap/gui/overlays/tracks.py
+++ b/sleap/gui/overlays/tracks.py
@@ -48,8 +48,8 @@ class TrackTrailOverlay(BaseOverlay):
     @classmethod
     def get_length_options(cls):
         if prefs["trail length"] != 0:
-            return (0, 10, 50, 100, 250, 500, prefs["trail length"])
-        return (0, 10, 50, 100, 250, 500)
+            return (0, 10, 50, 100, 250, 500, 1000, 2500, prefs["trail length"])
+        return (0, 10, 50, 100, 250, 500, 1000, 2500)
 
     @classmethod
     def get_shade_options(cls):


### PR DESCRIPTION
### Description
Expanded trail length viewing options as per https://github.com/talmolab/sleap/issues/2043


### Types of changes

- [X] Bugfix
- [ ] New feature
- [] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[Trail Length Viewing Options #2043](https://github.com/talmolab/sleap/issues/2043)
Notably, prefs and the 500 viewing option has been added since the issue was created. If those previous changes are deemed sufficient, then this PR is not needed, and we can respond to the issue #2043 thread with that information.

### Outside contributors checklist

- [X] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [X] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [X] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [X] Add tests that prove your fix is effective or that your feature works
- [X] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded trail length options to include new values: `1000` and `2500`.

- **Bug Fixes**
	- Improved configurability of trail length settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->