### PR TITLE
Fix minor bugs in inference dialog

### DIFF
--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -146,7 +146,7 @@ model:
     options: 1,2,4,8,16,32,64
   default: ''
   label: Heads
-  multi_instance:
+  bottomup:
   - default: 5.0
     help: Spread of the Gaussian distribution of the confidence maps as a scalar float.
       Smaller values are more precise but may be difficult to learn as they have a
@@ -313,7 +313,7 @@ model:
     name: model_config.head_configs.multi_class_bottomup.class_maps.loss_weight
     type: double
   name: _heads_name
-  options: single_instance,centroid,centered_instance,multi_instance,multi_class_topdown,multi_class_bottomup
+  options: single_instance,centroid,centered_instance,bottomup,multi_class_topdown,multi_class_bottomup
   single_instance:
   - default: 5.0
     help: Spread of the Gaussian distribution of the confidence maps as a scalar float.

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -88,7 +88,10 @@ class ConfigFileInfo:
         Returns:
             Full path + filename if found, otherwise None.
         """
-        for dir in [OmegaConf.select(self.config, "trainer_config.ckpt_dir", default="."), self.path_dir]:
+        for dir in [
+            OmegaConf.select(self.config, "trainer_config.ckpt_dir", default="."),
+            self.path_dir,
+        ]:
             full_path = os.path.join(dir, shortname)
             if os.path.exists(full_path):
                 return full_path
@@ -273,7 +276,8 @@ class TrainingConfigFilesWidget(FieldComboWidget):
             if cfg_info.has_trained_model:
                 display_name += "[Trained] "
 
-            display_name += f"{OmegaConf.select(cfg, 'trainer_config.run_name', default='')}({filename})"
+            run_name = OmegaConf.select(cfg, "trainer_config.run_name", default="")
+            display_name += f"{run_name}({filename})"
 
             if select is not None:
                 if select.config == cfg_info.config:

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -88,10 +88,7 @@ class ConfigFileInfo:
         Returns:
             Full path + filename if found, otherwise None.
         """
-        if not self.config.trainer_config.run_name:
-            return None
-
-        for dir in [self.config.trainer_config.ckpt_dir, self.path_dir]:
+        for dir in [OmegaConf.select(self.config, "trainer_config.ckpt_dir", default="."), self.path_dir]:
             full_path = os.path.join(dir, shortname)
             if os.path.exists(full_path):
                 return full_path
@@ -276,7 +273,7 @@ class TrainingConfigFilesWidget(FieldComboWidget):
             if cfg_info.has_trained_model:
                 display_name += "[Trained] "
 
-            display_name += f"{cfg.trainer_config.run_name}({filename})"
+            display_name += f"{OmegaConf.select(cfg, 'trainer_config.run_name', default='')}({filename})"
 
             if select is not None:
                 if select.config == cfg_info.config:
@@ -536,8 +533,6 @@ class TrainingConfigsGetter:
             else:
                 # Get the head from the model (i.e., what the model will predict)
                 key = get_head_from_omegaconf(cfg)
-                if key == "multi_instance":
-                    key = "bottomup"
 
                 filename = os.path.basename(path)
 

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -321,7 +321,7 @@ class LearningDialog(QtWidgets.QDialog):
             "single_instance",
             "centroid",
             "centered_instance",
-            "multi_instance",
+            "bottomup",
             "multi_class_topdown",
             "multi_class_bottomup",
         )
@@ -422,7 +422,7 @@ class LearningDialog(QtWidgets.QDialog):
                 return "top-down-id"
             if recent_cfg_info.head_name in ("centroid", "centered_instance"):
                 return "top-down"
-            if recent_cfg_info.head_name in ("multi_instance",):
+            if recent_cfg_info.head_name in ("bottomup",):
                 return "bottom-up"
             if recent_cfg_info.head_name in ("single_instance",):
                 return "single"
@@ -450,7 +450,7 @@ class LearningDialog(QtWidgets.QDialog):
             "single_instance": "Single Instance Model Configuration",
             "centroid": "Centroid Model Configuration",
             "centered_instance": "Centered Instance Model Configuration",
-            "multi_instance": "Bottom-Up Model Configuration",
+            "bottomup": "Bottom-Up Model Configuration",
             "multi_class_topdown": "Top-Down-Id Model Configuration",
             "multi_class_bottomup": "Bottom-Up-Id Model Configuration",
         }
@@ -469,7 +469,7 @@ class LearningDialog(QtWidgets.QDialog):
                 self.add_tab("centroid")
                 self.add_tab("centered_instance")
             elif pipeline == "bottom-up":
-                self.add_tab("multi_instance")
+                self.add_tab("bottomup")
             elif pipeline == "top-down-id":
                 self.add_tab("centroid")
                 self.add_tab("multi_class_topdown")


### PR DESCRIPTION
This PR fixes minor bugs in the inference dialog widget. Previously, the GUI could not run inference on bottom-up models due to inconsistent head naming and unsafe access of config parameters. This update makes head naming consistent and ensures safe access to config fields, restoring proper inference workflow for bottom-up models.