### PR TITLE
Add channels for pip conda env

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -8,7 +8,7 @@ on:
       # 'main' triggers updates to 'sleap.ai', all others to 'sleap.ai/develop'
       - main
       - develop
-      - liezl/update-intallation-docs-1.4.1 # again!
+      - liezl/add-channels-for-pip-conda-env
     paths:
       - "docs/**"
       - "README.rst"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ local:
    Installation requires entering commands in a terminal. To open one:
    ````{tabs}
       ```{tab} Windows
-         Open the *Start menu* and search for the *Anaconda Prompt* (if using Miniconda) or the *Command Prompt* if not. 
+         Open the *Start menu* and search for the *Anaconda Prompt* (if using Miniconda) or the *Command Prompt* if not.
          ```{note}
          On Windows, our personal preference is to use alternative terminal apps like [Cmder](https://cmder.net) or [Windows Terminal](https://aka.ms/terminal).
          ```
@@ -65,7 +65,6 @@ If you don't have a `conda` package manager installation, here are some quick in
 ### Miniforge (recommended)
 
 Miniforge is a minimal installer for conda that includes the `conda` package manager and is maintained by the [conda-forge](https://conda-forge.org) community. The only difference between Miniforge and Miniconda is that Miniforge uses the `conda-forge` channel by default, which provides a much wider selection of community-maintained packages.
-
 
 ````{tabs}
    ```{group-tab} Windows
@@ -135,20 +134,20 @@ This is a minimal installer for conda that includes the `conda` package manager 
 
 See the [Miniconda website](https://docs.anaconda.com/free/miniconda/) for up-to-date installation instructions if the above instructions don't work for your system.
 
-
 (installation-methods)=
+
 ## Installation methods
 
 SLEAP can be installed three different ways: via {ref}`conda package<condapackage>`, {ref}`conda from source<condasource>`, or {ref}`pip package<pippackage>`. Select one of the methods below to install SLEAP. We recommend {ref}`conda package<condapackage>`.
 
-````{tabs}
+`````{tabs}
    ```{tab} conda package
       **This is the recommended installation method**.
       ````{tabs}
          ```{group-tab} Windows and Linux
             ```bash
             conda create -y -n sleap -c conda-forge -c nvidia -c sleap -c anaconda sleap=1.4.1a2
-            ```  
+            ```
             ```{note}
             - This comes with CUDA to enable GPU support. All you need is to have an NVIDIA GPU and [updated drivers](https://nvidia.com/drivers).
             - If you already have CUDA installed on your system, this will not conflict with it.
@@ -222,7 +221,7 @@ SLEAP can be installed three different ways: via {ref}`conda package<condapackag
                ````{tabs}
                   ```{group-tab} NVIDIA GPU
                      ```bash
-                     conda create --name sleap pip python=3.7.12 cudatoolkit=11.3 cudnn=8.2
+                     conda create --name sleap pip python=3.7.12 cudatoolkit=11.3 cudnn=8.2 -c conda-forge -c nvidia
                      ```
                   ```
                   ```{group-tab} CPU or other GPU
@@ -256,7 +255,7 @@ SLEAP can be installed three different ways: via {ref}`conda package<condapackag
          ```
          ````
    ```
-````
+`````
 
 ## Testing that things are working
 


### PR DESCRIPTION
### Description
Previously, we had left out the channels for the conda environment (for GPU support) when opting to pip install SLEAP. This PR adds the `-c conda-forge` and `-c nvidia` channels to the command.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [x] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated installation documentation for SLEAP software, clarifying installation methods and emphasizing the use of Miniforge or Miniconda.

- **Bug Fixes**
	- Minor formatting corrections made to installation command blocks for improved readability.

- **Documentation**
	- Restructured installation methods section for better clarity.
	- Added detailed instructions for verifying installation success and managing updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->