### PR TITLE
Fix zmq parameters

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -271,13 +271,13 @@ training:
 - type: text
   text: '<b>ZMQ Options</b>'
 
-- name: trainer_config.zmq.controller_address
+- name: trainer_config.zmq.controller_port
   label: Controller Port
   type: int
   default: 9000
   range: 1024,65535
 
-- name: trainer_config.zmq.publish_address
+- name: trainer_config.zmq.publish_port
   label: Publish Port
   type: int
   default: 9001

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -500,10 +500,8 @@ def write_pipeline_files(
                 f"sleap-nn train --config-name {new_cfg_filename} --config-dir {''} "
                 f"trainer_config.ckpt_dir={Path(ckpt_path).parent.as_posix()} "
                 f"trainer_config.run_name={Path(ckpt_path).name}"
-                f"trainer_config.zmq.controller_address=tcp://127.0.0.1:"
-                f"{str(cfg_info.config.trainer_config.zmq.controller_address)} "
-                f"trainer_config.zmq.publish_address=tcp://127.0.0.1:"
-                f"{str(cfg_info.config.trainer_config.zmq.publish_address)}"
+                f"trainer_config.zmq.controller_port={cfg_info.config.trainer_config.zmq.controller_port}"
+                f"trainer_config.zmq.publish_port={cfg_info.config.trainer_config.zmq.publish_port}"
                 "\n"
             )
 
@@ -915,12 +913,8 @@ def train_subprocess(
 
         cfg.trainer_config.ckpt_dir = Path(run_path).parent.as_posix()
         cfg.trainer_config.run_name = Path(run_path).name
-        cfg.trainer_config.zmq.controller_address = (
-            f"tcp://127.0.0.1:{str(inference_params['controller_port'])}"
-        )
-        cfg.trainer_config.zmq.publish_address = (
-            f"tcp://127.0.0.1:{str(inference_params['publish_port'])}"
-        )
+        cfg.trainer_config.zmq.controller_port = inference_params["controller_port"]
+        cfg.trainer_config.zmq.publish_port = inference_params["publish_port"]
 
         OmegaConf.save(cfg, (Path(temp_dir) / f"{cfg_file_name}.yaml").as_posix())
 

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -159,8 +159,8 @@ def train_command(
     if keep_viz is not None and keep_viz:
         config.trainer_config.keep_viz = True
     if zmq is not None and not zmq:
-        config.trainer_config.zmq.publish_address = None
-        config.trainer_config.zmq.controller_address = None
+        config.trainer_config.zmq.publish_port = None
+        config.trainer_config.zmq.controller_port = None
     if run_name is not None:
         config.trainer_config.run_name = run_name
     if prefix is not None:

--- a/tests/data/configs/yaml/config_centroid_unet.yaml
+++ b/tests/data/configs/yaml/config_centroid_unet.yaml
@@ -138,8 +138,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/tests/data/configs/yaml/config_multi_class_bottomup_unet.yaml
+++ b/tests/data/configs/yaml/config_multi_class_bottomup_unet.yaml
@@ -137,8 +137,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/tests/data/configs/yaml/config_single_instance_unet.yaml
+++ b/tests/data/configs/yaml/config_single_instance_unet.yaml
@@ -130,8 +130,8 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    publish_address:
-    controller_address:
+    publish_port:
+    controller_port:
     controller_polling_timeout: 10
 name: ''
 description: ''

--- a/tests/data/configs/yaml/minimal_instance_centroid_training_config.yaml
+++ b/tests/data/configs/yaml/minimal_instance_centroid_training_config.yaml
@@ -151,9 +151,9 @@ trainer_config:
     max_hard_keypoints: null
     loss_scale: 5.0
   zmq:
-    controller_address: tcp://127.0.0.1:9000
+    controller_port: 9000
     controller_polling_timeout: 10
-    publish_address: tcp://127.0.0.1:9001
+    publish_port: 9001
 name: ''
 description: ''
 sleap_nn_version: 0.0.1


### PR DESCRIPTION
This PR fixes the zmq parameters according to `sleap-nn`. `sleap-nn` now takes in port numbers in the config instead of addresses.