### PR TITLE
Update installation docs and fix notebook install commands

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,7 +8,7 @@ SLEAP can be installed as a Python package on Windows, Linux, and Mac OS. The ne
 **Installation methods:**
 
 - **[Installation as a system-wide tool with uv](#installation-with-uv-tool-install)**: Use `uv tool install` to install SLEAP globally as a tool (**strongly recommended**)
-- **[Installation with pip](#installation-with-pip)**: Use `pip` to install from pypi in a conda env.
+- **[Installation with conda/pip](#installation-with-conda/pip)**: Use `pip` to install from pypi in a conda env.
 - **[Installation from source](#installation-from-source)**: Use `uv sync` to install from source. (For developmental purposes)
 
 If you need to import SLEAP as a library in your own scripts, add custom packages for analysis, or share reproducible environments with collaborators, see **[Installation with uv add](installation-uv-add.md)**.
@@ -84,7 +84,7 @@ powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
 !!! tip "About uv tool install"
     This method automatically downloads SLEAP with all dependencies, won't interfere with your existing Python packages, and always uses the latest version from PyPI.
 
-    **Limitation:** Unlike conda or virtual environments, this does not create an activatable environment. You cannot `import sleap` in Python scripts or access dependencies directly—only CLI commands (e.g., `sleap-label`, `sleap-track`) are available. If you need SLEAP as a library, use [uv add](installation-uv-add.md) or [pip](#installation-with-pip) instead.
+    **Limitation:** Unlike conda or virtual environments, this does not create an activatable environment. You cannot `import sleap` in Python scripts or access dependencies directly—only CLI commands (e.g., `sleap-label`, `sleap-track`) are available. If you need SLEAP as a library, use [uv add](installation-uv-add.md) or [conda/pip](#installation-with-conda/pip) instead.
 
 ### Verify Installation
 ```bash
@@ -106,7 +106,10 @@ uv tool upgrade sleap
 
 ---
 
-## Installation with pip
+## Installation with conda/pip
+
+!!! note "No conda package available"
+    Starting with SLEAP 1.5, we only distribute SLEAP via pip (PyPI). There is no `conda install sleap` package. However, we recommend using conda/mamba to manage your Python environment before installing SLEAP with pip.
 
 We recommend creating a dedicated environment with [conda](https://docs.conda.io/en/latest/miniconda.html) or [mamba/miniforge](https://github.com/conda-forge/miniforge) before installing `sleap` with pip. This helps avoid dependency conflicts and keeps your Python setup clean. After installing Miniconda or Miniforge, create and activate an environment, then run the pip install commands below inside the activated environment.
 

--- a/docs/notebooks/Data_structures.ipynb
+++ b/docs/notebooks/Data_structures.ipynb
@@ -63,7 +63,7 @@
         "!pip install -qqq \"sleap-nn[torch-cpu]\" \n",
         "\n",
         "# if you have GPU (in colab, enable GPU runtime)\n",
-        "# !pip install -qqq \"sleap-nn[torch-cuda-128]\"\n"
+        "# !pip install -qqq \"sleap-nn[torch-cuda128]\"\n"
       ]
     },
     {

--- a/docs/notebooks/Interactive_and_resumable_training.ipynb
+++ b/docs/notebooks/Interactive_and_resumable_training.ipynb
@@ -40,7 +40,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -61,7 +61,7 @@
         "!pip install -qqq \"sleap-nn[torch-cpu]\"\n",
         "\n",
         "# if you have GPU (in colab, enable GPU runtime)\n",
-        "# !pip install -qqq \"sleap-nn[torch-cuda-128]\""
+        "# !pip install -qqq \"sleap-nn[torch-cuda128]\""
       ]
     },
     {

--- a/docs/notebooks/Training_and_inference_on_an_example_dataset.ipynb
+++ b/docs/notebooks/Training_and_inference_on_an_example_dataset.ipynb
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -63,7 +63,7 @@
     "!pip install -qqq \"sleap-nn[torch-cpu]\"\n",
     "\n",
     "# if you have GPU (in colab, enable GPU runtime)\n",
-    "# !pip install -qqq \"sleap-nn[torch-cuda-128]\""
+    "# !pip install -qqq \"sleap-nn[torch-cuda128]\""
    ]
   },
   {

--- a/docs/notebooks/Training_and_inference_using_Google_Drive.ipynb
+++ b/docs/notebooks/Training_and_inference_using_Google_Drive.ipynb
@@ -50,7 +50,7 @@
     "!pip install -qqq \"sleap-nn[torch-cpu]\"\n",
     "\n",
     "# if you have GPU (in colab, enable GPU runtime)\n",
-    "# !pip install -qqq \"sleap-nn[torch-cuda-128]\""
+    "# !pip install -qqq \"sleap-nn[torch-cuda128]\""
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Rename "Installation with pip" section to "Installation with conda/pip" for better discoverability by conda users
- Add note clarifying that SLEAP 1.5+ is pip-only (no conda package), while still recommending conda for environment management
- Fix `sleap-nn` install commands in notebooks: `torch-cuda-128` → `torch-cuda128`

## Test plan
- [ ] Verify installation.md renders correctly
- [ ] Verify notebook install commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)