### PR TITLE
Fix Run Training Button and Replace `Video.frames` to `Video.shape[0]`

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1511,7 +1511,7 @@ class MainWindow(QMainWindow):
 
         selection["random"] = {
             video: remove_user_labeled(
-                video, random.sample(range(video.frames), min(20, video.frames))
+                video, random.sample(range(video.shape[0]), min(20, video.shape[0]))
             )
             for video in self.labels.videos
         }
@@ -1521,7 +1521,7 @@ class MainWindow(QMainWindow):
                 current_video: remove_user_labeled(
                     current_video,
                     random.sample(
-                        range(current_video.frames), min(20, current_video.frames)
+                        range(current_video.shape[0]), min(20, current_video.shape[0])
                     ),
                 )
             }

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2002,7 +2002,7 @@ class GoFrameGui(NavCommand):
             "Frame Number:",
             context.state["frame_idx"] + 1,
             1,
-            context.state["video"].frames,
+            context.state["video"].shape[0],
         )
         params["frame_idx"] = frame_number - 1
 
@@ -2024,7 +2024,7 @@ class SelectToFrameGui(NavCommand):
             "Frame Number:",
             context.state["frame_idx"] + 1,
             1,
-            context.state["video"].frames,
+            context.state["video"].shape[0],
         )
         params["from_frame_idx"] = context.state["frame_idx"]
         params["to_frame_idx"] = frame_number - 1

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1077,7 +1077,7 @@ class TrainingEditorWidget(QtWidgets.QWidget):
             self._receptive_field_widget = receptivefield.ReceptiveFieldWidget(
                 self.head
             )
-            self._receptive_field_widget.setImage(self._video.test_frame)
+            self._receptive_field_widget.setImage(self._video.backend.read_test_frame())
 
         self._set_head()
 


### PR DESCRIPTION
This PR updates how video frame counts are accessed throughout the codebase with `sleap-io` integration. Therefore, this PR fixes "Run Traning" button and "Go To Frame..." button in the GUI. 