### PR TITLE
Fix import PySide2 -> qtpy

### DIFF
--- a/sleap/gui/dialogs/frame_range.py
+++ b/sleap/gui/dialogs/frame_range.py
@@ -1,5 +1,5 @@
 """Frame range dialog."""
-from PySide2 import QtWidgets
+from qtpy import QtWidgets
 from sleap.gui.dialogs.formbuilder import FormBuilderModalDialog
 from typing import Optional
 

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -1590,7 +1590,6 @@ class QtNode(QGraphicsEllipseItem):
 
     def mouseMoveEvent(self, event):
         """Custom event handler for mouse move."""
-        # print(event)
         if self.dragParent:
             self.parentObject().mouseMoveEvent(event)
         else:
@@ -1601,7 +1600,6 @@ class QtNode(QGraphicsEllipseItem):
 
     def mouseReleaseEvent(self, event):
         """Custom event handler for mouse release."""
-        # print(event)
         self.unsetCursor()
         if self.dragParent:
             self.parentObject().mouseReleaseEvent(event)
@@ -1631,7 +1629,7 @@ class QtNode(QGraphicsEllipseItem):
             view.instanceDoubleClicked.emit(self.parentObject().instance, event)
 
     def hoverEnterEvent(self, event):
-        print("QtNode: hover enter")
+        """Custom event handler for mouse hover enter."""
         return super().hoverEnterEvent(event)
 
 


### PR DESCRIPTION
### Description
Hotfix for a bug in #1797 where an import that was using `PySide2` instead of `qtpy`.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the import statement for the `QtWidgets` class to improve compatibility with the Qt framework.

- **Documentation**
	- Enhanced clarity by adding comments and docstrings to key methods in the `QtNode` and `QtNodeLabel` classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->