### PR TITLE
Fix sleap-diagnostic and Installation Options

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,30 +5,20 @@
     If you are using **SLEAP version 1.4.1 or earlier**, please visit the [legacy documentation](http://legacy.sleap.ai).
 
 
-SLEAP can be installed as a Python package on Windows, Linux, and Mac OS. For a quick sample using [`uv`](https://docs.astral.sh/uv/)- an ultra-fast Python package and project manager, see below (no installation required!):
+SLEAP can be installed as a Python package on Windows, Linux, and Mac OS. For **quick start** using [`uv`](https://docs.astral.sh/uv/)- an ultra-fast Python package and project manager, see below:
 
-=== "Windows/Linux (CUDA 12.8)"
-    ```bash
-    uvx --from "sleap[nn]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128 sleap-label
-    ```
-    !!! info "Other CUDA versions"
-        - For more information on which CUDA version to use for your system, see the [PyTorch installation](https://pytorch.org/get-started/locally/) guide. The `--extra-index-url` in the install command should match the CUDA version you need (e.g., `https://download.pytorch.org/whl/cuda118` for CUDA 11.8, `https://download.pytorch.org/whl/cuda128` for CUDA 12.8, etc.).
-        - On macOS, MPS (Metal Performance Shaders) is automatically enabled for Apple Silicon acceleration.
+```bash
+# CUDA 12.8
+uv tool install "sleap[nn]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128
 
-=== "macOS/CPU Only"
-    ```bash
-    uvx --from "sleap[nn]" sleap-label
-    ```
+# CPU
+uv tool install "sleap[nn]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu
+```
 
-=== "SLEAP GUI Only"
-    ```bash
-    uvx --from "sleap" sleap-label
-    ```
-    !!! warning "GUI <u>ONLY</u>"
-        Installing this version of SLEAP will **NOT** include any training/inference capabilities, as it will not include the sleap-nn backend. This should primarily be used for **labeling**.
-
-!!! tip "Sample with `uvx`"
-    Note that opening SLEAP w/ `uvx` will **not** install SLEAP onto your system, it will only **'invoke'** SLEAP.
+Then run:
+```bash
+sleap-label
+```
 
 For more in-depth installation instructions, see the [installation methods](#installation-methods). The newest version of SLEAP can always be found in the [Releases page](https://github.com/talmolab/sleap/releases).
 
@@ -66,6 +56,7 @@ For more in-depth installation instructions, see the [installation methods](#ins
 
 !!! tip "Choose Your Installation Method"
     - **[Installation with as a system-wide tool with uv](#installation-with-uv-tool-install)**: Use `uv tool install` to install SLEAP globally as a tool (Installation needed, **strongly recommended**)
+    - **[Installation with uvx](#installation-with-uvx)**: Use `uvx` for one-off commands. (no installation needed!)
     - **[Installation with uv pip](#installation-with-uv-pip)**: Use `uv pip` to install from pypi in a uv virtual env.
     - **[Installation with pip](#installation-with-pip)**: Use `pip` to install from pypi in a conda env. (Recommended to use with a conda env)
     - **[Installation from source](#development-setup-with-uv)**: Use `uv sync` to install from source. (For developmental purposes)
@@ -124,6 +115,43 @@ For more in-depth installation instructions, see the [installation methods](#ins
 # Test the installation
 sleap-label --help
 ```
+
+---
+## Installation with uvx
+`uvx` automatically installs sleap-nn and runs your command inside a temporary virtual environment (venv). This means each run is fully isolated and leaves no trace on your system—perfect for trying out sleap-nn without any *permanent* installation.
+
+!!! note "Install uv"
+    Install [`uv`](https://docs.astral.sh/uv/)- an ultra-fast Python package manager:
+    ```bash
+    # macOS/Linux
+    curl -LsSf http://astral.sh/uv/install.sh | sh
+
+    # Windows
+    powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+### Platform-Specific Commands
+=== "Windows/Linux (CUDA 12.8)"
+    ```bash
+    uvx --from "sleap[nn]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128 sleap-label
+    ```
+    !!! info "Other CUDA versions"
+        - For more information on which CUDA version to use for your system, see the [PyTorch installation](https://pytorch.org/get-started/locally/) guide. The `--extra-index-url` in the install command should match the CUDA version you need (e.g., `https://download.pytorch.org/whl/cuda118` for CUDA 11.8, `https://download.pytorch.org/whl/cuda128` for CUDA 12.8, etc.).
+        - On macOS, MPS (Metal Performance Shaders) is automatically enabled for Apple Silicon acceleration.
+
+=== "macOS/CPU Only"
+    ```bash
+    uvx --from "sleap[nn]" sleap-label
+    ```
+
+=== "SLEAP GUI Only"
+    ```bash
+    uvx --from "sleap" sleap-label
+    ```
+    !!! warning "GUI <u>ONLY</u>"
+        Installing this version of SLEAP will **NOT** include any training/inference capabilities, as it will not include the sleap-nn backend. This should primarily be used for **labeling**.
+
+!!! tip "Sample with `uvx`"
+    Note that opening SLEAP w/ `uvx` will **not** install SLEAP onto your system, it will only **'invoke'** SLEAP.
 
 ---
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -37,7 +37,7 @@ SLEAP 1.5 introduces three powerful new backbone architectures (check [here](htt
 We've maintained full backward compatibility:
 
 - **GUI Support**: SLEAP now uses a new <u>YAML-based</u> config file structure, but you can still upload and work with old SLEAP JSON files in the GUI. For details on converting legacy SLEAP 1.4 config/JSON files to the new YAML format, see our [conversion guide](https://nn.sleap.ai/latest/config/#converting-legacy-sleap-14-configjson-to-sleap-nn-yaml).
-- **TensorFlow Model Inference**: Continue to support running inference on old TensorFlow models (UNet backbone only). Check [using legacy models](https://nn.sleap.ai/latest/inference/#legacy-sleap-model-support) for more details.
+- **Using TensorFlow Model Weights**: Continue to support running inference on SLEAP <1.4 TensorFlow model weights (UNet backbone only). Check [using legacy models](https://nn.sleap.ai/latest/inference/#legacy-sleap-model-support) for more details.
 
 
 *For a complete list of changes, see our [Changelog](changelog.md).*

--- a/sleap/diagnostic.py
+++ b/sleap/diagnostic.py
@@ -112,6 +112,23 @@ def tensorflow_section():
     label("tensorflow", "Neural network functionality has been removed")
 
 
+def pytorch_section():
+    header("PYTORCH")
+    try:
+        import torch
+
+        label("pytorch import", True)
+        label("pytorch version", torch.__version__)
+        label("pytorch path", torch.__file__)
+        label("cuda available", torch.cuda.is_available())
+        if torch.cuda.is_available():
+            label("cuda device count", torch.cuda.device_count())
+            for i in range(torch.cuda.device_count()):
+                label(f"cuda device {i} name", torch.cuda.get_device_name(i))
+    except Exception:
+        label("pytorch import", False)
+
+
 def package_section():
     header("CONDA")
     call(["conda", "list"])
@@ -135,7 +152,8 @@ def get_diagnostics(output_path=None):
     system_section()
     imports_section()
     git_section()
-    tensorflow_section()
+    # tensorflow_section()
+    pytorch_section()
     package_section()
     nvidia_section()
 


### PR DESCRIPTION
This pull request updates the SLEAP installation documentation for improved clarity and adds PyTorch diagnostics to the codebase. The documentation now better distinguishes between installation methods, especially clarifying the difference between `uv tool install` and `uvx`, and provides more detailed, platform-specific instructions. In the code, the diagnostics script now reports PyTorch environment details instead of TensorFlow.

**Notes**:
* Updated `docs/installation.md` to clarify the difference between `uv tool install` (for global installation) and `uvx` (for one-off, no-install runs), and provided clearer, platform-specific installation commands for both methods. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L8-L31) [[2]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R59) [[3]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R119-R155)
* Added a new section in the documentation for `uvx` usage, including installation instructions for `uv` and detailed notes on temporary environments.
* Improved language in `docs/whats-new.md` to clarify legacy TensorFlow model support.
* Added a new `pytorch_section()` function in `sleap/diagnostic.py` to report PyTorch version, installation path, CUDA availability, and GPU device information.
* Replaced the TensorFlow diagnostics section with the new PyTorch diagnostics in the main diagnostics routine.