### PR TITLE
Fix Timestamp Field in Metrics Table

### DIFF
--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -148,7 +148,7 @@ class ConfigFileInfo:
     def timestamp(self):
         """Timestamp on file; parsed from filename (not OS timestamp)."""
         match = re.match(
-            r"_?(\d\d)(\d\d)(\d\d)_(\d\d)(\d\d)(\d\d)\b",
+            r".*?(?<!\d)(\d{2})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})\b",
             self.config.trainer_config.run_name,
         )
         if match:


### PR DESCRIPTION
This pull request updates the regular expression used to parse timestamps from filenames in the `timestamp` method of `sleap/gui/learning/configs.py`. The change makes the timestamp extraction more flexible and robust by allowing for additional characters before the timestamp and ensuring it does not match unwanted digit sequences.

* Improved timestamp extraction: The regular expression in the `timestamp` method now matches any leading characters before the timestamp and prevents matching digits that are part of a longer sequence, making it more reliable for varied filename formats.