### PR TITLE
Exclude docs and tests from build artifacts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include README.md
+include LICENSE
+include pyproject.toml
+
+recursive-exclude docs *
+recursive-exclude tests *
+prune docs
+prune tests


### PR DESCRIPTION
## Summary
- Added `MANIFEST.in` to exclude `docs/` and `tests/` directories from source distributions
- Reduces build artifact size by removing unnecessary documentation and test files from distributed packages

## Test plan
- [x] Verified with `uv build` that docs/ and tests/ are no longer included in the source distribution
- [x] Confirmed build output shows "no previously-included directories found matching 'docs'" and "'tests'"

🤖 Generated with [Claude Code](https://claude.com/claude-code)