### PR TITLE
Fix Prediction Instance Not Showing Up After Inference

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -21,6 +21,7 @@ from qtpy import QtWidgets
 from sleap_io import Labels, Video, LabeledFrame
 import sleap_io as sio
 from sleap.gui.learning.configs import ConfigFileInfo
+
 # from sleap.sleap_io_adaptors.lf_labels_utils import load_and_match
 from sleap.gui.config_utils import filter_cfg
 

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -21,7 +21,7 @@ from qtpy import QtWidgets
 from sleap_io import Labels, Video, LabeledFrame
 import sleap_io as sio
 from sleap.gui.learning.configs import ConfigFileInfo
-from sleap.sleap_io_adaptors.lf_labels_utils import load_and_match
+# from sleap.sleap_io_adaptors.lf_labels_utils import load_and_match
 from sleap.gui.config_utils import filter_cfg
 
 logger = logging.getLogger(__name__)
@@ -394,7 +394,8 @@ class InferenceTask:
 
         if success and append_results:
             # Load frames from inference into results list
-            # new_inference_labels = load_and_match(output_path, match_to=self.labels) # FIXME:If necessary
+            # new_inference_labels = load_and_match(output_path, match_to=self.labels)
+            # FIXME:If necessary
             new_inference_labels = sio.load_slp(output_path)
             self.results.extend(new_inference_labels.labeled_frames)
 

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -19,6 +19,7 @@ import logging
 from qtpy import QtWidgets
 
 from sleap_io import Labels, Video, LabeledFrame
+import sleap_io as sio
 from sleap.gui.learning.configs import ConfigFileInfo
 from sleap.sleap_io_adaptors.lf_labels_utils import load_and_match
 from sleap.gui.config_utils import filter_cfg
@@ -393,7 +394,8 @@ class InferenceTask:
 
         if success and append_results:
             # Load frames from inference into results list
-            new_inference_labels = load_and_match(output_path, match_to=self.labels)
+            # new_inference_labels = load_and_match(output_path, match_to=self.labels) # FIXME:If necessary
+            new_inference_labels = sio.load_slp(output_path)
             self.results.extend(new_inference_labels.labeled_frames)
 
         # Return "success" or return code if failed.
@@ -415,7 +417,7 @@ class InferenceTask:
         new_labels = Labels(self.results)
 
         # Merge pred results into base labels
-        self.labels.merge(new_labels)
+        self.labels.merge(new_labels, frame_strategy="keep_both")
 
 
 def write_pipeline_files(


### PR DESCRIPTION
This pull request updates the inference results handling in the `sleap/gui/learning/runners.py` module to improve label merging and frame loading logic. The main changes are focused on how predicted labels are loaded and merged, ensuring that both original and predicted frames are preserved during the merge process.

**Inference results loading and merging:**

* Replaced the use of `load_and_match` with `sio.load_slp` for loading inference results, which solves the problem of double-labeling for predictions
* Updated the label merging strategy in the `merge` method to use `frame_strategy="keep_both"`, ensuring that both base and predicted frames are retained instead of potentially overwriting frames.