### PR TITLE
Remove `TrainingJobConfig` use in `LossViewer`

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -672,7 +672,13 @@ def run_gui_training(
 
             if gui:
                 print("Resetting monitor window.")
-                win.reset(what=str(model_type), config=job)
+                plateau_patience = job.optimization.early_stopping.plateau_patience
+                plateau_min_delta = job.optimization.early_stopping.plateau_min_delta
+                win.reset(
+                    what=str(model_type),
+                    plateau_patience=plateau_patience,
+                    plateau_min_delta=plateau_min_delta,
+                )
                 win.setWindowTitle(f"Training Model - {str(model_type)}")
                 win.set_message(f"Preparing to run training...")
                 if save_viz:

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -1,10 +1,11 @@
 """GUI for monitoring training progress interactively."""
 
+from __future__ import annotations
+
 import logging
 from time import perf_counter
 from typing import Dict, Optional, Tuple
 
-import attr
 import jsonpickle
 import numpy as np
 import zmq
@@ -14,7 +15,6 @@ from qtpy import QtCore, QtWidgets
 
 from sleap.gui.utils import find_free_port
 from sleap.gui.widgets.mpl import MplCanvas
-from sleap.nn.config.training_job import TrainingJobConfig
 
 logger = logging.getLogger(__name__)
 
@@ -222,7 +222,7 @@ class LossPlot(MplCanvas):
         mean_epoch_time_sec: int = None,
         eta_ten_epochs_min: int = None,
         epochs_in_plateau: int = None,
-        plateau_patience: int = None,
+        plateau_patience: int | None = None,
         epoch_in_plateau_flag: bool = False,
         best_val_x: int = None,
         best_val_y: float = None,
@@ -664,13 +664,17 @@ class LossViewer(QtWidgets.QMainWindow):
     def reset(
         self,
         what: str = "",
-        config: TrainingJobConfig = attr.ib(factory=TrainingJobConfig),
+        plateau_patience: int | None = None,
+        plateau_min_delta: float | None = None,
     ):
         """Reset all chart series.
 
         Args:
             what: String identifier indicating which job type the current run
                 corresponds to.
+            plateau_patience: Number of epochs to wait in plateau before stopping.
+            plateau_min_delta: Minimum change in validation loss to be considered
+                significant.
         """
         self.canvas = LossPlot(
             width=5,
@@ -741,7 +745,8 @@ class LossViewer(QtWidgets.QMainWindow):
         wid.setLayout(layout)
         self.setCentralWidget(wid)
 
-        self.config = config
+        self.plateau_patience = plateau_patience
+        self.plateau_min_delta = plateau_min_delta
         self.X = []
         self.Y = []
         self.best_val_x = None
@@ -851,7 +856,7 @@ class LossViewer(QtWidgets.QMainWindow):
                 mean_epoch_time_sec=self.mean_epoch_time_sec,
                 eta_ten_epochs_min=self.eta_ten_epochs_min,
                 epochs_in_plateau=self.epochs_in_plateau,
-                plateau_patience=self.config.optimization.early_stopping.plateau_patience,
+                plateau_patience=self.plateau_patience,
                 epoch_in_plateau_flag=self.epoch_in_plateau_flag,
                 best_val_x=self.best_val_x,
                 best_val_y=self.best_val_y,
@@ -935,9 +940,11 @@ class LossViewer(QtWidgets.QMainWindow):
                                 - self.last_epoch_val_loss
                             )
                             self.epoch_in_plateau_flag = (
-                                val_loss_delta
-                                < self.config.optimization.early_stopping.plateau_min_delta
-                            ) or (self.best_val_y < self.last_epoch_val_loss)
+                                self.plateau_min_delta is not None
+                            ) and (
+                                (val_loss_delta < self.plateau_min_delta)
+                                or (self.best_val_y < self.last_epoch_val_loss)
+                            )
                             self.epochs_in_plateau = (
                                 self.epochs_in_plateau + 1
                                 if self.epoch_in_plateau_flag

--- a/tests/gui/test_monitor.py
+++ b/tests/gui/test_monitor.py
@@ -1,14 +1,4 @@
 from sleap.gui.widgets.monitor import LossViewer
-from sleap import TrainingJobConfig
-
-
-def test_monitor_reset(qtbot, min_centroid_model_path):
-    win = LossViewer()
-    win.show()
-
-    # Ensure win loads config correctly
-    win.reset(what="Model Type")
-    assert isinstance(win.config, TrainingJobConfig)
 
 
 def test_monitor_release(qtbot, min_centroid_model_path):
@@ -16,9 +6,9 @@ def test_monitor_release(qtbot, min_centroid_model_path):
     win.show()
 
     # Ensure win loads config correctly
-    config = TrainingJobConfig.load_json(min_centroid_model_path, False)
-    win.reset(what="Model Type", config=config)
-    assert win.config.optimization.early_stopping.plateau_patience == 10
+    win.reset(what="Model Type", plateau_patience=10, plateau_min_delta=1e-06)
+    assert win.plateau_patience == 10
+    assert win.plateau_min_delta == 1e-06
 
     # Ensure zmq port is set correctly
     assert win.zmq_ports["controller_port"] == 9000
@@ -27,7 +17,7 @@ def test_monitor_release(qtbot, min_centroid_model_path):
     win.is_running = True
     win.t0 = 0
     # Enter "last_epoch_val_loss is not None" conditional
-    win.last_epoch_val_loss = win.config.optimization.early_stopping.plateau_min_delta
+    win.last_epoch_val_loss = win.plateau_min_delta
     # Enter "penultimate_epoch_val_loss is not None" conditional
     win.penultimate_epoch_val_loss = win.last_epoch_val_loss
     win.mean_epoch_time_min = 0

--- a/tests/gui/test_monitor.py
+++ b/tests/gui/test_monitor.py
@@ -2,6 +2,15 @@ from sleap.gui.widgets.monitor import LossViewer
 from sleap import TrainingJobConfig
 
 
+def test_monitor_reset(qtbot, min_centroid_model_path):
+    win = LossViewer()
+    win.show()
+
+    # Ensure win loads config correctly
+    win.reset(what="Model Type")
+    assert isinstance(win.config, TrainingJobConfig)
+
+
 def test_monitor_release(qtbot, min_centroid_model_path):
     win = LossViewer()
     win.show()


### PR DESCRIPTION
### Description
This PR examines the use of a `sleap.nn` class in the GUI code, i.e. `TrainingJobConfig`'s role/use in `LossViewer`.

We find that the `LossViewer` only uses the `TrainingJobConfig` for its `TrainingJobConfig.optimization.early_stopping.plateau_patience` and `TrainingJobConfig.optimization.early_stopping.plateau_min_delta`. 

While it is convenient to pass in a single `TraningJobConfig` and then have `LossViewer` extract these parameters, since there are only two parameters being used, passing these values straight into the `LossViewer` isn't such a big ask. Moreover, we only call `LossViewer.reset` (where the `TrainingJobConfig` is passed in) in one place.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [x] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
- #2159

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
