### PR TITLE
Fix node relabelling nodes random placement

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -89,7 +89,6 @@ from sleap.sleap_io_adaptors.skeleton_utils import (
 from sleap.sleap_io_adaptors.video_utils import video_util_reset
 from sleap.sleap_io_adaptors.lf_labels_utils import (
     get_next_suggestion,
-    merge_nodes,
     track_swap,
     find_track_occupancy,
     track_set_instance,

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2576,10 +2576,10 @@ class SetNodeName(EditCommand):
         name = params["name"]
         skeleton = params["skeleton"]
 
-        if name in skeleton.node_names:
+        # if name in skeleton.node_names:
+        if context.labels is not None:
             # Merge
-            # context.labels.merge_nodes(name, node.name)
-            merge_nodes(name, node.name, context.labels, skeleton)
+            context.labels.rename_nodes({node.name: name})
         else:
             # Simple relabel
             skeleton.rename_node(node.name, name)


### PR DESCRIPTION
This pull request updates the node renaming logic in the `do_action` function within `sleap/gui/commands.py`. The main change is that the decision to merge or relabel nodes now depends on whether `context.labels` is present, rather than simply checking if the new name exists in `skeleton.node_names`.

**Notes:**

* Changed the condition to check for `context.labels` instead of whether the `name` exists in `skeleton.node_names`, which alters when merging versus relabeling occurs.
* Updated the merging process to use `context.labels.rename_nodes` for renaming nodes, replacing the previous call to `merge_nodes`.
* The original warning message "QAbstractItemView::commitData called with an editor that does not belong to this view" remains.

