### PR TITLE
Update predictions output path for inference

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -260,9 +260,20 @@ class InferenceTask:
 
             # Build filename with video name and timestamp
             timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
+            video_name_prefix = ""
+            if "--video_index" in item_for_inference.cli_args:
+                video_index = int(
+                    item_for_inference.cli_args[
+                        item_for_inference.cli_args.index("--video_index") + 1
+                    ]
+                )
+                video_name_prefix = Path(self.labels.videos[video_index].filename).name
+            video_name_prefix = (
+                video_name_prefix + "_" if video_name_prefix != "" else ""
+            )
             output_path = os.path.join(
                 predictions_dir,
-                f"{os.path.basename(item_for_inference.path)}.{timestamp}."
+                f"{video_name_prefix}{os.path.basename(item_for_inference.path)}.{timestamp}."
                 "predictions.slp",
             )
 


### PR DESCRIPTION
## Summary
- Adds video name prefix to prediction output filenames when running inference with `--video_index`
- Prevents filename collisions when running inference on multiple videos from the same project

## Changes

**Updated `make_predict_cli_call` in runners.py (lines 263-273):**
- Extracts video index from CLI args when `--video_index` is present
- Prepends video filename to prediction output path
- Ensures unique output files for each video in multi-video inference

## Before vs After

### Before
When running inference on multiple videos from `project.slp`:
```
predictions/project.slp.250121_142530.predictions.slp  # All videos overwrite same file ❌
```

### After
```
predictions/video1.mp4_project.slp.250121_142530.predictions.slp
predictions/video2.mp4_project.slp.250121_142530.predictions.slp
predictions/video3.mp4_project.slp.250121_142530.predictions.slp
```

## Why
Previously, when running inference on multiple videos from the same project, all predictions used the same output filename (based on the project name), causing each video's predictions to overwrite the previous one. This fix ensures each video gets a unique output file by prepending the video filename.

## Related
Addresses the filename collision issue discussed for v1.4.1: when running inference on all videos, predictions would overwrite each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)