### PR TITLE
Add warning for latest python and uv version releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup UV
       uses: astral-sh/setup-uv@v6
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: Build distributions
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
           # uv pip install PySide6==6.8.1.1  # exit code 139
           # uv pip install PySide6==6.8.3  # exit code 139
           # uv pip install PySide6==6.9.1  # exit code 139
-          uv pip install matplotlib==3.8.4
 
       - name: Print environment info
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup UV
         uses: astral-sh/setup-uv@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ You can find the latest version of SLEAP in the [Releases](https://github.com/ta
 
 ### Quick install
 
+> **Python 3.14 is not yet supported**
+>
+> SLEAP currently supports **Python 3.11, 3.12, and 3.13**.  
+> **Python 3.14 is not yet tested or supported.**  
+> By default, `uv` will use your system-installed Python.  
+> If you have Python 3.14 installed, you must specify the Python version (≤3.13) in the install command.  
+>
+> For example:
+>
+> ```bash
+> uv tool install --python 3.13 "sleap[nn]"  ...
+> ```
+> Replace `...` with the rest of your install command as needed.
+
 **`uv tool install` (any OS):**
 
 First, install [`uv`](https://github.com/astral-sh/uv) if you haven't already:

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,6 +65,14 @@ You can find the latest version of SLEAP in the [Releases](https://github.com/ta
     powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
     ```
 
+!!! warning "Python 3.14 is not yet supported"
+    SLEAP currently supports **Python 3.11, 3.12, and 3.13**. **Python 3.14 is not yet tested or supported.** `uv` will use the system-installed python by default. If you have python 3.14 installed on your system, then specify the Python version (<=3.13) in the installation command.  
+    For example:
+    ```bash
+    uv tool install --python 3.13 "sleap[nn]"  ...
+    ```
+    Replace `...` with the rest of your install command as needed.
+
 ```bash
 # Windows/ Linux CUDA 12.8
 uv tool install "sleap[nn]" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ Python 3.11 (or) 3.12 (or) 3.13 (required for all installation methods)
 !!! tip "Choose Your Installation Method"
     - **[Installation as a system-wide tool with uv](#installation-with-uv-tool-install)**: Use `uv tool install` to install SLEAP globally as a tool (Installation needed, **strongly recommended**)
     - **[Installation with uvx](#installation-with-uvx)**: Use `uvx` for one-off commands. (no installation needed!)
-    - **[Installation with uv pip](#installation-with-uv-pip)**: Use `uv pip` to install from pypi in a uv virtual env.
+    - **[Installation with uv add](#installation-with-uv-add)**: Use `uv add` to install sleap in a uv virtual env.
     - **[Installation with pip](#installation-with-pip)**: Use `pip` to install from pypi in a conda env.
     - **[Installation from source](#installation-from-source)**: Use `uv sync` to install from source. (For developmental purposes)
 
@@ -176,9 +176,9 @@ sleap-label --help
 
 ---
 
-## Installation with uv pip
+## Installation with uv add
 
-This method creates a dedicated project environment using uv's modern Python project management. It initializes a new project with `uv init`, creates an isolated virtual environment with `uv venv`, and installs SLEAP using `uv pip`.
+This method creates a dedicated project environment using uv's modern Python project management. It initializes a new project with `uv init`, creates an isolated virtual environment with `uv venv`, and installs SLEAP using `uv add`.
 
 !!! warning "Python 3.14 is not yet supported"
     SLEAP currently supports **Python 3.11, 3.12, and 3.13**. **Python 3.14 is not yet tested or supported.** `uv` will use the system-installed python by default. If you have python 3.14 installed on your system, then specify the Python version (<=3.13) in the venv command.  
@@ -206,10 +206,20 @@ This method creates a dedicated project environment using uv's modern Python pro
 
 ### Platform-Specific Commands
 
+!!! tip "How `uv add` works"
+    - When you run `uv init`, it creates a `pyproject.toml` file in your working directory to manage your project's dependencies.
+    - When you use `uv add "sleap[nn]"`, it adds `sleap` as a dependency in your `pyproject.toml` and installs it in your virtual environment.
+    - To add other packages, simply run `uv add <package>`. After adding new packages, you should run `uv sync` to update your environment with all dependencies specified in `pyproject.toml`.
+    - To install a local package (such as a local clone of sleap-nn) in editable mode, use:
+      ```bash
+      uv add --editable "./sleap[nn]" ...
+      ```
+      This is useful for development, as changes to the code are immediately reflected in your environment.
+
 === "Windows/Linux (CUDA)"
     ```bash
     # CUDA 12.8
-    uv pip install "sleap[nn]" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv add "sleap[nn]" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
     !!! info "Other CUDA versions"
         - For more information on which CUDA version to use for your system, see the [PyTorch installation](https://pytorch.org/get-started/locally/) guide. The `--index` in the install command should match the CUDA version you need (e.g., `https://download.pytorch.org/whl/cuda118` for CUDA 11.8, `https://download.pytorch.org/whl/cuda128` for CUDA 12.8, etc.).
@@ -217,25 +227,25 @@ This method creates a dedicated project environment using uv's modern Python pro
 === "Windows/Linux (CPU)"
     ```bash
     # CUDA 12.8
-    uv pip install "sleap[nn]" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv add "sleap[nn]" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```bash
-    uv pip install "sleap[nn]"
+    uv add "sleap[nn]"
     ```
     !!! info "Mac MPS support"
         - On macOS, MPS (Metal Performance Shaders) is automatically enabled for Apple Silicon acceleration.
 
 === "SLEAP GUI Only"
     ```bash
-    uv pip install "sleap"
+    uv add "sleap"
     ```
     !!! warning "GUI <u>ONLY</u>"
         Installing this version of SLEAP will **NOT** include any training/inference capabilities, as it will not include the sleap-nn backend. This should primarily be used for **labeling**.
 
 !!! info "Running With `uv run`"
-    `uv pip install` creates a `.venv` (virtual environment) inside your current working directory. To use all installed packages, <u>**you must run commands with `uv run`**</u> (e.g., `uv run sleap-label ...` or `uv run pytest ...`) with these installation methods.
+    `uv add` creates a `.venv` (virtual environment) inside your current working directory. To use all installed packages, <u>**you must run commands with `uv run`**</u> (e.g., `uv run sleap-label ...` or `uv run pytest ...`) with these installation methods.
 
 ### Verify Installation
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,9 +18,21 @@ SLEAP can be installed as a Python package on Windows, Linux, and Mac OS. The ne
 
 ---
 
+## Prerequisites
+
+Python 3.11 (or) 3.12 (or) 3.13 (required for all installation methods)
+
+!!! warning "Python 3.14 is not yet supported"
+    SLEAP currently supports **Python 3.11, 3.12, and 3.13**. **Python 3.14 is not yet tested or supported.** If you have Python 3.14 installed, you must specify the Python version in all `uv` install commands by adding `--python 3.13`.  
+    For example:
+    ```bash
+    uv tool install --python 3.13 "sleap[nn]"  ...
+    ```
+    Replace `...` with the rest of your install command as needed.
+
+
 ## Installation methods
 
-**Prerequisites:** Python 3.11+ (required for all installation methods)
 
 !!! tip "Choose Your Installation Method"
     - **[Installation as a system-wide tool with uv](#installation-with-uv-tool-install)**: Use `uv tool install` to install SLEAP globally as a tool (Installation needed, **strongly recommended**)
@@ -60,6 +72,14 @@ To install SLEAP, you'll need to enter commands in a terminal. Here's how to ope
     ```
 
 ### Platform-Specific Commands
+
+!!! warning "Python 3.14 is not yet supported"
+    SLEAP currently supports **Python 3.11, 3.12, and 3.13**. **Python 3.14 is not yet tested or supported.** `uv` will use the system-installed python by default. If you have python 3.14 installed on your system, then specify the Python version (<=3.13) in the installation command.  
+    For example:
+    ```bash
+    uv tool install --python 3.13 "sleap[nn]"  ...
+    ```
+    Replace `...` with the rest of your install command as needed.
 
 === "Windows/Linux (CUDA)"
     ```bash
@@ -116,6 +136,14 @@ sleap-label --help
 
 ### Platform-Specific Commands
 
+!!! warning "Python 3.14 is not yet supported"
+    SLEAP currently supports **Python 3.11, 3.12, and 3.13**. **Python 3.14 is not yet tested or supported.** `uv` will use the system-installed python by default. If you have python 3.14 installed on your system, then specify the Python version (<=3.13) in the installation command.  
+    For example:
+    ```bash
+    uvx --python 3.13 "sleap[nn]"  ...
+    ```
+    Replace `...` with the rest of your install command as needed.
+
 === "Windows/Linux (CUDA)"
     ```bash
     # CUDA 12.8
@@ -151,6 +179,14 @@ sleap-label --help
 ## Installation with uv pip
 
 This method creates a dedicated project environment using uv's modern Python project management. It initializes a new project with `uv init`, creates an isolated virtual environment with `uv venv`, and installs SLEAP using `uv pip`.
+
+!!! warning "Python 3.14 is not yet supported"
+    SLEAP currently supports **Python 3.11, 3.12, and 3.13**. **Python 3.14 is not yet tested or supported.** `uv` will use the system-installed python by default. If you have python 3.14 installed on your system, then specify the Python version (<=3.13) in the venv command.  
+    For example:
+    ```bash
+    uv venv --python 3.13  ...
+    ```
+    Replace `...` with the rest of your install command as needed.
 
 !!! note "Install and set-up uv"
     Step-1: Install [`uv`](https://github.com/astral-sh/uv) - an ultra-fast Python package manager:
@@ -224,9 +260,12 @@ uv run sleap-label --help
 
 We recommend creating a dedicated environment with [conda](https://docs.conda.io/en/latest/miniconda.html) or [mamba/miniforge](https://github.com/conda-forge/miniforge) before installing `sleap` with pip. This helps avoid dependency conflicts and keeps your Python setup clean. After installing Miniconda or Miniforge, create and activate an environment, then run the pip install commands below inside the activated environment.
 
+!!! warning "Python 3.14 is not yet supported"
+    SLEAP currently supports **Python 3.11, 3.12, and 3.13**. **Python 3.14 is not yet tested or supported.**
+
 To create a conda environment, run:
 ```bash
-conda create -n sleap python=3.12
+conda create -n sleap python=3.13
 conda activate sleap
 ```
 
@@ -294,6 +333,14 @@ cd sleap
     ```
 
 **3. Install Dependencies**
+
+!!! warning "Python 3.14 is not yet supported"
+    SLEAP currently supports **Python 3.11, 3.12, and 3.13**. **Python 3.14 is not yet tested or supported.** `uv` will use the system-installed python by default. If you have python 3.14 installed on your system, then specify the Python version (<=3.13) in the installation command.  
+    For example:
+    ```bash
+    uv sync --python 3.13 ...
+    ```
+    Replace `...` with the rest of your install command as needed.
 
 === "Windows/Linux (CUDA)"
     ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,5 +166,5 @@ nav:
       - Command line interfaces: reference/command-line-interfaces.md
       - Evaluation metrics: reference/evaluation_metrics.md
       - Full API: api/
-      - Changelog: CHANGELOG.md
+      - Changelog: changelog.md
   - Help: help.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     {name = "Talmo Pereira", email = "talmo@salk.edu"}
 ]
 license = {text = "BSD-3-Clause"}
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 keywords = ["deep learning", "pose estimation", "tracking", "neuroscience"]
 classifiers = [
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
This PR adds warnings to the documentation that Python 3.14 is not yet supported and updates install instructions to pin Python (e.g., --python 3.13) when using uv so users don’t accidentally end up on 3.14. It also updates the CI workflows to run on Python 3.13 (instead of 3.12).