### PR TITLE
Add Config for `sleap-nn` in the GUI

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -211,6 +211,13 @@ training:
   options: ',RGB,grayscale'
   type: list
 
+- name: data.data_pipeline_fw
+  help: Framework to create the data loaders. 
+  label: Data Pipeline Framework
+  type: list
+  default: "torch_dataset"
+  options: "torch_dataset,torch_dataset_cache_img_memory,torch_dataset_cache_img_disk"
+
 - type: text
   text: '<b>ZMQ Options</b>'
 
@@ -225,6 +232,25 @@ training:
   type: int
   default: 9001
   range: 1024,65535
+
+- type: text
+  text: '<b>Trainer Options</b>'
+
+- name: num_workers
+  label: Number of Workers
+  type: int
+  default: 0
+
+- name: trainer_devices
+  label: Trainer Devices
+  type: str
+  default: "auto"
+
+- name: trainer_accelerator
+  label: Trainer Accelerator
+  type: list
+  default: "Auto"
+  options: auto,cpu,gpu,tpu,ipu
 
 - type: text
   text: '<b>Output Options</b>'
@@ -283,6 +309,44 @@ training:
   type: list
   options: current frame,random frames
   default: current frame
+
+- type: text
+  text: '<b>WandB Configuration</b>'
+
+- name: wandb_entity
+  label: Entity
+  type: string
+  default: ''
+
+- name: wandb_project
+  label: Project
+  type: string
+  default: ''
+
+- name: wandb_run_name
+  label: Run Name
+  type: string
+  default: ''
+
+- name: wandb_api_key
+  label: API Key
+  type: string
+  default: ''
+
+- name: wandb_mode
+  label: Mode
+  type: string
+  default: 'None'
+
+- name: wandb_prev_runid
+  label: Previous Run ID
+  type: string
+  default: ''
+
+- name: wandb_group
+  label: Group
+  type: string
+  default: ''
 
 inference:
 

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -314,37 +314,42 @@ training:
 - type: text
   text: '<b>WandB Configuration</b>'
 
-- name: wandb_entity
+- name: outputs.use_wandb
+  label: Use WandB
+  type: bool
+  default: false
+
+- name: outputs.wandb.entity
   label: Entity
   type: string
   default: ''
 
-- name: wandb_project
+- name: outputs.wandb.project
   label: Project
   type: string
   default: ''
 
-- name: wandb_run_name
+- name: outputs.wandb.name
   label: Run Name
   type: string
   default: ''
 
-- name: wandb_api_key
+- name: outputs.wandb.api_key
   label: API Key
   type: string
   default: ''
 
-- name: wandb_mode
+- name: outputs.wandb.wandb_mode
   label: Mode
   type: string
   default: 'None'
 
-- name: wandb_prev_runid
+- name: outputs.wandb.prv_runid
   label: Previous Run ID
   type: string
   default: ''
 
-- name: wandb_group
+- name: outputs.wandb.group
   label: Group
   type: string
   default: ''

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -242,12 +242,12 @@ training:
   default: 0
   help: Number of worker threads to use for data loading and preprocessing. 0 means that the data will be loaded in the main process.
 
-- name: trainer_devices
+- name: optimization.trainer_devices
   label: Trainer Devices
   type: str
   default: "auto"
 
-- name: trainer_accelerator
+- name: optimization.trainer_accelerator
   label: Trainer Accelerator
   type: list
   default: "Auto"

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -236,10 +236,11 @@ training:
 - type: text
   text: '<b>Trainer Options</b>'
 
-- name: num_workers
+- name: optimization.num_workers
   label: Number of Workers
   type: int
   default: 0
+  help: Number of worker threads to use for data loading and preprocessing. 0 means that the data will be loaded in the main process.
 
 - name: trainer_devices
   label: Trainer Devices

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -940,6 +940,12 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
         self.pipeline_field = self.form_widget.form_layout.find_field("_pipeline")[0]
         self.pipeline_field.valueChanged.connect(self.emitPipeline)
 
+        # Connect to wandb field changes
+        wandb_field = self.form_widget.form_layout.find_field("outputs.use_wandb")
+        if wandb_field:
+            wandb_field[0].stateChanged.connect(self.update_wandb_fields)
+            self.update_wandb_fields()
+
         self.form_widget.form_layout.valueChanged.connect(self.valueChanged)
 
         self.setLayout(self.form_widget.form_layout)
@@ -1001,6 +1007,31 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
 
         self.pipeline_field.setValue(val)
         self.emitPipeline()
+
+    def update_wandb_fields(self):
+        """Enable/disable wandb fields based on use_wandb checkbox"""
+        use_wandb_field = self.form_widget.form_layout.find_field("outputs.use_wandb")
+        if not use_wandb_field:
+            return
+
+        use_wandb = use_wandb_field[0].isChecked()
+
+        wandb_fields = [
+            "outputs.wandb.entity",
+            "outputs.wandb.project",
+            "outputs.wandb.name",
+            "outputs.wandb.api_key",
+            "outputs.wandb.wandb_mode",
+            "outputs.wandb.prev_runid",
+            "outputs.wandb.group",
+        ]
+
+        for field_name in wandb_fields:
+            field = self.form_widget.form_layout.find_field(field_name)
+            if field:
+                field[0].setEnabled(use_wandb)
+                if not use_wandb:
+                    field[0].clear()
 
 
 class TrainingEditorWidget(QtWidgets.QWidget):

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1,6 +1,7 @@
 """
 Dialogs for running training and/or inference in GUI.
 """
+
 import json
 import shutil
 import tempfile
@@ -181,7 +182,7 @@ class LearningDialog(QtWidgets.QDialog):
 
     @staticmethod
     def count_total_frames_for_selection_option(
-        videos_frames: Dict[Video, List[int]]
+        videos_frames: Dict[Video, List[int]],
     ) -> int:
         if not videos_frames:
             return 0
@@ -348,9 +349,9 @@ class LearningDialog(QtWidgets.QDialog):
         if set_anchor:
             updated_data["model.heads.centroid.anchor_part"] = anchor_part
             updated_data["model.heads.centered_instance.anchor_part"] = anchor_part
-            updated_data[
-                "model.heads.multi_class_topdown.confmaps.anchor_part"
-            ] = anchor_part
+            updated_data["model.heads.multi_class_topdown.confmaps.anchor_part"] = (
+                anchor_part
+            )
             updated_data["data.instance_cropping.center_on_part"] = anchor_part
 
     def update_tabs_from_pipeline(self, source_data):
@@ -1320,9 +1321,9 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         if self._cfg_list_widget is None:
             return None
 
-        selected_config_info: Optional[
-            configs.ConfigFileInfo
-        ] = self._cfg_list_widget.getSelectedConfigInfo()
+        selected_config_info: Optional[configs.ConfigFileInfo] = (
+            self._cfg_list_widget.getSelectedConfigInfo()
+        )
         if (selected_config_info is None) or (
             not selected_config_info.has_trained_model
         ):

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -284,7 +284,10 @@ class InferenceTask:
         if "batch_size" in self.inference_params:
             cli_args.extend(["--batch_size", str(self.inference_params["batch_size"])])
 
-        if "max_instances" in self.inference_params and self.inference_params["max_instances"] is not None:
+        if (
+            "max_instances" in self.inference_params
+            and self.inference_params["max_instances"] is not None
+        ):
             cli_args.extend(["--max_instances", self.inference_params["max_instances"]])
 
         # add tracking args
@@ -322,7 +325,7 @@ class InferenceTask:
                     ]
                 )
 
-            if self.inference_params["tracking.similarity"]=="oks":
+            if self.inference_params["tracking.similarity"] == "oks":
                 cli_args.extend(["--features", "keypoints"])
                 cli_args.extend(["--scoring_method", "oks"])
             elif self.inference_params["tracking.similarity"] == "centroids":
@@ -930,8 +933,12 @@ def train_subprocess(
         cfg.trainer_config.save_ckpt_path = run_path
         cfg.trainer_config.visualize_preds_during_training = save_viz
         cfg.trainer_config.keep_viz = keep_viz
-        cfg.trainer_config.zmq.controller_address = f"tcp://127.0.0.1:{str(inference_params['controller_port'])}"
-        cfg.trainer_config.zmq.publish_address = f"tcp://127.0.0.1:{str(inference_params['publish_port'])}"
+        cfg.trainer_config.zmq.controller_address = (
+            f"tcp://127.0.0.1:{str(inference_params['controller_port'])}"
+        )
+        cfg.trainer_config.zmq.publish_address = (
+            f"tcp://127.0.0.1:{str(inference_params['publish_port'])}"
+        )
 
         OmegaConf.save(cfg, (Path(temp_dir) / f"{cfg_file_name}.yaml").as_posix())
 

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -943,6 +943,9 @@ def train_subprocess(
                 job_config.optimization.trainer_accelerator
             )
 
+        if hasattr(job_config.optimization, "trainer_devices"):
+            cfg.trainer_config.trainer_devices = job_config.optimization.trainer_devices
+
         cfg.trainer_config.save_ckpt_path = run_path
         cfg.trainer_config.visualize_preds_during_training = save_viz
         cfg.trainer_config.keep_viz = keep_viz

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -930,6 +930,9 @@ def train_subprocess(
         cfg = snn_TrainingJobConfig.load_sleap_config(training_job_path)
         cfg.data_config.train_labels_path = [labels_filename]
 
+        if hasattr(job_config.data, "data_pipeline_fw"):
+            cfg.data_config.data_pipeline_fw = job_config.data.data_pipeline_fw
+
         cfg.trainer_config.save_ckpt_path = run_path
         cfg.trainer_config.visualize_preds_during_training = save_viz
         cfg.trainer_config.keep_viz = keep_viz

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -946,6 +946,20 @@ def train_subprocess(
         if hasattr(job_config.optimization, "trainer_devices"):
             cfg.trainer_config.trainer_devices = job_config.optimization.trainer_devices
 
+        if hasattr(job_config.outputs, "use_wandb"):
+            cfg.trainer_config.use_wandb = job_config.outputs.use_wandb
+
+            if job_config.outputs.use_wandb:
+                cfg.trainer_config.wandb.entity = job_config.outputs.wandb.entity
+                cfg.trainer_config.wandb.project = job_config.outputs.wandb.project
+                cfg.trainer_config.wandb.name = job_config.outputs.wandb.name
+                cfg.trainer_config.wandb.api_key = job_config.outputs.wandb.api_key
+                cfg.trainer_config.wandb.wandb_mode = (
+                    job_config.outputs.wandb.wandb_mode
+                )
+                cfg.trainer_config.wandb.prv_runid = job_config.outputs.wandb.prv_runid
+                cfg.trainer_config.wandb.group = job_config.outputs.wandb.group
+
         cfg.trainer_config.save_ckpt_path = run_path
         cfg.trainer_config.visualize_preds_during_training = save_viz
         cfg.trainer_config.keep_viz = keep_viz

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -933,6 +933,11 @@ def train_subprocess(
         if hasattr(job_config.data, "data_pipeline_fw"):
             cfg.data_config.data_pipeline_fw = job_config.data.data_pipeline_fw
 
+        if hasattr(job_config.optimization, "num_workers"):
+            cfg.trainer_config.train_data_loader.num_workers = (
+                job_config.optimization.num_workers
+            )
+
         cfg.trainer_config.save_ckpt_path = run_path
         cfg.trainer_config.visualize_preds_during_training = save_viz
         cfg.trainer_config.keep_viz = keep_viz

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -938,6 +938,11 @@ def train_subprocess(
                 job_config.optimization.num_workers
             )
 
+        if hasattr(job_config.optimization, "trainer_accelerator"):
+            cfg.trainer_config.trainer_accelerator = (
+                job_config.optimization.trainer_accelerator
+            )
+
         cfg.trainer_config.save_ckpt_path = run_path
         cfg.trainer_config.visualize_preds_during_training = save_viz
         cfg.trainer_config.keep_viz = keep_viz

--- a/sleap/gui/learning/scopedkeydict.py
+++ b/sleap/gui/learning/scopedkeydict.py
@@ -3,6 +3,7 @@ Conversion between flat (form data) and hierarchical (config object) dicts.
 """
 
 from typing import Any, Dict, Optional, Text, Tuple, Union
+import re
 
 import attr
 import cattr
@@ -179,7 +180,7 @@ def resolve_strides_from_key_val_dict(
 
 
 def make_training_config_from_key_val_dict(
-    key_val_dict: Union[dict, ScopedKeyDict]
+    key_val_dict: Union[dict, ScopedKeyDict],
 ) -> TrainingJobConfig:
     """
     Make :py:class:`TrainingJobConfig` object from flat dictionary.

--- a/sleap/gui/learning/scopedkeydict.py
+++ b/sleap/gui/learning/scopedkeydict.py
@@ -111,6 +111,22 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict: dict):
         if key_val_dict["model.backbone.resnet.upsampling.skip_connections"] == "":
             key_val_dict["model.backbone.resnet.upsampling.skip_connections"] = None
 
+    if "optimization.trainer_devices" in key_val_dict:
+        # if "optimization.trainer_devices" is not auto and is a string, split into list of int
+        if (
+            isinstance(key_val_dict["optimization.trainer_devices"], str)
+            and key_val_dict["optimization.trainer_devices"] != "auto"
+        ):
+            key_val_dict["optimization.trainer_devices"] = [
+                int(device.strip())
+                for device in key_val_dict["optimization.trainer_devices"].split(",")
+            ]
+        # If it's not a string, ensure it's an int
+        elif isinstance(key_val_dict["optimization.trainer_devices"], int):
+            key_val_dict["optimization.trainer_devices"] = int(
+                key_val_dict["optimization.trainer_devices"]
+            )
+
     # Overwrite backbone strides with stride from head.
     backbone_name = find_backbone_name_from_key_val_dict(key_val_dict)
     if backbone_name is not None:

--- a/sleap/gui/legacy/config/data.py
+++ b/sleap/gui/legacy/config/data.py
@@ -156,3 +156,4 @@ class DataConfig:
     labels: LabelsConfig = attr.ib(factory=LabelsConfig)
     preprocessing: PreprocessingConfig = attr.ib(factory=PreprocessingConfig)
     instance_cropping: InstanceCroppingConfig = attr.ib(factory=InstanceCroppingConfig)
+    data_pipeline_fw: str = "torch_dataset"

--- a/sleap/gui/legacy/config/optimization.py
+++ b/sleap/gui/legacy/config/optimization.py
@@ -230,6 +230,7 @@ class OptimizationConfig:
             mining.
         early_stopping: Configuration options related to early stopping of training on
             plateau/convergence is detected.
+        num_workers: Number of worker threads to use for data loading and preprocessing.
     """
 
     preload_data: bool = True
@@ -252,3 +253,4 @@ class OptimizationConfig:
         factory=HardKeypointMiningConfig
     )
     early_stopping: EarlyStoppingConfig = attr.ib(factory=EarlyStoppingConfig)
+    num_workers: int = 0

--- a/sleap/gui/legacy/config/optimization.py
+++ b/sleap/gui/legacy/config/optimization.py
@@ -1,5 +1,5 @@
 import attr
-from typing import Optional, Text
+from typing import Optional, Text, Any
 
 
 @attr.s(auto_attribs=True)
@@ -255,4 +255,24 @@ class OptimizationConfig:
     )
     early_stopping: EarlyStoppingConfig = attr.ib(factory=EarlyStoppingConfig)
     num_workers: int = 0
+    trainer_devices: Any = attr.field(
+        default="auto",
+        validator=lambda inst, attr, val: OptimizationConfig.validate_trainer_devices(
+            val
+        ),
+    )
     trainer_accelerator: str = "auto"
+
+    @staticmethod
+    def validate_trainer_devices(value):
+        """Validate the value of trainer_devices."""
+        if isinstance(value, int) and value >= 0:
+            return
+        if isinstance(value, list) and all(
+            isinstance(x, int) and x >= 0 for x in value
+        ):
+            return
+        if isinstance(value, str) and value == "auto":
+            return
+        message = "trainer_devices must be an integer >= 0, a list of integers >= 0, or the string 'auto'."
+        raise ValueError(message)

--- a/sleap/gui/legacy/config/optimization.py
+++ b/sleap/gui/legacy/config/optimization.py
@@ -231,6 +231,7 @@ class OptimizationConfig:
         early_stopping: Configuration options related to early stopping of training on
             plateau/convergence is detected.
         num_workers: Number of worker threads to use for data loading and preprocessing.
+        trainer_accelerator: The accelerator to use for training (e.g., "auto", "gpu", "tpu").
     """
 
     preload_data: bool = True
@@ -254,3 +255,4 @@ class OptimizationConfig:
     )
     early_stopping: EarlyStoppingConfig = attr.ib(factory=EarlyStoppingConfig)
     num_workers: int = 0
+    trainer_accelerator: str = "auto"

--- a/sleap/gui/legacy/config/outputs.py
+++ b/sleap/gui/legacy/config/outputs.py
@@ -70,6 +70,33 @@ class TensorBoardConfig:
 
 
 @attr.s(auto_attribs=True)
+class WandBConfig:
+    """Configuration for WandB.
+
+    Only if use_wandb is True, else skip this
+
+    Attributes:
+        entity: (str) Entity of wandb project. *Default*: `None`.
+        project: (str) Project name for the wandb project. *Default*: `None`.
+        name: (str) Name of the current run. *Default*: `None`.
+        api_key: (str) API key. The API key is masked when saved to config files. *Default*: `None`.
+        wandb_mode: (str) "offline" if only local logging is required. *Default*: `"None"`.
+        prv_runid: (str) Previous run ID if training should be resumed from a previous ckpt. *Default*: `None`.
+        group: (str) Group for wandb logging. *Default*: `None`.
+        current_run_id: (str) Run ID for the current model training. (stored once the training starts). *Default*: `None`.
+    """
+
+    entity: Optional[str] = None
+    project: Optional[str] = None
+    name: Optional[str] = None
+    api_key: Optional[str] = None
+    wandb_mode: Optional[str] = None
+    prv_runid: Optional[str] = None
+    group: Optional[str] = None
+    current_run_id: Optional[str] = None
+
+
+@attr.s(auto_attribs=True)
 class ZMQConfig:
     """Configuration of ZeroMQ-based monitoring of the training.
 
@@ -160,6 +187,8 @@ class OutputsConfig:
             epoch to "{run_folder}/training_log.csv"
         checkpointing: Configuration options related to model checkpointing.
         tensorboard: Configuration options related to TensorBoard logging.
+        use_wandb: Flag for using Weights & Biases (WandB) logging.
+        wandb: Configuration options related to Weights & Biases (WandB) logging.
         zmq: Configuration options related to ZeroMQ-based control and monitoring.
     """
 
@@ -175,6 +204,8 @@ class OutputsConfig:
     log_to_csv: bool = True
     checkpointing: CheckpointingConfig = attr.ib(factory=CheckpointingConfig)
     tensorboard: TensorBoardConfig = attr.ib(factory=TensorBoardConfig)
+    use_wandb: bool = False
+    wandb: WandBConfig = attr.ib(factory=WandBConfig)
     zmq: ZMQConfig = attr.ib(factory=ZMQConfig)
 
     @property


### PR DESCRIPTION
This PR adds new GUI config inputs for training:
              - `data_config`: data_pipeline_fw
              - `trainer_config`: num_workers, trainer_devices, trainer_accelerator, wandb_config

This PR also adds new legacy configurations for SLEAP training for successful GUI integration. 