### PR TITLE
Fix TypeError when loading image sequences

### DIFF
--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -810,11 +810,30 @@ def make_video_callback(
             context: A dictionary containing a "changed_on_load" key with a boolean
                 value. Used externally to determine if any filenames were updated.
         """
-        filenames = [item.filename for item in video_list]
+        # Extract filenames, handling both single files and image sequences
+        # Video.filename can be either str or list[str] (for image sequences)
+        filenames = []
+        is_image_sequence = []  # Track which videos are image sequences
+        for item in video_list:
+            if isinstance(item.filename, (list, tuple)):
+                # For image sequences, use the first filename for checking existence
+                is_image_sequence.append(True)
+                filenames.append(item.filename[0] if item.filename else None)
+            else:
+                is_image_sequence.append(False)
+                filenames.append(item.filename)
+
         context = context or {"changed_on_load": False}
 
         # Equivalent to pathutils.list_file_missing(filenames)
-        missing = [not os.path.exists(filename) for filename in filenames]
+        # Convert Path objects to strings for os.path.exists()
+        missing = []
+        for filename in filenames:
+            if filename is None:
+                missing.append(True)
+            else:
+                filename_str = str(filename)
+                missing.append(not os.path.exists(filename_str))
 
         # Try changing the prefix using saved patterns
         if sum(missing):
@@ -870,7 +889,19 @@ def make_video_callback(
 
         # Replace the video filenames with changes by user
         for i, item in enumerate(video_list):
-            item.replace_filename(filenames[i])
+            if is_image_sequence[i]:
+                # For image sequences, update all filenames in the list with the new directory
+                original_filenames = item.filename
+                if filenames[i] != original_filenames[0]:
+                    # The first filename changed, update the directory for all files
+                    new_dir = os.path.dirname(filenames[i])
+                    updated_filenames = [
+                        os.path.join(new_dir, os.path.basename(str(f)))
+                        for f in original_filenames
+                    ]
+                    item.replace_filename(updated_filenames)
+            else:
+                item.replace_filename(filenames[i])
 
     return video_callback
 

--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -890,7 +890,7 @@ def make_video_callback(
         # Replace the video filenames with changes by user
         for i, item in enumerate(video_list):
             if is_image_sequence[i]:
-                # For image sequences, update all filenames in the list with the new directory
+                # For image sequences, update all filenames with new directory
                 original_filenames = item.filename
                 if filenames[i] != original_filenames[0]:
                     # The first filename changed, update the directory for all files


### PR DESCRIPTION
## Summary

Fixes a `TypeError` that occurred when loading SLEAP files containing image sequences (e.g., from DeepLabCut projects) in the GUI.

## Problem

After a recent update, opening certain `.slp` files in the GUI resulted in:

```
TypeError: _path_exists: path should be string, bytes, os.PathLike or integer, not list
```

**Error location**: `sleap/sleap_io_adaptors/lf_labels_utils.py:817`

## Root Cause

The `sleap-io` library's `Video.filename` attribute can be either:
- `str` - for regular video files (mp4, avi, etc.)
- `list[str]` - for image sequences (multiple PNG/JPG files)

The video callback code assumed `filename` was always a single value. When processing image sequences, this created a list of lists, causing `os.path.exists()` to fail with a TypeError.

### Example Issue
```python
# Old code
filenames = [item.filename for item in video_list]
# For image sequences: filenames = [[path1, path2, ...], [path1, path2, ...]]

missing = [not os.path.exists(filename) for filename in filenames]
# TypeError! os.path.exists() can't accept a list
```

## Solution

Modified the video callback in `lf_labels_utils.py` to handle both single files and image sequences:

1. **Detect video type**: Track whether each video is an image sequence
2. **Use representative file**: For image sequences, use the first file to check existence
3. **Preserve structure**: Maintain the full list of filenames for later updates
4. **Update correctly**: When paths change, update the directory for all files in the sequence

### Code Changes

**Before**:
```python
filenames = [item.filename for item in video_list]
missing = [not os.path.exists(filename) for filename in filenames]
```

**After**:
```python
filenames = []
is_image_sequence = []
for item in video_list:
    if isinstance(item.filename, (list, tuple)):
        is_image_sequence.append(True)
        filenames.append(item.filename[0] if item.filename else None)
    else:
        is_image_sequence.append(False)
        filenames.append(item.filename)

missing = []
for filename in filenames:
    if filename is None:
        missing.append(True)
    else:
        filename_str = str(filename)
        missing.append(not os.path.exists(filename_str))
```

Also updated the filename restoration logic to preserve image sequence lists when updating paths.

## Testing

Tested with a DeepLabCut project file containing:
- 42 image sequence videos
- 756 labeled frames

**Results**:
- ✅ Successfully loads without errors
- ✅ Correctly handles image sequences
- ✅ Maintains compatibility with regular video files
- ✅ Path correction functionality works for image sequences

## Investigation

Detailed investigation materials are available in `scratch/video_path_bug_investigation/`:
- Root cause analysis
- Test scripts validating the fix
- Complete documentation of the issue and solution

## Impact

- Fixes loading of DeepLabCut image sequence projects
- Maintains compatibility with regular video files
- Preserves path correction functionality for image sequences
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)