### PR TITLE
Replace `instance_to_show`attribute to `get_instance_to_show()` function

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -598,7 +598,7 @@ class MainWindow(QMainWindow):
             "select next",
             "Select Next Instance",
             lambda: self.state.increment_in_list(
-                "instance", self.state["labeled_frame"].instances_to_show
+                "instance", get_instances_to_show(self.state["labeled_frame"])
             ),
         )
         add_menu_item(

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -96,6 +96,7 @@ from sleap.sleap_io_adaptors.lf_labels_utils import (
     make_video_callback,
     load_labels_video_search,
     clear_suggestion,
+    get_instances_to_show,
 )
 from sleap.sleap_io_adaptors.video_utils import get_last_frame_idx
 
@@ -1984,7 +1985,7 @@ class GoNextTrackFrame(NavCommand):
             # Select the instance in the new track
             lf = context.labels.find(video, next_idx, return_new=True)[0]
             track_instances = [
-                inst for inst in lf.instances_to_show if inst.track == next_track
+                inst for inst in get_instances_to_show(lf) if inst.track == next_track
             ]
             if track_instances:
                 context.state["instance"] = track_instances[0]

--- a/sleap/gui/overlays/tracks.py
+++ b/sleap/gui/overlays/tracks.py
@@ -11,6 +11,7 @@ from sleap_io import LabeledFrame
 from sleap_io.model.instance import Track
 from sleap_io import Video
 from sleap.prefs import prefs
+from sleap.sleap_io_adaptors.lf_labels_utils import get_instances_to_show
 
 
 @attr.s(auto_attribs=True)
@@ -83,7 +84,7 @@ class TrackTrailOverlay(BaseOverlay):
 
         for frame in frame_selection:
             # Prefer user instances over predicted instances
-            for inst in frame.instances_to_show:
+            for inst in get_instances_to_show(frame):
                 if inst.track is not None:
                     if inst.track not in all_track_trails:
                         all_track_trails[inst.track] = [[] for _ in range(len(nodes))]

--- a/sleap/io/visuals.py
+++ b/sleap/io/visuals.py
@@ -19,7 +19,10 @@ from sleap.gui.color import ColorManager
 from sleap_io.model.instance import Instance
 from sleap_io import Video, Labels
 from sleap.sleap_io_adaptors.video_utils import _sentinel
-from sleap.sleap_io_adaptors.lf_labels_utils import load_labels_video_search
+from sleap.sleap_io_adaptors.lf_labels_utils import (
+    load_labels_video_search,
+    get_instances_to_show,
+)
 from sleap_io import save_video
 from sleap.util import usable_cpu_count
 
@@ -194,7 +197,7 @@ class VideoMarkerThread(Thread):
         if len(lfs) == 0:
             return self._crop_frame(img)[0] if self.crop else img
 
-        instances = lfs[0].instances_to_show
+        instances = get_instances_to_show(lfs[0])
 
         offset = None
         if self.crop:


### PR DESCRIPTION
This pull request fixes several parts of the codebase to consistently use the `get_instances_to_show` utility function instead of directly accessing the `instances_to_show` attribute. 

**Refactoring for consistent instance selection:**

* Replaced direct access to `instances_to_show` with calls to `get_instances_to_show` in the `prev_vid` function in `sleap/gui/app.py`, ensuring consistent retrieval of instances for navigation actions.
* Updated the selection logic in the `do_action` method in `sleap/gui/commands.py` to use `get_instances_to_show` when filtering instances by track.
* Modified the instance iteration in the `get_track_trails` function in `sleap/gui/overlays/tracks.py` to use `get_instances_to_show`, improving consistency in track overlays.
* Refactored the `_plot_instances_cv` method in `sleap/io/visuals.py` to utilize `get_instances_to_show` for plotting, centralizing the instance selection logic.