### PR TITLE
Remove cattrs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 dynamic = ["version", "readme"]
 dependencies = [
     "attrs",
-    "cattrs",
     "omegaconf",
     "imageio",
     "imageio-ffmpeg",

--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -7,7 +7,6 @@ import copy
 from typing import List, Dict, Optional, Text, Union
 
 from pathlib import Path
-import cattr
 import os
 
 from sleap import util
@@ -872,14 +871,6 @@ def make_video_callback(
         # Replace the video filenames with changes by user
         for i, item in enumerate(video_list):
             item.replace_filename(filenames[i])
-
-        if USE_DUMMY_FOR_MISSING_VIDEOS and sum(missing):
-            # Replace any video still missing with "dummy" video
-            for is_missing, item in zip(missing, video_list):
-                from sleap.io.video import DummyVideo
-
-                vid = DummyVideo(filename=item.filename)
-                item["backend"] = cattr.unstructure(vid)
 
     return video_callback
 

--- a/tests/fixtures/datasets.py
+++ b/tests/fixtures/datasets.py
@@ -77,20 +77,6 @@ def siv_robot():
 
 
 @pytest.fixture
-def siv_robot_caching():
-    """Created after caching attribute was added to `SingleImageVideo` backend.
-
-    The typehinting of the `caching` attribute (#1243) caused it to be used by cattrs to
-    determine which type of dataclass to use. However, the older datasets containing
-    `SingleImageVideo`s were now being read in as `NumpyVideo`s. Although removing the
-    typehinting from `caching` seems to do the trick (and never made it into an official
-    release), this is a fixture to test that datasets created while `caching` was added
-    into the serialization are read in correctly.
-    """
-    return sio.load_file(TEST_SLP_SIV_ROBOT_CACHING)
-
-
-@pytest.fixture
 def min_tracks_2node_labels():
     return sio.load_file(TEST_MIN_TRACKS_2NODE_LABELS)
 


### PR DESCRIPTION
This PR removes `cattrs` dependency across SLEAP repo. 