### PR TITLE
remove extra argument

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -314,7 +314,7 @@ class InferenceTask:
                     ["--max_tracks", str(self.inference_params["tracking.max_tracks"])]
                 )
             if "flow" in self.inference_params["tracking.tracker"]:
-                cli_args.extend(["--use_flow", "True"])
+                cli_args.extend(["--use_flow"])
 
             if self.inference_params["tracking.post_connect_single_breaks"] == 1:
                 cli_args.extend(["--post_connect_single_breaks"])


### PR DESCRIPTION
This pull request makes a minor update to the way CLI arguments are constructed for the prediction command in `sleap/gui/learning/runners.py`. The change simplifies the inclusion of the `--use_flow` argument when flow tracking is enabled. This solves the error: `Error: Got unexpected extra argument (True)`

* Simplified the CLI argument for enabling flow tracking by removing the explicit `"True"` value, now only passing `--use_flow` when required.