### PR TITLE
Fix sleap-track CLI command & flags

### DIFF
--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -12,7 +12,7 @@ import sleap_io as sio
 from sleap_nn.training.model_trainer import ModelTrainer
 
 # from sleap_nn.track import main as track
-from sleap_nn.predict import main as predict
+from sleap_nn.predict import run_inference as predict
 from sleap_nn.config.training_job_config import TrainingJobConfig
 from sleap_nn.evaluation import Evaluator
 from sleap.sleap_io_adaptors.lf_labels_utils import load_labels_video_search
@@ -454,6 +454,7 @@ def train_command(
     "tracking_tracker",
     help="Options: simple, flow, simplemaxtracks, flowmaxtracks, None (default: None)",
 )
+# tracking.max_tracking is a boolean flag now, not integer
 @click.option(
     "--tracking.max_tracking",
     "tracking_max_tracking",
@@ -583,7 +584,6 @@ def track_command(
     """Track instances in video data using trained SLEAP models."""
     # Build kwargs for the tracking function
     kwargs = {}
-    kwargs["data_path"] = data_path
 
     if models is not None:
         kwargs["model_paths"] = models
@@ -663,4 +663,4 @@ def track_command(
         kwargs["of_max_levels"] = tracking_of_max_levels
 
     # # Call the original tracking function with kwargs
-    # track(data_path, **kwargs)
+    predict(data_path=data_path, **kwargs)


### PR DESCRIPTION
This pull request makes small changes to the `sleap/legacy_cli_adaptors.py` file, primarily to update the tracking command to use the correct inference function, adjust argument handling, and clarify option types.

**Notes:**
* Replaces the import of `main` from `sleap_nn.predict` with `run_inference` and updates the call in `track_command` to use the new `predict` function, ensuring the command uses the correct inference entry point. [[1]](diffhunk://#diff-19e077aee6e2954470a2e17d9aa3f0b9e0685df0a40f459da4877c666f2cfb14L15-R15) [[2]](diffhunk://#diff-19e077aee6e2954470a2e17d9aa3f0b9e0685df0a40f459da4877c666f2cfb14L666-R666)
* Removes the assignment of `data_path` to the `kwargs` dictionary in `track_command`, since `data_path` is now passed directly as a function argument.
* Adds a comment clarifying that `tracking.max_tracking` is now a boolean flag, not an integer, to avoid confusion.