### PR TITLE
Pin miniforge version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3.0.3
         with:
-          miniforge-version: latest
+          miniforge-version: 23.11.0-0
           condarc-file: ${{ matrix.condarc }}
           python-version: ${{ matrix.pyver }}
           environment-file: environment_build.yml

--- a/.github/workflows/build_conda_ci.yml
+++ b/.github/workflows/build_conda_ci.yml
@@ -51,7 +51,7 @@ jobs:
         if: env.RUN_BUILD_JOB == 'true'
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-version: latest
+          miniforge-version: 23.11.0-0
           condarc-file: ${{ matrix.condarc }}
           python-version: ${{ matrix.pyver }}
           environment-file: environment_build.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-version: latest
+          miniforge-version: 23.11.0-0
           condarc-file: ${{ matrix.condarc }}
           python-version: ${{ matrix.pyver }}
           conda-solver: "libmamba"

--- a/.github/workflows/build_manual.yml
+++ b/.github/workflows/build_manual.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3.0.3
         with:
-          miniforge-version: latest
+          miniforge-version: 23.11.0-0
           condarc-file: ${{ matrix.condarc }}
           python-version: ${{ matrix.pyver }}
           environment-file: environment_build.yml

--- a/.github/workflows/build_pypi_ci.yml
+++ b/.github/workflows/build_pypi_ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3.0.3
         with:
-          miniforge-version: latest
+          miniforge-version: 23.11.0-0
           condarc-file: ${{ matrix.condarc }}
           python-version: ${{ matrix.pyver }}
           environment-file: environment_build.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3.0.3
         with:
-          miniforge-version: latest
+          miniforge-version: 23.11.0-0
           conda-solver: "libmamba"
           environment-file: ${{ matrix.env_file }}
           activate-environment: sleap_ci

--- a/pypi_requirements.txt
+++ b/pypi_requirements.txt
@@ -26,7 +26,7 @@ python-rapidjson; sys_platform != 'win32'
 pyyaml
 pyzmq
 qtpy>=2.0.1
-rich==10.16.1
+rich>=10.16.1
 imgaug==0.4.0
 scipy>=1.4.1,<=1.9.0
 scikit-image


### PR DESCRIPTION
### Description
This PR pins the miniforge version to `23.11.0-0` instead of latest to not break the github CI pipelines.

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
