### PR TITLE
Add condition to handle bool output_dir

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -814,7 +814,7 @@ class LearningDialog(QtWidgets.QDialog):
         self, output_dir: Optional[str] = None, labels_filename: Optional[str] = None
     ):
         """Save scripts and configs to run pipeline."""
-        if output_dir is None:
+        if output_dir is None or not output_dir:
             labels_fn = Path(self.labels_filename)
             models_dir = Path(labels_fn.parent, "models")
             output_dir = FileDialog.openDir(
@@ -832,6 +832,8 @@ class LearningDialog(QtWidgets.QDialog):
 
         if labels_filename is None:
             labels_filename = self.labels_filename
+
+        print(output_dir, type(output_dir))
 
         runners.write_pipeline_files(
             output_dir=output_dir,


### PR DESCRIPTION
This pull request makes minor updates to the `save` method in `sleap/gui/learning/dialog.py`, improving how the output directory is handled.

- Notes:
  * The check for `output_dir` now considers both `None` and empty values, ensuring that the directory dialog is shown if `output_dir` is not set or is empty.