### PR TITLE
Fix: Set `trainer_devices` to `null` in Trainings Config in GUI to indicate `"auto"`

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1233,6 +1233,8 @@ class TrainingEditorWidget(QtWidgets.QWidget):
 
         cfg = cfg_info.config
         key_val_dict = get_keyval_dict_from_omegaconf(cfg)
+        if key_val_dict.get("trainer_config.trainer_devices") == "auto":
+            key_val_dict["trainer_config.trainer_devices"] = None
         self.set_fields_from_key_val_dict(key_val_dict)
 
     # def _set_user_config(self):


### PR DESCRIPTION
### Description

This PR fixes a bug that caused a traceback when loading training configurations in the GUI.

The traceback was caused by the `trainer_devices` parameter being set to "auto" in the `training_config.yml` file, while the GUI expected an integer or a null value.

This PR addresses the issue in two ways:
- It ensures that new training configurations are generated with `trainer_devices` set to `null`.
- It handles the case where an old configuration file with `trainer_devices: auto` is loaded, by converting the value to `null` before it is passed to the GUI.