### PR TITLE
Fix Bug When Matching Nodes

### DIFF
--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -540,7 +540,7 @@ def load_and_match(filename: str, match_to: Labels):
             nodes = labels.skeleton.nodes
             for i, node in enumerate(nodes):
                 if node.name in old_node_names:
-                    node[i] = old_skel.nodes[old_node_names.index(node.name)]
+                    nodes[i] = old_skel.nodes[old_node_names.index(node.name)]
             labels.skeletons[0] = old_skel
 
         # Match Videos


### PR DESCRIPTION
This pull request corrects an assignment in the `load_and_match` function within `sleap_io_adaptors/lf_labels_utils.py`. The change ensures that the correct variable is updated when matching skeleton nodes, improving the reliability of skeleton matching logic.

* Bug fix for skeleton node matching:
  * In the `load_and_match` function, replaced assignment to `node[i]` with assignment to `nodes[i]` to properly update the list of skeleton nodes.