### PR TITLE
Fix prediction deletion to prevent removing labeled instances

### DIFF
--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -114,18 +114,16 @@ def remove_frames(labels: Labels, frames: List[LabeledFrame]):
 
 def remove_instance(labels: Labels, instance: Instance, lf: LabeledFrame):
     """Remove an instance from a labeled frame and update all related instances."""
-    import numpy as np
-
     lf_inst_to_remove = labels.find(video=lf.video, frame_idx=lf.frame_idx)[0]
     if lf_inst_to_remove:
         # Iterate backwards to safely remove from list
         for inst_idx in range(len(lf_inst_to_remove.instances) - 1, -1, -1):
             inst = lf_inst_to_remove.instances[inst_idx]
+            if type(inst) != type(instance):
+                continue
 
             # Compare instances using numpy arrays with NaN handling
-            points_match = np.array_equal(
-                inst.numpy(), instance.numpy(), equal_nan=True
-            )
+            points_match = inst.same_pose_as(instance)
 
             if points_match:
                 # Also check track matching


### PR DESCRIPTION
## Summary
Fixes a bug where deleting predicted instances would also remove labeled instances with matching poses.

## Changes
- Added type check in `remove_instance()` to ensure only instances of the same type are compared and removed
- Replaced manual numpy array comparison with `same_pose_as()` method for cleaner code
- Removed unused numpy import

## Bug Details
Previously, when deleting a predicted instance, the code would iterate through all instances in the frame and remove any instance with matching node coordinates, regardless of instance type. This meant that if a user had converted a prediction to a labeled instance (e.g., by double-clicking), deleting predictions would also remove the labeled instance.

## Test Plan
- [ ] Verify that deleting predictions only removes `PredictedInstance` objects
- [ ] Verify that labeled instances created from predictions remain after deleting predictions
- [ ] Verify that the type check prevents accidental deletion of user-created instances