### PR TITLE
Fix Bug for Displaying Mean Score in Labeling Suggestion Table

### DIFF
--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -546,7 +546,7 @@ class SuggestionsTableModel(GenericTableModel):
             for inst in lf
             if hasattr(inst, "score")
         ]
-        val = sum(scores) / len(scores) if scores else ""
+        val = float(sum(scores) / len(scores)) if scores else ""
         item_dict["mean score"] = val
 
         return item_dict


### PR DESCRIPTION
  The "Mean Score" in the `SuggestionsTableModel` was not being displayed correctly in the GUI. This was because
  the calculated mean score was a numpy.float32 type, which is not always handled correctly by the table view.

  This change explicitly casts the calculated mean score to a standard Python float to ensure it is displayed
  correctly in the suggestions table.


  This addresses the issue where the "Mean Score" column would appear empty.