### PR TITLE
Remove train val split

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,12 @@ jupyter = [
     "jupyterlab",
 ]
 
-sleap-nn = [
+nn-cpu = [
     "sleap-nn[torch-cpu]"
+]
+
+nn-gpu = [
+    "sleap-nn[torch-cuda128]"
 ]
 
 [project.urls]

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -188,14 +188,6 @@ def train_command(
         train = sio.load_slp(labels_path)
         val = sio.load_slp(val_labels) if val_labels is not None else None
 
-    # TODO: DS
-    if val is None:
-        train, val = train.make_training_splits(
-            n_train=1 - config.data_config.validation_fraction,
-            n_val=config.data_config.validation_fraction,
-            seed=42,
-        )
-
     start_train_time = time.time()
     start_timestamp = str(datetime.now())
     logger.info(f"Started training at: {start_timestamp}")
@@ -203,7 +195,7 @@ def train_command(
     trainer = ModelTrainer.get_model_trainer_from_config(
         config=config,
         train_labels=[train],
-        val_labels=[val],
+        val_labels=[val] if val is not None else None,
     )
     trainer.train()
 

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -169,12 +169,15 @@ def train_command(
         config.trainer_config.run_name = config.trainer_config.run_name + suffix
     if cpu is not None and cpu:
         config.trainer_config.trainer_accelerator = "cpu"
-    # if first_gpu: #TODO
-    #     args.append('--first-gpu')
-    # if last_gpu:
-    #     args.append('--last-gpu')
-    # if gpu:
-    #     args.extend(['--gpu', gpu])
+    if first_gpu:
+        config.trainer_config.trainer_accelerator = "gpu"
+        config.trainer_config.trainer_device_indices = [0]
+    if last_gpu:
+        config.trainer_config.trainer_accelerator = "gpu"
+        config.trainer_config.trainer_device_indices = [-1]
+    if gpu:
+        config.trainer_config.trainer_accelerator = "gpu"
+        config.trainer_config.trainer_device_indices = [gpu] if gpu != "auto" else None
 
     # Call the original training function with the arguments
     if video_paths is not None:
@@ -574,6 +577,8 @@ def track_command(
     tracking_of_max_levels,
 ):
     """Track instances in video data using trained SLEAP models."""
+    import torch
+
     # Build kwargs for the tracking function
     kwargs = {}
 
@@ -595,12 +600,14 @@ def track_command(
         kwargs["video_index"] = video_index
     if cpu is not None and cpu:
         kwargs["device"] = "cpu"
-    # if first_gpu:
-    #     kwargs['first_gpu'] = True
-    # if last_gpu:
-    #     kwargs['last_gpu'] = True
-    # if gpu:
-    #     kwargs['gpu'] = gpu #TODO
+    if torch.cuda.is_available():
+        if first_gpu:
+            kwargs["device"] = "cuda:0"
+        if last_gpu:
+            n_gpus = torch.cuda.device_count()
+            kwargs["device"] = f"cuda:{n_gpus - 1}"
+        if gpu:
+            kwargs["device"] = f"cuda:{gpu}" if gpu != "auto" else "cuda"
     if max_edge_length_ratio is not None:
         kwargs["max_edge_length_ratio"] = max_edge_length_ratio
     if dist_penalty_weight is not None:


### PR DESCRIPTION
This PR includes the following fixes:

- Removes the train/val split logic from the CLI adaptors. This is handled in `sleap-nn`.

- Adds separate installation groups for CPU and GPU dependencies for `sleap-nn`.

- Add mapping parameters for `--first-gpu`, `--last-gpu` and `--gpu`.