### PR TITLE
Add pred_as_nan input to TriangulateSession do_action

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -656,6 +656,7 @@ class CommandContext:
         session: Optional[RecordingSession] = None,
         frame_idx: Optional[int] = None,
         instance: Optional[Instance] = None,
+        triangulate_predictions: bool = False,
     ):
         """Triangulates `Instance`s for selected views in a `RecordingSession`."""
         self.execute(
@@ -663,6 +664,7 @@ class CommandContext:
             session=session,
             frame_idx=frame_idx,
             instance=instance,
+            triangulate_predictions=triangulate_predictions,
         )
 
     def openWebsite(self, url):

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3714,7 +3714,9 @@ class TriangulateSession(EditCommand):
 
     @classmethod
     def do_action(
-        cls, context: CommandContext, params: dict, pred_as_nan: bool = False
+        cls,
+        context: CommandContext,
+        params: dict,
     ):
         """Triangulate, reproject, and update instances in a session at a frame index.
 
@@ -3725,10 +3727,9 @@ class TriangulateSession(EditCommand):
                     video's session.
                 frame_idx: The frame index to use. Default is current frame index.
                 instance: The `Instance` object to use. Default is current instance.
-                show_dialog: If True, then show a warning dialog. Default is True.
-                ask_again: If True, then ask for views/instances again. Default is False.
-                pre
-            pred_as_nan: If True, then set predicted values as NaN. Default is False.
+                triangulate_predictions: If True, then include predicted instances in
+                    triangulation. Otherwise, only use user labeled instances. Default
+                    is False.
         """
 
         session: RecordingSession = (
@@ -3749,6 +3750,8 @@ class TriangulateSession(EditCommand):
         instance = params.get("instance", None) or context.state["instance"]
         instance_group = frame_group.get_instance_group(instance)
 
+        triangulate_predictions = params.get("triangulate_predictions", False)
+
         # If instance_group is None, then we will try to triangulate entire frame_group
         instance_groups = (
             [instance_group]
@@ -3767,11 +3770,10 @@ class TriangulateSession(EditCommand):
             return  # Not enough instances for triangulation
 
         # Get the `FrameGroup` of shape  M=include x T x N x 2
-        fg_tensor = frame_group.numpy(instance_groups=instance_groups, pred_as_nan=True)
-
-        # Save the predicted values if pred_as_nan is False
-        if not pred_as_nan:
-            context.state["predicted_values"] = fg_tensor
+        pred_as_nan = not triangulate_predictions
+        fg_tensor = frame_group.numpy(
+            instance_groups=instance_groups, pred_as_nan=pred_as_nan
+        )
 
         # Add extra dimension for number of frames
         frame_group_tensor = np.expand_dims(fg_tensor, axis=1)  # M=include x F=1 xTxNx2
@@ -3792,10 +3794,6 @@ class TriangulateSession(EditCommand):
 
         # Sqeeze back to the original shape
         points_reprojected = np.squeeze(pts_reprojected, axis=1)  # M=include x TxNx2
-
-        # If pred_as_nan is True, set the predictions to NaN
-        if pred_as_nan:
-            points_reprojected[:] = np.nan
 
         # Update or create/insert ("upsert") instance points
         frame_group.upsert_points(

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3711,7 +3711,9 @@ class TriangulateSession(EditCommand):
     topics = [UpdateTopic.frame, UpdateTopic.project_instances]
 
     @classmethod
-    def do_action(cls, context: CommandContext, params: dict):
+    def do_action(
+        cls, context: CommandContext, params: dict, pred_as_nan: bool = False
+    ):
         """Triangulate, reproject, and update instances in a session at a frame index.
 
         Args:
@@ -3723,6 +3725,8 @@ class TriangulateSession(EditCommand):
                 instance: The `Instance` object to use. Default is current instance.
                 show_dialog: If True, then show a warning dialog. Default is True.
                 ask_again: If True, then ask for views/instances again. Default is False.
+                pre
+            pred_as_nan: If True, then set predicted values as NaN. Default is False.
         """
 
         session: RecordingSession = (

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3767,6 +3767,10 @@ class TriangulateSession(EditCommand):
         # Get the `FrameGroup` of shape  M=include x T x N x 2
         fg_tensor = frame_group.numpy(instance_groups=instance_groups, pred_as_nan=True)
 
+        # Save the predicted values if pred_as_nan is False
+        if not pred_as_nan:
+            context.state["predicted_values"] = fg_tensor
+
         # Add extra dimension for number of frames
         frame_group_tensor = np.expand_dims(fg_tensor, axis=1)  # M=include x F=1 xTxNx2
 
@@ -3786,6 +3790,10 @@ class TriangulateSession(EditCommand):
 
         # Sqeeze back to the original shape
         points_reprojected = np.squeeze(pts_reprojected, axis=1)  # M=include x TxNx2
+
+        # If pred_as_nan is True, set the predictions to NaN
+        if pred_as_nan:
+            points_reprojected[:] = np.nan
 
         # Update or create/insert ("upsert") instance points
         frame_group.upsert_points(

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1140,7 +1140,7 @@ def test_TriangulateSession_do_action(multiview_min_session_frame_groups):
     assert not np.allclose(frame_group_np, frame_group.numpy(), equal_nan=True)
 
 
-def test_TriangulateSession_with_predictions(multiview_min_session_frame_groups):
+def test_triangulateSession_with_predictions(multiview_min_session_frame_groups):
     """Test that `triangulateSession` command works with triangulate_predictions"""
 
     labels: Labels = multiview_min_session_frame_groups

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1140,6 +1140,45 @@ def test_TriangulateSession_do_action(multiview_min_session_frame_groups):
     assert not np.allclose(frame_group_np, frame_group.numpy(), equal_nan=True)
 
 
+def test_TriangulateSession_with_predictions(multiview_min_session_frame_groups):
+    """Test that `triangulateSession` command works with triangulate_predictions"""
+
+    labels: Labels = multiview_min_session_frame_groups
+    session: RecordingSession = labels.sessions[0]
+    frame_idx: int = 0
+    frame_group: FrameGroup = session.frame_groups[frame_idx]
+
+    # Test triangulateSession command with triangulate_predictions set to True and False
+
+    # Looping through labeled frames and calling remove_instance on each instance to
+    # ensure only predicted instances in FrameGroup
+    for labeled_frame in frame_group.labeled_frames:
+        for instance in labeled_frame.user_instances:
+            labels.remove_instance(labeled_frame, instance)
+    for instance_group in frame_group.instance_groups:
+        for instance in instance_group.instances:
+            assert isinstance(instance, PredictedInstance)
+    frame_group_np = frame_group.numpy()
+
+    context = CommandContext.from_labels(labels)
+
+    # Test triangulate session with triangulate_predictions set to default (False)
+    context.triangulateSession(session=session, frame_idx=frame_idx)
+    assert np.allclose(frame_group_np, frame_group.numpy(), equal_nan=True)
+
+    # Test triangulate session with triangulate_predictions set to False
+    context.triangulateSession(
+        session=session, frame_idx=frame_idx, triangulate_predictions=False
+    )
+    assert np.allclose(frame_group_np, frame_group.numpy(), equal_nan=True)
+
+    # Test triangulate session with triangulate_predictions set to True
+    context.triangulateSession(
+        session=session, frame_idx=frame_idx, triangulate_predictions=True
+    )
+    assert not np.allclose(frame_group_np, frame_group.numpy(), equal_nan=True)
+
+
 def test_SetSelectedInstanceGroup(multiview_min_session_frame_groups: Labels):
     """Test that setting a new instance group works."""
 

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1103,7 +1103,41 @@ def test_TriangulateSession_do_action(multiview_min_session_frame_groups):
         else:
             assert np.allclose(inst_group_np, inst_group_np_post_tri, equal_nan=True)
 
-    # TODO(LM): Test with `PredictedInstance`s
+    # Test triangulate session with `triangulate_predictions` set to `True` and `False`
+
+    # Looping through labeled frames and calling remove_instance on each instance to
+    # ensure only predicted instances in FrameGroup
+    for labeled_frame in frame_group.labeled_frames:
+        for instance in labeled_frame.user_instances:
+            labels.remove_instance(labeled_frame, instance)
+    for instance_group in frame_group.instance_groups:
+        for instance in instance_group.instances:
+            assert isinstance(instance, PredictedInstance)
+    frame_group_np = frame_group.numpy()
+
+    # Test triangulate session with `triangulate_predictions` set to default
+    TriangulateSession.do_action(context, params)
+    assert np.allclose(frame_group_np, frame_group.numpy(), equal_nan=True)
+
+    # Test triangulate session with `triangulate_predictions` set to `False`
+    params = {
+        "session": session,
+        "frame_idx": frame_idx,
+        "frame_group": frame_group,
+        "triangulate_predictions": False,
+    }
+    TriangulateSession.do_action(context, params)
+    assert np.allclose(frame_group_np, frame_group.numpy(), equal_nan=True)
+
+    # Test triangulate session with `triangulate_predictions` set to `True`
+    params = {
+        "session": session,
+        "frame_idx": frame_idx,
+        "frame_group": frame_group,
+        "triangulate_predictions": True,
+    }
+    TriangulateSession.do_action(context, params)
+    assert not np.allclose(frame_group_np, frame_group.numpy(), equal_nan=True)
 
 
 def test_SetSelectedInstanceGroup(multiview_min_session_frame_groups: Labels):


### PR DESCRIPTION
### Description
Add pred_as_nan input to TriangulateSession do_action, where if true we set predicted values to NaN and if false, we save those predicted values.

### Types of changes

- [ ] Bugfix
- [X] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
