### PR TITLE
Fix qt widget attribute error in windows

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -407,7 +407,7 @@ class MainWindow(QMainWindow):
         # check and uncheck submenu items
         def _menu_check_single(menu, item_text):
             """Helper method to select exactly one submenu item."""
-            for menu_item in menu.children():
+            for menu_item in menu.actions():
                 if menu_item.text() == str(item_text):
                     menu_item.setChecked(True)
                 else:


### PR DESCRIPTION
Previously, on Windows, loading an .slp file would throw an error because the code iterated over all `menu.children()`, which on Windows includes a `QGraphicsDropShadowEffect` object. This object doesn’t have a `.text()` or `.setChecked()` method, leading to the crash. 
```bash
[<function MainWindow._create_menus.<locals>.add_submenu_choices.<locals>.<lambda> at 0x00000187FF0BD440>, <function MainWindow._load_overlays.<locals>.overlay_state_connect.<locals>.<lambda> at 0x0000018783954FE0>, <bound method MainWindow.plotFrame of <sleap.gui.app.MainWindow(0x187f97e5660) at 0x00000187FED65280>>, <function MainWindow._load_overlays.<locals>.<lambda> at 0x00000187839551C0>, <function MainWindow._load_overlays.<locals>.<lambda> at 0x0000018783955260>, <function MainWindow._load_overlays.<locals>.overlay_state_connect.<locals>.<lambda> at 0x00000187FEEC8AE0>, <bound method MainWindow.plotFrame of <sleap.gui.app.MainWindow(0x187f97e5660) at 0x00000187FED65280>>, <function MainWindow._load_overlays.<locals>.<lambda> at 0x0000018783955580>, <function MainWindow._load_overlays.<locals>.<lambda> at 0x0000018783955760>]
'PySide6.QtWidgets.QGraphicsDropShadowEffect' object has no attribute 'text'
Error occurred during callback 0 for distinctly_color!
```
The fix updates the logic to only check `action` objects using `menu.actions()`, ensuring that only action items are processed.