### PR TITLE
Fix incorrect save/export dialog call

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -169,8 +169,8 @@ class LearningDialog(QtWidgets.QDialog):
 
         # Connect actions for buttons
         self.copy_button.clicked.connect(self.copy)
-        self.save_button.clicked.connect(self.save)
-        self.export_button.clicked.connect(self.export_package)
+        self.save_button.clicked.connect(lambda: self.save())
+        self.export_button.clicked.connect(lambda: self.export_package())
         self.cancel_button.clicked.connect(self.reject)
         self.run_button.clicked.connect(self.run)
 
@@ -833,8 +833,6 @@ class LearningDialog(QtWidgets.QDialog):
         if labels_filename is None:
             labels_filename = self.labels_filename
 
-        print(output_dir, type(output_dir))
-
         runners.write_pipeline_files(
             output_dir=output_dir,
             labels_filename=labels_filename,
@@ -846,7 +844,6 @@ class LearningDialog(QtWidgets.QDialog):
     def export_package(self, output_path: Optional[str] = None, gui: bool = True):
         """Export training job package."""
         # TODO: Warn if self.mode != "training"?
-
         if output_path is None or not output_path:
             # Prompt for output path.
             output_path, _ = FileDialog.save(


### PR DESCRIPTION
This pull request makes minor changes to the `sleap/gui/learning/dialog.py` file, changing how the save() and export_package() functions are called when clicked.

**Notes:**
  * Changed the way `save_button` and `export_button` actions are connected by wrapping their calls in lambda functions to ensure the methods are called correctly when the buttons are clicked.
* PySide6 has different behavior when calling `button.clicked.connect(slot)` than previous PySide2: IF the slot function has more than one argument, the connect signal emits a boolean ('False') to the slot as an argument.
* Previous issue: 'False' passed to `save(self, output_dir: Optional[str] = None, labels_filename: Optional[str] = None)`  function in place of where `output_dir` was. -> Therefore couldn't be caught/handled in function by: `if output_dir is None` since the boolean from the button click event emit would always pass a boolean to where output_dir was.
* 'False' is emitted to indicate that the button is not 'checkable', and 'True otherwise.
* Source: https://www.pythonguis.com/tutorials/pyside6-signals-slots-events/#receiving-data