### PR TITLE
Restore legacy tracking args for backwards compatibility

### DIFF
--- a/docs/reference/command-line-interfaces.md
+++ b/docs/reference/command-line-interfaces.md
@@ -138,13 +138,15 @@ For more detailed information about training configurations, model architectures
 If you specify how many identities there should be in a frame (i.e., the number of animals) with the `--tracking.clean_instance_count` argument, then we will use a heuristic method to connect "breaks" in the track identities where we lose one identity and spawn another. This can be used as part of the inference pipeline (if models are specified), as part of the tracking-only pipeline (if the predictions file is specified and no models are specified), or by itself on predictions with pre-tracked identities (if you specify `--tracking.tracker none`). See [`Tracking and proofreading`](../guides/tracking-and-proofreading.md) for more details on tracking.
 
 ```none
-usage: sleap-track [-h] [-m MODELS] [--frames FRAMES] [--only-labeled-frames] [--only-suggested-frames] [-o OUTPUT]
+usage: sleap-track [-h] [-m MODELS] [--frames FRAMES] [--only-labeled-frames] [--only-suggested-frames] [-o OUTPUT] [--no-empty-frames]
                    [--video.dataset VIDEO.DATASET] [--video.input_format VIDEO.INPUT_FORMAT]
                    [--video.index VIDEO.INDEX] [--cpu | --first-gpu | --last-gpu | --gpu GPU] [--max_edge_length_ratio MAX_EDGE_LENGTH_RATIO]
                    [--dist_penalty_weight DIST_PENALTY_WEIGHT] [--batch_size BATCH_SIZE] [--open-in-gui] [--peak_threshold PEAK_THRESHOLD]
                    [-n MAX_INSTANCES] [--tracking.tracker TRACKING.TRACKER] [--tracking.max_tracking TRACKING.MAX_TRACKING]
-                   [--tracking.max_tracks TRACKING.MAX_TRACKS]
+                   [--tracking.max_tracks TRACKING.MAX_TRACKS] [--tracking.target_instance_count TRACKING.TARGET_INSTANCE_COUNT]
+                   [--tracking.pre_cull_to_target TRACKING.PRE_CULL_TO_TARGET] [--tracking.pre_cull_iou_threshold TRACKING.PRE_CULL_IOU_THRESHOLD]
                    [--tracking.post_connect_single_breaks TRACKING.POST_CONNECT_SINGLE_BREAKS]
+                   [--tracking.clean_instance_count TRACKING.CLEAN_INSTANCE_COUNT] [--tracking.clean_iou_threshold TRACKING.CLEAN_IOU_THRESHOLD]
                    [--tracking.similarity TRACKING.SIMILARITY] [--tracking.match TRACKING.MATCH] [--tracking.robust TRACKING.ROBUST]
                    [--tracking.track_window TRACKING.TRACK_WINDOW] [--tracking.min_new_track_points TRACKING.MIN_NEW_TRACK_POINTS]
                    [--tracking.min_match_points TRACKING.MIN_MATCH_POINTS] [--tracking.img_scale TRACKING.IMG_SCALE]
@@ -171,6 +173,7 @@ optional arguments:
                         initialization during labeling.
   -o OUTPUT, --output OUTPUT
                         The output filename or directory path to use for the predicted data. If not provided, defaults to '[data_path].predictions.slp'.
+  --no-empty-frames     Clear any empty frames that did not have any detected instances before saving to output.
   --video.dataset VIDEO.DATASET
                         The dataset for HDF5 videos.
   --video.input_format VIDEO.INPUT_FORMAT
@@ -203,9 +206,19 @@ optional arguments:
                         Maximum number of tracks to be tracked by the tracker. (default: None)
   --tracking.target_instance_count TRACKING.TARGET_INSTANCE_COUNT
                         Target number of instances to track per frame. (default: 0)
+  --tracking.pre_cull_to_target TRACKING.PRE_CULL_TO_TARGET
+                        If non-zero and target_instance_count is also non-zero, then cull instances over target count per frame *before* tracking.
+                        (default: 0)
+  --tracking.pre_cull_iou_threshold TRACKING.PRE_CULL_IOU_THRESHOLD
+                        If non-zero and pre_cull_to_target also set, then use IOU threshold to remove overlapping instances over count *before*
+                        tracking. (default: 0)
   --tracking.post_connect_single_breaks TRACKING.POST_CONNECT_SINGLE_BREAKS
                         If non-zero and target_instance_count is also non-zero, then connect track breaks when exactly one track is lost and exactly
                         one track is spawned in frame. (default: 0)
+  --tracking.clean_instance_count TRACKING.CLEAN_INSTANCE_COUNT
+                        Target number of instances to clean *after* tracking. (default: 0)
+  --tracking.clean_iou_threshold TRACKING.CLEAN_IOU_THRESHOLD
+                        IOU to use when culling instances *after* tracking. (default: 0)
   --tracking.similarity TRACKING.SIMILARITY
                         Options: instance, normalized_instance, object_keypoint, centroid, iou (default: instance)
   --tracking.match TRACKING.MATCH
@@ -226,6 +239,14 @@ optional arguments:
   --tracking.of_max_levels TRACKING.OF_MAX_LEVELS
                         For optical-flow: Number of pyramid scale levels to consider (default: 3)
 ```
+
+!!! warning "Tracking cleaning and pre-cull parameters"
+
+    The parameters `--tracking.pre_cull_iou_threshold`, `--tracking.target_instance_count`, `tracking.pre_cull_iou_threshold`, `tracking.clean_iou_threshold` and `--tracking.clean_instance_count` are provided for backwards compatibility with legacy SLEAP workflows and **may be deprecated in future releases**. 
+
+    - To restrict the number of instances per frame, use the `--max_instances` parameter, which selects the top instances with the highest prediction scores.
+
+    We recommend using `--max_instances` for controlling the number of predicted instances per frame in new projects.
 
 #### Examples
 

--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -226,6 +226,12 @@ def train(config_name, config_dir, overrides):
     "labels dataset.This is useful for generating predictions for initialization.",
 )
 @click.option(
+    "--no_empty_frames",
+    is_flag=True,
+    default=False,
+    help=("Clear empty frames that did not have predictions before saving to output."),
+)
+@click.option(
     "--video_index",
     type=int,
     default=None,
@@ -426,6 +432,42 @@ def train(config_name, config_dir, overrides):
     help="If True and `max_tracks` is not None with local queues candidate method, "
     "connects track breaks when exactly one track is lost and exactly"
     "one new track is spawned in the frame.",
+)
+@click.option(
+    "--tracking_target_instance_count",
+    type=int,
+    default=0,
+    help="Target number of instances to track per frame. (default: 0)",
+)
+@click.option(
+    "--tracking_pre_cull_to_target",
+    type=int,
+    default=0,
+    help=(
+        "If non-zero and target_instance_count is also non-zero, then cull instances "
+        "over target count per frame *before* tracking. (default: 0)"
+    ),
+)
+@click.option(
+    "--tracking_pre_cull_iou_threshold",
+    type=float,
+    default=0,
+    help=(
+        "If non-zero and pre_cull_to_target also set, then use IOU threshold to remove "
+        "overlapping instances over count *before* tracking. (default: 0)"
+    ),
+)
+@click.option(
+    "--tracking_clean_instance_count",
+    type=int,
+    default=0,
+    help="Target number of instances to clean *after* tracking. (default: 0)",
+)
+@click.option(
+    "--tracking_clean_iou_threshold",
+    type=float,
+    default=0,
+    help="IOU to use when culling instances *after* tracking. (default: 0)",
 )
 def track(**kwargs):
     """Run Inference and Tracking workflow.

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -5,6 +5,7 @@ from omegaconf import OmegaConf
 import numpy as np
 from pathlib import Path
 from datetime import datetime
+from typing import Optional, List
 import time
 import logging
 
@@ -297,6 +298,25 @@ def train_command(
         )
 
 
+def frame_list(frame_str: str) -> Optional[List[int]]:
+    """Converts 'n-m' string to list of ints.
+
+    Args:
+        frame_str: string representing range
+
+    Returns:
+        List of ints, or None if string does not represent valid range.
+    """
+    # Handle ranges of frames. Must be of the form "1-200" (or "1,-200")
+    if "-" in frame_str:
+        min_max = frame_str.split("-")
+        min_frame = int(min_max[0].rstrip(","))
+        max_frame = int(min_max[1])
+        return list(range(min_frame, max_frame + 1))
+
+    return [int(x) for x in frame_str.split(",")] if len(frame_str) else None
+
+
 @click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("data_path", required=True)
 @click.option(
@@ -312,7 +332,6 @@ def train_command(
 @click.option(
     "--frames",
     "frames",
-    default="",
     help=(
         "List of frames to predict when running on a video. Can be specified as a "
         "comma separated list (e.g. 1,2,3) or a range separated by hyphen (e.g., 1-3, "
@@ -638,6 +657,12 @@ def track_command(
         # Build kwargs for the tracking function
         kwargs = {}
 
+        # Convert frames string to list
+        if frames is not None:
+            kwargs["frames"] = frame_list(frames)
+        else:
+            kwargs["frames"] = None
+
         if models is not None:
             kwargs["model_paths"] = models
         if frames is not None:
@@ -681,6 +706,7 @@ def track_command(
             kwargs["max_instances"] = max_instances
 
         if tracking_tracker:
+            kwargs["tracking"] = True
             if "flow" in tracking_tracker:
                 kwargs["use_flow"] = True
 

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -346,6 +346,12 @@ def train_command(
         "provided, defaults to '[data_path].predictions.slp'."
     ),
 )
+@click.option(
+    "--no-empty-frames",
+    "no_empty_frames",
+    is_flag=True,
+    help=("Clear empty frames that did not have predictions before saving to output."),
+)
 @click.option("--video.dataset", "video_dataset", help="The dataset for HDF5 videos.")
 @click.option(
     "--video.input_format",
@@ -457,6 +463,33 @@ def train_command(
     help="Maximum number of tracks to be tracked by the tracker. (default: None)",
 )
 @click.option(
+    "--tracking.target_instance_count",
+    "tracking_target_instance_count",
+    type=int,
+    default=0,
+    help="Target number of instances to track per frame. (default: 0)",
+)
+@click.option(
+    "--tracking.pre_cull_to_target",
+    "tracking_pre_cull_to_target",
+    type=int,
+    default=0,
+    help=(
+        "If non-zero and target_instance_count is also non-zero, then cull instances "
+        "over target count per frame *before* tracking. (default: 0)"
+    ),
+)
+@click.option(
+    "--tracking.pre_cull_iou_threshold",
+    "tracking_pre_cull_iou_threshold",
+    type=float,
+    default=0,
+    help=(
+        "If non-zero and pre_cull_to_target also set, then use IOU threshold to remove "
+        "overlapping instances over count *before* tracking. (default: 0)"
+    ),
+)
+@click.option(
     "--tracking.post_connect_single_breaks",
     "tracking_post_connect_single_breaks",
     type=int,
@@ -465,6 +498,20 @@ def train_command(
         "breaks when exactly one track is lost and exactly one track is spawned in "
         "frame. (default: 0)"
     ),
+)
+@click.option(
+    "--tracking.clean_instance_count",
+    "tracking_clean_instance_count",
+    type=int,
+    default=0,
+    help="Target number of instances to clean *after* tracking. (default: 0)",
+)
+@click.option(
+    "--tracking.clean_iou_threshold",
+    "tracking_clean_iou_threshold",
+    type=float,
+    default=0,
+    help="IOU to use when culling instances *after* tracking. (default: 0)",
 )
 @click.option(
     "--tracking.similarity",
@@ -534,6 +581,7 @@ def track_command(
     only_labeled_frames,
     only_suggested_frames,
     output,
+    no_empty_frames,
     video_dataset,
     video_input_format,
     video_index,
@@ -550,7 +598,12 @@ def track_command(
     tracking_tracker,
     tracking_max_tracking,
     tracking_max_tracks,
+    tracking_target_instance_count,
+    tracking_pre_cull_to_target,
+    tracking_pre_cull_iou_threshold,
     tracking_post_connect_single_breaks,
+    tracking_clean_instance_count,
+    tracking_clean_iou_threshold,
     tracking_similarity,
     tracking_match,
     tracking_robust,
@@ -577,6 +630,8 @@ def track_command(
             kwargs["only_labeled_frames"] = True
         if only_suggested_frames is not None and only_suggested_frames:
             kwargs["only_suggested_frames"] = True
+        if no_empty_frames is not None and no_empty_frames:
+            kwargs["no_empty_frames"] = True
         kwargs["output_path"] = output
         if output is None:
             kwargs["output_path"] = f"{data_path}.predictions.slp"
@@ -618,6 +673,21 @@ def track_command(
             kwargs["candidates_method"] = "local_queues"
             kwargs["max_tracks"] = tracking_max_tracks
 
+        if (
+            tracking_target_instance_count is not None
+            and tracking_target_instance_count > 0
+        ):
+            kwargs["target_instance_count"] = tracking_target_instance_count
+
+        if tracking_pre_cull_to_target is not None and tracking_pre_cull_to_target > 0:
+            kwargs["pre_cull_to_target"] = tracking_pre_cull_to_target
+
+        if (
+            tracking_pre_cull_iou_threshold is not None
+            and tracking_pre_cull_iou_threshold > 0
+        ):
+            kwargs["pre_cull_iou_threshold"] = tracking_pre_cull_iou_threshold
+
         if tracking_similarity is not None:
             if tracking_similarity == "oks":
                 kwargs["features"] = "keypoints"
@@ -633,6 +703,19 @@ def track_command(
             and tracking_post_connect_single_breaks
         ):
             kwargs["post_connect_single_breaks"] = tracking_post_connect_single_breaks
+
+        if (
+            tracking_clean_instance_count is not None
+            and tracking_clean_instance_count > 0
+        ):
+            kwargs["clean_instance_count"] = tracking_clean_instance_count
+
+        if (
+            tracking_clean_iou_threshold is not None
+            and tracking_clean_iou_threshold > 0
+        ):
+            kwargs["clean_iou_threshold"] = tracking_clean_iou_threshold
+
         if tracking_match is not None:
             kwargs["track_matching_method"] = tracking_match
         if tracking_robust is not None:

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -312,6 +312,7 @@ def train_command(
 @click.option(
     "--frames",
     "frames",
+    default="",
     help=(
         "List of frames to predict when running on a video. Can be specified as a "
         "comma separated list (e.g. 1,2,3) or a range separated by hyphen (e.g., 1-3, "
@@ -322,6 +323,7 @@ def train_command(
     "--only-labeled-frames",
     "only_labeled_frames",
     is_flag=True,
+    default=False,
     help=(
         "Only run inference on user labeled frames when running on labels dataset. "
         "This is useful for generating predictions to compare against ground truth."
@@ -331,6 +333,7 @@ def train_command(
     "--only-suggested-frames",
     "only_suggested_frames",
     is_flag=True,
+    default=False,
     help=(
         "Only run inference on unlabeled suggested frames when running on labels "
         "dataset. This is useful for generating predictions for initialization during "
@@ -341,6 +344,7 @@ def train_command(
     "-o",
     "--output",
     "output",
+    default=None,
     help=(
         "The output filename or directory path to use for the predicted data. If not "
         "provided, defaults to '[data_path].predictions.slp'."
@@ -350,18 +354,21 @@ def train_command(
     "--no-empty-frames",
     "no_empty_frames",
     is_flag=True,
+    default=False,
     help=("Clear empty frames that did not have predictions before saving to output."),
 )
 @click.option("--video.dataset", "video_dataset", help="The dataset for HDF5 videos.")
 @click.option(
     "--video.input_format",
     "video_input_format",
+    default="channels_last",
     help="The input_format for HDF5 videos.",
 )
 @click.option(
     "--video.index",
     "video_index",
     type=int,
+    default=None,
     help=(
         "Integer index of video in .slp file to predict on. To be used with an .slp "
         "path as an alternative to specifying the video path."
@@ -371,18 +378,21 @@ def train_command(
     "--cpu",
     "cpu",
     is_flag=True,
+    default=False,
     help="Run inference only on CPU. If not specified, will use available GPU.",
 )
 @click.option(
     "--first-gpu",
     "first_gpu",
     is_flag=True,
+    default=False,
     help="Run inference on the first GPU, if available.",
 )
 @click.option(
     "--last-gpu",
     "last_gpu",
     is_flag=True,
+    default=False,
     help="Run inference on the last GPU, if available.",
 )
 @click.option(
@@ -397,6 +407,7 @@ def train_command(
     "--max_edge_length_ratio",
     "max_edge_length_ratio",
     type=float,
+    default=0.25,
     help=(
         "The maximum expected length of a connected pair of points as a fraction of "
         "the "
@@ -408,6 +419,7 @@ def train_command(
     "--dist_penalty_weight",
     "dist_penalty_weight",
     type=float,
+    default=1.0,
     help=(
         "A coefficient to scale weight of the distance penalty. Set to values greater "
         "than 1.0 to enforce the distance penalty more strictly. Only applies to "
@@ -418,6 +430,7 @@ def train_command(
     "--batch_size",
     "batch_size",
     type=int,
+    default=4,
     help=(
         "Number of frames to predict at a time. Larger values result in faster "
         "inference speeds, but require more memory."
@@ -427,12 +440,14 @@ def train_command(
     "--open-in-gui",
     "open_in_gui",
     is_flag=True,
+    default=False,
     help="Open the resulting predictions in the GUI when finished.",
 )
 @click.option(
     "--peak_threshold",
     "peak_threshold",
     type=float,
+    default=0.2,
     help="Minimum confidence map value to consider a peak as valid.",
 )
 @click.option(
@@ -440,6 +455,7 @@ def train_command(
     "--max_instances",
     "max_instances",
     type=int,
+    default=None,
     help=(
         "Limit maximum number of instances in multi-instance models. Not available for "
         "ID models. Defaults to None."
@@ -677,16 +693,16 @@ def track_command(
             tracking_target_instance_count is not None
             and tracking_target_instance_count > 0
         ):
-            kwargs["target_instance_count"] = tracking_target_instance_count
+            kwargs["tracking_target_instance_count"] = tracking_target_instance_count
 
         if tracking_pre_cull_to_target is not None and tracking_pre_cull_to_target > 0:
-            kwargs["pre_cull_to_target"] = tracking_pre_cull_to_target
+            kwargs["tracking_pre_cull_to_target"] = tracking_pre_cull_to_target
 
         if (
             tracking_pre_cull_iou_threshold is not None
             and tracking_pre_cull_iou_threshold > 0
         ):
-            kwargs["pre_cull_iou_threshold"] = tracking_pre_cull_iou_threshold
+            kwargs["tracking_pre_cull_iou_threshold"] = tracking_pre_cull_iou_threshold
 
         if tracking_similarity is not None:
             if tracking_similarity == "oks":
@@ -708,13 +724,13 @@ def track_command(
             tracking_clean_instance_count is not None
             and tracking_clean_instance_count > 0
         ):
-            kwargs["clean_instance_count"] = tracking_clean_instance_count
+            kwargs["tracking_clean_instance_count"] = tracking_clean_instance_count
 
         if (
             tracking_clean_iou_threshold is not None
             and tracking_clean_iou_threshold > 0
         ):
-            kwargs["clean_iou_threshold"] = tracking_clean_iou_threshold
+            kwargs["tracking_clean_iou_threshold"] = tracking_clean_iou_threshold
 
         if tracking_match is not None:
             kwargs["track_matching_method"] = tracking_match


### PR DESCRIPTION
This PR reintroduces the legacy track-cleaning arguments to the CLI, mapping them to the current options so existing scripts and pipelines keep working.