### PR TITLE
Fix CLI for inference with tracker

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -298,7 +298,7 @@ class InferenceTask:
             "tracking.tracker" in self.inference_params
             and self.inference_params["tracking.tracker"] != "none"
         ):
-            cli_args.extend(["--tracking", "True"])
+            cli_args.extend(["--tracking"])
             cli_args.extend(
                 ["--track_matching_method", self.inference_params["tracking.match"]]
             )
@@ -321,12 +321,13 @@ class InferenceTask:
 
             if self.inference_params["tracking.robust"] != 1.0:
                 cli_args.extend(["--scoring_reduction", "robust_quantile"])
-                cli_args.extend(
-                    [
-                        "--robust_best_instance",
-                        str(self.inference_params["tracking.robust"]),
-                    ]
-                )
+                if self.inference_params["tracking.robust"] is not None:
+                    cli_args.extend(
+                        [
+                            "--robust_best_instance",
+                            str(self.inference_params["tracking.robust"]),
+                        ]
+                    )
 
             if self.inference_params["tracking.similarity"] == "oks":
                 cli_args.extend(["--features", "keypoints"])


### PR DESCRIPTION
This pull request makes small adjustments to the CLI argument construction for tracking in the `make_predict_cli_call` function. The changes improve the way tracking options are passed to the CLI and add a conditional check for robustness settings.

Tracking CLI argument improvements:

* Changed the tracking argument to omit the explicit `"True"` value, now passing only `"--tracking"` for better CLI compatibility.

Robustness settings handling:

* Added a conditional check to ensure that `--robust_best_instance` is only included if `tracking.robust` is not `None`, preventing potential errors when the value is unset.