### PR TITLE
Add support for any augmentations functions in `albumentations` in training_config. 

### DIFF
--- a/sleap/nn/config/optimization.py
+++ b/sleap/nn/config/optimization.py
@@ -57,11 +57,11 @@ class AugmentationConfig:
             symmetric must be marked on the skeleton in order to be swapped correctly.
         flip_horizontal: If `True`, flip images left/right when randomly reflecting
             them. If `False`, flipping is down up/down instead.
-        custom_albumentation_funcs: If provided, a list of dictionaries where each 
-            dictionary contains 'function' (the albumentations function name) and 
-            'params' (keyword arguments for that function). This allows for more complex 
-            augmentations that are not supported by the default augmentation stack. 
-            Will throw an error if provided params are not compatible with the 
+        custom_albumentation_funcs: If provided, a list of dictionaries where each
+            dictionary contains 'function' (the albumentations function name) and
+            'params' (keyword arguments for that function). This allows for more complex
+            augmentations that are not supported by the default augmentation stack.
+            Will throw an error if provided params are not compatible with the
             albumentations library.
             Example Usage: [{"function": "MotionBlur", "params": {"blur_limit": [10, 12], "p": 0.5}}]
     """

--- a/sleap/nn/config/optimization.py
+++ b/sleap/nn/config/optimization.py
@@ -1,5 +1,5 @@
 import attr
-from typing import Optional, Text
+from typing import Optional, Text, List, Dict, Any
 
 
 @attr.s(auto_attribs=True)
@@ -57,6 +57,13 @@ class AugmentationConfig:
             symmetric must be marked on the skeleton in order to be swapped correctly.
         flip_horizontal: If `True`, flip images left/right when randomly reflecting
             them. If `False`, flipping is down up/down instead.
+        custom_albumentation_funcs: If provided, a list of dictionaries where each 
+            dictionary contains 'function' (the albumentations function name) and 
+            'params' (keyword arguments for that function). This allows for more complex 
+            augmentations that are not supported by the default augmentation stack. 
+            Will throw an error if provided params are not compatible with the 
+            albumentations library.
+            Example Usage: [{"function": "MotionBlur", "params": {"blur_limit": [10, 12], "p": 0.5}}]
     """
 
     rotate: bool = False
@@ -85,6 +92,7 @@ class AugmentationConfig:
     random_crop_width: int = 256
     random_flip: bool = False
     flip_horizontal: bool = True
+    custom_albumentation_funcs: Optional[List[Dict[str, Any]]] = None
 
 
 @attr.s(auto_attribs=True)

--- a/sleap/nn/data/augmentation.py
+++ b/sleap/nn/data/augmentation.py
@@ -192,7 +192,7 @@ class AlbumentationsAugmenter:
                     limit=(config.brightness_min_val, config.brightness_max_val), p=1.0
                 )
             )
-        if config.custom_albumentation_funcs: 
+        if config.custom_albumentation_funcs:
             for func_config in config.custom_albumentation_funcs:
                 func = func_config["function"]
                 kwargs = func_config["params"]
@@ -211,10 +211,15 @@ class AlbumentationsAugmenter:
                 aug_stack.append(func_cls(**kwargs))
                 print(
                     f"Added custom albumentation function: \n\tA.{func}("
-                    + (", ".join(f"{k}={v}" for k, v in kwargs.items() if v is not None) if kwargs else "")
+                    + (
+                        ", ".join(
+                            f"{k}={v}" for k, v in kwargs.items() if v is not None
+                        )
+                        if kwargs
+                        else ""
+                    )
                     + ")"
                 )
-                
 
         return cls(
             augmenter=A.Compose(
@@ -250,6 +255,7 @@ class AlbumentationsAugmenter:
             The "scale" key in examples are not modified when scaling augmentation is
             applied.
         """
+
         # Define augmentation function to map over each sample.
         def py_augment(image, instances):
             """Local processing function that will not be autographed."""

--- a/sleap/nn/data/augmentation.py
+++ b/sleap/nn/data/augmentation.py
@@ -192,6 +192,29 @@ class AlbumentationsAugmenter:
                     limit=(config.brightness_min_val, config.brightness_max_val), p=1.0
                 )
             )
+        if config.custom_albumentation_funcs: 
+            for func_config in config.custom_albumentation_funcs:
+                func = func_config["function"]
+                kwargs = func_config["params"]
+                if not hasattr(A, func):
+                    raise ValueError(
+                        f"Custom albumentation function '{func}' is not a valid albumentation function."
+                    )
+                # Check if kwargs are valid for the albumentations function
+                func_cls = getattr(A, func)
+                valid_args = func_cls.__init__.__code__.co_varnames
+                for key in kwargs:
+                    if key not in valid_args:
+                        raise ValueError(
+                            f"Keyword argument '{key}' is not valid for albumentations function '{func}'."
+                        )
+                aug_stack.append(func_cls(**kwargs))
+                print(
+                    f"Added custom albumentation function: \n\tA.{func}("
+                    + (", ".join(f"{k}={v}" for k, v in kwargs.items() if v is not None) if kwargs else "")
+                    + ")"
+                )
+                
 
         return cls(
             augmenter=A.Compose(

--- a/tests/nn/data/test_augmentation.py
+++ b/tests/nn/data/test_augmentation.py
@@ -9,6 +9,7 @@ use_cpu_only()  # hide GPUs for test
 from sleap.nn.data import providers
 from sleap.nn.data import augmentation
 from sleap.nn.data.pipelines import Pipeline
+import albumentations as A
 
 
 @pytest.fixture
@@ -300,3 +301,123 @@ def test_random_flipper():
         ex["instances"],
         [[[25, 333], [25, 358], [50, 358]], [[125, 233], [125, 258], [150, 258]]],
     )
+
+
+def test_custom_albumentations_augmenter():
+    """Test custom albumentations functionality with configuration validation."""
+    
+    # Test 1: Valid configuration
+    config = augmentation.AugmentationConfig(
+        custom_albumentation_funcs=[
+            {"function": "MotionBlur", "params": {"blur_limit": [3, 7], "p": 0.5}},
+            {"function": "CLAHE", "params": {"clip_limit": 2.0, "p": 0.3}},
+            {"function": "Blur", "params": {"blur_limit": 3, "p": 0.2}}
+        ]
+    )
+    
+    augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
+    assert len(augmenter.augmenter.transforms) == 3
+    
+    # Test 2: Invalid function name should raise ValueError
+    with pytest.raises(ValueError, match="not a valid albumentation function"):
+        config = augmentation.AugmentationConfig(
+            custom_albumentation_funcs=[
+                {"function": "NonExistentFunction", "params": {"p": 0.5}}
+            ]
+        )
+        augmentation.AlbumentationsAugmenter.from_config(config)
+    
+    # Test 3: Invalid parameter should raise ValueError
+    with pytest.raises(ValueError, match="not valid for albumentations function"):
+        config = augmentation.AugmentationConfig(
+            custom_albumentation_funcs=[
+                {"function": "MotionBlur", "params": {"invalid_param": 5, "p": 0.5}}
+            ]
+        )
+        augmentation.AlbumentationsAugmenter.from_config(config)
+    
+    # Test 4: Empty/None configuration should work
+    config = augmentation.AugmentationConfig(custom_albumentation_funcs=None)
+    augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
+    assert len(augmenter.augmenter.transforms) == 0
+    
+    config = augmentation.AugmentationConfig(custom_albumentation_funcs=[])
+    augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
+    assert len(augmenter.augmenter.transforms) == 0
+
+
+def test_custom_albumentations_with_dummy_data(dummy_image_data, dummy_instances_data_zeros):
+    """Test custom albumentations with dummy data using existing fixtures."""
+    
+    # Create dataset using existing fixtures
+    dataset = tf.data.Dataset.from_tensor_slices(
+        {"image": [dummy_image_data], "instances": [dummy_instances_data_zeros]}
+    )
+    
+    # Test with noise augmentation (deterministic for testing)
+    config = augmentation.AugmentationConfig(
+        custom_albumentation_funcs=[
+            {"function": "GaussNoise", "params": {"var_limit": [10, 10], "p": 1.0}},  # Fixed variance for consistency
+        ]
+    )
+    
+    augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
+    augmented_dataset = augmenter.transform_dataset(dataset)
+    
+    original_example = next(iter(dataset))
+    augmented_example = next(iter(augmented_dataset))
+    
+    # Check shapes are preserved
+    assert augmented_example["image"].shape == original_example["image"].shape
+    assert augmented_example["instances"].shape == original_example["instances"].shape
+    
+    # Check that augmentation was applied (image should be different due to noise)
+    assert not tf.reduce_all(augmented_example["image"] == original_example["image"])
+    
+    # Check that keypoints are preserved (GaussNoise doesn't affect keypoints)
+    np.testing.assert_array_equal(
+        augmented_example["instances"].numpy(), 
+        original_example["instances"].numpy()
+    )
+
+
+def test_custom_albumentations_with_pipeline(min_labels):
+    """Test custom albumentations integration with SLEAP pipeline using min_labels fixture."""
+    
+    # Test with a transform that affects both image and keypoints
+    config = augmentation.AugmentationConfig(
+        custom_albumentation_funcs=[
+            {"function": "Affine", "params": {"scale": 1.1, "p": 1.0}},  # Deterministic scaling
+        ]
+    )
+    
+    labels_reader = providers.LabelsReader.from_user_instances(min_labels)
+    ds = labels_reader.make_dataset()
+    example_preaug = next(iter(ds))
+    
+    augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
+    ds = augmenter.transform_dataset(ds)
+    example = next(iter(ds))
+    
+    # Check that shapes are preserved
+    assert example["image"].shape == example_preaug["image"].shape
+    assert example["instances"].shape == example_preaug["instances"].shape
+    assert example["image"].dtype == example_preaug["image"].dtype
+    assert example["instances"].dtype == example_preaug["instances"].dtype
+    
+    # Check that scaling was applied (keypoints should be different)
+    assert not tf.reduce_all(example["instances"] == example_preaug["instances"])
+    
+    # Test combining with built-in augmentations
+    config_combined = augmentation.AugmentationConfig(
+        rotate=True,
+        rotation_min_angle=0,
+        rotation_max_angle=0,  # No rotation for predictable results
+        custom_albumentation_funcs=[
+            {"function": "CLAHE", "params": {"clip_limit": 2.0, "p": 1.0}},
+        ]
+    )
+    
+    augmenter_combined = augmentation.AlbumentationsAugmenter.from_config(config_combined)
+    # Should have 2 transforms: rotation + CLAHE
+    assert len(augmenter_combined.augmenter.transforms) == 2

--- a/tests/nn/data/test_augmentation.py
+++ b/tests/nn/data/test_augmentation.py
@@ -1,4 +1,5 @@
 import pytest
+import albumentations as A
 import numpy as np
 import tensorflow as tf
 import sleap
@@ -9,7 +10,6 @@ use_cpu_only()  # hide GPUs for test
 from sleap.nn.data import providers
 from sleap.nn.data import augmentation
 from sleap.nn.data.pipelines import Pipeline
-import albumentations as A
 
 
 @pytest.fixture
@@ -305,19 +305,19 @@ def test_random_flipper():
 
 def test_custom_albumentations_augmenter():
     """Test custom albumentations functionality with configuration validation."""
-    
+
     # Test 1: Valid configuration
     config = augmentation.AugmentationConfig(
         custom_albumentation_funcs=[
             {"function": "MotionBlur", "params": {"blur_limit": [3, 7], "p": 0.5}},
             {"function": "CLAHE", "params": {"clip_limit": 2.0, "p": 0.3}},
-            {"function": "Blur", "params": {"blur_limit": 3, "p": 0.2}}
+            {"function": "Blur", "params": {"blur_limit": 3, "p": 0.2}},
         ]
     )
-    
+
     augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
     assert len(augmenter.augmenter.transforms) == 3
-    
+
     # Test 2: Invalid function name should raise ValueError
     with pytest.raises(ValueError, match="not a valid albumentation function"):
         config = augmentation.AugmentationConfig(
@@ -326,7 +326,7 @@ def test_custom_albumentations_augmenter():
             ]
         )
         augmentation.AlbumentationsAugmenter.from_config(config)
-    
+
     # Test 3: Invalid parameter should raise ValueError
     with pytest.raises(ValueError, match="not valid for albumentations function"):
         config = augmentation.AugmentationConfig(
@@ -335,79 +335,86 @@ def test_custom_albumentations_augmenter():
             ]
         )
         augmentation.AlbumentationsAugmenter.from_config(config)
-    
+
     # Test 4: Empty/None configuration should work
     config = augmentation.AugmentationConfig(custom_albumentation_funcs=None)
     augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
     assert len(augmenter.augmenter.transforms) == 0
-    
+
     config = augmentation.AugmentationConfig(custom_albumentation_funcs=[])
     augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
     assert len(augmenter.augmenter.transforms) == 0
 
 
-def test_custom_albumentations_with_dummy_data(dummy_image_data, dummy_instances_data_zeros):
+def test_custom_albumentations_with_dummy_data(
+    dummy_image_data, dummy_instances_data_zeros
+):
     """Test custom albumentations with dummy data using existing fixtures."""
-    
+
     # Create dataset using existing fixtures
     dataset = tf.data.Dataset.from_tensor_slices(
         {"image": [dummy_image_data], "instances": [dummy_instances_data_zeros]}
     )
-    
+
     # Test with noise augmentation (deterministic for testing)
     config = augmentation.AugmentationConfig(
         custom_albumentation_funcs=[
-            {"function": "GaussNoise", "params": {"var_limit": [10, 10], "p": 1.0}},  # Fixed variance for consistency
+            {
+                "function": "GaussNoise",
+                "params": {"var_limit": [10, 10], "p": 1.0},
+            },  # Fixed variance for consistency
         ]
     )
-    
+
     augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
     augmented_dataset = augmenter.transform_dataset(dataset)
-    
+
     original_example = next(iter(dataset))
     augmented_example = next(iter(augmented_dataset))
-    
+
     # Check shapes are preserved
     assert augmented_example["image"].shape == original_example["image"].shape
     assert augmented_example["instances"].shape == original_example["instances"].shape
-    
+
     # Check that augmentation was applied (image should be different due to noise)
     assert not tf.reduce_all(augmented_example["image"] == original_example["image"])
-    
+
     # Check that keypoints are preserved (GaussNoise doesn't affect keypoints)
     np.testing.assert_array_equal(
-        augmented_example["instances"].numpy(), 
-        original_example["instances"].numpy()
+        augmented_example["instances"].numpy(), original_example["instances"].numpy()
     )
 
 
 def test_custom_albumentations_with_pipeline(min_labels):
     """Test custom albumentations integration with SLEAP pipeline using min_labels fixture."""
-    
+
     # Test with a transform that affects both image and keypoints
     config = augmentation.AugmentationConfig(
         custom_albumentation_funcs=[
-            {"function": "Affine", "params": {"scale": 1.1, "p": 1.0}},  # Deterministic scaling
+            {
+                "function": "Affine",
+                "params": {"scale": 1.1, "p": 1.0},
+            },  # Deterministic scaling
         ]
     )
-    
+
     labels_reader = providers.LabelsReader.from_user_instances(min_labels)
     ds = labels_reader.make_dataset()
     example_preaug = next(iter(ds))
-    
+
     augmenter = augmentation.AlbumentationsAugmenter.from_config(config)
     ds = augmenter.transform_dataset(ds)
     example = next(iter(ds))
-    
+
     # Check that shapes are preserved
     assert example["image"].shape == example_preaug["image"].shape
     assert example["instances"].shape == example_preaug["instances"].shape
     assert example["image"].dtype == example_preaug["image"].dtype
     assert example["instances"].dtype == example_preaug["instances"].dtype
-    
+
     # Check that scaling was applied (keypoints should be different)
     assert not tf.reduce_all(example["instances"] == example_preaug["instances"])
-    
+
     # Test combining with built-in augmentations
     config_combined = augmentation.AugmentationConfig(
         rotate=True,
@@ -415,9 +422,11 @@ def test_custom_albumentations_with_pipeline(min_labels):
         rotation_max_angle=0,  # No rotation for predictable results
         custom_albumentation_funcs=[
             {"function": "CLAHE", "params": {"clip_limit": 2.0, "p": 1.0}},
-        ]
+        ],
     )
-    
-    augmenter_combined = augmentation.AlbumentationsAugmenter.from_config(config_combined)
+
+    augmenter_combined = augmentation.AlbumentationsAugmenter.from_config(
+        config_combined
+    )
     # Should have 2 transforms: rotation + CLAHE
     assert len(augmenter_combined.augmenter.transforms) == 2


### PR DESCRIPTION
### Description
This PR adds support for any arbitrary function that's defined in the `albumentations` package to be used in the training process of models. Usage: 
In `training_config.json`: 
```json
{
...
  "optimization": {
    ...
    "augmentation_config": {
      ...
      "custom_albumentation_funcs": [
        {"function": "MotionBlur", "params": {"blue_limit": [3,7], "p": 0.5}},
        {"function": "Blur", "params": {"blur_limit": 3, "p": 0.2}}
      ]
    }
  }
}
```

### Types of changes

- [ ] Bugfix
- [x] New feature
- [ ] Refactor / Code style update (no logical changes)
- [ ] Build / CI changes
- [ ] Documentation Update
- [ ] Other (explain)

### Does this address any currently open issues?
N/A

### Outside contributors checklist

- [x] Review the [guidelines for contributing](https://github.com/talmolab/sleap/blob/develop/docs/CONTRIBUTING.md) to this repository
- [ ] Read and sign the [CLA](https://github.com/talmolab/sleap/blob/develop/sleap-cla.pdf) and add yourself to the [authors list](https://github.com/talmolab/sleap/blob/develop/AUTHORS)
- [x] Make sure you are making a pull request against the **develop** branch (not *main*). Also you should start *your branch* off *develop*
- [x] Add tests that prove your fix is effective or that your feature works
- [x] Add necessary documentation (if appropriate)

#### Thank you for contributing to SLEAP!
:heart:
