### PR TITLE
Fix Removing Labeling Suggestions Functionality in the GUI

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -95,6 +95,7 @@ from sleap.sleap_io_adaptors.lf_labels_utils import (
     track_set_instance,
     make_video_callback,
     load_labels_video_search,
+    clear_suggestion,
 )
 from sleap.sleap_io_adaptors.video_utils import get_last_frame_idx
 
@@ -3216,7 +3217,7 @@ class RemoveSuggestion(EditCommand):
         if selected_frame is not None:
             for sug_idx, suggestion in enumerate(context.labels.suggestions):
                 if (
-                    suggestion.video.match_content(selected_frame.video)
+                    suggestion.video.matches_content(selected_frame.video)
                     and suggestion.frame_idx == selected_frame.frame_idx
                 ):
                     context.labels.suggestions.pop(sug_idx)
@@ -3248,7 +3249,7 @@ class ClearSuggestions(EditCommand):
 
     @classmethod
     def do_action(cls, context: CommandContext, params: dict):
-        context.labels.clear_suggestions()
+        clear_suggestion(context.labels)
 
 
 class MergeProject(EditCommand):

--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -12,6 +12,7 @@ from sleap.info.feature_suggestions import (
     FeatureSuggestionPipeline,
     ParallelFeaturePipeline,
 )
+from sleap.sleap_io_adaptors.lf_labels_utils import get_instances_to_show
 
 GroupType = int
 
@@ -210,7 +211,7 @@ class VideoFrameSuggestions(object):
 
         for i, lf in enumerate(lfs):
             # Scores from visible instances in frame
-            pred_fs = lf.instances_to_show
+            pred_fs = get_instances_to_show(lf)
             frame_scores = np.array(
                 [inst.score for inst in pred_fs if hasattr(inst, "score")]
             )

--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -1135,3 +1135,8 @@ def track_set_instance(
         (frame.frame_idx, frame.frame_idx + 1),
     )
     instance.track = new_track
+
+
+def clear_suggestion(labels: Labels):
+    """Delete all suggestions."""
+    labels.suggestions.clear()


### PR DESCRIPTION
This pull request fixes how suggestions are cleared in the GUI. The main change is the extraction of suggestion-clearing logic from the GUI command into a dedicated utility function, along with a minor method name correction for video matching.

**Bug Fix:**

* Corrected the method name from `match_content` to `matches_content` when comparing video content in the suggestion removal logic in `sleap/gui/commands.py`.
* Added a new utility function to clear all suggestions given `Labels` object
* Fixed the usage of `instances_to_show()` to `get_instances_to_show`