### PR TITLE
Fix exportLabelsFilePackage Test Failure

### DIFF
--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1031,7 +1031,7 @@ def test_exportLabelsPackage(export_extension, centered_pair_labels: Labels, tmp
         lf.instances = []
         labels_add_instance(centered_pair_labels, lf, predicted_inst)
         # for inst in lf.user_instances:
-            # remove_instance(centered_pair_labels, inst, lf)
+        # remove_instance(centered_pair_labels, inst, lf)
 
     # FIXME: DEEPCOPY Labels to prevent mutation during case exports
     context = CommandContext.from_labels(deepcopy(centered_pair_labels))

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -50,6 +50,8 @@ from sleap.sleap_io_adaptors.lf_labels_utils import (
 )
 from sleap.sleap_io_adaptors.instance_utils import instance_same_pose_as_compat
 
+from copy import deepcopy
+
 
 def test_delete_user_dialog(centered_pair_predictions):
     context = CommandContext.from_labels(centered_pair_predictions)
@@ -1026,10 +1028,13 @@ def test_exportLabelsPackage(export_extension, centered_pair_labels: Labels, tmp
         predicted_inst = PredictedInstance.from_numpy(
             lf.instances[0].points["xy"], skeleton=lf.instances[0].skeleton, score=0.5
         )
+        lf.instances = []
         labels_add_instance(centered_pair_labels, lf, predicted_inst)
-        for inst in lf.user_instances:
-            remove_instance(centered_pair_labels, inst, lf)
-    context = CommandContext.from_labels(centered_pair_labels)
+        # for inst in lf.user_instances:
+            # remove_instance(centered_pair_labels, inst, lf)
+
+    # FIXME: DEEPCOPY Labels to prevent mutation during case exports
+    context = CommandContext.from_labels(deepcopy(centered_pair_labels))
 
     # Case 1: Export user-labeled frames with image data into a single SLP file.
     context.exportUserLabelsPackage()
@@ -1037,10 +1042,12 @@ def test_exportLabelsPackage(export_extension, centered_pair_labels: Labels, tmp
     assert_loaded_package_similar(path_to_pkg)
 
     # Case 2: Export user-labeled frames and suggested frames with image data.
+    context = CommandContext.from_labels(deepcopy(centered_pair_labels))
     context.exportTrainingPackage()
     assert_loaded_package_similar(path_to_pkg, sugg=True)
 
     # Case 3: Export all frames and suggested frames with image data.
+    context = CommandContext.from_labels(deepcopy(centered_pair_labels))
     context.exportFullPackage()
     assert_loaded_package_similar(path_to_pkg, sugg=True, pred=True)
 

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -46,7 +46,6 @@ from sleap.sleap_io_adaptors.lf_labels_utils import (
     add_suggestion,
     remove_video,
     labels_add_instance,
-    remove_instance,
 )
 from sleap.sleap_io_adaptors.instance_utils import instance_same_pose_as_compat
 


### PR DESCRIPTION
This pull request addresses issues with mutation of the `Labels` object during test case exports in `tests/gui/test_commands.py`. The main change is the use of `deepcopy` to ensure that each export test operates on an independent copy of the labels, preventing unintended(?) Labels backend mutation.

Main Issue: In the process of saving/exporting .pkg.slp in Case 1 (Export user-labeled frames only), sleap-io's `save_file()` function checks for embed value (i.e. embed = "user"), which calls labels.replace_videos() and mutates the labels backend from MediaVideo -> HDF5, s.t. the embedded frames are user-labeled frames only.

When this labels file is accessed by Case 2 (via context), it only had access to the embedded user-labeled frames, and NOT the suggested frames, which are needed to pass the frame assertion test. (got 66, expected 68 user-labeled + suggested)

(sleap_io/io/slp.py -> embed_frames(), line 642)

Notes:
* Imported `deepcopy` from the `copy` module and used it to create independent copies of `centered_pair_labels` before each export test, ensuring that mutations in one test do not affect others. [[1]](diffhunk://#diff-f4a4e045eb79380b8a26772064d5a5f8825ed5c216ca8c64fcfe75c70a465924R53-R54) [[2]](diffhunk://#diff-f4a4e045eb79380b8a26772064d5a5f8825ed5c216ca8c64fcfe75c70a465924R1031-R1050)
* Added comments and a `FIXME` note to clarify the reason for using `deepcopy` and to highlight the need for further investigation or refactoring.