### PR TITLE
Fix input scaling in centered-instance model

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,7 +178,7 @@ html_static_path = ["_static"]
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)
 html_css_files = [
-    'css/tabs.css',
+    "css/tabs.css",
 ]
 
 # Custom sidebar templates, must be a dictionary that maps document names

--- a/sleap/nn/data/pipelines.py
+++ b/sleap/nn/data/pipelines.py
@@ -775,6 +775,7 @@ class TopdownConfmapsPipeline:
                 provider=data_provider,
             )
         pipeline += Normalizer.from_config(self.data_config.preprocessing)
+        pipeline += Resizer.from_config(self.data_config.preprocessing)
         pipeline += InstanceCentroidFinder.from_config(
             self.data_config.instance_cropping,
             skeletons=self.data_config.labels.skeletons,


### PR DESCRIPTION
### Description
This fixes the issue with input scaling in centered-instance model, addressed [here](https://github.com/talmolab/sleap/issues/1993#issuecomment-2546776734). 
- We fix the issue with the visualizer pipeline by applying `resizing` to the [`make_viz_pipeline`](https://github.com/talmolab/sleap/blob/3417a18641390909ee26665b4cb483a93fe1e009/sleap/nn/data/pipelines.py#L760).
- We also resize the images in `CentroidCropGroundTruth` while running inference on a centered-instance model, instead of resizing the crops in `FindInstancePeaks` class.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#1993 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
