### PR TITLE
QGraphicsItem ungrabMouse function call fix

### DIFF
--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -1862,6 +1862,9 @@ class QtInstance(QGraphicsObject):
         # Show predicted instances behind non-predicted ones
         self.setZValue(1 if self.predicted else 2)
 
+        # Set mouse grabbed boolean
+        self._mouse_grabbed = False
+
         if not self.predicted:
             # Initialize missing nodes with random points marked as non-visible.
             fill_missing(
@@ -2220,7 +2223,8 @@ class QtInstance(QGraphicsObject):
             self.setFlag(QGraphicsItem.ItemIsMovable, False)
             self.updatePoints(user_change=True)
             self.updateBox()
-            self.ungrabMouse()
+            # removed ungrabMouse since Qt grab method automatically releases on mouse release
+            # self.ungrabMouse() 
             super().mouseReleaseEvent(event)
 
 

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -2223,8 +2223,7 @@ class QtInstance(QGraphicsObject):
             self.setFlag(QGraphicsItem.ItemIsMovable, False)
             self.updatePoints(user_change=True)
             self.updateBox()
-            # removed ungrabMouse since Qt grab method automatically releases on mouse release
-            # self.ungrabMouse() 
+            # self.ungrabMouse()
             super().mouseReleaseEvent(event)
 
 


### PR DESCRIPTION
This PR removes an unnecessary call to QGraphicsItem.ungrabMouse() in the mouseReleaseEvent() function in order to address the 'QGraphicsItem::ungrabMouse: not a mouse grabber after dragging w/ option key' when dragging an instance w/ the option key + left mouse click. 

QGraphicsItems object automatically releases upon mouse release:
- https://forum.qt.io/topic/156957/detect-when-qgraphicsitem-dropped