### PR TITLE
Fix Failing Test for Write Visuals

### DIFF
--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -2167,7 +2167,8 @@ class QtInstance(QGraphicsObject):
         """Duplicate the instance and add it to the scene."""
         # Add instance to the context
         if self.player.context is None:
-            print("self.player.context is None, cannot duplicate instance")
+            if self.player.state["debug mode"]:
+                print("self.player.context is None, cannot duplicate instance")
             return
 
         # Copy the instance and add it to the context

--- a/sleap/io/visuals.py
+++ b/sleap/io/visuals.py
@@ -212,7 +212,7 @@ class VideoMarkerThread(Thread):
         self, img: np.ndarray, instances: Optional[List["Instance"]] = None
     ) -> Tuple[int, int]:
         if instances:
-            centroids = np.array([inst.centroid for inst in instances])
+            centroids = np.array([np.nanmedian(inst.numpy(), axis=0) for inst in instances])
             center_xy = np.nanmedian(centroids, axis=0)
             self._crop_centers.append(center_xy)
 

--- a/sleap/io/visuals.py
+++ b/sleap/io/visuals.py
@@ -212,7 +212,9 @@ class VideoMarkerThread(Thread):
         self, img: np.ndarray, instances: Optional[List["Instance"]] = None
     ) -> Tuple[int, int]:
         if instances:
-            centroids = np.array([np.nanmedian(inst.numpy(), axis=0) for inst in instances])
+            centroids = np.array(
+                [np.nanmedian(inst.numpy(), axis=0) for inst in instances]
+            )
             center_xy = np.nanmedian(centroids, axis=0)
             self._crop_centers.append(center_xy)
 


### PR DESCRIPTION
This pull request fixes a failing test in test_visuals that uses a deprecated sleap.io attribute (centroid) and uses the debug mode flag to check before debug printing.

**Notes:**
* Improved error messaging in `duplicate_instance` in `video.py` by adding a debug mode check before printing a warning when `self.player.context` is `None`.
* Updated `_get_crop_center` in `visuals.py` to use the median of instance coordinates for centroid calculation, which replaces the old accessed centroid attribute in old sleap.io.