### PR TITLE
Fix default for pad_to_stride parameter

### DIFF
--- a/sleap/nn/training.py
+++ b/sleap/nn/training.py
@@ -1018,7 +1018,10 @@ class SingleInstanceModelTrainer(Trainer):
 
     def _update_config(self):
         """Update the configuration with inferred values."""
-        if self.config.data.preprocessing.pad_to_stride is None:
+        if (
+            self.config.data.preprocessing.pad_to_stride is None
+            or self.config.data.preprocessing.pad_to_stride < self.model.maximum_stride
+        ):
             self.config.data.preprocessing.pad_to_stride = self.model.maximum_stride
 
         if self.config.optimization.batches_per_epoch is None:
@@ -1135,7 +1138,10 @@ class CentroidConfmapsModelTrainer(Trainer):
 
     def _update_config(self):
         """Update the configuration with inferred values."""
-        if self.config.data.preprocessing.pad_to_stride is None:
+        if (
+            self.config.data.preprocessing.pad_to_stride is None
+            or self.config.data.preprocessing.pad_to_stride < self.model.maximum_stride
+        ):
             self.config.data.preprocessing.pad_to_stride = self.model.maximum_stride
 
         if self.config.optimization.batches_per_epoch is None:
@@ -1371,7 +1377,10 @@ class BottomUpModelTrainer(Trainer):
 
     def _update_config(self):
         """Update the configuration with inferred values."""
-        if self.config.data.preprocessing.pad_to_stride is None:
+        if (
+            self.config.data.preprocessing.pad_to_stride is None
+            or self.config.data.preprocessing.pad_to_stride < self.model.maximum_stride
+        ):
             self.config.data.preprocessing.pad_to_stride = self.model.maximum_stride
 
         if self.config.optimization.batches_per_epoch is None:
@@ -1512,7 +1521,10 @@ class BottomUpMultiClassModelTrainer(Trainer):
 
     def _update_config(self):
         """Update the configuration with inferred values."""
-        if self.config.data.preprocessing.pad_to_stride is None:
+        if (
+            self.config.data.preprocessing.pad_to_stride is None
+            or self.config.data.preprocessing.pad_to_stride < self.model.maximum_stride
+        ):
             self.config.data.preprocessing.pad_to_stride = self.model.maximum_stride
 
         if self.config.optimization.batches_per_epoch is None:
@@ -1651,7 +1663,10 @@ class TopDownMultiClassModelTrainer(Trainer):
 
     def _update_config(self):
         """Update the configuration with inferred values."""
-        if self.config.data.preprocessing.pad_to_stride is None:
+        if (
+            self.config.data.preprocessing.pad_to_stride is None
+            or self.config.data.preprocessing.pad_to_stride < self.model.maximum_stride
+        ):
             self.config.data.preprocessing.pad_to_stride = self.model.maximum_stride
 
         if (self.config.data.instance_cropping.crop_size is None) or (


### PR DESCRIPTION
### Description
This PR updates `pad_to_stride` to match with `max_stride` from the model config during training.

### Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
#2163 

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
