### PR TITLE
Fix skeleton loading returning list instead of single Skeleton

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2301,6 +2301,7 @@ class OpenSkeleton(EditCommand):
                 else skeleton_data
             )
         skel = SkeletonDecoder().decode(data=skeleton_data)
+        skel = skel[0] if isinstance(skel, list) else skel
         return skel
 
     @staticmethod
@@ -2498,12 +2499,7 @@ class OpenSkeleton(EditCommand):
             try_and_skip_if_error(skeleton.add_node, node)
 
         # Add edges
-        # skeleton.clear_edges()
-        if isinstance(skeleton, Skeleton):
-            skeleton.edges = []
-        elif isinstance(skeleton, List[Skeleton]):
-            for skl in skeleton:
-                skl.edges = []
+        skeleton.edges = []
         for src, dest in new_skeleton.edges:
             try_and_skip_if_error(skeleton.add_edge, src.name, dest.name)
 


### PR DESCRIPTION
## Summary
- Handle case where `SkeletonDecoder.decode()` returns a list by extracting the first skeleton
- Remove dead code that would raise `TypeError` on Python 3.9+ (`isinstance` with `List[Skeleton]` is not valid)

Fixes #2432

## Details
When saving a skeleton via the GUI, SLEAP wraps it in a list before calling `sleap_io.save_skeleton()`. When loading that file back, `SkeletonDecoder.decode()` returns a `List[Skeleton]`, but callers of `load_skeleton()` expect a single `Skeleton` object. This caused `AttributeError: 'list' object has no attribute 'nodes'` errors.

Also removed dead code at lines 2503-2507 that checked `isinstance(skeleton, List[Skeleton])` - this would raise a `TypeError` on Python 3.9+ since subscripted generics cannot be used with `isinstance()`.

## Test plan
- [ ] Load a `.json` skeleton file that was saved via the SLEAP GUI
- [ ] Verify no `AttributeError` when loading skeletons
- [ ] Verify skeleton operations (add node, add edge) work after loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)