### PR TITLE
Core Training and Inference Workflow with GUI Integration

### DIFF
--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -590,10 +590,12 @@ augmentation:
   type: bool
 - default: 0.0
   help: Minimum value to add.
+  range: 0.0, 1.0
   label: Uniform Noise Min Val
   name: optimization.augmentation_config.uniform_noise_min_val
   type: double
-- default: 10.0
+- default: 1.0
+  range: 0.0, 1.0
   help: Maximum value to add.
   label: Uniform Noise Max Val
   name: optimization.augmentation_config.uniform_noise_max_val

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1706,15 +1706,6 @@ def main(args: Optional[list] = None, labels: Optional[Labels] = None):
     window.showMaximized()
 
     # Disable GPU in GUI process. This does not affect subprocesses.
-    try:
-        sleap.use_cpu_only()
-    except RuntimeError:  # Visible devices cannot be modified after being initialized
-        logger.warning(
-            "Running processes on the GPU. Restarting your GUI should allow switching "
-            "back to CPU-only mode.\n"
-            "Received the following error when trying to switch back to CPU-only mode:"
-        )
-        traceback.print_exc()
 
     # Print versions.
     print()

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -170,7 +170,7 @@ class ConfigFileInfo:
         if path.endswith("yaml") or path.endswith("yml"):
             # convert yaml to legacy GUI config.
             from omegaconf import OmegaConf
-            from sleap.gui.legacy.config.yaml_to_training_job import mapper
+            from sleap.gui.legacy.config.yaml_cfg_sleap_trainingjob_cfg import mapper
 
             omegaconf_cfg = OmegaConf.load(path)
             cfg = mapper(omegaconf_cfg)
@@ -309,11 +309,12 @@ class TrainingConfigFilesWidget(FieldComboWidget):
 
     def doFileSelection(self):
         """Shows file browser to add training profile for given model type."""
+        filters = ["JSON (*.json)", "YAML (*.yaml)", "YML (*.yml)"]
         filename, _ = FileDialog.open(
             None,
             dir=None,
             caption="Select training configuration file...",
-            filter="JSON (*.json) | YAML (*.yaml) | YML (*.yml)",
+            filter=";;".join(filters),
         )
         return self._cfg_getter.try_loading_path(filename) if filename else None
 
@@ -384,12 +385,12 @@ class TrainingConfigsGetter:
             )
             json_files.extend(
                 sleap_utils.find_files_by_suffix(
-                    config_dir, ".yaml", depth=self.search_depth
+                    config_dir, "training_config.yaml", depth=self.search_depth
                 )
             )
             json_files.extend(
                 sleap_utils.find_files_by_suffix(
-                    config_dir, ".yml", depth=self.search_depth
+                    config_dir, "training_config.yml", depth=self.search_depth
                 )
             )
 
@@ -469,7 +470,7 @@ class TrainingConfigsGetter:
         if path.endswith("yaml") or path.endswith("yml"):
             # Get the head from the model (i.e., what the model will predict)
             from omegaconf import OmegaConf
-            from sleap.gui.legacy.config.yaml_to_training_job import mapper
+            from sleap.gui.legacy.config.yaml_cfg_sleap_trainingjob_cfg import mapper
 
             cfg = OmegaConf.load(path)
             for head in cfg.model_config.head_configs:

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -467,34 +467,26 @@ class TrainingConfigsGetter:
     def try_loading_path(self, path: Text) -> Optional[ConfigFileInfo]:
         """Attempts to load config file and wrap in `ConfigFileInfo` object."""
         if path.endswith("yaml") or path.endswith("yml"):
-            try:
-                # cfg = TrainingJobConfig.load_json(path)
-                pass
-            except Exception as e:
-                # Couldn't load so just ignore
-                print(e)
-                pass
-            else:
-                # Get the head from the model (i.e., what the model will predict)
-                from omegaconf import OmegaConf
-                from sleap.gui.legacy.config.yaml_to_training_job import mapper
+            # Get the head from the model (i.e., what the model will predict)
+            from omegaconf import OmegaConf
+            from sleap.gui.legacy.config.yaml_to_training_job import mapper
 
-                cfg = OmegaConf.load(path)
-                for head in cfg.model_config.head_configs:
-                    if cfg.model_config.head_configs[f"{head}"] is not None:
-                        key = head
-                        break
+            cfg = OmegaConf.load(path)
+            for head in cfg.model_config.head_configs:
+                if cfg.model_config.head_configs[f"{head}"] is not None:
+                    key = head
+                    break
 
-                if key == "bottomup":
-                    key = "multi_instance"
+            if key == "bottomup":
+                key = "multi_instance"
 
-                filename = os.path.basename(path)
+            filename = os.path.basename(path)
 
-                # If filter isn't set or matches head name, add config to list
-                if self.head_filter in (None, key):
-                    return ConfigFileInfo(
-                        path=path, filename=filename, config=mapper(cfg), head_name=key
-                    )
+            # If filter isn't set or matches head name, add config to list
+            if self.head_filter in (None, key):
+                return ConfigFileInfo(
+                    path=path, filename=filename, config=mapper(cfg), head_name=key
+                )
         else:
             # Get the head from the model (i.e., what the model will predict)
             try:

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -53,11 +53,17 @@ class ConfigFileInfo:
         #  what we'll do here, but both should check for other models
         #  depending on the training config settings.
 
-        return self._get_file_path("best_model.h5") is not None
+        # allow to run inference on both torch weights (`.ckpt`) and keras weights (`.h5`).
+        # sleap-nn supports running inference on the keras weights (Note: currently only for unet models).
+        # TODO: add support for running inference on the keras weights for other models.
+        return (
+            self._get_file_path("best.ckpt") is not None
+            or self._get_file_path("best_model.h5") is not None
+        )
 
     @property
     def path_dir(self):
-        return os.path.dirname(self.path) if self.path.endswith("json") else self.path
+        return os.path.dirname(self.path) if self.path.endswith("yaml") else self.path
 
     def _get_file_path(self, shortname) -> Optional[Text]:
         """
@@ -161,7 +167,16 @@ class ConfigFileInfo:
 
     @classmethod
     def from_config_file(cls, path: Text) -> "ConfigFileInfo":
-        cfg = TrainingJobConfig.load_json(path)
+        if path.endswith("yaml") or path.endswith("yml"):
+            # convert yaml to legacy GUI config.
+            from omegaconf import OmegaConf
+            from sleap.gui.legacy.config.yaml_to_training_job import mapper
+
+            omegaconf_cfg = OmegaConf.load(path)
+            cfg = mapper(omegaconf_cfg)
+
+        else:
+            cfg = TrainingJobConfig.load_json(path)
         head_name = cfg.model.heads.which_oneof_attrib_name()
         filename = os.path.basename(path)
         return cls(config=cfg, path=path, filename=filename, head_name=head_name)
@@ -298,7 +313,7 @@ class TrainingConfigFilesWidget(FieldComboWidget):
             None,
             dir=None,
             caption="Select training configuration file...",
-            filter="JSON (*.json)",
+            filter="JSON (*.json) | YAML (*.yaml) | YML (*.yml)",
         )
         return self._cfg_getter.try_loading_path(filename) if filename else None
 
@@ -366,6 +381,16 @@ class TrainingConfigsGetter:
             # Find all json files in dir and subdirs to specified depth
             json_files = sleap_utils.find_files_by_suffix(
                 config_dir, ".json", depth=self.search_depth
+            )
+            json_files.extend(
+                sleap_utils.find_files_by_suffix(
+                    config_dir, ".yaml", depth=self.search_depth
+                )
+            )
+            json_files.extend(
+                sleap_utils.find_files_by_suffix(
+                    config_dir, ".yml", depth=self.search_depth
+                )
             )
 
             if Path(config_dir).as_posix().endswith("sleap/training_profiles"):
@@ -441,23 +466,54 @@ class TrainingConfigsGetter:
 
     def try_loading_path(self, path: Text) -> Optional[ConfigFileInfo]:
         """Attempts to load config file and wrap in `ConfigFileInfo` object."""
-        try:
-            cfg = TrainingJobConfig.load_json(path)
-        except Exception as e:
-            # Couldn't load so just ignore
-            print(e)
-            pass
+        if path.endswith("yaml") or path.endswith("yml"):
+            try:
+                # cfg = TrainingJobConfig.load_json(path)
+                pass
+            except Exception as e:
+                # Couldn't load so just ignore
+                print(e)
+                pass
+            else:
+                # Get the head from the model (i.e., what the model will predict)
+                from omegaconf import OmegaConf
+                from sleap.gui.legacy.config.yaml_to_training_job import mapper
+
+                cfg = OmegaConf.load(path)
+                for head in cfg.model_config.head_configs:
+                    if cfg.model_config.head_configs[f"{head}"] is not None:
+                        key = head
+                        break
+
+                if key == "bottomup":
+                    key = "multi_instance"
+
+                filename = os.path.basename(path)
+
+                # If filter isn't set or matches head name, add config to list
+                if self.head_filter in (None, key):
+                    return ConfigFileInfo(
+                        path=path, filename=filename, config=mapper(cfg), head_name=key
+                    )
         else:
             # Get the head from the model (i.e., what the model will predict)
-            key = cfg.model.heads.which_oneof_attrib_name()
+            try:
+                cfg = TrainingJobConfig.load_json(path)
+            except Exception as e:
+                # Couldn't load so just ignore
+                print(e)
+                pass
+            else:
+                # Get the head from the model (i.e., what the model will predict)
+                key = cfg.model.heads.which_oneof_attrib_name()
 
-            filename = os.path.basename(path)
+                filename = os.path.basename(path)
 
-            # If filter isn't set or matches head name, add config to list
-            if self.head_filter in (None, key):
-                return ConfigFileInfo(
-                    path=path, filename=filename, config=cfg, head_name=key
-                )
+                # If filter isn't set or matches head name, add config to list
+                if self.head_filter in (None, key):
+                    return ConfigFileInfo(
+                        path=path, filename=filename, config=cfg, head_name=key
+                    )
 
         return None
 

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -63,7 +63,13 @@ class ConfigFileInfo:
 
     @property
     def path_dir(self):
-        return os.path.dirname(self.path) if self.path.endswith("yaml") else self.path
+        return (
+            os.path.dirname(self.path)
+            if self.path.endswith("yaml")
+            or self.path.endswith("json")
+            or self.path.endswith("yml")
+            else self.path
+        )
 
     def _get_file_path(self, shortname) -> Optional[Text]:
         """

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -770,10 +770,17 @@ class LearningDialog(QtWidgets.QDialog):
         for config_info in config_info_list:
             config_info = config_info.config.to_json()
             config_info = json.loads(config_info)
-            config_info = json.dumps(config_info, indent=2)
-            output.append(config_info)
-        output = "\n".join(output)
+            # convert to sleap-nn cfg (yaml)
+            from omegaconf import OmegaConf
+            from sleap_nn.config.training_job_config import (
+                TrainingJobConfig as snn_TrainingJobConfig,
+            )
 
+            cfg = snn_TrainingJobConfig.load_sleap_config_from_json(config_info)
+            cfg.data_config.train_labels_path.append(self.labels_filename)
+            output.append(OmegaConf.to_yaml(cfg))
+
+        output = "\n".join(output)
         # Set the clipboard text
         clipboard = QtWidgets.QApplication.clipboard()
         clipboard.setText(output)

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -514,7 +514,7 @@ def write_pipeline_files(
             new_cfg_filenames.append(cfg_info.config.outputs.run_path)
 
             # Add a line to the script for training this model
-            train_script += f"sleap-nn-train --config-name {new_cfg_filename} --config-path {''} hydra.run.dir=. hydra.output_subdir=null trainer_config.save_ckpt_path={ckpt_path} trainer_config.zmq.controller_address=tcp://127.0.0.1:{str(inference_params['controller_port'])} trainer_config.zmq.publish_address=tcp://127.0.0.1:{str(inference_params['publish_port'])}"
+            train_script += f"sleap-nn-train --config-name {new_cfg_filename} --config-dir {''} hydra.run.dir=. hydra.output_subdir=null trainer_config.save_ckpt_path={ckpt_path} trainer_config.zmq.controller_address=tcp://127.0.0.1:{str(inference_params['controller_port'])} trainer_config.zmq.publish_address=tcp://127.0.0.1:{str(inference_params['publish_port'])}"
 
             # Setup job params
             training_jobs.append(
@@ -946,7 +946,7 @@ def train_subprocess(
             "sleap-nn-train",
             "--config-name",
             f"{cfg_file_name}",
-            "--config-path",
+            "--config-dir",
             f"{temp_dir}",
             "hydra.run.dir=.",
             "hydra.output_subdir=null",

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -240,9 +240,7 @@ class InferenceTask:
     ) -> List[Text]:
         """Makes list of CLI arguments needed for running inference."""
         cli_args = [
-            "python",
-            "-m",
-            "sleap_nn.predict",
+            "sleap-nn-track",
         ]
         cli_args.extend(
             item_for_inference.cli_args
@@ -511,7 +509,7 @@ def write_pipeline_files(
             new_cfg_filenames.append(cfg_info.config.outputs.run_path)
 
             # Add a line to the script for training this model
-            train_script += f"python -m sleap_nn.train --config-name {new_cfg_filename} --config-path {''} hydra.run.dir=. hydra.output_subdir=null trainer_config.save_ckpt_path={ckpt_path} trainer_config.zmq.controller_address=tcp://127.0.0.1:{str(inference_params['controller_port'])} trainer_config.zmq.publish_address=tcp://127.0.0.1:{str(inference_params['publish_port'])}"
+            train_script += f"sleap-nn-train --config-name {new_cfg_filename} --config-path {''} hydra.run.dir=. hydra.output_subdir=null trainer_config.save_ckpt_path={ckpt_path} trainer_config.zmq.controller_address=tcp://127.0.0.1:{str(inference_params['controller_port'])} trainer_config.zmq.publish_address=tcp://127.0.0.1:{str(inference_params['publish_port'])}"
 
             # Setup job params
             training_jobs.append(
@@ -931,15 +929,14 @@ def train_subprocess(
         # convert json to yaml (to sleap-nn config format)
         cfg_file_name = datetime.now().strftime("%y%m%d_%H%M%S") + "_config"
         cfg = snn_TrainingJobConfig.load_sleap_config(training_job_path)
-        cfg.data_config.train_labels_path.append(labels_filename)
+        if len(cfg.data_config.train_labels_path) == 0:
+            cfg.data_config.train_labels_path.append(labels_filename)
 
         OmegaConf.save(cfg, (Path(temp_dir) / f"{cfg_file_name}.yaml").as_posix())
 
         # Build CLI arguments for training
         cli_args = [
-            "python",
-            "-m",
-            "sleap_nn.train",
+            "sleap-nn-train",
             "--config-name",
             f"{cfg_file_name}",
             "--config-path",

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -271,7 +271,11 @@ class InferenceTask:
             )
 
         for job_path in self.trained_job_paths:
-            if job_path.endswith(".yaml"):
+            if (
+                job_path.endswith(".yaml")
+                or job_path.endswith(".json")
+                or job_path.endswith(".yml")
+            ):
                 job_path = str(
                     Path(job_path).parent
                 )  # get the model ckpt folder path from the path of `training_config.yaml`

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -129,19 +129,19 @@ class VideoItemForInference(ItemForInference):
     @property
     def cli_args(self):
         arg_list = list()
-        arg_list.append(self.path)
+        arg_list.extend(["--data_path", f"{self.path}"])
         if self.labels_path is not None:
-            arg_list.extend(["--video.index", str(self.video_idx)])
+            arg_list.extend(["--video_index", str(self.video_idx)])
 
         # TODO: better support for video params
         if hasattr(self.video.backend, "dataset") and self.video.backend.dataset:
-            arg_list.extend(("--video.dataset", self.video.backend.dataset))
+            arg_list.extend(("--video_dataset", self.video.backend.dataset))
 
         if (
             hasattr(self.video.backend, "input_format")
             and self.video.backend.input_format
         ):
-            arg_list.extend(("--video.input_format", self.video.backend.input_format))
+            arg_list.extend(("--video_input_format", self.video.backend.input_format))
 
         # -Y represents endpoint of [X, Y) range but inference cli expects
         # [X, Y-1] range (so add 1 since negative).
@@ -178,10 +178,11 @@ class DatasetItemForInference(ItemForInference):
     @property
     def cli_args(self):
         args_list = [self.path]
+        args_list = ["--data_path", self.path]
         if self.frame_filter == "user":
-            args_list.append("--only-labeled-frames")
+            args_list.append("--only_labeled_frames")
         elif self.frame_filter == "suggested":
-            args_list.append("--only-suggested-frames")
+            args_list.append("--only_suggested_frames")
         return args_list
 
 
@@ -238,8 +239,14 @@ class InferenceTask:
         gui: bool = True,
     ) -> List[Text]:
         """Makes list of CLI arguments needed for running inference."""
-        cli_args = ["sleap-track"]
-        cli_args.extend(item_for_inference.cli_args)
+        cli_args = [
+            "python",
+            "-m",
+            "sleap_nn.predict",
+        ]
+        cli_args.extend(
+            item_for_inference.cli_args
+        )  # sample inference CLI args:['--data_path', '/Users/divyasesh/Desktop/its_me/slp_datasets_models/wt_13/clips/190719_090330_wt_18159206_rig1.2@15000-17560.slp', '--video_index', '0', '--video_input_format', 'channels_last', '--frames', '0,-2559']
 
         # Make path where we'll save predictions (if not specified)
         if output_path is None:
@@ -264,65 +271,68 @@ class InferenceTask:
             )
 
         for job_path in self.trained_job_paths:
-            cli_args.extend(("-m", job_path))
+            if job_path.endswith(".yaml"):
+                job_path = str(
+                    Path(job_path).parent
+                )  # get the model ckpt folder path from the path of `training_config.yaml`
+            cli_args.extend(("--model_paths", job_path))
 
-        optional_items_as_nones = (
-            "tracking.target_instance_count",
-            "tracking.max_tracks",
-            "tracking.kf_init_frame_count",
-            "tracking.robust",
-            "max_instances",
-        )
+        cli_args.extend(["-o", output_path])
 
-        for key in optional_items_as_nones:
-            if key in self.inference_params and self.inference_params[key] is None:
-                del self.inference_params[key]
+        if "batch_size" in self.inference_params:
+            cli_args.extend(["--batch_size", str(self.inference_params["batch_size"])])
 
-        # Setting max_tracks to True means we want to use the max_tracking mode.
-        if "tracking.max_tracks" in self.inference_params:
-            self.inference_params["tracking.max_tracking"] = True
+        if self.inference_params["max_instances"] is not None:
+            cli_args.extend(["--max_instances", self.inference_params["max_instances"]])
 
-            # Hacky:  Update the tracker name to include "maxtracks" suffix.
-            if self.inference_params["tracking.tracker"] in ("simple", "flow"):
-                self.inference_params["tracking.tracker"] = (
-                    self.inference_params["tracking.tracker"] + "maxtracks"
+        # add tracking args
+        if (
+            "tracking.tracker" in self.inference_params
+            and self.inference_params["tracking.tracker"] != "none"
+        ):
+            cli_args.extend(["--tracking", "True"])
+            cli_args.extend(
+                ["--track_matching_method", self.inference_params["tracking.match"]]
+            )
+            cli_args.extend(
+                [
+                    "--tracking_window_size",
+                    str(self.inference_params["tracking.track_window"]),
+                ]
+            )
+            if self.inference_params["tracking.max_tracks"] is not None:
+                cli_args.extend(["--candidates_method", "local_queues"])
+                cli_args.extend(
+                    ["--max_tracks", str(self.inference_params["tracking.max_tracks"])]
+                )
+            if "flow" in self.inference_params["tracking.tracker"]:
+                cli_args.extend(["--use_flow", "True"])
+
+            if self.inference_params["tracking.post_connect_single_breaks"] == 1:
+                cli_args.extend(["--post_connect_single_breaks"])
+
+            if self.inference_params["tracking.robust"] != 1.0:
+                cli_args.extend(["--scoring_reduction", "robust_quantile"])
+                cli_args.extend(
+                    [
+                        "--robust_best_instance",
+                        str(self.inference_params["tracking.robust"]),
+                    ]
                 )
 
-        # --tracking.kf_init_frame_count enables the kalman filter tracking
-        # so if not set, then remove other (unused) args
-        if "tracking.kf_init_frame_count" not in self.inference_params:
-            if "tracking.kf_node_indices" in self.inference_params:
-                del self.inference_params["tracking.kf_node_indices"]
-
-        bool_items_as_ints = (
-            "tracking.pre_cull_to_target",
-            "tracking.max_tracking",
-            "tracking.post_connect_single_breaks",
-            "tracking.save_shifted_instances",
-            "tracking.oks_score_weighting",
-        )
-
-        for key in bool_items_as_ints:
-            if key in self.inference_params:
-                self.inference_params[key] = int(self.inference_params[key])
-
-        remove_spaces_items = ("tracking.similarity",)
-
-        for key in remove_spaces_items:
-            if key in self.inference_params:
-                value = self.inference_params[key]
-                self.inference_params[key] = value.replace(" ", "_")
-
-        for key, val in self.inference_params.items():
-            if not key.startswith(("_", "outputs.", "model.", "data.")):
-                cli_args.extend((f"--{key}", str(val)))
-
-        cli_args.extend(("-o", output_path))
-
-        if gui:
-            cli_args.extend(("--verbosity", "json"))
-
-        cli_args.extend(("--no-empty-frames",))
+            if self.inference_params["tracking.similarity"] in [
+                "instance",
+                "normalized_instance",
+                "object_keypoint",
+            ]:
+                cli_args.extend(["--features", "keypoints"])
+                cli_args.extend(["--scoring_method", "oks"])
+            elif self.inference_params["tracking.similarity"] == "centroid":
+                cli_args.extend(["--features", "centroids"])
+                cli_args.extend(["--scoring_method", "euclidean_dist"])
+            elif self.inference_params["tracking.similarity"] == "iou":
+                cli_args.extend(["--features", "bboxes"])
+                cli_args.extend(["--scoring_method", "iou"])
 
         return cli_args, output_path
 
@@ -470,7 +480,7 @@ def write_pipeline_files(
             # is the main reason we're setting it to the output directory rather
             # than just using normpath.
             # cfg_info.config.outputs.runs_folder = ""
-            setup_new_run_folder(cfg_info.config.outputs)
+            ckpt_path = setup_new_run_folder(cfg_info.config.outputs)
             # training.setup_new_run_folder(
             #     cfg_info.config.outputs,
             #     # base_run_name=f"{model_type}.n={len(labels.user_labeled_frames)}",
@@ -478,18 +488,26 @@ def write_pipeline_files(
             # )
 
             # Now we set the filename for the training config file
-            new_cfg_filename = f"{cfg_info.head_name}.json"
+            new_cfg_filename = f"{cfg_info.head_name}.yaml"
+
+            # Save the config file (convert to yaml)
+            from omegaconf import OmegaConf
+            from sleap_nn.config.training_job_config import (
+                TrainingJobConfig as snn_TrainingJobConfig,
+            )
 
             # Save the config file
-            cfg_info.config.save_json(new_cfg_filename)
+            cfg = snn_TrainingJobConfig.load_sleap_config_from_json(
+                json.loads(cfg_info.config.to_json())
+            )
+            cfg.data_config.train_labels_path.append(os.path.basename(labels_filename))
+            OmegaConf.save(cfg, new_cfg_filename)
 
             # Keep track of the path where we'll find the trained model
             new_cfg_filenames.append(cfg_info.config.outputs.run_path)
 
             # Add a line to the script for training this model
-            train_script += (
-                f"sleap-train {new_cfg_filename} {os.path.basename(labels_filename)}\n"
-            )
+            train_script += f"python -m sleap_nn.train --config-name {new_cfg_filename} --config-path {''} hydra.run.dir=. hydra.output_subdir=null trainer_config.save_ckpt_path={ckpt_path} trainer_config.zmq.controller_address=tcp://127.0.0.1:{str(inference_params['controller_port'])} trainer_config.zmq.publish_address=tcp://127.0.0.1:{str(inference_params['publish_port'])}"
 
             # Setup job params
             training_jobs.append(
@@ -901,26 +919,34 @@ def train_subprocess(
         training_job_path = os.path.join(temp_dir, temp_filename)
         job_config.save_json(training_job_path)
 
+        from omegaconf import OmegaConf
+        from sleap_nn.config.training_job_config import (
+            TrainingJobConfig as snn_TrainingJobConfig,
+        )
+
+        # convert json to yaml (to sleap-nn config format)
+        cfg_file_name = datetime.now().strftime("%y%m%d_%H%M%S") + "_config"
+        cfg = snn_TrainingJobConfig.load_sleap_config(training_job_path)
+        cfg.data_config.train_labels_path.append(labels_filename)
+
+        OmegaConf.save(cfg, (Path(temp_dir) / f"{cfg_file_name}.yaml").as_posix())
+
         # Build CLI arguments for training
         cli_args = [
-            "sleap-train",
-            training_job_path,
-            labels_filename,
-            "--zmq",
-            "--controller_port",
-            str(inference_params["controller_port"]),
-            "--publish_port",
-            str(inference_params["publish_port"]),
+            "python",
+            "-m",
+            "sleap_nn.train",
+            "--config-name",
+            f"{cfg_file_name}",
+            "--config-path",
+            f"{temp_dir}",
+            "hydra.run.dir=.",
+            "hydra.output_subdir=null",
+            f"trainer_config.save_ckpt_path={run_path}",
+            f"trainer_config.visualize_preds_during_training={save_viz}",
+            f"trainer_config.zmq.controller_address=tcp://127.0.0.1:{str(inference_params['controller_port'])}",
+            f"trainer_config.zmq.publish_address=tcp://127.0.0.1:{str(inference_params['publish_port'])}",
         ]
-
-        if save_viz:
-            cli_args.append("--save_viz")
-        if keep_viz:
-            cli_args.append("--keep_viz")
-
-        # Use cli arg since cli ignores setting in config
-        if job_config.outputs.tensorboard.write_logs:
-            cli_args.append("--tensorboard")
 
         # Run training in a subprocess.
         print(cli_args)

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -944,6 +944,7 @@ def train_subprocess(
             "hydra.output_subdir=null",
             f"trainer_config.save_ckpt_path={run_path}",
             f"trainer_config.visualize_preds_during_training={save_viz}",
+            f"trainer_config.keep_viz={keep_viz}",
             f"trainer_config.zmq.controller_address=tcp://127.0.0.1:{str(inference_params['controller_port'])}",
             f"trainer_config.zmq.publish_address=tcp://127.0.0.1:{str(inference_params['publish_port'])}",
         ]

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -502,7 +502,12 @@ def write_pipeline_files(
             cfg = snn_TrainingJobConfig.load_sleap_config_from_json(
                 json.loads(cfg_info.config.to_json())
             )
-            cfg.data_config.train_labels_path.append(os.path.basename(labels_filename))
+            if cfg.data_config.train_labels_path is None:
+                cfg.data_config.train_labels_path = [os.path.basename(labels_filename)]
+            else:
+                cfg.data_config.train_labels_path.append(
+                    os.path.basename(labels_filename)
+                )
             OmegaConf.save(cfg, new_cfg_filename)
 
             # Keep track of the path where we'll find the trained model
@@ -929,7 +934,9 @@ def train_subprocess(
         # convert json to yaml (to sleap-nn config format)
         cfg_file_name = datetime.now().strftime("%y%m%d_%H%M%S") + "_config"
         cfg = snn_TrainingJobConfig.load_sleap_config(training_job_path)
-        if len(cfg.data_config.train_labels_path) == 0:
+        if cfg.data_config.train_labels_path is None:
+            cfg.data_config.train_labels_path = [labels_filename]
+        else:
             cfg.data_config.train_labels_path.append(labels_filename)
 
         OmegaConf.save(cfg, (Path(temp_dir) / f"{cfg_file_name}.yaml").as_posix())

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -942,7 +942,7 @@ def train_subprocess(
             f"{temp_dir}",
             "hydra.run.dir=.",
             "hydra.output_subdir=null",
-            f"trainer_config.save_ckpt_path={run_path}",
+            f"trainer_config.save_ckpt_path='{run_path}'",
             f"trainer_config.visualize_preds_during_training={save_viz}",
             f"trainer_config.keep_viz={keep_viz}",
             f"trainer_config.zmq.controller_address=tcp://127.0.0.1:{str(inference_params['controller_port'])}",

--- a/sleap/gui/legacy/config/optimization.py
+++ b/sleap/gui/legacy/config/optimization.py
@@ -70,7 +70,7 @@ class AugmentationConfig:
     scale_max: float = 1.1
     uniform_noise: bool = False
     uniform_noise_min_val: float = 0.0
-    uniform_noise_max_val: float = 10.0
+    uniform_noise_max_val: float = 1.0
     gaussian_noise: bool = False
     gaussian_noise_mean: float = 5.0
     gaussian_noise_stddev: float = 1.0

--- a/sleap/gui/legacy/config/yaml_cfg_sleap_trainingjob_cfg.py
+++ b/sleap/gui/legacy/config/yaml_cfg_sleap_trainingjob_cfg.py
@@ -220,6 +220,7 @@ def mapper(config: OmegaConf):
     outputs = OutputsConfig(
         run_name=trainer_cfg.save_ckpt_path.split("/")[-1],
         save_visualizations=trainer_cfg.visualize_preds_during_training,
+        keep_viz_images=trainer_cfg.keep_viz,
         checkpointing=CheckpointingConfig(
             best_model=trainer_cfg.save_ckpt,
             latest_model=trainer_cfg.model_ckpt.save_last,

--- a/sleap/gui/legacy/config/yaml_cfg_sleap_trainingjob_cfg.py
+++ b/sleap/gui/legacy/config/yaml_cfg_sleap_trainingjob_cfg.py
@@ -31,11 +31,30 @@ from sleap.gui.legacy.config.outputs import CheckpointingConfig, ZMQConfig
 
 
 def mapper(config: OmegaConf):
+    import sleap_io as sio
+    from sleap_io.io.skeleton import SkeletonEncoder
+
     data_cfg = config.data_config
     backbone_cfg = config.model_config.backbone_config
     head_cfgs = config.model_config.head_configs
     trainer_cfg = config.trainer_config
     crop_size = OmegaConf.select(data_cfg, "preprocessing.crop_hw", default=None)
+
+    skeletons = []
+    for skel_cfg in data_cfg.skeletons:
+
+        skel = sio.Skeleton(
+            nodes=[n["name"] for n in skel_cfg.nodes], name=skel_cfg.name
+        )
+        skel.add_edges(
+            [(e["source"]["name"], e["destination"]["name"]) for e in skel_cfg.edges]
+        )
+        if skel_cfg.symmetries:
+            for n1, n2 in skel_cfg.symmetries:
+                skel.add_symmetry(n1["name"], n2["name"])
+
+        skeletons.append(skel)
+
     data = DataConfig(
         labels=LabelsConfig(
             training_labels=data_cfg.train_labels_path[0],
@@ -44,6 +63,7 @@ def mapper(config: OmegaConf):
             else None,
             validation_fraction=data_cfg.validation_fraction,
             test_labels=data_cfg.test_file_path,
+            skeletons=SkeletonEncoder().encode(skeletons),
         ),
         preprocessing=PreprocessingConfig(
             ensure_rgb=data_cfg.preprocessing.ensure_rgb,
@@ -165,11 +185,11 @@ def mapper(config: OmegaConf):
     aug_cfg = data_cfg.augmentation_config
     ac = AugmentationConfig(
         rotate=True if aug_cfg.geometric.affine_p > 0 else False,
-        rotation_min_angle=-aug_cfg.geometric.rotation,
-        rotation_max_angle=aug_cfg.geometric.rotation,
+        rotation_min_angle=-aug_cfg.geometric.rotation_min,
+        rotation_max_angle=aug_cfg.geometric.rotation_max,
         scale=True if aug_cfg.geometric.affine_p > 0 else False,
-        scale_min=aug_cfg.geometric.scale[0],
-        scale_max=aug_cfg.geometric.scale[1],
+        scale_min=aug_cfg.geometric.scale_min,
+        scale_max=aug_cfg.geometric.scale_max,
         uniform_noise=True if aug_cfg.intensity.uniform_noise_p > 0 else False,
         uniform_noise_min_val=aug_cfg.intensity.uniform_noise_min,
         uniform_noise_max_val=aug_cfg.intensity.uniform_noise_max,
@@ -180,8 +200,8 @@ def mapper(config: OmegaConf):
         contrast_min_gamma=aug_cfg.intensity.contrast_min,
         contrast_max_gamma=aug_cfg.intensity.contrast_max,
         brightness=True if aug_cfg.intensity.brightness_p > 0 else False,
-        brightness_min_val=aug_cfg.intensity.brightness[0],
-        brightness_max_val=aug_cfg.intensity.brightness[1],
+        brightness_min_val=aug_cfg.intensity.brightness_min,
+        brightness_max_val=aug_cfg.intensity.brightness_max,
     )
     augmentaion_config = (
         AugmentationConfig() if not data_cfg.use_augmentations_train else ac

--- a/sleap/gui/legacy/config/yaml_cfg_sleap_trainingjob_cfg.py
+++ b/sleap/gui/legacy/config/yaml_cfg_sleap_trainingjob_cfg.py
@@ -1,0 +1,247 @@
+from omegaconf import OmegaConf
+from sleap.gui.legacy.config import (
+    TrainingJobConfig,
+    DataConfig,
+    ModelConfig,
+    OptimizationConfig,
+    OutputsConfig,
+    LabelsConfig,
+    PreprocessingConfig,
+    InstanceCroppingConfig,
+    BackboneConfig,
+    HeadsConfig,
+    UNetConfig,
+    SingleInstanceConfmapsHeadConfig,
+    CentroidsHeadConfig,
+    CenteredInstanceConfmapsHeadConfig,
+    MultiInstanceConfig,
+    MultiInstanceConfmapsHeadConfig,
+    PartAffinityFieldsHeadConfig,
+    MultiClassBottomUpConfig,
+    MultiClassTopDownConfig,
+    ClassMapsHeadConfig,
+    ClassVectorsHeadConfig,
+    AugmentationConfig,
+    LearningRateScheduleConfig,
+    HardKeypointMiningConfig,
+    EarlyStoppingConfig,
+)
+
+from sleap.gui.legacy.config.outputs import CheckpointingConfig, ZMQConfig
+
+
+def mapper(config: OmegaConf):
+    data_cfg = config.data_config
+    backbone_cfg = config.model_config.backbone_config
+    head_cfgs = config.model_config.head_configs
+    trainer_cfg = config.trainer_config
+    crop_size = OmegaConf.select(data_cfg, "preprocessing.crop_hw", default=None)
+    data = DataConfig(
+        labels=LabelsConfig(
+            training_labels=data_cfg.train_labels_path[0],
+            validation_labels=data_cfg.val_labels_path[0]
+            if data_cfg.val_labels_path is not None and len(data_cfg.val_labels_path)
+            else None,
+            validation_fraction=data_cfg.validation_fraction,
+            test_labels=data_cfg.test_file_path,
+        ),
+        preprocessing=PreprocessingConfig(
+            ensure_rgb=data_cfg.preprocessing.ensure_rgb,
+            ensure_grayscale=data_cfg.preprocessing.ensure_grayscale,
+            input_scaling=data_cfg.preprocessing.scale,
+            resize_and_pad_to_target=True,
+            target_height=data_cfg.preprocessing.max_height,
+            target_width=data_cfg.preprocessing.max_width,
+        ),
+        instance_cropping=InstanceCroppingConfig(
+            crop_size=crop_size[0] if crop_size is not None else None
+        ),
+    )
+
+    # head type
+    for head in config.model_config.head_configs:
+        if config.model_config.head_configs[f"{head}"] is not None:
+            head_type = head
+            break
+
+    model = ModelConfig(
+        backbone=BackboneConfig(
+            unet=UNetConfig(
+                stem_stride=backbone_cfg.unet.stem_stride,
+                max_stride=backbone_cfg.unet.max_stride,
+                output_stride=backbone_cfg.unet.output_stride,
+                filters=backbone_cfg.unet.filters,
+                filters_rate=backbone_cfg.unet.filters_rate,
+                middle_block=backbone_cfg.unet.middle_block,
+                up_interpolate=backbone_cfg.unet.up_interpolate,
+                stacks=backbone_cfg.unet.stacks,
+            )
+        ),
+        heads=HeadsConfig(
+            single_instance=SingleInstanceConfmapsHeadConfig(
+                part_names=[x for x in head_cfgs.single_instance.confmaps.part_names],
+                sigma=head_cfgs.single_instance.confmaps.sigma,
+                output_stride=head_cfgs.single_instance.confmaps.output_stride,
+            )
+            if head_type == "single_instance"
+            else None,
+            centroid=CentroidsHeadConfig(
+                anchor_part=head_cfgs.centroid.confmaps.anchor_part,
+                sigma=head_cfgs.centroid.confmaps.sigma,
+                output_stride=head_cfgs.centroid.confmaps.output_stride,
+            )
+            if head_type == "centroid"
+            else None,
+            centered_instance=CenteredInstanceConfmapsHeadConfig(
+                part_names=[x for x in head_cfgs.centered_instance.confmaps.part_names],
+                anchor_part=head_cfgs.centered_instance.confmaps.anchor_part,
+                sigma=head_cfgs.centered_instance.confmaps.sigma,
+                output_stride=head_cfgs.centered_instance.confmaps.output_stride,
+                loss_weight=head_cfgs.centered_instance.confmaps.loss_weight,
+            )
+            if head_type == "centered_instance"
+            else None,
+            multi_instance=MultiInstanceConfig(
+                confmaps=MultiInstanceConfmapsHeadConfig(
+                    part_names=[x for x in head_cfgs.bottomup.confmaps.part_names],
+                    sigma=head_cfgs.bottomup.confmaps.sigma,
+                    output_stride=head_cfgs.bottomup.confmaps.output_stride,
+                    loss_weight=head_cfgs.bottomup.confmaps.loss_weight,
+                ),
+                pafs=PartAffinityFieldsHeadConfig(
+                    edges=[edge for edge in head_cfgs.bottomup.pafs.edges],
+                    sigma=head_cfgs.bottomup.pafs.sigma,
+                    output_stride=head_cfgs.bottomup.pafs.output_stride,
+                    loss_weight=head_cfgs.bottomup.pafs.loss_weight,
+                ),
+            )
+            if head_type == "bottomup"
+            else None,
+            multi_class_bottomup=MultiClassBottomUpConfig(
+                confmaps=MultiInstanceConfmapsHeadConfig(
+                    part_names=[
+                        x for x in head_cfgs.multi_class_bottomup.confmaps.part_names
+                    ],
+                    sigma=head_cfgs.multi_class_bottomup.confmaps.sigma,
+                    output_stride=head_cfgs.multi_class_bottomup.confmaps.output_stride,
+                    loss_weight=head_cfgs.multi_class_bottomup.confmaps.loss_weight,
+                ),
+                class_maps=ClassMapsHeadConfig(
+                    classes=[
+                        x for x in head_cfgs.multi_class_bottomup.class_maps.classes
+                    ],
+                    sigma=head_cfgs.multi_class_bottomup.class_maps.sigma,
+                    output_stride=head_cfgs.multi_class_bottomup.class_maps.output_stride,
+                    loss_weight=head_cfgs.multi_class_bottomup.class_maps.loss_weight,
+                ),
+            )
+            if head_type == "multi_class_bottomup"
+            else None,
+            multi_class_topdown=MultiClassTopDownConfig(
+                confmaps=CenteredInstanceConfmapsHeadConfig(
+                    part_names=[
+                        x for x in head_cfgs.multi_class_topdown.confmaps.part_names
+                    ],
+                    anchor_part=head_cfgs.multi_class_topdown.confmaps.anchor_part,
+                    sigma=head_cfgs.multi_class_topdown.confmaps.sigma,
+                    output_stride=head_cfgs.multi_class_topdown.confmaps.output_stride,
+                    loss_weight=head_cfgs.multi_class_topdown.confmaps.loss_weight,
+                ),
+                class_vectors=ClassVectorsHeadConfig(
+                    classes=[
+                        x for x in head_cfgs.multi_class_topdown.class_vectors.classes
+                    ],
+                    num_fc_layers=head_cfgs.multi_class_topdown.class_vectors.num_fc_layers,
+                    num_fc_units=head_cfgs.multi_class_topdown.class_vectors.num_fc_units,
+                    global_pool=head_cfgs.multi_class_topdown.class_vectors.global_pool,
+                    output_stride=head_cfgs.multi_class_topdown.class_vectors.output_stride,
+                    loss_weight=head_cfgs.multi_class_topdown.class_vectors.loss_weight,
+                ),
+            )
+            if head_type == "multi_class_topdown"
+            else None,
+        ),
+    )
+    aug_cfg = data_cfg.augmentation_config
+    ac = AugmentationConfig(
+        rotate=True if aug_cfg.geometric.affine_p > 0 else False,
+        rotation_min_angle=-aug_cfg.geometric.rotation,
+        rotation_max_angle=aug_cfg.geometric.rotation,
+        scale=True if aug_cfg.geometric.affine_p > 0 else False,
+        scale_min=aug_cfg.geometric.scale[0],
+        scale_max=aug_cfg.geometric.scale[1],
+        uniform_noise=True if aug_cfg.intensity.uniform_noise_p > 0 else False,
+        uniform_noise_min_val=aug_cfg.intensity.uniform_noise_min,
+        uniform_noise_max_val=aug_cfg.intensity.uniform_noise_max,
+        gaussian_noise=True if aug_cfg.intensity.gaussian_noise_p > 0 else False,
+        gaussian_noise_mean=aug_cfg.intensity.gaussian_noise_mean,
+        gaussian_noise_stddev=aug_cfg.intensity.gaussian_noise_std,
+        contrast=True if aug_cfg.intensity.contrast_p > 0 else False,
+        contrast_min_gamma=aug_cfg.intensity.contrast_min,
+        contrast_max_gamma=aug_cfg.intensity.contrast_max,
+        brightness=True if aug_cfg.intensity.brightness_p > 0 else False,
+        brightness_min_val=aug_cfg.intensity.brightness[0],
+        brightness_max_val=aug_cfg.intensity.brightness[1],
+    )
+    augmentaion_config = (
+        AugmentationConfig() if not data_cfg.use_augmentations_train else ac
+    )
+    optimization = OptimizationConfig(
+        augmentation_config=augmentaion_config,
+        batch_size=trainer_cfg.train_data_loader.batch_size,
+        epochs=trainer_cfg.max_epochs,
+        optimizer=trainer_cfg.optimizer_name,
+        min_batches_per_epoch=trainer_cfg.min_train_steps_per_epoch,
+        batches_per_epoch=trainer_cfg.train_steps_per_epoch,
+        initial_learning_rate=trainer_cfg.optimizer.lr,
+        learning_rate_schedule=LearningRateScheduleConfig(
+            reduce_on_plateau=True
+            if trainer_cfg.lr_scheduler.reduce_lr_on_plateau is not None
+            else False,
+            reduction_factor=trainer_cfg.lr_scheduler.reduce_lr_on_plateau.factor,
+            plateau_min_delta=trainer_cfg.lr_scheduler.reduce_lr_on_plateau.factor,
+            plateau_patience=trainer_cfg.lr_scheduler.reduce_lr_on_plateau.patience,
+            plateau_cooldown=trainer_cfg.lr_scheduler.reduce_lr_on_plateau.cooldown,
+            min_learning_rate=trainer_cfg.lr_scheduler.reduce_lr_on_plateau.min_lr,
+        ),
+        hard_keypoint_mining=HardKeypointMiningConfig(
+            online_mining=trainer_cfg.online_hard_keypoint_mining.online_mining,
+            hard_to_easy_ratio=trainer_cfg.online_hard_keypoint_mining.hard_to_easy_ratio,
+            min_hard_keypoints=trainer_cfg.online_hard_keypoint_mining.min_hard_keypoints,
+            max_hard_keypoints=trainer_cfg.online_hard_keypoint_mining.max_hard_keypoints,
+            loss_scale=trainer_cfg.online_hard_keypoint_mining.loss_scale,
+        ),
+        early_stopping=EarlyStoppingConfig(
+            stop_training_on_plateau=trainer_cfg.early_stopping.stop_training_on_plateau,
+            plateau_min_delta=trainer_cfg.early_stopping.min_delta,
+            plateau_patience=trainer_cfg.early_stopping.patience,
+        ),
+    )
+    outputs = OutputsConfig(
+        run_name=trainer_cfg.save_ckpt_path.split("/")[-1],
+        save_visualizations=trainer_cfg.visualize_preds_during_training,
+        checkpointing=CheckpointingConfig(
+            best_model=trainer_cfg.save_ckpt,
+            latest_model=trainer_cfg.model_ckpt.save_last,
+        ),
+        zmq=ZMQConfig(
+            subscribe_to_controller=True
+            if trainer_cfg.zmq.controller_address is not None
+            else False,
+            controller_address=trainer_cfg.zmq.controller_address,
+            publish_updates=True
+            if trainer_cfg.zmq.publish_address is not None
+            else False,
+            publish_address=trainer_cfg.zmq.publish_address,
+            controller_polling_timeout=trainer_cfg.zmq.controller_polling_timeout,
+        ),
+    )
+    filename = trainer_cfg.save_ckpt_path + "/training_config.yaml"
+
+    return TrainingJobConfig(
+        data=data,
+        model=model,
+        optimization=optimization,
+        outputs=outputs,
+        filename=filename,
+    )

--- a/sleap/gui/web.py
+++ b/sleap/gui/web.py
@@ -150,14 +150,12 @@ def get_analytics_data() -> Dict[str, Any]:
     """Gather data to be transmitted to analytics backend."""
     import os
     import sleap
-    import tensorflow as tf
     from pathlib import Path
     import platform
 
     return {
         "sleap_version": sleap.__version__,
         "python_version": platform.python_version(),
-        "tf_version": tf.__version__,
         "conda_env": Path(os.environ.get("CONDA_PREFIX", "")).stem,
         "platform": platform.platform(),
     }

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -51,7 +51,7 @@ class LossPlot(MplCanvas):
         )
 
         # Initialize line series for epoch training loss
-        self.series["epoch_loss"] = self._init_series(
+        self.series["train_loss"] = self._init_series(
             series_type=self.axes.plot,
             name="Epoch Training Loss",
             color=COLOR_TRAIN + (255,),
@@ -160,7 +160,7 @@ class LossPlot(MplCanvas):
             x: The x-coordinate of the data point.
             y: The y-coordinate of the data point.
             which: The type of data point. Possible values are:
-                * "epoch_loss"
+                * "train_loss"
                 * "val_loss"
         """
 
@@ -254,7 +254,7 @@ class LossPlot(MplCanvas):
 
             # Add best epoch validation loss if available
             if best_val_x is not None:
-                best_epoch = (best_val_x // epoch_size) + 1
+                best_epoch = best_val_x // epoch_size
                 best_val_text = self._get_best_validation_loss_text(
                     best_val_y, best_epoch
                 )
@@ -686,7 +686,7 @@ class LossViewer(QtWidgets.QMainWindow):
 
         self.mp_series = dict()
         self.mp_series["batch"] = self.canvas.series["batch"]
-        self.mp_series["epoch_loss"] = self.canvas.series["epoch_loss"]
+        self.mp_series["train_loss"] = self.canvas.series["train_loss"]
         self.mp_series["val_loss"] = self.canvas.series["val_loss"]
         self.mp_series["val_loss_best"] = self.canvas.series["val_loss_best"]
 
@@ -766,6 +766,7 @@ class LossViewer(QtWidgets.QMainWindow):
         self.epoch_in_plateau_flag = False
         self.last_batch_number = 0
         self.is_running = False
+        self.best_epoch_loss = None
 
     def set_message(self, text: str):
         """Set the chart title text."""
@@ -880,7 +881,7 @@ class LossViewer(QtWidgets.QMainWindow):
                 a new training session (when we're training multiple types
                 of models in a sequence, as for the top-down pipeline).
             * logs - dictionary with data relevant for plotting, can include
-                * loss
+                * train_loss
                 * val_loss
 
         Args:
@@ -912,9 +913,9 @@ class LossViewer(QtWidgets.QMainWindow):
                 elif msg["event"] == "epoch_end":
                     self.epoch_size = max(self.epoch_size, self.last_batch_number + 1)
                     self._add_datapoint(
-                        (self.epoch + 1) * self.epoch_size,
-                        msg["logs"]["loss"],
-                        "epoch_loss",
+                        x=(self.epoch + 1) * self.epoch_size,
+                        y=msg["logs"]["train_loss"],
+                        which="train_loss",
                     )
                     if "val_loss" in msg["logs"].keys():
                         # update variables and add points to plot
@@ -935,28 +936,36 @@ class LossViewer(QtWidgets.QMainWindow):
                             )
                             self.eta_ten_epochs_min = (mean_epoch_time * 10) // 60
 
-                            val_loss_delta = (
-                                self.penultimate_epoch_val_loss
-                                - self.last_epoch_val_loss
-                            )
-                            self.epoch_in_plateau_flag = (
-                                self.plateau_min_delta is not None
-                            ) and (
-                                (val_loss_delta < self.plateau_min_delta)
-                                or (self.best_val_y < self.last_epoch_val_loss)
-                            )
+                            if self.best_epoch_loss is None:
+                                self.best_epoch_loss = self.last_epoch_val_loss
+
+                            if self.plateau_min_delta is not None:
+                                # check plateau condition according to `rel` threshold model in pytorch.
+                                is_better = (
+                                    self.last_epoch_val_loss
+                                    < self.best_epoch_loss
+                                    * (1.0 - self.plateau_min_delta)
+                                )
+                            else:
+                                is_better = (
+                                    self.last_epoch_val_loss < self.best_epoch_loss
+                                )
+
+                            self.epoch_in_plateau_flag = not is_better
                             self.epochs_in_plateau = (
                                 self.epochs_in_plateau + 1
                                 if self.epoch_in_plateau_flag
                                 else 0
                             )
+                            if is_better:
+                                self.best_epoch_loss = self.last_epoch_val_loss
                     self.on_epoch.emit()
                 elif msg["event"] == "batch_end":
                     self.last_batch_number = msg["batch"]
                     self._add_datapoint(
-                        (self.epoch * self.epoch_size) + msg["batch"],
-                        msg["logs"]["loss"],
-                        "batch",
+                        x=(self.epoch * self.epoch_size) + msg["batch"],
+                        y=msg["logs"]["train_loss"],
+                        which="batch",
                     )
 
             # Check for messages again (up to times_to_check times).
@@ -976,7 +985,7 @@ class LossViewer(QtWidgets.QMainWindow):
             y: The loss value.
             which: Type of data point we're adding. Possible values are:
                 * "batch" (loss for the batch)
-                * "epoch_loss" (loss for the entire epoch)
+                * "train_loss" (loss for the entire epoch)
                 * "val_loss" (validation loss for the epoch)
         """
         if which == "batch":
@@ -1041,7 +1050,7 @@ class LossViewer(QtWidgets.QMainWindow):
             x: The x-coordinate of the data point.
             y: The y-coordinate of the data point.
             which: The type of data point. Possible values are:
-                * "epoch_loss"
+                * "train_loss"
                 * "val_loss"
         """
 

--- a/sleap/training_profiles/baseline.centroid.json
+++ b/sleap/training_profiles/baseline.centroid.json
@@ -63,7 +63,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/baseline_large_rf.bottomup.json
+++ b/sleap/training_profiles/baseline_large_rf.bottomup.json
@@ -72,7 +72,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/baseline_large_rf.single.json
+++ b/sleap/training_profiles/baseline_large_rf.single.json
@@ -63,7 +63,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/baseline_large_rf.topdown.json
+++ b/sleap/training_profiles/baseline_large_rf.topdown.json
@@ -64,7 +64,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/baseline_medium_rf.bottomup.json
+++ b/sleap/training_profiles/baseline_medium_rf.bottomup.json
@@ -72,7 +72,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/baseline_medium_rf.single.json
+++ b/sleap/training_profiles/baseline_medium_rf.single.json
@@ -63,7 +63,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/baseline_medium_rf.topdown.json
+++ b/sleap/training_profiles/baseline_medium_rf.topdown.json
@@ -64,7 +64,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/pretrained.bottomup.json
+++ b/sleap/training_profiles/pretrained.bottomup.json
@@ -69,7 +69,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/pretrained.centroid.json
+++ b/sleap/training_profiles/pretrained.centroid.json
@@ -60,7 +60,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/pretrained.single.json
+++ b/sleap/training_profiles/pretrained.single.json
@@ -60,7 +60,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/training_profiles/pretrained.topdown.json
+++ b/sleap/training_profiles/pretrained.topdown.json
@@ -61,7 +61,7 @@
             "scale_max": 1.1,
             "uniform_noise": false,
             "uniform_noise_min_val": 0.0,
-            "uniform_noise_max_val": 10.0,
+            "uniform_noise_max_val": 1.0,
             "gaussian_noise": false,
             "gaussian_noise_mean": 5.0,
             "gaussian_noise_stddev": 1.0,

--- a/sleap/version.py
+++ b/sleap/version.py
@@ -16,13 +16,11 @@ __version__ = "1.4.1"
 
 def versions():
     """Print versions of SLEAP and other libraries."""
-    import tensorflow as tf
     import numpy as np
     import platform
 
     vers = {}
     vers["SLEAP"] = __version__
-    vers["TensorFlow"] = tf.__version__
     vers["Numpy"] = np.__version__
     vers["Python"] = platform.python_version()
     vers["OS"] = platform.platform()


### PR DESCRIPTION
### Description
This is the third PR addressing #2223 and focuses on integrating SLEAP-NN's training and inference APIs into the SLEAP GUI workflow. It updates the training runner to convert legacy JSON configs to YAML using a SLEAP-NN mapper and replaces sleap-train with the sleap-nn train CLI. The inference runner is also updated to translate SLEAP CLI arguments into SLEAP-NN-compatible predict arguments, along with adjusting tracker parameters. Loss monitoring is fixed to correctly handle PyTorch-style validation loss plateaus. A new YAML -> JSON converter is added to load SLEAP-NN config files into the GUI, and the training dialog is updated to support YAML and `.ckpt` file types. 

### Types of changes

- [ ] Bugfix
- [ ] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
[list open issues here]

### Outside contributors checklist

- [ ] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [ ] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [ ] Add tests that prove your fix is effective or that your feature works
- [ ] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
