### PR TITLE
Fix sleap-train ports

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -272,15 +272,15 @@ training:
   text: '<b>ZMQ Options</b>'
 
 - name: trainer_config.zmq.controller_address
-  label: Controller Address
-  type: string
-  default: tcp://127.0.0.1:9000
+  label: Controller Port
+  type: int
+  default: 9000
   range: 1024,65535
 
 - name: trainer_config.zmq.publish_address
-  label: Publish Address
-  type: string
-  default: tcp://127.0.0.1:9001
+  label: Publish Port
+  type: int
+  default: 9001
   range: 1024,65535
 
 - type: text

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -188,6 +188,7 @@ def train_command(
         train = sio.load_slp(labels_path)
         val = sio.load_slp(val_labels) if val_labels is not None else None
 
+    # TODO: DS
     if val is None:
         train, val = train.make_training_splits(
             n_train=1 - config.data_config.validation_fraction,


### PR DESCRIPTION
This pull request reverts back from address strings to integer port numbers, such that random port selection and training split handling will soon be handled on sleap-nn side.

Notes:
* Changed `trainer_config.zmq.controller_address` and `trainer_config.zmq.publish_address` fields in `pipeline_form.yaml` to use integer port numbers (`controller_port` and `publish_port`) instead of full address strings.
* Added a TODO comment in the `train_command` function in `sleap/legacy_cli_adaptors.py` to indicate further work or clarification is needed regarding validation splitting (sleap-nn, make_training_splits() function). 