### PR TITLE
Add More Metrics to SLEAP from `sleap-nn`

### DIFF
--- a/sleap/gui/dialogs/metrics.py
+++ b/sleap/gui/dialogs/metrics.py
@@ -283,6 +283,7 @@ class DetailedMetricsDialog(QtWidgets.QWidget):
             for key, val in self.metrics.items():
                 if (
                     isinstance(val, np.float64)
+                    or isinstance(val, np.int64)
                     or isinstance(val, np.ndarray)
                     and not len(val.shape)
                 ):

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -148,7 +148,7 @@ class ConfigFileInfo:
     def timestamp(self):
         """Timestamp on file; parsed from filename (not OS timestamp)."""
         match = re.match(
-            r"(\d\d)(\d\d)(\d\d)_(\d\d)(\d\d)(\d\d)\b",
+            r"_?(\d\d)(\d\d)(\d\d)_(\d\d)(\d\d)(\d\d)\b",
             self.config.trainer_config.run_name,
         )
         if match:
@@ -188,13 +188,25 @@ class ConfigFileInfo:
                 return data["metrics"].item()
 
             return_dict = {
-                "oks_voc.mAP": data["voc_metrics"].item().get("oks_voc.mAP"),
+                "vis.tp": data["visibility_metrics"].item().get("tp"),
+                "vis.fp": data["visibility_metrics"].item().get("fp"),
+                "vis.tn": data["visibility_metrics"].item().get("tn"),
+                "vis.fn": data["visibility_metrics"].item().get("fn"),
                 "vis.precision": data["visibility_metrics"].item().get("precision"),
                 "vis.recall": data["visibility_metrics"].item().get("recall"),
-                "dist.p95": data["distance_metrics"].item().get("p95"),
-                "dist.p75": data["distance_metrics"].item().get("p75"),
-                "dist.avg": data["distance_metrics"].item().get("avg"),
                 "dist.dists": data["distance_metrics"].item().get("dists"),
+                "dist.avg": data["distance_metrics"].item().get("avg"),
+                "dist.p50": data["distance_metrics"].item().get("p50"),
+                "dist.p75": data["distance_metrics"].item().get("p75"),
+                "dist.p90": data["distance_metrics"].item().get("p90"),
+                "dist.p95": data["distance_metrics"].item().get("p95"),
+                "dist.p99": data["distance_metrics"].item().get("p99"),
+                "pck.mPCK": data["pck_metrics"].item().get("mPCK"),
+                "oks.mOKS": data["mOKS"].item().get("mOKS"),
+                "oks_voc.mAP": data["voc_metrics"].item().get("oks_voc.mAP"),
+                "oks_voc.mAR": data["voc_metrics"].item().get("oks_voc.mAR"),
+                "pck_voc.mAP": data["voc_metrics"].item().get("pck_voc.mAP"),
+                "pck_voc.mAR": data["voc_metrics"].item().get("pck_voc.mAR"),
             }
             return return_dict
 


### PR DESCRIPTION
This pull request improves metric handling and timestamp parsing in the SLEAP GUI codebase. The main changes are the expansion of metric extraction and the enhancement of timestamp parsing logic.

**Metrics extraction improvements:**

* Expanded the metrics returned by `_get_metrics` in `sleap/gui/learning/configs.py` to include additional visibility, distance, PCK, OKS, and VOC metrics, providing more comprehensive evaluation data.
* Updated the metric value type handling in `sleap/gui/dialogs/metrics.py` to support `np.int64` values in addition to `np.float64`, improving compatibility with different metric types.

**Timestamp parsing enhancement:**

* Improved the regular expression in the `timestamp` method of `sleap/gui/learning/configs.py` to optionally match an underscore at the start, making parsing more robust to filename variations.