### PR TITLE
Fix RGB/BGR channel flip in training visualization popup

### DIFF
--- a/sleap/gui/widgets/imagedir.py
+++ b/sleap/gui/widgets/imagedir.py
@@ -99,7 +99,7 @@ class QtImageDirectoryWidget(QtVideoPlayer):
             self.files = files
             import sleap_io as sio
 
-            self.video = sio.load_video(files)
+            self.video = sio.load_video(files, plugin="imageio")
             self.load_video(video=self.video)
 
             if was_on_last_image:

--- a/sleap/gui/widgets/video_worker.py
+++ b/sleap/gui/widgets/video_worker.py
@@ -99,6 +99,14 @@ class FrameLoaderThread(QThread):
             frame = video[frame_idx]
 
             if frame is not None:
+                # Handle 4-channel images (RGBA/BGRA)
+                # sleap-io's opencv backend loads 4-channel images as BGRA but
+                # doesn't convert to RGBA. Since we don't need alpha for display,
+                # strip it and convert BGR to RGB if needed.
+                if frame.ndim == 3 and frame.shape[-1] == 4:
+                    # Drop alpha and swap BGR to RGB (opencv loads as BGRA)
+                    frame = frame[..., 2::-1]  # BGRA -> RGB (takes channels 2,1,0)
+
                 # Convert to QImage
                 qimage = ndarray_to_qimage(frame, copy=True)
 


### PR DESCRIPTION
## Summary
- Fixed color channel swap (red/blue flipped) in the training visualization popup window
- Root cause: Matplotlib saves 4-channel RGBA PNGs, but after `deepcopy` in video_worker, opencv loads them as BGRA without conversion
- Added BGRA→RGB conversion in `video_worker.py` for 4-channel images
- Also set explicit `imageio` plugin in `imagedir.py` as a safeguard

## Test plan
- [x] Run training with visualization enabled
- [x] Verify training viz popup displays correct colors (not red/blue swapped)
- [x] Verify main SLEAP GUI video display still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)