### PR TITLE
Goto instance change key binding

### DIFF
--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -19,6 +19,7 @@ goto next labeled: Alt+Right
 goto prev suggestion: Shift+Space
 goto prev labeled: Alt+Left
 goto next instance change: Ctrl+Shift+Right
+goto prev instance change: Ctrl+Shift+Left
 learning: Ctrl+L
 mark frame: Ctrl+M
 new: Ctrl+N

--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -18,6 +18,7 @@ goto next user: Ctrl+U
 goto next labeled: Alt+Right
 goto prev suggestion: Shift+Space
 goto prev labeled: Alt+Left
+goto next instance change: Ctrl+Shift+Right
 learning: Ctrl+L
 mark frame: Ctrl+M
 new: Ctrl+N

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -578,8 +578,15 @@ class MainWindow(QMainWindow):
         add_menu_item(
             goMenu,
             "goto next instance change",
-            "Next Instance Change",
+            "Next Instance Count Change",
             self.commands.nextInstanceChange,
+        )
+
+        add_menu_item(
+            goMenu,
+            "goto prev instance change",
+            "Previous Instance Count Change",
+            self.commands.prevInstanceChange,
         )
 
         goMenu.addSeparator()

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -578,7 +578,7 @@ class MainWindow(QMainWindow):
         add_menu_item(
             goMenu,
             "goto next instance change",
-            "Next Instance Change",
+            "Next Instance Count Change",
             self.commands.nextInstanceChange,
         )
 

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -575,6 +575,13 @@ class MainWindow(QMainWindow):
             self.commands.nextTrackFrame,
         )
 
+        add_menu_item(
+            goMenu,
+            "goto next instance change",
+            "Next Instance Change",
+            self.commands.nextInstanceChange,
+        )
+
         goMenu.addSeparator()
 
         def next_vid():

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1613,17 +1613,43 @@ class GoNextInstanceChange(NavCommand):
 
         # Get current number of instances
         current_frame = context.labels.find(video, cur_idx, return_new=True)[0]
-        current_instance_count = len(current_frame.instances)
+        current_instance_count = len(current_frame.instances_to_show)
 
         # Get all labeled frames after current frame
-        later_frames = context.labels.frames(video, from_frame_idx=cur_idx + 1)
-        later_frames_list = list(later_frames)
+        for frame in range(cur_idx + 1, video.frames):
+            if (
+                len(
+                    context.labels.find(video, frame, return_new=True)[
+                        0
+                    ].instances_to_show
+                )
+                != current_instance_count
+            ):
+                cls.go_to(context, frame)
+                break
 
-        # Find first frame where instance count changes
-        for frame in later_frames_list:
-            instance_count = len(frame.instances)
-            if instance_count != current_instance_count:
-                cls.go_to(context, frame.frame_idx)
+
+class GoPrevInstanceChange(NavCommand):
+    @classmethod
+    def do_action(cls, context: CommandContext, params: dict):
+        video = context.state["video"]
+        cur_idx = context.state["frame_idx"]
+
+        # Get current number of instances
+        current_frame = context.labels.find(video, cur_idx, return_new=True)[0]
+        current_instance_count = len(current_frame.instances_to_show)
+
+        # Get all labeled frames after current frame
+        for frame in range(cur_idx - 1, -1, -1):
+            if (
+                len(
+                    context.labels.find(video, frame, return_new=True)[
+                        0
+                    ].instances_to_show
+                )
+                != current_instance_count
+            ):
+                cls.go_to(context, frame)
                 break
 
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -636,6 +636,10 @@ class CommandContext:
         """Go to next frame where number of instances changes."""
         self.execute(GoNextInstanceChange)
 
+    def prevInstanceChange(self):
+        """Goes to previous frame with different instance count."""
+        self.execute(GoPrevInstanceChange)
+
 
 # File Commands
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -632,6 +632,10 @@ class CommandContext:
         """Open the current prerelease version."""
         self.execute(OpenPrereleaseVersion)
 
+    def nextInstanceChange(self):
+        """Go to next frame where number of instances changes."""
+        self.execute(GoNextInstanceChange)
+
 
 # File Commands
 
@@ -1599,6 +1603,28 @@ class GoNextSuggestedFrame(NavCommand):
 
 class GoPrevSuggestedFrame(GoNextSuggestedFrame):
     seek_direction = -1
+
+
+class GoNextInstanceChange(NavCommand):
+    @classmethod
+    def do_action(cls, context: CommandContext, params: dict):
+        video = context.state["video"]
+        cur_idx = context.state["frame_idx"]
+
+        # Get current number of instances
+        current_frame = context.labels.find(video, cur_idx, return_new=True)[0]
+        current_instance_count = len(current_frame.instances)
+
+        # Get all labeled frames after current frame
+        later_frames = context.labels.frames(video, from_frame_idx=cur_idx + 1)
+        later_frames_list = list(later_frames)
+
+        # Find first frame where instance count changes
+        for frame in later_frames_list:
+            instance_count = len(frame.instances)
+            if instance_count != current_instance_count:
+                cls.go_to(context, frame.frame_idx)
+                break
 
 
 class GoNextTrackFrame(NavCommand):

--- a/sleap/gui/shortcuts.py
+++ b/sleap/gui/shortcuts.py
@@ -41,6 +41,7 @@ class Shortcuts(object):
         "goto next suggestion",
         "goto prev suggestion",
         "goto next track spawn",
+        "goto next instance change",
         "show instances",
         "show labels",
         "show edges",

--- a/sleap/gui/shortcuts.py
+++ b/sleap/gui/shortcuts.py
@@ -42,6 +42,7 @@ class Shortcuts(object):
         "goto prev suggestion",
         "goto next track spawn",
         "goto next instance change",
+        "goto prev instance change",
         "show instances",
         "show labels",
         "show edges",

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -22,6 +22,7 @@ from sleap.gui.commands import (
     SaveProjectAs,
     DeleteFrameLimitPredictions,
     get_new_version_filename,
+    GoNextInstanceChange,
 )
 from sleap.instance import Instance, LabeledFrame
 from sleap.io.convert import default_analysis_filename
@@ -1046,3 +1047,32 @@ def test_newInstance(qtbot, centered_pair_predictions: Labels):
     )
     diff = np.nan_to_num(new_inst.numpy() - copy_instance.numpy(), nan=offset)
     assert np.all(diff == offset)
+
+
+def test_go_next_instance_change(centered_pair_predictions: Labels):
+    """Test that goto next instance change command works correctly."""
+    # Set up test data
+    labels = centered_pair_predictions
+    video = labels.videos[0]
+    
+    # Create frames with different numbers of instances
+    lf1 = labels[0]  # First frame (already exists)
+    initial_count = len(lf1.instances)
+    
+    # Create a new frame with different number of instances
+    lf2 = LabeledFrame(frame_idx=lf1.frame_idx + 10, video=video)
+    new_instance = Instance(labels.skeleton)  # Create one new instance
+    lf2.add_instance(new_instance)
+    labels.add_frame(lf2)
+    
+    # Set up command context
+    context = CommandContext.from_labels(labels)
+    context.state["video"] = video
+    context.state["frame_idx"] = lf1.frame_idx
+    
+    # Execute the command
+    context.execute(GoNextInstanceChange)
+    
+    # Verify that we moved to the frame with different instance count
+    assert context.state["frame_idx"] == lf2.frame_idx
+    assert len(labels.find(video, lf2.frame_idx)[0].instances) != initial_count

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1057,13 +1057,11 @@ def test_go_next_instance_change(centered_pair_predictions: Labels):
     video = labels.videos[0]
 
     # Create frames with different numbers of instances
-    lf1 = context.labels.find(video, 0, return_new=True)[
-        0
-    ]  # First frame (already exists)
+    lf1 = labels.find(video, 0, return_new=True)[0]  # First frame (already exists)
     initial_count = len(lf1.instances_to_show)
 
     for frame_idx in range(1, video.num_frames):
-        lf = context.labels.find(video, frame_idx, return_new=True)[0]
+        lf = labels.find(video, frame_idx, return_new=True)[0]
         if len(lf.instances_to_show) != initial_count:
             skipped_to_frame = lf.frame_idx
             break
@@ -1088,13 +1086,13 @@ def test_go_prev_instance_change(centered_pair_predictions: Labels):
     video = labels.videos[0]
 
     # Create frames with different numbers of instances
-    lf1 = context.labels.find(video, video.num_frames - 1, return_new=True)[
+    lf1 = labels.find(video, video.num_frames - 1, return_new=True)[
         0
     ]  # First frame (already exists)
     initial_count = len(lf1.instances_to_show)
 
     for frame_idx in range(video.num_frames - 1, 0, -1):
-        lf = context.labels.find(video, frame_idx, return_new=True)[0]
+        lf = labels.find(video, frame_idx, return_new=True)[0]
         if len(lf.instances_to_show) != initial_count:
             skipped_to_frame = lf.frame_idx
             break

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1057,7 +1057,9 @@ def test_go_next_instance_change(centered_pair_predictions: Labels):
     video = labels.videos[0]
 
     # Create frames with different numbers of instances
-    lf1 = context.labels.find(video, 0, return_new=True)[0]  # First frame (already exists)
+    lf1 = context.labels.find(video, 0, return_new=True)[
+        0
+    ]  # First frame (already exists)
     initial_count = len(lf1.instances_to_show)
 
     for frame_idx in range(1, video.num_frames):
@@ -1078,6 +1080,7 @@ def test_go_next_instance_change(centered_pair_predictions: Labels):
     assert context.state["frame_idx"] == skipped_to_frame
     assert len(labels.find(video, skipped_to_frame)[0].instances) != initial_count
 
+
 def test_go_prev_instance_change(centered_pair_predictions: Labels):
     """Test that goto next instance change command works correctly."""
     # Set up test data
@@ -1085,7 +1088,9 @@ def test_go_prev_instance_change(centered_pair_predictions: Labels):
     video = labels.videos[0]
 
     # Create frames with different numbers of instances
-    lf1 = context.labels.find(video, video.num_frames - 1, return_new=True)[0]  # First frame (already exists)
+    lf1 = context.labels.find(video, video.num_frames - 1, return_new=True)[
+        0
+    ]  # First frame (already exists)
     initial_count = len(lf1.instances_to_show)
 
     for frame_idx in range(video.num_frames - 1, 0, -1):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -23,6 +23,7 @@ from sleap.gui.commands import (
     DeleteFrameLimitPredictions,
     get_new_version_filename,
     GoNextInstanceChange,
+    GoPrevInstanceChange,
 )
 from sleap.instance import Instance, LabeledFrame
 from sleap.io.convert import default_analysis_filename
@@ -1056,11 +1057,12 @@ def test_go_next_instance_change(centered_pair_predictions: Labels):
     video = labels.videos[0]
 
     # Create frames with different numbers of instances
-    lf1 = labels[0]  # First frame (already exists)
-    initial_count = len(lf1.instances)
+    lf1 = context.labels.find(video, 0, return_new=True)[0]  # First frame (already exists)
+    initial_count = len(lf1.instances_to_show)
 
-    for lf in labels.labeled_frames[1:]:
-        if len(lf.instances) != initial_count:
+    for frame_idx in range(1, video.num_frames):
+        lf = context.labels.find(video, frame_idx, return_new=True)[0]
+        if len(lf.instances_to_show) != initial_count:
             skipped_to_frame = lf.frame_idx
             break
 
@@ -1071,6 +1073,34 @@ def test_go_next_instance_change(centered_pair_predictions: Labels):
 
     # Execute the command
     context.execute(GoNextInstanceChange)
+
+    # Verify that we moved to the frame with different instance count
+    assert context.state["frame_idx"] == skipped_to_frame
+    assert len(labels.find(video, skipped_to_frame)[0].instances) != initial_count
+
+def test_go_prev_instance_change(centered_pair_predictions: Labels):
+    """Test that goto next instance change command works correctly."""
+    # Set up test data
+    labels = centered_pair_predictions
+    video = labels.videos[0]
+
+    # Create frames with different numbers of instances
+    lf1 = context.labels.find(video, video.num_frames - 1, return_new=True)[0]  # First frame (already exists)
+    initial_count = len(lf1.instances_to_show)
+
+    for frame_idx in range(video.num_frames - 1, 0, -1):
+        lf = context.labels.find(video, frame_idx, return_new=True)[0]
+        if len(lf.instances_to_show) != initial_count:
+            skipped_to_frame = lf.frame_idx
+            break
+
+    # Set up command context
+    context = CommandContext.from_labels(labels)
+    context.state["video"] = video
+    context.state["frame_idx"] = lf1.frame_idx
+
+    # Execute the command
+    context.execute(GoPrevInstanceChange)
 
     # Verify that we moved to the frame with different instance count
     assert context.state["frame_idx"] == skipped_to_frame

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1046,3 +1046,31 @@ def test_newInstance(qtbot, centered_pair_predictions: Labels):
     )
     diff = np.nan_to_num(new_inst.numpy() - copy_instance.numpy(), nan=offset)
     assert np.all(diff == offset)
+
+
+def test_go_next_instance_change(centered_pair_predictions: Labels):
+    """Test that goto next instance change command works correctly."""
+    # Set up test data
+    labels = centered_pair_predictions
+    video = labels.videos[0]
+
+    # Create frames with different numbers of instances
+    lf1 = labels[0]  # First frame (already exists)
+    initial_count = len(lf1.instances)
+
+    for lf in labels.labeled_frames[1:]:
+        if len(lf.instances) != initial_count:
+            skipped_to_frame = lf.frame_idx
+            break
+
+    # Set up command context
+    context = CommandContext.from_labels(labels)
+    context.state["video"] = video
+    context.state["frame_idx"] = lf1.frame_idx
+
+    # Execute the command
+    context.execute(GoNextInstanceChange)
+
+    # Verify that we moved to the frame with different instance count
+    assert context.state["frame_idx"] == skipped_to_frame
+    assert len(labels.find(video, skipped_to_frame)[0].instances) != initial_count


### PR DESCRIPTION
### Description
Adding a keybinding to jump to the next (or previous) frame where the number of displayed instances changes from the current frame
### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new keyboard shortcuts (Ctrl+Shift+Right and Ctrl+Shift+Left) for quick navigation to the next and previous instance changes.
	- Added corresponding menu items under the "Go" menu for both next and previous instance changes, enhancing navigation within the application.
	- Expanded the list of available shortcuts with the addition of "goto next instance change" and "goto prev instance change".
- **Tests**
	- Added a new test to validate the functionality of navigating to the next instance change in labeled frames.
	- Added a new test to validate the functionality of navigating to the previous instance change in labeled frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->