### PR TITLE
Add `get_centroid()` Function for Centroid Computation

### DIFF
--- a/sleap/info/summary.py
+++ b/sleap/info/summary.py
@@ -14,6 +14,7 @@ from sleap_io import Labels
 from sleap_io import Video
 from sleap.sleap_io_adaptors.skeleton_utils import node_to_index
 from sleap.sleap_io_adaptors.video_utils import get_last_frame_idx
+from sleap.sleap_io_adaptors.instance_utils import get_centroid
 
 
 @attr.s(auto_attribs=True)
@@ -210,7 +211,7 @@ class StatisticSeries:
             if len(instances) < 2:
                 return np.nan
             # centroids for all instances in frame
-            centroids = np.array([inst.centroid for inst in instances])
+            centroids = np.array([get_centroid(inst) for inst in instances])
             # calculate distance between each pair of instance centroids
             distances = np.linalg.norm(
                 centroids[np.newaxis, :, :] - centroids[:, np.newaxis, :], axis=-1

--- a/sleap/sleap_io_adaptors/instance_utils.py
+++ b/sleap/sleap_io_adaptors/instance_utils.py
@@ -283,3 +283,20 @@ def instance_same_pose_as_compat(instance1, instance2):
         points1 = instance_get_points_array(instance1)
         points2 = instance_get_points_array(instance2)
         return np.array_equal(points1, points2, equal_nan=True)
+
+
+def get_centroid(instance: Instance) -> np.ndarray:
+    """Return instance centroid as an array of `(x, y)` coordinates.
+
+    Notes:
+        This computes the centroid as the median of the visible points.
+
+    Args:
+        instance: sleap_io Instance object
+
+    Returns:
+        Centroid as a numpy array [x, y] or np.array([np.nan, np.nan]) if no points are labeled.
+    """
+    points = instance.points["xy"]
+    centroid = np.nanmedian(points, axis=0)
+    return centroid

--- a/sleap/sleap_io_adaptors/instance_utils.py
+++ b/sleap/sleap_io_adaptors/instance_utils.py
@@ -290,12 +290,6 @@ def get_centroid(instance: Instance) -> np.ndarray:
 
     Notes:
         This computes the centroid as the median of the visible points.
-
-    Args:
-        instance: sleap_io Instance object
-
-    Returns:
-        Centroid as a numpy array [x, y] or np.array([np.nan, np.nan]) if no points are labeled.
     """
     points = instance.points["xy"]
     centroid = np.nanmedian(points, axis=0)


### PR DESCRIPTION
This PR fixes the error when selecting “Min Centroid Proximity” for Seekbar Header in the GUI. The error was due to the fact that `centroid` attribute is no longer supported in sleap-io's `Instance` objects. To fix this, a new function is added to replace the centroid attribute based on legacy SLEAP. 