### PR TITLE
Fix Table Not Showing up When Merging Projects

### DIFF
--- a/sleap/gui/dialogs/merge.py
+++ b/sleap/gui/dialogs/merge.py
@@ -88,6 +88,7 @@ class MergeDialog(QtWidgets.QDialog):
                 frame_strategy="keep_both",  # Use sleap-io frame strategy
             )
 
+
             # Analyze what was merged vs conflicts
             self._analyze_merge_result(merge_result)
 
@@ -103,9 +104,7 @@ class MergeDialog(QtWidgets.QDialog):
 
         # Count merged frames
         self.frames_merged = (
-            merge_result.frames_merged
-            if hasattr(merge_result, "frames_merged")
-            else 0
+            merge_result.frames_merged if hasattr(merge_result, "frames_merged") else 0
         )
 
         # Check for conflicts (frames that couldn't be merged)
@@ -356,8 +355,8 @@ class MergeTable(QtWidgets.QTableView):
 class MergeTableModel(QtCore.QAbstractTableModel):
     """Qt table model for summarizing merged frames."""
 
-    _props = ["video", "frame", "merged instances"]
 
+    _props = ["frames merged", "instances added", "instances updated", "instances skipped"]
     def __init__(self, merge_result):
         super(MergeTableModel, self).__init__()
         self.merge_result = merge_result
@@ -365,35 +364,22 @@ class MergeTableModel(QtCore.QAbstractTableModel):
 
     def _extract_merge_data(self):
         """Extract merge data from merge result."""
-        data_table = []
+        metadata = {
+            "frames_merged": self.merge_result.frames_merged
+            if hasattr(self.merge_result, "frames_merged")
+            else 0,
+            "instances_added": self.merge_result.instances_added
+            if hasattr(self.merge_result, "instances_added")
+            else 0,
+            "instances_updated": self.merge_result.instances_updated
+            if hasattr(self.merge_result, "instances_updated")
+            else 0,
+            "instances_skipped": self.merge_result.instances_skipped
+            if hasattr(self.merge_result, "instances_skipped")
+            else 0,
+        }
 
-        if hasattr(self.merge_result, "frames_merged") and isinstance(
-            self.merge_result.frames_merged, list
-        ):
-            # Extract data from merge result object
-            for frame_info in self.merge_result.frames_merged:
-                data_table.append(
-                    {
-                        "filename": (
-                            frame_info.video.filename
-                            if hasattr(frame_info, "video")
-                            else "Unknown"
-                        ),
-                        "frame_idx": (
-                            frame_info.frame_idx
-                            if hasattr(frame_info, "frame_idx")
-                            else 0
-                        ),
-                        "instances": (
-                            frame_info.instances
-                            if hasattr(frame_info, "instances")
-                            else []
-                        ),
-                    }
-                )
-        else:
-            # Fallback for different merge result formats
-            data_table = [{"filename": "Unknown", "frame_idx": 0, "instances": []}]
+        data_table = [metadata]
 
         return data_table
 
@@ -404,12 +390,14 @@ class MergeTableModel(QtCore.QAbstractTableModel):
             prop = self._props[index.column()]
 
             if idx < self.rowCount():
-                if prop == "video":
-                    return self.data_table[idx]["filename"]
-                elif prop == "frame":
-                    return self.data_table[idx]["frame_idx"]
-                elif prop == "merged instances":
-                    return show_instance_type_counts(self.data_table[idx]["instances"])
+                if prop == "frames merged":
+                    return self.data_table[idx]["frames_merged"]
+                elif prop == "instances added":
+                    return self.data_table[idx]["instances_added"]
+                elif prop == "instances updated":
+                    return self.data_table[idx]["instances_updated"]
+                elif prop == "instances skipped":
+                    return self.data_table[idx]["instances_skipped"]
 
         return None
 

--- a/sleap/gui/dialogs/merge.py
+++ b/sleap/gui/dialogs/merge.py
@@ -103,7 +103,7 @@ class MergeDialog(QtWidgets.QDialog):
 
         # Count merged frames
         self.frames_merged = (
-            len(merge_result.frames_merged)
+            merge_result.frames_merged
             if hasattr(merge_result, "frames_merged")
             else 0
         )
@@ -367,7 +367,9 @@ class MergeTableModel(QtCore.QAbstractTableModel):
         """Extract merge data from merge result."""
         data_table = []
 
-        if hasattr(self.merge_result, "frames_merged"):
+        if hasattr(self.merge_result, "frames_merged") and isinstance(
+            self.merge_result.frames_merged, list
+        ):
             # Extract data from merge result object
             for frame_info in self.merge_result.frames_merged:
                 data_table.append(

--- a/sleap/gui/dialogs/merge.py
+++ b/sleap/gui/dialogs/merge.py
@@ -88,7 +88,6 @@ class MergeDialog(QtWidgets.QDialog):
                 frame_strategy="keep_both",  # Use sleap-io frame strategy
             )
 
-
             # Analyze what was merged vs conflicts
             self._analyze_merge_result(merge_result)
 
@@ -355,8 +354,13 @@ class MergeTable(QtWidgets.QTableView):
 class MergeTableModel(QtCore.QAbstractTableModel):
     """Qt table model for summarizing merged frames."""
 
+    _props = [
+        "frames merged",
+        "instances added",
+        "instances updated",
+        "instances skipped",
+    ]
 
-    _props = ["frames merged", "instances added", "instances updated", "instances skipped"]
     def __init__(self, merge_result):
         super(MergeTableModel, self).__init__()
         self.merge_result = merge_result


### PR DESCRIPTION
**Summary:**
This PR refactors the `MergeDialog` to display statistics about the merge result, rather than a table of merged frames. This provides a more concise summary of the merge operation and matches the format returned by `sleap-io`.

**Changes:**
- The `MergeTableModel` is updated to display merge statistics (frames merged, instances added/updated/skipped) instead of a list of merged frames.
- The `_extract_merge_data` method is updated to extract these statistics from the `merge_result` object.
- The `data` method is updated to display the new statistics in the table.
- The calculation of `frames_merged` in `_analyze_merge_result` is simplified.

**Example Usage:**
When merging two projects, the dialog will now show a summary of the merge, like this:

| frames merged | instances added | instances updated | instances skipped |
|---|---|---|---|
| 10 | 5 | 2 | 1 |

**Notes for future consideration:**
This change improves the usability of the merge dialog by providing a clear and concise summary of the merge operation.