### PR TITLE
Fix export package dialog error

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -844,7 +844,8 @@ class LearningDialog(QtWidgets.QDialog):
     def export_package(self, output_path: Optional[str] = None, gui: bool = True):
         """Export training job package."""
         # TODO: Warn if self.mode != "training"?
-        if output_path is None:
+
+        if output_path is None or not output_path:
             # Prompt for output path.
             output_path, _ = FileDialog.save(
                 caption="Export Training Job Package...",

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -477,6 +477,7 @@ def write_pipeline_files(
             from sleap_nn.config.training_job_config import verify_training_cfg
 
             # Save the config file
+            cfg_info.config = filter_cfg(cfg_info.config)
             cfg = verify_training_cfg(cfg_info.config)
             cfg.data_config.train_labels_path = [os.path.basename(labels_filename)]
             OmegaConf.save(cfg, new_cfg_filename)
@@ -495,9 +496,10 @@ def write_pipeline_files(
                 f"trainer_config.ckpt_dir={Path(ckpt_path).parent.as_posix()} "
                 f"trainer_config.run_name={Path(ckpt_path).name}"
                 f"trainer_config.zmq.controller_address=tcp://127.0.0.1:"
-                f"{str(inference_params['controller_port'])} "
+                f"{str(cfg_info.config.trainer_config.zmq.controller_address)} "
                 f"trainer_config.zmq.publish_address=tcp://127.0.0.1:"
-                f"{str(inference_params['publish_port'])}"
+                f"{str(cfg_info.config.trainer_config.zmq.publish_address)}"
+                "\n"
             )
 
             # Setup job params


### PR DESCRIPTION
This pull request fixes the training job export dialog and pipeline file writing processes.

**Notes:**
* In `sleap/gui/learning/dialog.py`, the `export_package` method now checks if `output_path` is either `None` or empty, ensuring the file dialog is prompted whenever a valid output path is not provided.
* In `sleap/gui/learning/runners.py`, the `write_pipeline_files` function applies the `filter_cfg` function to the configuration before verification.
* The same function now uses the `controller_address` and `publish_address` directly from `cfg_info.config.trainer_config.zmq` rather than from the `inference_params` dictionary.