### PR TITLE
Fix sleap-nn cli and add training params

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dynamic = ["version", "readme"]
 dependencies = [
     "attrs",
     "cattrs",
+    "omegaconf",
     "imageio",
     "imageio-ffmpeg",
     "imgstore",

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -212,6 +212,63 @@ training:
   type: list
 
 - type: text
+  text: '<b>Data Pipeline framework options</b>'
+
+- default: 'torch_dataset'
+  help: Framework to create the data loaders. (When using torch_dataset,
+    num_workers in trainer_config should be set to 0 as multiprocessing
+    doesn't work with pickling video backends.)
+  label: Data Pipeline Framework
+  name: data_config.data_pipeline_fw
+  options: 'torch_dataset,torch_dataset_cache_img_memory,torch_dataset_cache_img_disk'
+  type: list
+
+- type: text
+  text: '<b>WandB options</b>'
+
+- default: false
+  help: If True, the model training will be logged to WandB.
+  label: Enable WandB for logging
+  name: trainer_config.use_wandb
+  type: bool
+
+- name: trainer_config.wandb.entity
+  label:  Entity Name
+  type: string
+  default: null
+
+- name: trainer_config.wandb.project
+  label:  Project Name
+  type: string
+  default: null
+
+- name: trainer_config.wandb.name
+  label:  Run Name
+  type: string
+  default: null
+
+- name: trainer_config.wandb.api_key
+  label: WandBAPI Key
+  type: string
+  default: null
+  help: WandB API Key. You could also set it in your terminal by exporting the WANDB_API_KEY environment variable.
+    Or `wandb.login()` in your Python shell.
+  hidden: true
+
+- name: trainer_config.wandb.prv_runid
+  label: Previous Run ID
+  type: string
+  default: null
+  help: Previous run ID if you want to resume training from a previous run. If None, a new run will be created.
+
+- name: trainer_config.wandb.group
+  label: Group Name
+  type: string
+  default: null
+  help: Group name if you want to group runs together.
+
+
+- type: text
   text: '<b>ZMQ Options</b>'
 
 - name: trainer_config.zmq.controller_address
@@ -256,12 +313,12 @@ training:
   name: trainer_config.model_ckpt.save_last
   type: bool
 
-- name: _save_viz
+- name: trainer_config.visualize_preds_during_training
   label: Visualize Predictions During Training
   type: bool
   default: true
 
-- name: _keep_viz
+- name: trainer_config.keep_viz
   label: Keep Prediction Visualization Images After Training
   type: bool
   default: false

--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -443,6 +443,27 @@ optimization:
   name: trainer_config.train_data_loader.batch_size
   type: int
   range: 1,512
+- default: 0
+  help: Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process.
+    This can help improve data loading speed. However, when using `data_pipeline_fw` as `torch_dataset`, i.e., when
+    not caching the data samples, then the number of workers should be set to 0 to avoid race conditions. If using caching,
+    then set number of workers to a value greater than 0. (Start with 2 and increase if needed)
+  label: Number of workers
+  name: trainer_config.train_data_loader.num_workers
+  type: int
+  range: 0,16
+- default: "auto"
+  help: Number of devices to train on (int), or "auto" to select automatically. 
+  label: Number of GPU devices
+  name: trainer_config.trainer_devices
+  type: str
+- default: "auto"
+  help: Accelerator to use for training. "auto" means "cuda" if GPUs are available, otherwise "cpu".
+    For mac, "mps" can be used for Apple Silicon.
+  label: Device Accelerator
+  name: trainer_config.trainer_accelerator
+  type: list
+  options: auto,cuda,cpu,mps
 - default: 100
   help: Maximum number of epochs to train for. Training can be stopped manually or automatically if early stopping is enabled and a plateau is detected.
   label: Epochs

--- a/sleap/gui/config_utils.py
+++ b/sleap/gui/config_utils.py
@@ -144,3 +144,6 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict):
     key_val_dict["trainer_config.val_data_loader.batch_size"] = key_val_dict[
         "trainer_config.train_data_loader.batch_size"
     ]
+    key_val_dict["trainer_config.val_data_loader.num_workers"] = key_val_dict[
+        "trainer_config.train_data_loader.num_workers"
+    ]

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -231,7 +231,8 @@ class InferenceTask:
     ) -> List[Text]:
         """Makes list of CLI arguments needed for running inference."""
         cli_args = [
-            "sleap-nn-track",
+            "sleap-nn",
+            "track",
         ]
         cli_args.extend(
             item_for_inference.cli_args
@@ -479,7 +480,7 @@ def write_pipeline_files(
 
             # Add a line to the script for training this model
             train_script += (
-                f"sleap-nn-train --config-name {new_cfg_filename} --config-dir {''} "
+                f"sleap-nn train --config-name {new_cfg_filename} --config-dir {''} "
                 f"trainer_config.save_ckpt_path={ckpt_path} "
                 f"trainer_config.zmq.controller_address=tcp://127.0.0.1:"
                 f"{str(inference_params['controller_port'])} "
@@ -591,9 +592,6 @@ def run_learning_pipeline(
 
     """
 
-    save_viz = inference_params.get("_save_viz", False)
-    keep_viz = inference_params.get("_keep_viz", False)
-
     if "movenet" in inference_params["_pipeline"]:
         trained_job_paths = [inference_params["_pipeline"]]
 
@@ -605,8 +603,6 @@ def run_learning_pipeline(
             config_info_list=config_info_list,
             inference_params=inference_params,
             gui=True,
-            save_viz=save_viz,
-            keep_viz=keep_viz,
         )
 
         # Check that all the models were trained
@@ -634,8 +630,6 @@ def run_gui_training(
     config_info_list: List[ConfigFileInfo],
     inference_params: Dict[str, Any],
     gui: bool = True,
-    save_viz: bool = False,
-    keep_viz: bool = False,
 ) -> Dict[Text, Text]:
     """
     Runs training for each training job.
@@ -644,8 +638,6 @@ def run_gui_training(
         labels: Labels object from which we'll get training data.
         config_info_list: List of ConfigFileInfo with configs for training.
         gui: Whether to show gui windows and process gui events.
-        save_viz: Whether to save visualizations from training.
-        keep_viz: Whether to keep prediction visualization images after training.
 
     Returns:
         Dictionary, keys are head name, values are path to trained config.
@@ -720,7 +712,7 @@ def run_gui_training(
                 )
                 win.setWindowTitle(f"Training Model - {str(model_type)}")
                 win.set_message("Preparing to run training...")
-                if save_viz:
+                if job.trainer_config.visualize_preds_during_training:
                     viz_window = QtImageDirectoryWidget.make_training_vizualizer(
                         job.trainer_config.save_ckpt_path
                     )
@@ -742,8 +734,6 @@ def run_gui_training(
                 labels_filename=labels_filename,
                 video_paths=video_path_list,
                 waiting_callback=waiting,
-                save_viz=save_viz,
-                keep_viz=keep_viz,
             )
 
             if ret == "success":
@@ -885,8 +875,6 @@ def train_subprocess(
     inference_params: Dict[str, Any],
     video_paths: Optional[List[Text]] = None,
     waiting_callback: Optional[Callable] = None,
-    save_viz: bool = False,
-    keep_viz: bool = False,
 ):
     """Runs training inside subprocess."""
     run_path = job_config.trainer_config.save_ckpt_path
@@ -903,8 +891,6 @@ def train_subprocess(
         cfg.data_config.train_labels_path = [labels_filename]
 
         cfg.trainer_config.save_ckpt_path = run_path
-        cfg.trainer_config.visualize_preds_during_training = save_viz
-        cfg.trainer_config.keep_viz = keep_viz
         cfg.trainer_config.zmq.controller_address = (
             f"tcp://127.0.0.1:{str(inference_params['controller_port'])}"
         )
@@ -916,7 +902,8 @@ def train_subprocess(
 
         # Build CLI arguments for training
         cli_args = [
-            "sleap-nn-train",
+            "sleap-nn",
+            "train",
             "--config-name",
             f"{cfg_file_name}",
             "--config-dir",


### PR DESCRIPTION
This PR changes the CLI command use din SLEAP GUI from `lseap-nn-train` to `sleap-nn train`.  In this PR, we also add a few more training parameters to the GUI form to match with sleap-nn training options.