### PR TITLE
Fix sleap-track flag syntax

### DIFF
--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -2166,8 +2166,6 @@ class QtInstance(QGraphicsObject):
     def duplicate_instance(self):
         """Duplicate the instance and add it to the scene."""
         # Add instance to the context
-        print("duplicate instance method called")
-
         if self.player.context is None:
             print("self.player.context is None, cannot duplicate instance")
             return

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -459,7 +459,7 @@ def train_command(
     "--tracking.max_tracking",
     "tracking_max_tracking",
     type=int,
-    help="If 1 (True) then the tracker will cap the max number of tracks. 0 (False)"
+    help="If 1 (True) then the tracker will cap the max number of tracks. 0 (False)",
 )
 @click.option(
     "--tracking.max_tracks",

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -459,7 +459,7 @@ def train_command(
     "--tracking.max_tracking",
     "tracking_max_tracking",
     type=int,
-    help="If 1 (True) then the tracker will cap the max number of tracks. (default: 0, (False))",
+    help="If 1 (True) then the tracker will cap the max number of tracks. 0 (False)"
 )
 @click.option(
     "--tracking.max_tracks",

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -455,12 +455,11 @@ def train_command(
     "tracking_tracker",
     help="Options: simple, flow, simplemaxtracks, flowmaxtracks, None (default: None)",
 )
-# tracking.max_tracking is a boolean flag now, not integer
 @click.option(
     "--tracking.max_tracking",
     "tracking_max_tracking",
-    is_flag=True,
-    help="If true then the tracker will cap the max number of tracks. (default: False)",
+    type=int,
+    help="If 1 (True) then the tracker will cap the max number of tracks. (default: 0, (False))",
 )
 @click.option(
     "--tracking.max_tracks",
@@ -627,7 +626,8 @@ def track_command(
         if "flow" in tracking_tracker:
             kwargs["use_flow"] = True
 
-    if tracking_max_tracking is not None and tracking_max_tracking:
+    # Check max_tracking flag int value for True/False
+    if tracking_max_tracking is not None and tracking_max_tracking == 1:
         kwargs["candidates_method"] = "local_queues"
         kwargs["max_tracks"] = tracking_max_tracks
 


### PR DESCRIPTION
This pull request mainly updates the sleap-track flag in CLI adaptors and cleans up debugging output in the video widget. The most significant changes are a refactor of the `tracking.max_tracking` CLI option to accept an integer instead of a boolean flag, and the corresponding logic update in the tracking command.

**Notes:**
* Changed the `tracking.max_tracking` CLI option in `train_command` from a boolean flag to an integer type, allowing explicit specification of True/False using 1/0. The help text was updated accordingly.
* Updated `track_command` logic to check if `tracking_max_tracking` is set to 1 (True) before enabling the relevant tracking options, aligning with the new integer-based CLI option.
* Removed an unnecessary debug print statement from the `duplicate_instance` method in `video.py` to reduce console clutter.