### PR TITLE
Fix add average instance corner bug

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3754,20 +3754,20 @@ class AddMissingInstanceNodes(EditCommand):
     def add_nodes_from_template(
         cls,
         context,
-        instance, # should be zeroes
+        instance,  # should be zeroes
         visible: bool = False,
         center_point: QtCore.QPoint = None,
     ):
         # Get the "template" instance
         # context.labels.get_template_instance()
-        template_points = get_template_instance_points( # <---- sleap_io adapter function
+        template_points = get_template_instance_points(
             context.labels, skeleton=instance.skeleton
         )
 
         # Align the template on to the current instance with missing points
         if not np.all(np.isnan(instance.numpy())) and not np.allclose(
-                instance.numpy(), 0.0
-            ):
+            instance.numpy(), 0.0
+        ):
             aligned_template = align.align_instance_points(
                 source_points_array=template_points,
                 target_points_array=instance.points["xy"],
@@ -3783,11 +3783,10 @@ class AddMissingInstanceNodes(EditCommand):
         input_arrays = PointsArray.empty(len(instance.skeleton.nodes))
         # Make missing points from the aligned template
         for i, node in enumerate(instance.skeleton.nodes):
-            if np.all(np.isnan(instance.points[i]['xy'])) or np.allclose(
+            if np.all(np.isnan(instance.points[i]["xy"])) or np.allclose(
                 instance.points[i]["xy"], 0.0, equal_nan=True
             ):
                 x, y = aligned_template[i]
-                
                 input_array = np.array(
                     [([x, y], visible, False, node.name)],
                     dtype=[

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3457,7 +3457,6 @@ class AddInstance(EditCommand):
         Returns:
             Whether the new instance has missing nodes.
         """
-
         if copy_instance is None:
             return True
 
@@ -3755,19 +3754,20 @@ class AddMissingInstanceNodes(EditCommand):
     def add_nodes_from_template(
         cls,
         context,
-        instance,
+        instance, # should be zeroes
         visible: bool = False,
         center_point: QtCore.QPoint = None,
     ):
         # Get the "template" instance
-        template_points = get_template_instance_points(
+        # context.labels.get_template_instance()
+        template_points = get_template_instance_points( # <---- sleap_io adapter function
             context.labels, skeleton=instance.skeleton
         )
 
         # Align the template on to the current instance with missing points
         if not np.all(np.isnan(instance.numpy())) and not np.allclose(
-            instance.points["xy"], 0.0, equal_nan=True
-        ):
+                instance.numpy(), 0.0
+            ):
             aligned_template = align.align_instance_points(
                 source_points_array=template_points,
                 target_points_array=instance.points["xy"],
@@ -3783,8 +3783,11 @@ class AddMissingInstanceNodes(EditCommand):
         input_arrays = PointsArray.empty(len(instance.skeleton.nodes))
         # Make missing points from the aligned template
         for i, node in enumerate(instance.skeleton.nodes):
-            if node.name not in instance.points["name"]:
+            if np.all(np.isnan(instance.points[i]['xy'])) or np.allclose(
+                instance.points[i]["xy"], 0.0, equal_nan=True
+            ):
                 x, y = aligned_template[i]
+                
                 input_array = np.array(
                     [([x, y], visible, False, node.name)],
                     dtype=[
@@ -3797,6 +3800,7 @@ class AddMissingInstanceNodes(EditCommand):
                 input_arrays[i] = input_array
             else:
                 input_arrays[i] = instance.points[i]
+
         instance.points = PointsArray.from_array(input_arrays)
 
     @classmethod

--- a/sleap/info/align.py
+++ b/sleap/info/align.py
@@ -250,7 +250,7 @@ def get_instances_points(instances: List[Instance]) -> np.ndarray:
     for inst in instances:
         # Extract xy coordinates from the list of (x, y, visible, ...) tuples
         xy_coords = np.array(
-            [p[0] for p in inst.points]
+            [p['xy'] for p in inst.points]
         )  # Extract x, y from each tuple
         points_list.append(xy_coords)
 

--- a/sleap/info/align.py
+++ b/sleap/info/align.py
@@ -250,7 +250,7 @@ def get_instances_points(instances: List[Instance]) -> np.ndarray:
     for inst in instances:
         # Extract xy coordinates from the list of (x, y, visible, ...) tuples
         xy_coords = np.array(
-            [p['xy'] for p in inst.points]
+            [p["xy"] for p in inst.points]
         )  # Extract x, y from each tuple
         points_list.append(xy_coords)
 

--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -685,9 +685,6 @@ def get_template_instance_points(labels: Labels, skeleton: Skeleton):
             # Fallback if networkx is not available
             template_points = np.random.randint(0, 50, size=(len(skeleton.nodes), 2))
             return template_points
-        except Exception as e:
-            template_points = np.random.randint(0, 50, size=(len(skeleton.nodes), 2))
-            return template_points
 
     # Check if there are any instances
     if not hasattr(labels, "instances") or not instances(labels):

--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -655,7 +655,7 @@ def get_template_instance_points(labels: Labels, skeleton: Skeleton):
     if not hasattr(labels, "labeled_frames"):
         print("Labels object has no labeled_frames attribute")
         return None
-    
+
     # Check if labeled_frame list is empty
     if not labels.labeled_frames:
         # No labeled frames so use force-directed graph layout
@@ -694,7 +694,6 @@ def get_template_instance_points(labels: Labels, skeleton: Skeleton):
         # No instances, use fallback
         template_points = np.random.randint(0, 50, size=(len(skeleton.nodes), 2))
         return template_points
-
 
     # Get first 1000 instances for this skeleton
     try:

--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -635,7 +635,7 @@ def iterate_labeled_frames(
             yield frame_map[idx]
 
 
-def get_template_instance_points(labels, skeleton):
+def get_template_instance_points(labels: Labels, skeleton: Skeleton):
     """Get template instance points for a skeleton.
 
     This function recreates labels.get_template_instance_points(skeleton)
@@ -653,14 +653,15 @@ def get_template_instance_points(labels, skeleton):
 
     # Check if labels has labeled_frames attribute
     if not hasattr(labels, "labeled_frames"):
+        print("Labels object has no labeled_frames attribute")
         return None
-
-    # Check if there are any labeled frames
+    
+    # Check if labeled_frame list is empty
     if not labels.labeled_frames:
         # No labeled frames so use force-directed graph layout
         try:
             import networkx as nx
-            from sleap.util import to_graph
+            from sleap.sleap_io_adaptors.skeleton_utils import to_graph
 
             # Create graph from skeleton and get spring layout
             G = to_graph(skeleton)
@@ -684,12 +685,16 @@ def get_template_instance_points(labels, skeleton):
             # Fallback if networkx is not available
             template_points = np.random.randint(0, 50, size=(len(skeleton.nodes), 2))
             return template_points
+        except Exception as e:
+            template_points = np.random.randint(0, 50, size=(len(skeleton.nodes), 2))
+            return template_points
 
     # Check if there are any instances
     if not hasattr(labels, "instances") or not instances(labels):
         # No instances, use fallback
         template_points = np.random.randint(0, 50, size=(len(skeleton.nodes), 2))
         return template_points
+
 
     # Get first 1000 instances for this skeleton
     try:


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to handling template instance points, missing node detection, and array handling in the SLEAP GUI and IO adaptors. 

**Notes:**

* Improved logic in `add_nodes_from_template` (`sleap/gui/commands.py`) to more reliably detect missing nodes using `np.isnan` and `np.allclose` on the node coordinates, ensuring that nodes with near-zero or NaN coordinates are treated as missing.
* Updated the fallback logic in `get_template_instance_points` (`sleap/sleap_io_adaptors/lf_labels_utils.py`) to handle cases where `labeled_frames` are missing or empty, including additional exception handling and clearer messaging. [[1]](diffhunk://#diff-5b41bb4f7cf029a418858647f7ee7ef65dc149d42a892fb42729851b9934cb3aR656-R664) [[2]](diffhunk://#diff-5b41bb4f7cf029a418858647f7ee7ef65dc149d42a892fb42729851b9934cb3aR688-R698)
* Changed array access from tuple indexing to dictionary key access (`p['xy']`) in `get_instances_points` (`sleap/info/align.py`).
* Cleanups in `set_visible_nodes` and array assignment logic in `add_nodes_from_template` to ensure correct behavior when copying instances and updating node arrays. [[1]](diffhunk://#diff-c1c206e307dac324ccc9a1473de3f26e0c31be09a4cc2c2bcfffa8d157cf239fL3460) [[2]](diffhunk://#diff-c1c206e307dac324ccc9a1473de3f26e0c31be09a4cc2c2bcfffa8d157cf239fR3803)