### PR TITLE
Fix Suggestion Generation in the GUI

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1241,6 +1241,7 @@ class MainWindow(QMainWindow):
                         suggestion.video,
                         suggestion.frame_idx,  # ), use_cache=True
                     )
+                    lf = lf[0] if lf else None
                     if lf is not None and lf.has_user_instances:
                         labeled_count += 1
                 prc = (labeled_count / len(suggestion_list)) * 100

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -527,13 +527,14 @@ class SuggestionsTableModel(GenericTableModel):
         video_name = os.path.basename(item.video.filename)
         video_string = f"{video_idx}: {video_name}"
 
-        item_dict["group"] = str(item.group + 1) if item.group is not None else ""
-        item_dict["group_int"] = item.group if item.group is not None else -1
+        item_dict["group"] = "0"
+        item_dict["group_int"] = 0
         item_dict["video"] = video_string
         item_dict["frame"] = int(item.frame_idx) + 1  # start at frame 1 rather than 0
 
         # show how many labeled instances are in this frame
         lf = labels.find(item.video, item.frame_idx)
+        lf = lf[0] if lf else None
         val = 0 if lf is None else len(lf.user_instances)
         val = str(val) if val > 0 else ""
         item_dict["labeled"] = val

--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -372,7 +372,7 @@ class VideoFrameSuggestions(object):
     def idx_list_to_frame_list(
         idx_list, video: "Video", group: Optional[GroupType] = None
     ) -> List[SuggestionFrame]:
-        return [SuggestionFrame(video, frame_idx, group) for frame_idx in idx_list]
+        return [SuggestionFrame(video, frame_idx) for frame_idx in idx_list]
 
     @staticmethod
     def filter_unique_suggestions(


### PR DESCRIPTION
This pull request introduces several small updates to the GUI codebase, primarily aimed at simplifying logic and ensuring consistency in how group and label information is handled. This will fix the issue where GUI not able to generate suggestions. 

**Data consistency and simplification:**

* In `sleap/gui/dataviews.py`, the `group` and `group_int` fields in `item_to_data` are now always set to `"0"` and `0` respectively, instead of reflecting the actual group value or being empty/`-1` when not set. This enforces consistency in how group information is represented. This is a temporary fix.
* The lookup for labeled frames (`lf`) in both `item_to_data` and `_has_topic` is simplified by extracting the first element if available, or setting it to `None` if not. This makes subsequent checks for labeled instances more straightforward. (`sleap/gui/dataviews.py`, `sleap/gui/app.py`) [[1]](diffhunk://#diff-e6de16fd0e12f48959906b5b4dee803cc01d653a128890505804a8bf35ef1942R1244) [[2]](diffhunk://#diff-b22bf930ff85cd348c5765d7b5ad4406b38266388f065462f9328a257d23c0e8L530-R537)

**Suggestion frame creation:**

* In `sleap/gui/suggestions.py`, the `group` parameter is removed from the creation of `SuggestionFrame` objects in `idx_list_to_frame_list`, meaning suggestion frames are now created without explicit group assignment.