### PR TITLE
Fix Applying Distinct Colors To Edges and Nodes

### DIFF
--- a/sleap/gui/color.py
+++ b/sleap/gui/color.py
@@ -22,6 +22,7 @@ from sleap_io.model.skeleton import Node
 from sleap_io import Labels
 from sleap_io.model.skeleton import Skeleton
 from sleap.prefs import prefs
+from sleap.sleap_io_adaptors.skeleton_utils import node_to_index, edge_to_index
 
 
 ColorTupleStringType = Text
@@ -283,7 +284,7 @@ class ColorManager:
                 node = item[1]
 
             if node:
-                node_idx = parent_skeleton.node_to_index(node)
+                node_idx = node_to_index(parent_skeleton, node)
                 return self.get_color_by_idx(node_idx)
 
             # return (255, 0, 0)
@@ -291,7 +292,7 @@ class ColorManager:
         if self.distinctly_color == "edges" and parent_skeleton:
             edge_idx = 0
             if self.is_edge(item):
-                edge_idx = parent_skeleton.edge_to_index(*item)
+                edge_idx = edge_to_index(parent_skeleton, *item)
             elif self.is_node(item):
                 for i, (src, dst) in enumerate(parent_skeleton.edges):
                     if dst == item:


### PR DESCRIPTION
This pull request updates how node and edge indices are retrieved in the `sleap/gui/color.py` module. The main change is to use the utility functions from `sleap.sleap_io_adaptors.skeleton_utils` for more consistent and centralized index lookups.

Refactoring for index lookup:

* Replaced direct calls to `parent_skeleton.node_to_index` and `parent_skeleton.edge_to_index` with the imported utility functions `node_to_index` and `edge_to_index` from `sleap.sleap_io_adaptors.skeleton_utils` in `sleap/gui/color.py`. [[1]](diffhunk://#diff-539c58843f8d7cf462a047cff48c6ce6e07bb71d3fcb9940c4c8c4aa3fd4e519R25) [[2]](diffhunk://#diff-539c58843f8d7cf462a047cff48c6ce6e07bb71d3fcb9940c4c8c4aa3fd4e519L286-R295)