### PR TITLE
Gracefully handle sleap-nn import errors

### DIFF
--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -224,11 +224,18 @@ class ConfigFileInfo:
                 cfg = snn_TrainingJobConfig.load_sleap_config(path)
                 head_name = get_head_from_omegaconf(cfg)
                 filename = os.path.basename(path)
-                return cls(config=cfg, path=path, filename=filename, head_name=head_name)
-            except:
+                return cls(
+                    config=cfg, path=path, filename=filename, head_name=head_name
+                )
+            except ImportError:
                 show_sleap_nn_installation_message()
-                print("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+                print(
+                    "sleap-nn is not installed. This appears to be GUI-only install."
+                    "To enable training, please install SLEAP with the 'nn' dependency."
+                    "See the installation guide: https://docs.sleap.ai/latest/installation/"
+                )
                 return None
+
 
 class TrainingConfigFilesWidget(FieldComboWidget):
     """
@@ -544,7 +551,11 @@ class TrainingConfigsGetter:
                 cfg = snn_TrainingJobConfig.load_sleap_config(path)
             except ImportError:
                 show_sleap_nn_installation_message()
-                print("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+                print(
+                    "sleap-nn is not installed. This appears to be a GUI-only install."
+                    "To enable training, please install SLEAP with the 'nn' dependency."
+                    "See the installation guide: https://docs.sleap.ai/latest/installation/"
+                )
                 return None
             except Exception as e:
                 # Couldn't load so just ignore

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -20,6 +20,7 @@ from sleap.gui.config_utils import get_head_from_omegaconf, get_skeleton_from_co
 from sleap.gui.dialogs.filedialog import FileDialog
 from sleap.gui.dialogs.formbuilder import FieldComboWidget
 from omegaconf import OmegaConf
+from sleap.util import show_sleap_nn_installation_message
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -215,15 +216,19 @@ class ConfigFileInfo:
             cfg = OmegaConf.load(path)
 
         else:
-            from sleap_nn.config.training_job_config import (
-                TrainingJobConfig as snn_TrainingJobConfig,
-            )
+            try:
+                from sleap_nn.config.training_job_config import (
+                    TrainingJobConfig as snn_TrainingJobConfig,
+                )
 
-            cfg = snn_TrainingJobConfig.load_sleap_config(path)
-        head_name = get_head_from_omegaconf(cfg)
-        filename = os.path.basename(path)
-        return cls(config=cfg, path=path, filename=filename, head_name=head_name)
-
+                cfg = snn_TrainingJobConfig.load_sleap_config(path)
+                head_name = get_head_from_omegaconf(cfg)
+                filename = os.path.basename(path)
+                return cls(config=cfg, path=path, filename=filename, head_name=head_name)
+            except:
+                show_sleap_nn_installation_message()
+                print("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+                return None
 
 class TrainingConfigFilesWidget(FieldComboWidget):
     """
@@ -537,6 +542,10 @@ class TrainingConfigsGetter:
                 )
 
                 cfg = snn_TrainingJobConfig.load_sleap_config(path)
+            except ImportError:
+                show_sleap_nn_installation_message()
+                print("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+                return None
             except Exception as e:
                 # Couldn't load so just ignore
                 print(e)

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -30,7 +30,7 @@ from sleap.sleap_io_adaptors.skeleton_utils import (
     in_degree_over_one,
 )
 from sleap.sleap_io_adaptors.lf_labels_utils import instances
-
+from sleap.util import show_sleap_nn_installation_message
 # List of fields which should show list of skeleton nodes
 NODE_LIST_FIELDS = [
     "model.model_config.head_configs.centered_instance.confmaps.anchor_part",
@@ -798,12 +798,16 @@ class LearningDialog(QtWidgets.QDialog):
         for config_info in config_info_list:
             config_info = config_info.config
             # convert to sleap-nn cfg (yaml)
-            from sleap_nn.config.training_job_config import verify_training_cfg
+            try:
+                from sleap_nn.config.training_job_config import verify_training_cfg
 
-            config_info = filter_cfg(config_info)
-            cfg = verify_training_cfg(config_info)
-            cfg.data_config.train_labels_path = [self.labels_filename]
-            output.append(OmegaConf.to_yaml(cfg))
+                config_info = filter_cfg(config_info)
+                cfg = verify_training_cfg(config_info)
+                cfg.data_config.train_labels_path = [self.labels_filename]
+                output.append(OmegaConf.to_yaml(cfg))
+            except ImportError:
+                show_sleap_nn_installation_message()
+                print("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
 
         output = "\n".join(output)
         # Set the clipboard text

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -31,6 +31,7 @@ from sleap.sleap_io_adaptors.skeleton_utils import (
 )
 from sleap.sleap_io_adaptors.lf_labels_utils import instances
 from sleap.util import show_sleap_nn_installation_message
+
 # List of fields which should show list of skeleton nodes
 NODE_LIST_FIELDS = [
     "model.model_config.head_configs.centered_instance.confmaps.anchor_part",
@@ -807,7 +808,11 @@ class LearningDialog(QtWidgets.QDialog):
                 output.append(OmegaConf.to_yaml(cfg))
             except ImportError:
                 show_sleap_nn_installation_message()
-                print("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+                print(
+                    "sleap-nn is not installed. This appears to be GUI-only install."
+                    "To enable training, please install SLEAP with the 'nn' dependency."
+                    "See the installation guide: https://docs.sleap.ai/latest/installation/"
+                )
 
         output = "\n".join(output)
         # Set the clipboard text

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Text, Tuple
 import logging
+from sleap.util import show_sleap_nn_installation_message
 
 from qtpy import QtWidgets
 
@@ -480,43 +481,48 @@ def write_pipeline_files(
             new_cfg_filename = f"{cfg_info.head_name}.yaml"
 
             # Save the config file (convert to yaml)
-            from sleap_nn.config.training_job_config import verify_training_cfg
+            try:
+                from sleap_nn.config.training_job_config import verify_training_cfg
 
-            # Save the config file
-            cfg_info.config = filter_cfg(cfg_info.config)
-            cfg = verify_training_cfg(cfg_info.config)
-            cfg.data_config.train_labels_path = [os.path.basename(labels_filename)]
-            OmegaConf.save(cfg, new_cfg_filename)
+                # Save the config file
+                cfg_info.config = filter_cfg(cfg_info.config)
+                cfg = verify_training_cfg(cfg_info.config)
+                cfg.data_config.train_labels_path = [os.path.basename(labels_filename)]
+                OmegaConf.save(cfg, new_cfg_filename)
 
-            # Keep track of the path where we'll find the trained model
-            new_cfg_filenames.append(
-                (
-                    Path(cfg_info.config.trainer_config.ckpt_dir)
-                    / cfg_info.config.trainer_config.run_name
-                ).as_posix()
-            )
-
-            # Add a line to the script for training this model
-            train_script += (
-                f"sleap-nn train --config-name {new_cfg_filename} --config-dir {''} "
-                f"trainer_config.ckpt_dir={Path(ckpt_path).parent.as_posix()} "
-                f"trainer_config.run_name={Path(ckpt_path).name}"
-                f"trainer_config.zmq.controller_port={cfg_info.config.trainer_config.zmq.controller_port}"
-                f"trainer_config.zmq.publish_port={cfg_info.config.trainer_config.zmq.publish_port}"
-                "\n"
-            )
-
-            # Setup job params
-            training_jobs.append(
-                {
-                    "cfg": new_cfg_filename,
-                    "run_path": (
+                # Keep track of the path where we'll find the trained model
+                new_cfg_filenames.append(
+                    (
                         Path(cfg_info.config.trainer_config.ckpt_dir)
                         / cfg_info.config.trainer_config.run_name
-                    ).as_posix(),
-                    "train_labels": os.path.basename(labels_filename),
-                }
-            )
+                    ).as_posix()
+                )
+
+                # Add a line to the script for training this model
+                train_script += (
+                    f"sleap-nn train --config-name {new_cfg_filename} --config-dir {''} "
+                    f"trainer_config.ckpt_dir={Path(ckpt_path).parent.as_posix()} "
+                    f"trainer_config.run_name={Path(ckpt_path).name}"
+                    f"trainer_config.zmq.controller_port={cfg_info.config.trainer_config.zmq.controller_port}"
+                    f"trainer_config.zmq.publish_port={cfg_info.config.trainer_config.zmq.publish_port}"
+                    "\n"
+                )
+
+                # Setup job params
+                training_jobs.append(
+                    {
+                        "cfg": new_cfg_filename,
+                        "run_path": (
+                            Path(cfg_info.config.trainer_config.ckpt_dir)
+                            / cfg_info.config.trainer_config.run_name
+                        ).as_posix(),
+                        "train_labels": os.path.basename(labels_filename),
+                    }
+                )
+            except ImportError:
+                show_sleap_nn_installation_message()
+                logger.error("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+                return
 
     # Write the script to train the models which need to be trained
     with open(os.path.join(output_dir, "train-script.sh"), "w") as f:
@@ -904,51 +910,55 @@ def train_subprocess(
     with tempfile.TemporaryDirectory() as temp_dir:
         # Write a temporary file of the TrainingJob so that we can respect
         # any changed made to the job attributes after it was loaded.
-        from sleap_nn.config.training_job_config import verify_training_cfg
+        try:
+            from sleap_nn.config.training_job_config import verify_training_cfg
+            # convert json to yaml (to sleap-nn config format)
+            cfg_file_name = datetime.now().strftime("%y%m%d_%H%M%S") + "_config"
+            filter_job_config = filter_cfg(deepcopy(job_config))
+            cfg = verify_training_cfg(filter_job_config)
+            cfg.data_config.train_labels_path = [labels_filename]
 
-        # convert json to yaml (to sleap-nn config format)
-        cfg_file_name = datetime.now().strftime("%y%m%d_%H%M%S") + "_config"
-        filter_job_config = filter_cfg(deepcopy(job_config))
-        cfg = verify_training_cfg(filter_job_config)
-        cfg.data_config.train_labels_path = [labels_filename]
+            cfg.trainer_config.ckpt_dir = Path(run_path).parent.as_posix()
+            cfg.trainer_config.run_name = Path(run_path).name
+            cfg.trainer_config.zmq.controller_port = inference_params["controller_port"]
+            cfg.trainer_config.zmq.publish_port = inference_params["publish_port"]
 
-        cfg.trainer_config.ckpt_dir = Path(run_path).parent.as_posix()
-        cfg.trainer_config.run_name = Path(run_path).name
-        cfg.trainer_config.zmq.controller_port = inference_params["controller_port"]
-        cfg.trainer_config.zmq.publish_port = inference_params["publish_port"]
+            OmegaConf.save(cfg, (Path(temp_dir) / f"{cfg_file_name}.yaml").as_posix())
 
-        OmegaConf.save(cfg, (Path(temp_dir) / f"{cfg_file_name}.yaml").as_posix())
+            # Build CLI arguments for training
+            cli_args = [
+                "sleap-nn",
+                "train",
+                "--config-name",
+                f"{cfg_file_name}",
+                "--config-dir",
+                f"{temp_dir}",
+            ]
 
-        # Build CLI arguments for training
-        cli_args = [
-            "sleap-nn",
-            "train",
-            "--config-name",
-            f"{cfg_file_name}",
-            "--config-dir",
-            f"{temp_dir}",
-        ]
+            # Run training in a subprocess.
+            print(cli_args)
+            proc = subprocess.Popen(cli_args)
 
-        # Run training in a subprocess.
-        print(cli_args)
-        proc = subprocess.Popen(cli_args)
+            # Wait till training is done, calling a callback if given.
+            while proc.poll() is None:
+                if waiting_callback is not None:
+                    ret = waiting_callback()
+                    if ret == "cancel":
+                        print("Canceling training...")
+                        kill_process(proc.pid)
+                        print(f"Killed PID: {proc.pid}")
+                        return run_path, "canceled"
+                time.sleep(0.1)
 
-        # Wait till training is done, calling a callback if given.
-        while proc.poll() is None:
-            if waiting_callback is not None:
-                ret = waiting_callback()
-                if ret == "cancel":
-                    print("Canceling training...")
-                    kill_process(proc.pid)
-                    print(f"Killed PID: {proc.pid}")
-                    return run_path, "canceled"
-            time.sleep(0.1)
-
-        # Check return code.
-        if proc.returncode == 0:
-            ret = "success"
-        else:
-            ret = proc.returncode
+            # Check return code.
+            if proc.returncode == 0:
+                ret = "success"
+            else:
+                ret = proc.returncode
+        except ImportError:
+            show_sleap_nn_installation_message()
+            logger.error("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+            ret = "error"
 
     print("Run Path:", run_path)
 

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -500,7 +500,8 @@ def write_pipeline_files(
 
                 # Add a line to the script for training this model
                 train_script += (
-                    f"sleap-nn train --config-name {new_cfg_filename} --config-dir {''} "
+                    f"sleap-nn train --config-name {new_cfg_filename} "
+                    f"--config-dir {''} "
                     f"trainer_config.ckpt_dir={Path(ckpt_path).parent.as_posix()} "
                     f"trainer_config.run_name={Path(ckpt_path).name}"
                     f"trainer_config.zmq.controller_port={cfg_info.config.trainer_config.zmq.controller_port}"
@@ -521,7 +522,11 @@ def write_pipeline_files(
                 )
             except ImportError:
                 show_sleap_nn_installation_message()
-                logger.error("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+                logger.error(
+                    "sleap-nn is not installed. This appears to be GUI-only install."
+                    "To enable training, please install SLEAP with the 'nn' dependency."
+                    "See the installation guide: https://docs.sleap.ai/latest/installation/"
+                )
                 return
 
     # Write the script to train the models which need to be trained
@@ -912,6 +917,7 @@ def train_subprocess(
         # any changed made to the job attributes after it was loaded.
         try:
             from sleap_nn.config.training_job_config import verify_training_cfg
+
             # convert json to yaml (to sleap-nn config format)
             cfg_file_name = datetime.now().strftime("%y%m%d_%H%M%S") + "_config"
             filter_job_config = filter_cfg(deepcopy(job_config))
@@ -957,7 +963,11 @@ def train_subprocess(
                 ret = proc.returncode
         except ImportError:
             show_sleap_nn_installation_message()
-            logger.error("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+            logger.error(
+                "sleap-nn is not installed. This appears to be a GUI-only installation."
+                "To enable training, please install SLEAP with the 'nn' dependency."
+                "See the installation guide: https://docs.sleap.ai/latest/installation/"
+            )
             ret = "error"
 
     print("Run Path:", run_path)

--- a/sleap/info/labels.py
+++ b/sleap/info/labels.py
@@ -6,7 +6,7 @@ import os
 from sleap.sleap_io_adaptors.instance_utils import bounding_box
 from sleap.sleap_io_adaptors.lf_labels_utils import get_labeled_frame_count
 from sleap.sleap_io_adaptors.lf_labels_utils import labels_load_file
-
+from sleap.util import show_sleap_nn_installation_message
 
 def describe_labels(data_path, verbose=False):
     from sleap.sleap_io_adaptors.lf_labels_utils import (
@@ -85,9 +85,13 @@ def describe_model(model_path, verbose=False):
         return os.path.join(model_path, x)
 
     if "training_config.json" in os.listdir(model_path):
-        from sleap_nn.config.training_job_config import TrainingJobConfig
-
-        cfg = TrainingJobConfig.load_sleap_config(rel_path("training_config.json"))
+        try:
+            from sleap_nn.config.training_job_config import TrainingJobConfig
+            cfg = TrainingJobConfig.load_sleap_config(rel_path("training_config.json"))
+        except ImportError:
+            show_sleap_nn_installation_message()
+            print("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+            return
     elif "training_config.yaml" in os.listdir(model_path):
         cfg = OmegaConf.load(rel_path("training_config.yaml"))
 

--- a/sleap/info/labels.py
+++ b/sleap/info/labels.py
@@ -8,6 +8,7 @@ from sleap.sleap_io_adaptors.lf_labels_utils import get_labeled_frame_count
 from sleap.sleap_io_adaptors.lf_labels_utils import labels_load_file
 from sleap.util import show_sleap_nn_installation_message
 
+
 def describe_labels(data_path, verbose=False):
     from sleap.sleap_io_adaptors.lf_labels_utils import (
         make_video_callback,
@@ -87,10 +88,15 @@ def describe_model(model_path, verbose=False):
     if "training_config.json" in os.listdir(model_path):
         try:
             from sleap_nn.config.training_job_config import TrainingJobConfig
+
             cfg = TrainingJobConfig.load_sleap_config(rel_path("training_config.json"))
         except ImportError:
             show_sleap_nn_installation_message()
-            print("sleap-nn is not installed. This appears to be a GUI-only installation. To enable training, please install SLEAP with the 'nn' dependency. See the installation guide: https://docs.sleap.ai/latest/installation/")
+            print(
+                "sleap-nn is not installed. This appears to be a GUI-only installation."
+                "To enable training, please install SLEAP with the 'nn' dependency."
+                "See the installation guide: https://docs.sleap.ai/latest/installation/"
+            )
             return
     elif "training_config.yaml" in os.listdir(model_path):
         cfg = OmegaConf.load(rel_path("training_config.yaml"))

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -177,7 +177,9 @@ def train_command(
             config.trainer_config.trainer_device_indices = [-1]
         if gpu:
             config.trainer_config.trainer_accelerator = "gpu"
-            config.trainer_config.trainer_device_indices = [gpu] if gpu != "auto" else None
+            config.trainer_config.trainer_device_indices = (
+                [gpu] if gpu != "auto" else None
+            )
 
         # Call the original training function with the arguments
         if video_paths is not None:
@@ -215,7 +217,9 @@ def train_command(
             # run inference on val dataset
             if trainer.config.trainer_config.save_ckpt:
                 data_paths = {}
-                for index, path in enumerate(trainer.config.data_config.train_labels_path):
+                for index, path in enumerate(
+                    trainer.config.data_config.train_labels_path
+                ):
                     ckpt_path = (
                         Path(trainer.config.trainer_config.ckpt_dir)
                         / trainer.config.trainer_config.run_name
@@ -259,8 +263,8 @@ def train_command(
 
                     if not len(pred_labels):
                         logger.info(
-                            f"Skipping eval on `{d_name}` dataset as there are no labeled "
-                            f"frames..."
+                            f"Skipping eval on `{d_name}` dataset as there are no"
+                            f"labeled frames..."
                         )
                         continue  # skip if there are no labeled frames
 
@@ -279,7 +283,9 @@ def train_command(
 
                     logger.info(f"---------Evaluation on `{d_name}` dataset---------")
                     logger.info(f"OKS mAP: {metrics['voc_metrics']['oks_voc.mAP']}")
-                    logger.info(f"Average distance: {metrics['distance_metrics']['avg']}")
+                    logger.info(
+                        f"Average distance: {metrics['distance_metrics']['avg']}"
+                    )
                     logger.info(f"p90 dist: {metrics['distance_metrics']['p90']}")
                     logger.info(f"p50 dist: {metrics['distance_metrics']['p50']}")
 
@@ -289,6 +295,7 @@ def train_command(
             "To enable training, please install SLEAP with the 'nn' dependency. "
             "See the installation guide: https://docs.sleap.ai/latest/installation/"
         )
+
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("data_path", required=True)

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -9,12 +9,6 @@ import time
 import logging
 
 import sleap_io as sio
-from sleap_nn.training.model_trainer import ModelTrainer
-
-# from sleap_nn.track import main as track
-from sleap_nn.predict import run_inference as predict
-from sleap_nn.config.training_job_config import TrainingJobConfig
-from sleap_nn.evaluation import Evaluator
 from sleap.sleap_io_adaptors.lf_labels_utils import load_labels_video_search
 
 logger = logging.getLogger(__name__)
@@ -136,153 +130,165 @@ def train_command(
     gpu,
 ):
     """Train a SLEAP model with the specified configuration."""
-    # Convert click arguments to the format expected by the training function
-    if training_job_path.endswith(".json"):
-        config = TrainingJobConfig.load_sleap_config(training_job_path)
-    elif training_job_path.endswith((".yaml", ".yml")):
-        config = OmegaConf.load(training_job_path)
+    try:
+        from sleap_nn.training.model_trainer import ModelTrainer
+        from sleap_nn.predict import run_inference as predict
+        from sleap_nn.config.training_job_config import TrainingJobConfig
+        from sleap_nn.evaluation import Evaluator
 
-    if labels_path is not None:
-        config.data_config.train_labels_path = [labels_path]
+        # Convert click arguments to the format expected by the training function
+        if training_job_path.endswith(".json"):
+            config = TrainingJobConfig.load_sleap_config(training_job_path)
+        elif training_job_path.endswith((".yaml", ".yml")):
+            config = OmegaConf.load(training_job_path)
 
-    if video_paths:
-        video_paths = video_paths.split(",")
-    if val_labels is not None:
-        config.data_config.val_labels_path = [val_labels]
-    if test_labels is not None:
-        config.data_config.test_file_path = [test_labels]
-    if base_checkpoint is not None:
-        config.model_config.pretrained_backbone_weights = base_checkpoint
-        config.model_config.pretrained_head_weights = base_checkpoint
-    if save_viz is not None and save_viz:
-        config.trainer_config.visualize_preds_during_training = True
-    if keep_viz is not None and keep_viz:
-        config.trainer_config.keep_viz = True
-    if zmq is not None and not zmq:
-        config.trainer_config.zmq.publish_port = None
-        config.trainer_config.zmq.controller_port = None
-    if run_name is not None:
-        config.trainer_config.run_name = run_name
-    if prefix is not None:
-        config.trainer_config.run_name = prefix + config.trainer_config.run_name
-    if suffix is not None:
-        config.trainer_config.run_name = config.trainer_config.run_name + suffix
-    if cpu is not None and cpu:
-        config.trainer_config.trainer_accelerator = "cpu"
-    if first_gpu:
-        config.trainer_config.trainer_accelerator = "gpu"
-        config.trainer_config.trainer_device_indices = [0]
-    if last_gpu:
-        config.trainer_config.trainer_accelerator = "gpu"
-        config.trainer_config.trainer_device_indices = [-1]
-    if gpu:
-        config.trainer_config.trainer_accelerator = "gpu"
-        config.trainer_config.trainer_device_indices = [gpu] if gpu != "auto" else None
+        if labels_path is not None:
+            config.data_config.train_labels_path = [labels_path]
 
-    # Call the original training function with the arguments
-    if video_paths is not None:
-        train = load_labels_video_search(labels_path, video_paths)
-        val = (
-            load_labels_video_search(val_labels, video_paths)
-            if val_labels is not None
-            else None
+        if video_paths:
+            video_paths = video_paths.split(",")
+        if val_labels is not None:
+            config.data_config.val_labels_path = [val_labels]
+        if test_labels is not None:
+            config.data_config.test_file_path = [test_labels]
+        if base_checkpoint is not None:
+            config.model_config.pretrained_backbone_weights = base_checkpoint
+            config.model_config.pretrained_head_weights = base_checkpoint
+        if save_viz is not None and save_viz:
+            config.trainer_config.visualize_preds_during_training = True
+        if keep_viz is not None and keep_viz:
+            config.trainer_config.keep_viz = True
+        if zmq is not None and not zmq:
+            config.trainer_config.zmq.publish_port = None
+            config.trainer_config.zmq.controller_port = None
+        if run_name is not None:
+            config.trainer_config.run_name = run_name
+        if prefix is not None:
+            config.trainer_config.run_name = prefix + config.trainer_config.run_name
+        if suffix is not None:
+            config.trainer_config.run_name = config.trainer_config.run_name + suffix
+        if cpu is not None and cpu:
+            config.trainer_config.trainer_accelerator = "cpu"
+        if first_gpu:
+            config.trainer_config.trainer_accelerator = "gpu"
+            config.trainer_config.trainer_device_indices = [0]
+        if last_gpu:
+            config.trainer_config.trainer_accelerator = "gpu"
+            config.trainer_config.trainer_device_indices = [-1]
+        if gpu:
+            config.trainer_config.trainer_accelerator = "gpu"
+            config.trainer_config.trainer_device_indices = [gpu] if gpu != "auto" else None
+
+        # Call the original training function with the arguments
+        if video_paths is not None:
+            train = load_labels_video_search(labels_path, video_paths)
+            val = (
+                load_labels_video_search(val_labels, video_paths)
+                if val_labels is not None
+                else None
+            )
+        else:
+            train = sio.load_slp(labels_path)
+            val = sio.load_slp(val_labels) if val_labels is not None else None
+
+        start_train_time = time.time()
+        start_timestamp = str(datetime.now())
+        logger.info(f"Started training at: {start_timestamp}")
+
+        trainer = ModelTrainer.get_model_trainer_from_config(
+            config=config,
+            train_labels=[train],
+            val_labels=[val] if val is not None else None,
         )
-    else:
-        train = sio.load_slp(labels_path)
-        val = sio.load_slp(val_labels) if val_labels is not None else None
+        trainer.train()
 
-    start_train_time = time.time()
-    start_timestamp = str(datetime.now())
-    logger.info(f"Started training at: {start_timestamp}")
+        finish_timestamp = str(datetime.now())
+        total_elapsed = time.time() - start_train_time
+        logger.info(f"Finished training at: {finish_timestamp}")
+        logger.info(f"Total training time: {total_elapsed} secs")
 
-    trainer = ModelTrainer.get_model_trainer_from_config(
-        config=config,
-        train_labels=[train],
-        val_labels=[val] if val is not None else None,
-    )
-    trainer.train()
+        rank = trainer.trainer.global_rank if trainer.trainer is not None else -1
 
-    finish_timestamp = str(datetime.now())
-    total_elapsed = time.time() - start_train_time
-    logger.info(f"Finished training at: {finish_timestamp}")
-    logger.info(f"Total training time: {total_elapsed} secs")
+        logger.info(f"Training Config: {OmegaConf.to_yaml(trainer.config)}")
 
-    rank = trainer.trainer.global_rank if trainer.trainer is not None else -1
-
-    logger.info(f"Training Config: {OmegaConf.to_yaml(trainer.config)}")
-
-    if rank in [0, -1]:
-        # run inference on val dataset
-        if trainer.config.trainer_config.save_ckpt:
-            data_paths = {}
-            for index, path in enumerate(trainer.config.data_config.train_labels_path):
-                ckpt_path = (
-                    Path(trainer.config.trainer_config.ckpt_dir)
-                    / trainer.config.trainer_config.run_name
-                ).as_posix()
-                logger.info(f"Training labels path for index {index}: {ckpt_path}")
-                data_paths[f"train_{index}"] = (
-                    Path(trainer.config.trainer_config.ckpt_dir)
-                    / trainer.config.trainer_config.run_name
-                    / f"labels_train_gt_{index}.slp"
-                ).as_posix()
-                data_paths[f"val_{index}"] = (
-                    Path(trainer.config.trainer_config.ckpt_dir)
-                    / trainer.config.trainer_config.run_name
-                    / f"labels_val_gt_{index}.slp"
-                ).as_posix()
-
-            if (
-                OmegaConf.select(config, "data_config.test_file_path", default=None)
-                is not None
-            ):
-                data_paths["test"] = config.data_config.test_file_path
-
-            for d_name, path in data_paths.items():
-                labels = sio.load_slp(path)
-
-                pred_labels = predict(
-                    data_path=path,
-                    model_paths=[
+        if rank in [0, -1]:
+            # run inference on val dataset
+            if trainer.config.trainer_config.save_ckpt:
+                data_paths = {}
+                for index, path in enumerate(trainer.config.data_config.train_labels_path):
+                    ckpt_path = (
                         Path(trainer.config.trainer_config.ckpt_dir)
                         / trainer.config.trainer_config.run_name
-                    ],
-                    peak_threshold=0.2,
-                    make_labels=True,
-                    device=trainer.trainer.strategy.root_device,
-                    output_path=Path(trainer.config.trainer_config.ckpt_dir)
-                    / trainer.config.trainer_config.run_name
-                    / f"pred_{d_name}.slp",
-                    ensure_rgb=config.data_config.preprocessing.ensure_rgb,
-                    ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
-                )
+                    ).as_posix()
+                    logger.info(f"Training labels path for index {index}: {ckpt_path}")
+                    data_paths[f"train_{index}"] = (
+                        Path(trainer.config.trainer_config.ckpt_dir)
+                        / trainer.config.trainer_config.run_name
+                        / f"labels_train_gt_{index}.slp"
+                    ).as_posix()
+                    data_paths[f"val_{index}"] = (
+                        Path(trainer.config.trainer_config.ckpt_dir)
+                        / trainer.config.trainer_config.run_name
+                        / f"labels_val_gt_{index}.slp"
+                    ).as_posix()
 
-                if not len(pred_labels):
-                    logger.info(
-                        f"Skipping eval on `{d_name}` dataset as there are no labeled "
-                        f"frames..."
+                if (
+                    OmegaConf.select(config, "data_config.test_file_path", default=None)
+                    is not None
+                ):
+                    data_paths["test"] = config.data_config.test_file_path
+
+                for d_name, path in data_paths.items():
+                    labels = sio.load_slp(path)
+
+                    pred_labels = predict(
+                        data_path=path,
+                        model_paths=[
+                            Path(trainer.config.trainer_config.ckpt_dir)
+                            / trainer.config.trainer_config.run_name
+                        ],
+                        peak_threshold=0.2,
+                        make_labels=True,
+                        device=trainer.trainer.strategy.root_device,
+                        output_path=Path(trainer.config.trainer_config.ckpt_dir)
+                        / trainer.config.trainer_config.run_name
+                        / f"pred_{d_name}.slp",
+                        ensure_rgb=config.data_config.preprocessing.ensure_rgb,
+                        ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
                     )
-                    continue  # skip if there are no labeled frames
 
-                evaluator = Evaluator(
-                    ground_truth_instances=labels, predicted_instances=pred_labels
-                )
-                metrics = evaluator.evaluate()
-                np.savez(
-                    (
-                        Path(trainer.config.trainer_config.ckpt_dir)
-                        / trainer.config.trainer_config.run_name
-                        / f"{d_name}_pred_metrics.npz"
-                    ).as_posix(),
-                    **metrics,
-                )
+                    if not len(pred_labels):
+                        logger.info(
+                            f"Skipping eval on `{d_name}` dataset as there are no labeled "
+                            f"frames..."
+                        )
+                        continue  # skip if there are no labeled frames
 
-                logger.info(f"---------Evaluation on `{d_name}` dataset---------")
-                logger.info(f"OKS mAP: {metrics['voc_metrics']['oks_voc.mAP']}")
-                logger.info(f"Average distance: {metrics['distance_metrics']['avg']}")
-                logger.info(f"p90 dist: {metrics['distance_metrics']['p90']}")
-                logger.info(f"p50 dist: {metrics['distance_metrics']['p50']}")
+                    evaluator = Evaluator(
+                        ground_truth_instances=labels, predicted_instances=pred_labels
+                    )
+                    metrics = evaluator.evaluate()
+                    np.savez(
+                        (
+                            Path(trainer.config.trainer_config.ckpt_dir)
+                            / trainer.config.trainer_config.run_name
+                            / f"{d_name}_pred_metrics.npz"
+                        ).as_posix(),
+                        **metrics,
+                    )
 
+                    logger.info(f"---------Evaluation on `{d_name}` dataset---------")
+                    logger.info(f"OKS mAP: {metrics['voc_metrics']['oks_voc.mAP']}")
+                    logger.info(f"Average distance: {metrics['distance_metrics']['avg']}")
+                    logger.info(f"p90 dist: {metrics['distance_metrics']['p90']}")
+                    logger.info(f"p50 dist: {metrics['distance_metrics']['p50']}")
+
+    except ImportError:
+        logger.error(
+            "sleap-nn is not installed. This appears to be a GUI-only installation. "
+            "To enable training, please install SLEAP with the 'nn' dependency. "
+            "See the installation guide: https://docs.sleap.ai/latest/installation/"
+        )
 
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("data_path", required=True)
@@ -549,97 +555,106 @@ def track_command(
     tracking_of_max_levels,
 ):
     """Track instances in video data using trained SLEAP models."""
-    import torch
+    try:
+        import torch
+        from sleap_nn.predict import run_inference as predict
 
-    # Build kwargs for the tracking function
-    kwargs = {}
+        # Build kwargs for the tracking function
+        kwargs = {}
 
-    if models is not None:
-        kwargs["model_paths"] = models
-    if frames is not None:
-        kwargs["frames"] = frames
-    if only_labeled_frames is not None and only_labeled_frames:
-        kwargs["only_labeled_frames"] = True
-    if only_suggested_frames is not None and only_suggested_frames:
-        kwargs["only_suggested_frames"] = True
-    kwargs["output_path"] = output
-    if output is None:
-        kwargs["output_path"] = f"{data_path}.predictions.slp"
-    if video_dataset is not None:
-        kwargs["video_dataset"] = video_dataset
-    if video_input_format is not None:
-        kwargs["video_input_format"] = video_input_format
-    if video_index is not None:
-        kwargs["video_index"] = video_index
-    if cpu is not None and cpu:
-        kwargs["device"] = "cpu"
-    if torch.cuda.is_available():
-        if first_gpu:
-            kwargs["device"] = "cuda:0"
-        if last_gpu:
-            n_gpus = torch.cuda.device_count()
-            kwargs["device"] = f"cuda:{n_gpus - 1}"
-        if gpu:
-            kwargs["device"] = f"cuda:{gpu}" if gpu != "auto" else "cuda"
-    if max_edge_length_ratio is not None:
-        kwargs["max_edge_length_ratio"] = max_edge_length_ratio
-    if dist_penalty_weight is not None:
-        kwargs["dist_penalty_weight"] = dist_penalty_weight
-    if batch_size is not None:
-        kwargs["batch_size"] = batch_size
-    # if open_in_gui:
-    #     kwargs['open_in_gui'] = True #TODO
-    if peak_threshold is not None:
-        kwargs["peak_threshold"] = peak_threshold
-    if max_instances is not None:
-        kwargs["max_instances"] = max_instances
+        if models is not None:
+            kwargs["model_paths"] = models
+        if frames is not None:
+            kwargs["frames"] = frames
+        if only_labeled_frames is not None and only_labeled_frames:
+            kwargs["only_labeled_frames"] = True
+        if only_suggested_frames is not None and only_suggested_frames:
+            kwargs["only_suggested_frames"] = True
+        kwargs["output_path"] = output
+        if output is None:
+            kwargs["output_path"] = f"{data_path}.predictions.slp"
+        if video_dataset is not None:
+            kwargs["video_dataset"] = video_dataset
+        if video_input_format is not None:
+            kwargs["video_input_format"] = video_input_format
+        if video_index is not None:
+            kwargs["video_index"] = video_index
+        if cpu is not None and cpu:
+            kwargs["device"] = "cpu"
+        if torch.cuda.is_available():
+            if first_gpu:
+                kwargs["device"] = "cuda:0"
+            if last_gpu:
+                n_gpus = torch.cuda.device_count()
+                kwargs["device"] = f"cuda:{n_gpus - 1}"
+            if gpu:
+                kwargs["device"] = f"cuda:{gpu}" if gpu != "auto" else "cuda"
+        if max_edge_length_ratio is not None:
+            kwargs["max_edge_length_ratio"] = max_edge_length_ratio
+        if dist_penalty_weight is not None:
+            kwargs["dist_penalty_weight"] = dist_penalty_weight
+        if batch_size is not None:
+            kwargs["batch_size"] = batch_size
+        # if open_in_gui:
+        #     kwargs['open_in_gui'] = True #TODO
+        if peak_threshold is not None:
+            kwargs["peak_threshold"] = peak_threshold
+        if max_instances is not None:
+            kwargs["max_instances"] = max_instances
 
-    if tracking_tracker:
-        if "flow" in tracking_tracker:
-            kwargs["use_flow"] = True
+        if tracking_tracker:
+            if "flow" in tracking_tracker:
+                kwargs["use_flow"] = True
 
-    # Check max_tracking flag int value for True/False
-    if tracking_max_tracking is not None and tracking_max_tracking == 1:
-        kwargs["candidates_method"] = "local_queues"
-        kwargs["max_tracks"] = tracking_max_tracks
+        # Check max_tracking flag int value for True/False
+        if tracking_max_tracking is not None and tracking_max_tracking == 1:
+            kwargs["candidates_method"] = "local_queues"
+            kwargs["max_tracks"] = tracking_max_tracks
 
-    if tracking_similarity is not None:
-        if tracking_similarity == "oks":
-            kwargs["features"] = "keypoints"
-            kwargs["scoring_method"] = "oks"
-        elif tracking_similarity == "centroids":
-            kwargs["features"] = "centroids"
-            kwargs["scoring_method"] = "euclidean_dist"
-        elif tracking_similarity == "iou":
-            kwargs["features"] = "bboxes"
-            kwargs["scoring_method"] = "iou"
-    if (
-        tracking_post_connect_single_breaks is not None
-        and tracking_post_connect_single_breaks
-    ):
-        kwargs["post_connect_single_breaks"] = tracking_post_connect_single_breaks
-    if tracking_match is not None:
-        kwargs["track_matching_method"] = tracking_match
-    if tracking_robust is not None:
-        kwargs["robust_best_instance"] = tracking_robust
-    if tracking_track_window is not None:
-        kwargs["tracking_window_size"] = tracking_track_window
-    if tracking_min_new_track_points is not None:
-        kwargs["min_new_track_points"] = tracking_min_new_track_points
-    if tracking_min_match_points is not None:
-        kwargs["min_match_points"] = tracking_min_match_points
-    if tracking_img_scale is not None:
-        kwargs["of_img_scale"] = tracking_img_scale
-    if tracking_of_window_size is not None:
-        kwargs["of_window_size"] = tracking_of_window_size
-    if tracking_of_max_levels is not None:
-        kwargs["of_max_levels"] = tracking_of_max_levels
+        if tracking_similarity is not None:
+            if tracking_similarity == "oks":
+                kwargs["features"] = "keypoints"
+                kwargs["scoring_method"] = "oks"
+            elif tracking_similarity == "centroids":
+                kwargs["features"] = "centroids"
+                kwargs["scoring_method"] = "euclidean_dist"
+            elif tracking_similarity == "iou":
+                kwargs["features"] = "bboxes"
+                kwargs["scoring_method"] = "iou"
+        if (
+            tracking_post_connect_single_breaks is not None
+            and tracking_post_connect_single_breaks
+        ):
+            kwargs["post_connect_single_breaks"] = tracking_post_connect_single_breaks
+        if tracking_match is not None:
+            kwargs["track_matching_method"] = tracking_match
+        if tracking_robust is not None:
+            kwargs["robust_best_instance"] = tracking_robust
+        if tracking_track_window is not None:
+            kwargs["tracking_window_size"] = tracking_track_window
+        if tracking_min_new_track_points is not None:
+            kwargs["min_new_track_points"] = tracking_min_new_track_points
+        if tracking_min_match_points is not None:
+            kwargs["min_match_points"] = tracking_min_match_points
+        if tracking_img_scale is not None:
+            kwargs["of_img_scale"] = tracking_img_scale
+        if tracking_of_window_size is not None:
+            kwargs["of_window_size"] = tracking_of_window_size
+        if tracking_of_max_levels is not None:
+            kwargs["of_max_levels"] = tracking_of_max_levels
 
-    # # Call the original tracking function with kwargs
-    predict(data_path=data_path, **kwargs)
+        # # Call the original tracking function with kwargs
+        predict(data_path=data_path, **kwargs)
 
-    if open_in_gui:
-        import subprocess
+        if open_in_gui:
+            import subprocess
 
-        # Launch SLEAP GUI with the output file
-        subprocess.run(["sleap-label", str(kwargs.get("output_path", ""))])
+            # Launch SLEAP GUI with the output file
+            subprocess.run(["sleap-label", str(kwargs.get("output_path", ""))])
+
+    except ImportError:
+        logger.error(
+            "sleap-nn is not installed. This appears to be a GUI-only installation. "
+            "To enable training, please install SLEAP with the 'nn' dependency. "
+            "See the installation guide: https://docs.sleap.ai/latest/installation/"
+        )

--- a/sleap/util.py
+++ b/sleap/util.py
@@ -594,3 +594,32 @@ def plot_instances(
         h_lines.append(h_lines_i)
 
     return h_lines
+
+
+def show_sleap_nn_installation_message():
+    """Show a Qt popup message about SLEAP-NN installation requirements.
+
+    This function displays a popup window informing users that sleap-nn is not installed
+    and provides instructions for enabling training functionality.
+
+    """
+    from PySide6.QtWidgets import QMessageBox, QApplication
+
+    # Ensure QApplication exists
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+
+    msg_box = QMessageBox()
+    msg_box.setWindowTitle("SLEAP Training Not Available")
+    msg_box.setIcon(QMessageBox.Warning)
+
+    message = (
+        "sleap-nn is not installed. This appears to be a GUI-only installation. "
+        "To enable training, please install SLEAP with the 'nn' dependency. "
+        "See the installation guide: https://docs.sleap.ai/latest/installation/"
+    )
+
+    msg_box.setText(message)
+    msg_box.setStandardButtons(QMessageBox.Ok)
+    msg_box.exec()


### PR DESCRIPTION
This PR improves error handling for sleap-nn imports. When sleap-nn is not installed, the GUI now displays a clear pop-up directing users to the installation guide, while also printing an error message in the terminal. This helps avoid confusion for users who install only the GUI (without any PyTorch dependencies) and then attempt to run training. 