### PR TITLE
Fix status bar showing stale video info when switching videos

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1311,6 +1311,7 @@ class MainWindow(QMainWindow):
         if message is None:
             message = ""
             if len(self.labels.videos) > 0 and current_video is not None:
+                index = None
                 for i, video in enumerate(self.labels.videos):
                     if video.filename == current_video.filename:
                         same_dataset = (
@@ -1322,9 +1323,10 @@ class MainWindow(QMainWindow):
                         if same_dataset:
                             index = i
                             break
-                message += f"Video {index + 1}/"
-                message += f"{len(self.labels.videos)}"
-                message += spacer
+                if index is not None:
+                    message += f"Video {index + 1}/"
+                    message += f"{len(self.labels.videos)}"
+                    message += spacer
 
             if current_video is not None:
                 message += f"Frame: {frame_idx + 1:,}/{len(current_video):,}"


### PR DESCRIPTION
## Summary
Fixes a bug where the status bar would display information from the previously selected video instead of the currently selected video.

## Problem
When selecting a video from the video list (e.g., selecting video 27), the bottom status bar would sometimes show information from the previously selected video (e.g., video 26).

## Root Cause
In `updateStatusMessage()` at `sleap/gui/app.py:1314-1325`, the `index` variable was never initialized before the loop that searches for the current video. If the video matching logic failed (e.g., when `same_dataset` was False), the `index` variable would:
1. Be undefined (causing a NameError in Python), or
2. Retain its value from a previous call to the function (causing stale info to be displayed)

## Changes
- Initialize `index = None` before the video search loop
- Only display video number information if `index is not None`
- This ensures the status bar always shows correct info for the selected video

## Testing
- Select different videos from the video list
- Verify the status bar shows the correct video number and information
- Test with projects containing multiple videos with similar filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)