### PR TITLE
Fix Export Clip Video

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1567,7 +1567,7 @@ def export_dataset_gui(
         labels,
         filename,
         format="slp",
-        embed=embed_option,
+        embed=embed_option if as_package else False,
         # progress_callback=update_progress if verbose else None, #TODO
     )
 
@@ -1700,11 +1700,8 @@ class ExportLabelsSubset(ExportFullPackage):
         )
 
         # Save the labels subset to a new file.
-        if params.get("as_package", False):
-            params["labels"] = labels_subset
-            super().do_action(context=context, params=params)
-        else:
-            save_file(labels=labels_subset, filename=params["filename"])
+        params["labels"] = labels_subset
+        super().do_action(context=context, params=params)
 
         # Now let's open the new file.
         if params.get("open_new_project", False):

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1700,8 +1700,11 @@ class ExportLabelsSubset(ExportFullPackage):
         )
 
         # Save the labels subset to a new file.
-        params["labels"] = labels_subset
-        super().do_action(context=context, params=params)
+        if params.get("as_package", False):
+            params["labels"] = labels_subset
+            super().do_action(context=context, params=params)
+        else:
+            save_file(labels=labels_subset, filename=params["filename"])
 
         # Now let's open the new file.
         if params.get("open_new_project", False):

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1763,8 +1763,10 @@ class ExportLabelsSubset(ExportFullPackage):
 
         # Get subset of labels to export
         labels: Labels = context.state["labels"]
+        frames_in_labels = [frame for frame in frames]
+        print(frames_in_labels)
         labels_subset_unshifted: Labels = labels.extract(
-            inds=(video, frames), copy=True
+            inds=frames_in_labels, copy=True
         )
         return labels_subset_unshifted
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1763,8 +1763,7 @@ class ExportLabelsSubset(ExportFullPackage):
 
         # Get subset of labels to export
         labels: Labels = context.state["labels"]
-        frames_in_labels = [frame for frame in frames]
-        print(frames_in_labels)
+        frames_in_labels = [(video, frame) for frame in frames]
         labels_subset_unshifted: Labels = labels.extract(
             inds=frames_in_labels, copy=True
         )

--- a/tests/fixtures/skeletons.py
+++ b/tests/fixtures/skeletons.py
@@ -1,8 +1,6 @@
 import pytest
-import json
 
 from sleap_io import Skeleton, load_skeleton
-from sleap_io.io.skeleton import SkeletonDecoder
 
 TEST_FLY_LEGS_SKELETON = "tests/data/skeleton/fly_skeleton_legs.json"
 TEST_FLY_LEGS_SKELETON_DICT = "tests/data/skeleton/fly_skeleton_legs_pystate_dict.json"

--- a/tests/fixtures/skeletons.py
+++ b/tests/fixtures/skeletons.py
@@ -1,7 +1,8 @@
 import pytest
+import json
 
 from sleap_io import Skeleton
-from sleap_io import load_skeleton
+from sleap_io.io.skeleton import SkeletonDecoder
 
 TEST_FLY_LEGS_SKELETON = "tests/data/skeleton/fly_skeleton_legs.json"
 TEST_FLY_LEGS_SKELETON_DICT = "tests/data/skeleton/fly_skeleton_legs_pystate_dict.json"
@@ -75,4 +76,8 @@ def skeleton():
 
 @pytest.fixture
 def flies13_skeleton():
-    return load_skeleton("sleap/skeletons/flies13.json")
+    with open("sleap/skeletons/flies13.json", "r") as f:
+        skeleton_data = json.load(f)
+    skeleton = SkeletonDecoder().decode(data=skeleton_data["nx_graph"])
+
+    return skeleton

--- a/tests/fixtures/skeletons.py
+++ b/tests/fixtures/skeletons.py
@@ -1,7 +1,7 @@
 import pytest
 import json
 
-from sleap_io import Skeleton
+from sleap_io import Skeleton, load_skeleton
 from sleap_io.io.skeleton import SkeletonDecoder
 
 TEST_FLY_LEGS_SKELETON = "tests/data/skeleton/fly_skeleton_legs.json"
@@ -76,8 +76,4 @@ def skeleton():
 
 @pytest.fixture
 def flies13_skeleton():
-    with open("sleap/skeletons/flies13.json", "r") as f:
-        skeleton_data = json.load(f)
-    skeleton = SkeletonDecoder().decode(data=skeleton_data["nx_graph"])
-
-    return skeleton
+    return load_skeleton("sleap/skeletons/flies13.json")

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -44,6 +44,7 @@ from tests.info.test_h5 import extract_meta_hdf5
 from sleap.sleap_io_adaptors.video_utils import get_last_frame_idx
 from sleap.sleap_io_adaptors.lf_labels_utils import (
     add_suggestion,
+    labels_load_file,
     remove_video,
     labels_add_instance,
     remove_instance,
@@ -1226,7 +1227,7 @@ def test_ExportLabelsSubset(
     assert path_to_export.exists()
     assert path_to_export.is_file()
     assert path_to_export.name == name_to_export
-    labels_subset = Labels.load_file(path_to_export.as_posix())
+    labels_subset = labels_load_file(path_to_export.as_posix())
     # Should only contain video from selected clip.
     assert len(labels_subset.videos) == 1
     # Should only contain frames from selected clip.

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1269,7 +1269,7 @@ def test_ExportLabelsSubset(
     path_to_export = Path(path_to_export.with_suffix(".pkg.slp"))
     assert path_to_export.exists()
     assert path_to_export.is_file()
-    labels_subset: Labels = Labels.load_file(path_to_export.as_posix())
+    labels_subset: Labels = labels_load_file(path_to_export.as_posix())
     # Should only contain video from selected clip.
     assert len(labels_subset.videos) == 1
     n_frames_expected = upper_bound - lower_bound


### PR DESCRIPTION
## Summary


  This pull request fixes a bug in the exportLabelsSubset command where suggestions within the selected frame
  range were not being correctly included in the exported file.


Fixed the following tests: 
- `labels.extract` method should take in a list of `(video, indx)` tuples but it is not handled correctly in `sleap-io`

## Notes

- The test `tests/gui/test_dialogs.py::test_ReplaceSkeletonTableDialog` is failing due to out-of-date version of `sleap-io` package. If a new version of `sleap-io` is released, the test will pass
- The test will pass when the new version of `sleap-io` is released. 