### PR TITLE
MV: Add a general precull iou threshold

### DIFF
--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -194,6 +194,8 @@ optional arguments:
   --tracking.pre_cull_iou_threshold TRACKING.PRE_CULL_IOU_THRESHOLD
                         If non-zero and pre_cull_to_target also set, then use IOU threshold to remove overlapping instances over count *before*
                         tracking. (default: 0)
+  --tracking.pre_cull_general_iou_threshold TRACKING.PRE_CULL_GENERAL_IOU_THRESHOLD
+                        If non-zero, then use IOU threshold to remove overlapping instances regardless of the target count *before* tracking. (default: 0)
   --tracking.post_connect_single_breaks TRACKING.POST_CONNECT_SINGLE_BREAKS
                         If non-zero and target_instance_count is also non-zero, then connect track breaks when exactly one track is lost and exactly
                         one track is spawned in frame. (default: 0)

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -294,7 +294,7 @@ def cull_frame_instances(
     keep_instances = instances_list
 
     # First, let's remove instances over the general IOU threshold
-    if general_iou_threshold:
+    if general_iou_threshold is not None:
 
         # Use NMS to remove overlapping instances over target count
         keep_instances, extra_instances = nms_instances(
@@ -314,7 +314,7 @@ def cull_frame_instances(
     extra_instances = []
 
     # ...using NMS to remove overlapping instances over target count.
-    if iou_threshold:
+    if iou_threshold is not None:
         keep_instances, extra_instances = nms_instances(
             keep_instances,
             iou_threshold=iou_threshold,

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -282,10 +282,11 @@ def cull_frame_instances(
     if not instances_list:
         return
 
+    # List of instances which we'll pare down
+    keep_instances = instances_list
+
     # First, let's remove instances over the general IOU threshold
     if general_iou_threshold:
-        # List of instances which we'll pare down
-        keep_instances = instances_list
 
         # Use NMS to remove overlapping instances over target count
         keep_instances, extra_instances = nms_instances(
@@ -297,33 +298,30 @@ def cull_frame_instances(
         for inst in extra_instances:
             instances_list.remove(inst)
 
-    # Now, let's remove instances over the target count using the target IOU threshold
-    if len(instances_list) > instance_count:
-        # List of instances which we'll pare down
-        keep_instances = instances_list
+    # If we have no restrictions on instance count, return the list.
+    if instance_count is None or len(instances_list) <= instance_count:
+        return instances_list
 
-        # Use NMS to remove overlapping instances over target count
-        if iou_threshold:
-            keep_instances, extra_instances = nms_instances(
-                keep_instances,
-                iou_threshold=iou_threshold,
-                target_count=instance_count,
-            )
-            # Remove the extra instances
-            for inst in extra_instances:
-                instances_list.remove(inst)
+    # Otherwise, let's determine instances to remove over the target count...
+    extra_instances = []
 
-        # Use lower score to remove instances over target count
-        if len(keep_instances) > instance_count:
-            # Sort by ascending score, get target number of instances
-            # from the end of list (i.e., with highest score)
-            extra_instances = sorted(keep_instances, key=operator.attrgetter("score"))[
-                :-instance_count
-            ]
+    # ...using NMS to remove overlapping instances over target count.
+    if iou_threshold:
+        keep_instances, extra_instances = nms_instances(
+            keep_instances,
+            iou_threshold=iou_threshold,
+            target_count=instance_count,
+        )
 
-            # Remove the extra instances
-            for inst in extra_instances:
-                instances_list.remove(inst)
+    # ...using lower score to remove instances over target count.
+    elif len(keep_instances) > instance_count:  # Only true if no iou threshold.
+        extra_instances = sorted(keep_instances, key=operator.attrgetter("score"))[
+            :-instance_count
+        ]
+
+    # Remove the extra instances.
+    for inst in extra_instances:
+        instances_list.remove(inst)
 
     return instances_list
 

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -12,6 +12,9 @@ Main types of functions:
 
 
 """
+
+from __future__ import annotations
+
 import operator
 from collections import defaultdict
 from typing import List, Tuple, Optional, TypeVar, Callable
@@ -256,13 +259,12 @@ def cull_instances(
 
 
 def cull_frame_instances(
-    instances_list: List[InstanceType],
-    instance_count: int,
-    iou_threshold: Optional[float] = None,
-    general_iou_threshold: Optional[float] = None,
-) -> List["LabeledFrame"]:
-    """
-    Removes instances (for single frame) over instance per frame threshold.
+    instances_list: list[InstanceType],
+    instance_count: int | None = None,
+    iou_threshold: float | None = None,
+    general_iou_threshold: float | None = None,
+) -> list[InstanceType]:
+    """Removes instances (for single frame) over instance per frame threshold.
 
     Args:
         instances_list: The list of instances for a single frame.

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 import operator
 from collections import defaultdict
-from typing import List, Tuple, Optional, TypeVar, Callable
+from typing import Callable, List, Optional, Tuple, TypeVar
 
 import attr
 import numpy as np
 from scipy.optimize import linear_sum_assignment
 
-from sleap import PredictedInstance, Instance, Track
+from sleap import Instance, LabeledFrame, PredictedInstance, Track
 from sleap.nn import utils
 
 InstanceType = TypeVar("InstanceType", Instance, PredictedInstance)
@@ -113,11 +113,27 @@ def greedy_matching(cost_matrix: np.ndarray) -> List[Tuple[int, int]]:
 
 
 def nms_instances(
-    instances, iou_threshold, target_count=None
-) -> Tuple[List[PredictedInstance], List[PredictedInstance]]:
+    instances: list[PredictedInstance],
+    iou_threshold: float | None,
+    target_count: int | None = None,
+) -> tuple[list[PredictedInstance], list[PredictedInstance]]:
+    """Finds `Instance`s to keep using non-maximum suppression.
+
+    Args:
+        instances: The list of `PredictedInstance` objects to filter.
+        iou_threshold: The IOU threshold for suppression. If None, then no suppression
+            is applied and `PredictedInstance.score` is used to determine which
+            instances to keep.
+        target_count: The maximum number of instances to keep. Default is None,
+            which means all instances are kept.
+
+    Returns:
+        A tuple of two lists: the first list contains the instances to keep, and
+        the second list contains the instances to remove.
+    """
     boxes = np.array([inst.bounding_box for inst in instances])
     scores = np.array([inst.score for inst in instances])
-    picks = nms_fast(boxes, scores, iou_threshold, target_count)
+    picks: list[int] = nms_fast(boxes, scores, iou_threshold, target_count)
 
     to_keep = [inst for i, inst in enumerate(instances) if i in picks]
     to_remove = [inst for i, inst in enumerate(instances) if i not in picks]
@@ -136,18 +152,22 @@ def nms_fast(
     https://www.pyimagesearch.com/2015/02/16/faster-non-maximum-suppression-python/
 
     Args:
-        boxes: The bounding boxes to filter. Shape is (N, 4) where N is the number of
-            boxes. Each box is represented by its coordinates in the format
-            (x1, y1, x2, y2) where (x1, y1) is the top-left corner and (x2, y2) is the
-            bottom-right corner.
+        boxes: The bounding boxes to filter. Each box is represented by its coordinates
+            in the format (x1, y1, x2, y2) where (x1, y1) is the corner closest to
+            (0, 0) and (x2, y2) is the corner farthest from (0, 0). Shape is (N, 4)
+            where N is the number of boxes.
         scores: The scores for each bounding box (e.g., confidence scores associated
-            with `PredictedInstance`).
-        iou_threshold: The IOU threshold for suppression.
+            with `PredictedInstance`). Scores are used to pick which boxes to evaluate
+            first (i.e. the highest scoring box is never removed). Shape is (N,) where
+            N is the number of boxes.
+        iou_threshold: The IOU threshold for suppression. This is a soft threshold since
+            boxes are added back if there are too few boxes picked (determined by
+            `target_count`).
         target_count: The maximum number of boxes to keep. Default is None, which
-            means all boxes are kept.
+            means only boxes with IOU less than the threshold are kept.
 
     Returns:
-        A list of indices of the boxes that have an IOU greater than the IOU threshold.
+        A list of indices of the boxes that have an IOU less than the IOU threshold.
     """
     # Return an empty list if no boxes.
     if len(boxes) == 0:
@@ -210,12 +230,11 @@ def nms_fast(
 
 
 def cull_instances(
-    frames: List["LabeledFrame"],
+    frames: List[LabeledFrame],
     instance_count: int,
     iou_threshold: Optional[float] = None,
-):
-    """
-    Removes instances from frames over instance per frame threshold.
+) -> None:
+    """Removes instances from frames over instance per frame threshold.
 
     Args:
         frames: The list of `LabeledFrame` objects with predictions.

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -153,12 +153,11 @@ def nms_fast(
     if len(boxes) == 0:
         return []
 
-    # if we already have fewer boxes than the target count, return all boxes
+    # Return all boxes (if target_count is None or greater than the number of boxes).
     if target_count and len(boxes) < target_count:
         return list(range(len(boxes)))
 
-    # if the bounding boxes coordinates are integers, convert them to floats --
-    # this is important since we'll be doing a bunch of divisions
+    # Convert boxes to float if they are integers (for higher precision division).
     if boxes.dtype.kind == "i":
         boxes = boxes.astype("float")
 
@@ -184,42 +183,35 @@ def nms_fast(
 
         # we want to add the best box which is the last box in sorted list
         picked_box_idx = idxs[-1]
-
-        # last = len(idxs) - 1
-        # i = idxs[last]
         picked_idxs.append(picked_box_idx)
 
-        # find the largest (x, y) coordinates for the start of
-        # the bounding box and the smallest (x, y) coordinates
-        # for the end of the bounding box
+        # Find the smallest (x, y) coordinates for corner 1 of the bounding box.
         xx1 = np.maximum(x1[picked_box_idx], x1[idxs[:-1]])
         yy1 = np.maximum(y1[picked_box_idx], y1[idxs[:-1]])
+
+        # Find the largest (x, y) coordinates for corner 2 of the bounding box.
         xx2 = np.minimum(x2[picked_box_idx], x2[idxs[:-1]])
         yy2 = np.minimum(y2[picked_box_idx], y2[idxs[:-1]])
 
-        # compute the width and height of the bounding box
+        # Compute the ratio of overlap.
         w = np.maximum(0, xx2 - xx1 + 1)
         h = np.maximum(0, yy2 - yy1 + 1)
+        overlap = (w * h) / areas[idxs[:-1]]
 
-        # compute the ratio of overlap
-        overlap = (w * h) / area[idxs[:-1]]
-
-        # find boxes with iou over threshold
+        # Find and remove boxes with iou over threshold.
         nms_for_new_box = np.where(overlap > iou_threshold)[0]
         nms_idxs.extend(list(idxs[nms_for_new_box]))
 
         # delete new box (last in list) plus nms boxes
         idxs = np.delete(idxs, nms_for_new_box)[:-1]
 
-    # if we're below the target number of boxes, add some back
+    # Add some boxes back if we have too few picked boxes.
     if target_count and nms_idxs and len(picked_idxs) < target_count:
-        # sort by descending score
+        # Add back boxes with the highest scores.
         nms_idxs.sort(key=lambda idx: -scores[idx])
-
         add_back_count = min(len(nms_idxs), len(picked_idxs) - target_count)
         picked_idxs.extend(nms_idxs[:add_back_count])
 
-    # return the list of picked boxes
     return picked_idxs
 
 

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -125,10 +125,31 @@ def nms_instances(
     return to_keep, to_remove
 
 
-def nms_fast(boxes, scores, iou_threshold, target_count=None) -> List[int]:
-    """https://www.pyimagesearch.com/2015/02/16/faster-non-maximum-suppression-python/"""
+def nms_fast(
+    boxes: np.ndarray,
+    scores: np.ndarray,
+    iou_threshold: float,
+    target_count: int | None = None,
+) -> list[int]:
+    """Finds indices of boxes to keep using non-maximum suppression.
 
-    # if there are no boxes, return an empty list
+    https://www.pyimagesearch.com/2015/02/16/faster-non-maximum-suppression-python/
+
+    Args:
+        boxes: The bounding boxes to filter. Shape is (N, 4) where N is the number of
+            boxes. Each box is represented by its coordinates in the format
+            (x1, y1, x2, y2) where (x1, y1) is the top-left corner and (x2, y2) is the
+            bottom-right corner.
+        scores: The scores for each bounding box (e.g., confidence scores associated
+            with `PredictedInstance`).
+        iou_threshold: The IOU threshold for suppression.
+        target_count: The maximum number of boxes to keep. Default is None, which
+            means all boxes are kept.
+
+    Returns:
+        A list of indices of the boxes that have an IOU greater than the IOU threshold.
+    """
+    # Return an empty list if no boxes.
     if len(boxes) == 0:
         return []
 
@@ -268,16 +289,17 @@ def cull_frame_instances(
 
     Args:
         instances_list: The list of instances for a single frame.
-        instance_count: The maximum number of instances we want per frame.
+        instance_count: The maximum number of instances we want per frame. If None, then
+            no limit is applied. Default is None.
         iou_threshold: Intersection over Union (IOU) threshold to use when removing
-            overlapping instances over target count; if None, then only use score to
-            determine which instances to remove.
+            overlapping instances over `instance_count`. If None, then only use score to
+            determine which instances to remove over `instance_count`. Default is None.
         general_iou_threshold: Intersection over Union (IOU) threshold to use when
-            removing overlapping instances - regardless of count. If None, then only use
-            score to determine which instances to remove.
+            removing overlapping instances - regardless of `instance_count`. If None,
+            then no general IOU threshold is applied. Default is None.
 
     Returns:
-        Updated list of frames, also modifies frames in place.
+        Updated `instances_list` (modified in-place).
     """
     if not instances_list:
         return

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -161,27 +161,20 @@ def nms_fast(
     if boxes.dtype.kind == "i":
         boxes = boxes.astype("float")
 
-    # initialize the list of picked indexes
-    picked_idxs = []
-
-    # init list of boxes removed by nms
-    nms_idxs = []
-
-    # grab the coordinates of the bounding boxes
-    x1 = boxes[:, 0]
-    y1 = boxes[:, 1]
+    # Grab the coordinates of all the bounding boxes.
+    x1 = boxes[:, 0]  # x1 <= x2
+    y1 = boxes[:, 1]  # y1 <= y2
     x2 = boxes[:, 2]
     y2 = boxes[:, 3]
 
-    # compute the area of the bounding boxes and sort the bounding
-    # boxes by their scores
-    area = (x2 - x1 + 1) * (y2 - y1 + 1)
-    idxs = np.argsort(scores)
+    # Compute the area of all the bounding boxes.
+    areas = (x2 - x1 + 1) * (y2 - y1 + 1)
 
-    # keep looping while some indexes still remain in the indexes list
-    while len(idxs) > 0:
-
-        # we want to add the best box which is the last box in sorted list
+    picked_idxs = []
+    nms_idxs = []
+    idxs = np.argsort(scores)  # The higher-scoring boxes are at the end of the list.
+    while len(idxs) > 0:  # Each iteration, we remove the last box in `idxs`.
+        # Get highest score box (last in list) and add to picked boxes.
         picked_box_idx = idxs[-1]
         picked_idxs.append(picked_box_idx)
 
@@ -200,10 +193,11 @@ def nms_fast(
 
         # Find and remove boxes with iou over threshold.
         nms_for_new_box = np.where(overlap > iou_threshold)[0]
-        nms_idxs.extend(list(idxs[nms_for_new_box]))
+        nms_idxs.extend(list(idxs[nms_for_new_box]))  # In case we need to add back.
+        idxs = np.delete(idxs, nms_for_new_box)
 
-        # delete new box (last in list) plus nms boxes
-        idxs = np.delete(idxs, nms_for_new_box)[:-1]
+        # Remove the last box (the one we just picked).
+        idxs = idxs[:-1]
 
     # Add some boxes back if we have too few picked boxes.
     if target_count and nms_idxs and len(picked_idxs) < target_count:

--- a/sleap/nn/tracker/components.py
+++ b/sleap/nn/tracker/components.py
@@ -259,6 +259,7 @@ def cull_frame_instances(
     instances_list: List[InstanceType],
     instance_count: int,
     iou_threshold: Optional[float] = None,
+    general_iou_threshold: Optional[float] = None,
 ) -> List["LabeledFrame"]:
     """
     Removes instances (for single frame) over instance per frame threshold.
@@ -266,9 +267,12 @@ def cull_frame_instances(
     Args:
         instances_list: The list of instances for a single frame.
         instance_count: The maximum number of instances we want per frame.
-        iou_threshold: Intersection over Union (IOU) threshold to use when
-            removing overlapping instances over target count; if None, then
-            only use score to determine which instances to remove.
+        iou_threshold: Intersection over Union (IOU) threshold to use when removing
+            overlapping instances over target count; if None, then only use score to
+            determine which instances to remove.
+        general_iou_threshold: Intersection over Union (IOU) threshold to use when
+            removing overlapping instances - regardless of count. If None, then only use
+            score to determine which instances to remove.
 
     Returns:
         Updated list of frames, also modifies frames in place.
@@ -276,6 +280,22 @@ def cull_frame_instances(
     if not instances_list:
         return
 
+    # First, let's remove instances over the general IOU threshold
+    if general_iou_threshold:
+        # List of instances which we'll pare down
+        keep_instances = instances_list
+
+        # Use NMS to remove overlapping instances over target count
+        keep_instances, extra_instances = nms_instances(
+            keep_instances,
+            iou_threshold=general_iou_threshold,
+        )
+
+        # Remove the extra instances
+        for inst in extra_instances:
+            instances_list.remove(inst)
+
+    # Now, let's remove instances over the target count using the target IOU threshold
     if len(instances_list) > instance_count:
         # List of instances which we'll pare down
         keep_instances = instances_list

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -827,6 +827,7 @@ class Tracker(BaseTracker):
         target_instance_count: int = 0,
         pre_cull_to_target: bool = False,
         pre_cull_iou_threshold: Optional[float] = None,
+        pre_cull_general_iou_threshold: Optional[float] = None,
         # Post-tracking options to connect broken tracks
         post_connect_single_breaks: bool = False,
         # TODO: deprecate these post-tracking cleaning options
@@ -878,13 +879,18 @@ class Tracker(BaseTracker):
             )
 
         pre_cull_function = None
-        if target_instance_count and pre_cull_to_target:
+        if (
+            target_instance_count
+            and pre_cull_to_target
+            or pre_cull_general_iou_threshold
+        ):
 
             def pre_cull_function(inst_list):
                 cull_frame_instances(
                     inst_list,
                     instance_count=target_instance_count,
                     iou_threshold=pre_cull_iou_threshold,
+                    general_iou_threshold=pre_cull_general_iou_threshold,
                 )
 
         tracker_obj = cls(

--- a/sleap/nn/tracking.py
+++ b/sleap/nn/tracking.py
@@ -967,6 +967,14 @@ class Tracker(BaseTracker):
         )
         options.append(option)
 
+        option = dict(name="pre_cull_general_iou_threshold", default=0)
+        option["type"] = float
+        option["help"] = (
+            "If non-zero, then use IOU threshold to remove overlapping instances "
+            "regardless of the target count *before* tracking."
+        )
+        options.append(option)
+
         option = dict(name="post_connect_single_breaks", default=0)
         option["type"] = int
         option["help"] = (

--- a/tests/nn/test_inference.py
+++ b/tests/nn/test_inference.py
@@ -1408,12 +1408,19 @@ def test_retracking(
     assert new_inst.track != old_inst.track
 
 
-@pytest.mark.parametrize("cmd", ["--max_instances 1", "-n 1"])
-def test_valid_cli_command(cmd):
+def test_valid_cli_command():
     """Test that sleap-track CLI command is valid."""
     parser = _make_cli_parser()
+
+    for cmd in ["--max_instances 1", "-n 1"]:
+        args = parser.parse_args(cmd.split())
+        assert args.max_instances == 1
+
+    cmd = "--tracking.pre_cull_general_iou_threshold 0.5"
     args = parser.parse_args(cmd.split())
-    assert args.max_instances == 1
+    assert getattr(args, "tracking.pre_cull_general_iou_threshold") == 0.5
+    tracker = _make_tracker_from_cli(args)
+    assert tracker.pre_cull_function is not None
 
 
 def test_make_predictor_from_cli(

--- a/tests/nn/test_tracker_components.py
+++ b/tests/nn/test_tracker_components.py
@@ -6,7 +6,7 @@ from sleap.io.dataset import Labels
 from sleap.nn.tracker.components import (
     FrameMatches,
     cull_instances,
-    FrameMatches,
+    cull_frame_instances,
     greedy_matching,
     nms_fast,
     nms_instances,
@@ -41,6 +41,125 @@ def test_cull_instances(centered_pair_predictions):
 
     for frame in frames:
         assert len(frame.instances) == 1
+
+
+def test_cull_frame_instances_no_target(centered_pair_predictions: Labels):
+    labels = centered_pair_predictions
+    video = labels.video
+    labeled_frame: LabeledFrame = labels.find_last(video=video, frame_idx=1098)
+
+    # There will never be an IOU greater than 1, so expect all instances back.
+    assert len(labeled_frame.instances) == 3
+    cull_frame_instances(
+        instances_list=labeled_frame.instances, general_iou_threshold=1
+    )
+    assert len(labeled_frame.instances) == 3
+
+    # There is an instance with an IOU of 1 though, so expect 2 instances back.
+    assert len(labeled_frame.instances) == 3
+    cull_frame_instances(
+        instances_list=labeled_frame.instances, general_iou_threshold=0.999999999999999
+    )
+    assert len(labeled_frame.instances) == 2
+
+    # There is also an instance with an IOU of 0.67, so expect 1 instance back.
+    assert len(labeled_frame.instances) == 2
+    cull_frame_instances(
+        instances_list=labeled_frame.instances, general_iou_threshold=0.6
+    )
+    assert len(labeled_frame.instances) == 1
+
+
+def test_cull_frame_instances_with_target(centered_pair_predictions: Labels):
+    labels = centered_pair_predictions
+    video = labels.video
+    labeled_frame: LabeledFrame = labels.find_last(video=video, frame_idx=1098)
+
+    # Target count equal to the number of instances. Expect all instances back.
+    target_count = 3
+
+    # No IOU threshold.
+    assert len(labeled_frame.instances) == target_count
+    cull_frame_instances(instances_list=labeled_frame.instances, instance_count=3)
+    assert len(labeled_frame.instances) == target_count
+
+    # With IOU threshold.
+    assert len(labeled_frame.instances) == target_count
+    cull_frame_instances(
+        instances_list=labeled_frame.instances,
+        instance_count=target_count,
+        iou_threshold=0.0,
+    )
+    assert len(labeled_frame.instances) == target_count
+
+    # Target count less than the number of instances. Expect target count instances back
+
+    # Without IOU.
+    target_count = 2
+    assert len(labeled_frame.instances) == 3
+    cull_frame_instances(
+        instances_list=labeled_frame.instances, instance_count=target_count
+    )
+    assert len(labeled_frame.instances) == target_count
+
+    # With IOU.
+    target_count = 1
+    assert len(labeled_frame.instances) == 2
+    cull_frame_instances(
+        instances_list=labeled_frame.instances,
+        instance_count=target_count,
+        iou_threshold=0.0,
+    )
+    assert len(labeled_frame.instances) == target_count
+
+    # Test with both target count and general IOU threshold. Switching frames.
+
+    labeled_frame: LabeledFrame = labels.find_last(video=video, frame_idx=1095)
+
+    # No instances removed.
+
+    target_count = 4
+    general_iou_threshold = 1
+
+    # Without non-general IOU.
+    assert len(labeled_frame.instances) == target_count
+    cull_frame_instances(
+        instances_list=labeled_frame.instances,
+        instance_count=target_count,
+        general_iou_threshold=general_iou_threshold,
+    )
+
+    # With non-general IOU.
+    assert len(labeled_frame.instances) == target_count
+    cull_frame_instances(
+        instances_list=labeled_frame.instances,
+        instance_count=target_count,
+        general_iou_threshold=general_iou_threshold,
+        iou_threshold=0.0,
+    )
+    assert len(labeled_frame.instances) == target_count
+
+    # Instance removed via general IOU.
+    target_count = 4
+    general_iou_threshold = 0.999999999999999
+    assert len(labeled_frame.instances) == 4
+    cull_frame_instances(
+        instances_list=labeled_frame.instances,
+        instance_count=target_count,
+        general_iou_threshold=general_iou_threshold,
+    )
+    assert len(labeled_frame.instances) == target_count - 1
+
+    # Instance removed via non-general IOU.
+    target_count = 2
+    iou_threshold = 0.0
+    assert len(labeled_frame.instances) == 3
+    cull_frame_instances(
+        instances_list=labeled_frame.instances,
+        instance_count=target_count,
+        iou_threshold=iou_threshold,
+    )
+    assert len(labeled_frame.instances) == target_count
 
 
 def test_nms():

--- a/tests/nn/test_tracker_components.py
+++ b/tests/nn/test_tracker_components.py
@@ -62,11 +62,20 @@ def test_cull_frame_instances_no_target(centered_pair_predictions: Labels):
     )
     assert len(labeled_frame.instances) == 2
 
+    # Test with Tracker
+
+    tracker: Tracker = Tracker.make_tracker_by_name(
+        pre_cull_general_iou_threshold=0.999999999999999,
+    )
+    assert tracker.pre_cull_function is not None
+
     # There is also an instance with an IOU of 0.67, so expect 1 instance back.
     assert len(labeled_frame.instances) == 2
-    cull_frame_instances(
-        instances_list=labeled_frame.instances, general_iou_threshold=0.6
+    tracker: Tracker = Tracker.make_tracker_by_name(
+        pre_cull_general_iou_threshold=0.6,
     )
+    assert tracker.pre_cull_function is not None
+    tracker.pre_cull_function(inst_list=labeled_frame.instances)
     assert len(labeled_frame.instances) == 1
 
 
@@ -112,53 +121,63 @@ def test_cull_frame_instances_with_target(centered_pair_predictions: Labels):
     )
     assert len(labeled_frame.instances) == target_count
 
-    # Test with both target count and general IOU threshold. Switching frames.
+    # Test with both target count and general IOU threshold. Switching frames and using
+    # Tracker.
 
     labeled_frame: LabeledFrame = labels.find_last(video=video, frame_idx=1095)
+    tracker: Tracker = Tracker.make_tracker_by_name(target_instance_count=target_count)
+    assert tracker.pre_cull_function is None
 
     # No instances removed.
 
     target_count = 4
     general_iou_threshold = 1
+    tracker: Tracker = Tracker.make_tracker_by_name(
+        target_instance_count=target_count,
+        pre_cull_general_iou_threshold=general_iou_threshold,
+    )
+    assert tracker.pre_cull_function is not None
 
     # Without non-general IOU.
     assert len(labeled_frame.instances) == target_count
-    cull_frame_instances(
-        instances_list=labeled_frame.instances,
-        instance_count=target_count,
-        general_iou_threshold=general_iou_threshold,
-    )
+    tracker.pre_cull_function(inst_list=labeled_frame.instances)
+    assert len(labeled_frame.instances) == target_count
 
     # With non-general IOU.
+    iou_threshold = 0.0
     assert len(labeled_frame.instances) == target_count
-    cull_frame_instances(
-        instances_list=labeled_frame.instances,
-        instance_count=target_count,
-        general_iou_threshold=general_iou_threshold,
-        iou_threshold=0.0,
+    tracker: Tracker = Tracker.make_tracker_by_name(
+        target_instance_count=target_count,
+        pre_cull_iou_threshold=iou_threshold,
+        pre_cull_general_iou_threshold=general_iou_threshold,
     )
+    assert tracker.pre_cull_function is not None
+    tracker.pre_cull_function(inst_list=labeled_frame.instances)
     assert len(labeled_frame.instances) == target_count
 
     # Instance removed via general IOU.
     target_count = 4
     general_iou_threshold = 0.999999999999999
     assert len(labeled_frame.instances) == 4
-    cull_frame_instances(
-        instances_list=labeled_frame.instances,
-        instance_count=target_count,
-        general_iou_threshold=general_iou_threshold,
+    tracker: Tracker = Tracker.make_tracker_by_name(
+        target_instance_count=target_count,
+        pre_cull_general_iou_threshold=general_iou_threshold,
     )
+    assert tracker.pre_cull_function is not None
+    tracker.pre_cull_function(inst_list=labeled_frame.instances)
     assert len(labeled_frame.instances) == target_count - 1
 
     # Instance removed via non-general IOU.
     target_count = 2
     iou_threshold = 0.0
     assert len(labeled_frame.instances) == 3
-    cull_frame_instances(
-        instances_list=labeled_frame.instances,
-        instance_count=target_count,
-        iou_threshold=iou_threshold,
+    tracker: Tracker = Tracker.make_tracker_by_name(
+        target_instance_count=target_count,
+        pre_cull_to_target=True,
+        pre_cull_iou_threshold=iou_threshold,
     )
+    assert tracker.pre_cull_function is not None
+    tracker.pre_cull_function(inst_list=labeled_frame.instances)
     assert len(labeled_frame.instances) == target_count
 
 

--- a/tests/nn/test_tracker_components.py
+++ b/tests/nn/test_tracker_components.py
@@ -23,7 +23,7 @@ from sleap.skeleton import Skeleton
 @pytest.mark.parametrize("count", [0, 2])
 def test_tracker_by_name(tracker, similarity, match, count):
     t = Tracker.make_tracker_by_name(
-        "flow", "instance", "greedy", clean_instance_count=2
+        tracker=tracker, similarity=similarity, match=match, clean_instance_count=count
     )
     t.track([])
     t.final_pass([])

--- a/tests/nn/test_tracker_components.py
+++ b/tests/nn/test_tracker_components.py
@@ -1,16 +1,17 @@
-import pytest
 import numpy as np
+import pytest
 
-from sleap.nn.tracking import Tracker
+from sleap.instance import LabeledFrame, PredictedInstance
+from sleap.io.dataset import Labels
 from sleap.nn.tracker.components import (
-    nms_instances,
-    nms_fast,
+    FrameMatches,
     cull_instances,
     FrameMatches,
     greedy_matching,
+    nms_fast,
+    nms_instances,
 )
-
-from sleap.instance import PredictedInstance
+from sleap.nn.tracking import Tracker
 from sleap.skeleton import Skeleton
 
 


### PR DESCRIPTION
### Description
Currently, all our IOU thresholds for culling instances are only used (as a scoring mechanism - not really a threshold) to cull instances OVER the target count. However, it would be nice to have an actual IOU "threshold" that will cull instances over this IOU no matter the instance count.

This PR adds a `tracking.pre_cull_general_iou_threshold`  which does just that. Any instances that have an IOU past the specified `tracking.pre_cull_general_iou_threshold` will be removed - essentially eliminating cases where we see double detections.

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #2140

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
