### PR TITLE
Add OpenSpec framework for spec-driven development

### DIFF
--- a/.claude/commands/openspec/apply.md
+++ b/.claude/commands/openspec/apply.md
@@ -1,0 +1,23 @@
+---
+name: OpenSpec: Apply
+description: Implement an approved OpenSpec change and keep tasks in sync.
+category: OpenSpec
+tags: [openspec, apply]
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+Track these steps as TODOs and complete them one by one.
+1. Read `changes/<id>/proposal.md`, `design.md` (if present), and `tasks.md` to confirm scope and acceptance criteria.
+2. Work through tasks sequentially, keeping edits minimal and focused on the requested change.
+3. Confirm completion before updating statuses—make sure every item in `tasks.md` is finished.
+4. Update the checklist after all work is done so each task is marked `- [x]` and reflects reality.
+5. Reference `openspec list` or `openspec show <item>` when additional context is required.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` if you need additional context from the proposal while implementing.
+<!-- OPENSPEC:END -->

--- a/.claude/commands/openspec/archive.md
+++ b/.claude/commands/openspec/archive.md
@@ -1,0 +1,27 @@
+---
+name: OpenSpec: Archive
+description: Archive a deployed OpenSpec change and update specs.
+category: OpenSpec
+tags: [openspec, archive]
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+
+**Steps**
+1. Determine the change ID to archive:
+   - If this prompt already includes a specific change ID (for example inside a `<ChangeId>` block populated by slash-command arguments), use that value after trimming whitespace.
+   - If the conversation references a change loosely (for example by title or summary), run `openspec list` to surface likely IDs, share the relevant candidates, and confirm which one the user intends.
+   - Otherwise, review the conversation, run `openspec list`, and ask the user which change to archive; wait for a confirmed change ID before proceeding.
+   - If you still cannot identify a single change ID, stop and tell the user you cannot archive anything yet.
+2. Validate the change ID by running `openspec list` (or `openspec show <id>`) and stop if the change is missing, already archived, or otherwise not ready to archive.
+3. Run `openspec archive <id> --yes` so the CLI moves the change and applies spec updates without prompts (use `--skip-specs` only for tooling-only work).
+4. Review the command output to confirm the target specs were updated and the change landed in `changes/archive/`.
+5. Validate with `openspec validate --strict` and inspect with `openspec show <id>` if anything looks off.
+
+**Reference**
+- Use `openspec list` to confirm change IDs before archiving.
+- Inspect refreshed specs with `openspec list --specs` and address any validation issues before handing off.
+<!-- OPENSPEC:END -->

--- a/.claude/commands/openspec/proposal.md
+++ b/.claude/commands/openspec/proposal.md
@@ -1,0 +1,27 @@
+---
+name: OpenSpec: Proposal
+description: Scaffold a new OpenSpec change and validate strictly.
+category: OpenSpec
+tags: [openspec, change]
+---
+<!-- OPENSPEC:START -->
+**Guardrails**
+- Favor straightforward, minimal implementations first and add complexity only when it is requested or clearly required.
+- Keep changes tightly scoped to the requested outcome.
+- Refer to `openspec/AGENTS.md` (located inside the `openspec/` directory—run `ls openspec` or `openspec update` if you don't see it) if you need additional OpenSpec conventions or clarifications.
+- Identify any vague or ambiguous details and ask the necessary follow-up questions before editing files.
+
+**Steps**
+1. Review `openspec/project.md`, run `openspec list` and `openspec list --specs`, and inspect related code or docs (e.g., via `rg`/`ls`) to ground the proposal in current behaviour; note any gaps that require clarification.
+2. Choose a unique verb-led `change-id` and scaffold `proposal.md`, `tasks.md`, and `design.md` (when needed) under `openspec/changes/<id>/`.
+3. Map the change into concrete capabilities or requirements, breaking multi-scope efforts into distinct spec deltas with clear relationships and sequencing.
+4. Capture architectural reasoning in `design.md` when the solution spans multiple systems, introduces new patterns, or demands trade-off discussion before committing to specs.
+5. Draft spec deltas in `changes/<id>/specs/<capability>/spec.md` (one folder per capability) using `## ADDED|MODIFIED|REMOVED Requirements` with at least one `#### Scenario:` per requirement and cross-reference related capabilities when relevant.
+6. Draft `tasks.md` as an ordered list of small, verifiable work items that deliver user-visible progress, include validation (tests, tooling), and highlight dependencies or parallelizable work.
+7. Validate with `openspec validate <id> --strict` and resolve every issue before sharing the proposal.
+
+**Reference**
+- Use `openspec show <id> --json --deltas-only` or `openspec show <spec> --type spec` to inspect details when validation fails.
+- Search existing requirements with `rg -n "Requirement:|Scenario:" openspec/specs` before writing new ones.
+- Explore the codebase with `rg <keyword>`, `ls`, or direct file reads so proposals align with current implementation realities.
+<!-- OPENSPEC:END -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+<!-- OPENSPEC:START -->
+# OpenSpec Instructions
+
+These instructions are for AI assistants working in this project.
+
+Always open `@/openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like proposal, spec, change, plan)
+- Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+Use `@/openspec/AGENTS.md` to learn:
+- How to create and apply change proposals
+- Spec format and conventions
+- Project structure and guidelines
+
+Keep this managed block so 'openspec update' can refresh the instructions.
+
+<!-- OPENSPEC:END -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+<!-- OPENSPEC:START -->
+# OpenSpec Instructions
+
+These instructions are for AI assistants working in this project.
+
+Always open `@/openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like proposal, spec, change, plan)
+- Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+Use `@/openspec/AGENTS.md` to learn:
+- How to create and apply change proposals
+- Spec format and conventions
+- Project structure and guidelines
+
+Keep this managed block so 'openspec update' can refresh the instructions.
+
+<!-- OPENSPEC:END -->

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -1,0 +1,146 @@
+# OpenSpec Instructions
+
+Instructions for AI coding assistants using OpenSpec for spec-driven development.
+
+## When to Use OpenSpec
+
+Always open `@openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like "proposal", "spec", "change", "plan")
+- Introduces new capabilities, breaking changes, architecture shifts, or significant performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+## Three-Stage Workflow
+
+### 1. Create a Change (`/openspec:proposal`)
+
+When you describe a change, OpenSpec generates:
+- A proposal document
+- Broken-down implementation tasks
+- Technical design decisions
+- Spec deltas showing how requirements will change
+
+**Location**: `openspec/changes/<change-name>/`
+
+### 2. Implement (`/openspec:apply`)
+
+After user approval:
+- Work through tasks systematically
+- Update code according to spec deltas
+- Follow TDD: write tests first
+- Mark tasks complete as you go
+
+### 3. Archive (`openspec archive <change>`)
+
+When complete:
+- Merge approved spec deltas back into `openspec/specs/`
+- Archive the change folder
+- Single source of truth updated
+
+## Directory Structure
+
+```
+openspec/
+├── project.md          # Project overview, tech stack, conventions
+├── constitution.md     # Team principles and standards
+├── AGENTS.md          # This file - instructions for AI
+├── specs/             # Current truth - authoritative specifications
+│   └── <feature>/
+│       └── spec.md    # Feature requirements
+└── changes/           # Proposed updates
+    └── <change-name>/
+        ├── proposal.md    # What and why
+        ├── tasks.md       # Implementation checklist
+        └── spec-deltas.md # Requirement changes
+```
+
+## Spec File Format
+
+Each spec in `openspec/specs/<feature>/spec.md`:
+
+```markdown
+# Feature Name
+
+## Purpose
+Clear statement of what this feature does
+
+## Requirements
+
+### Requirement: <name>
+The system SHALL/MUST <behavior>
+
+#### Scenario: <name>
+WHEN <condition>
+THEN <expected behavior>
+```
+
+## Proposal Format
+
+Each proposal in `openspec/changes/<change-name>/proposal.md`:
+
+```markdown
+# Proposal: <Change Name>
+
+## Summary
+Brief description of the change
+
+## Motivation
+Why this change is needed
+
+## Design
+How it will be implemented
+
+## Spec Deltas
+
+### ADDED Requirements
+New capabilities being introduced
+
+### MODIFIED Requirements
+Changed behavior (complete updated text)
+
+### REMOVED Requirements
+Deprecated or eliminated features
+```
+
+## Commands
+
+- `/openspec:proposal` - Create a new change proposal
+- `/openspec:apply` - Implement an approved proposal
+- `openspec list` - Show active changes
+- `openspec show <change>` - Display change details
+- `openspec validate <change>` - Check spec formatting
+- `openspec archive <change>` - Complete and merge changes
+- `openspec update` - Refresh agent instructions
+
+## Best Practices
+
+### For AI Assistants
+1. **Read specs first**: Before coding, check `openspec/specs/` for existing requirements
+2. **Propose before implementing**: Significant changes need user approval
+3. **Update specs with code**: Keep spec deltas accurate as you implement
+4. **Follow TDD**: Write tests that verify scenario acceptance criteria
+5. **One task at a time**: Complete and mark tasks systematically
+
+### For SLEAP Specifically
+- Cross-repo awareness: Consider sleap, sleap-nn, and sleap-io impacts
+- User-first: Our users are scientists, not developers - keep it accessible
+- Test thoroughly: Use pytest fixtures, aim for high coverage
+- Document: Update relevant docs when behavior changes
+- Check labels: Use appropriate GitHub labels (see constitution.md)
+
+## When NOT to Use OpenSpec
+
+Skip OpenSpec for:
+- Trivial fixes (typos, formatting)
+- Documentation-only updates
+- Test-only changes
+- Obvious bugs with clear fixes
+
+For these, just make the change directly.
+
+## Troubleshooting
+
+**"I can't find the spec for X"**: Check `openspec/specs/`, or ask the user if it exists
+
+**"Should I create a proposal?"**: If the change affects behavior, architecture, or multiple files - yes
+
+**"The spec conflicts with the code"**: The spec is the source of truth; propose an update if needed

--- a/openspec/constitution.md
+++ b/openspec/constitution.md
@@ -1,0 +1,58 @@
+# SLEAP Project Constitution
+
+## Mission
+
+SLEAP (Social LEAP Estimates Animal Poses) enables researchers to track animal behavior through deep learning-based pose estimation. We prioritize accessibility for scientists who may not have ML expertise.
+
+## The SLEAP Ecosystem
+
+| Repository | Purpose | Primary Users |
+|------------|---------|---------------|
+| [sleap](https://github.com/talmolab/sleap) | GUI application for labeling, training, and inference | End users, researchers |
+| [sleap-nn](https://github.com/talmolab/sleap-nn) | PyTorch neural network backend | Developers, advanced users |
+| [sleap-io](https://github.com/talmolab/sleap-io) | Lightweight I/O utilities for pose data | Developers, analysts |
+
+## Core Principles
+
+### 1. User-First Design
+- Our users are scientists, not software engineers
+- Error messages should be actionable, not cryptic
+- Documentation is as important as code
+
+### 2. Reproducibility
+- Research must be reproducible
+- Model configs and training parameters should be explicit
+- Data formats should be well-documented and stable
+
+### 3. Accessibility
+- Support multiple platforms (Linux, macOS, Windows)
+- Support multiple hardware configs (GPU, Apple Silicon, CPU-only)
+- Minimize dependencies where possible (see: sleap-io's design)
+
+### 4. Community Support
+- Respond to issues and discussions promptly
+- Distinguish between bugs, feature requests, and support questions
+- Point users to existing documentation before writing custom responses
+
+## Code Standards
+
+### Python
+- Type hints for public APIs
+- Google-style docstrings
+- TDD: write tests first, then implementation
+- Format with `black` and lint with `ruff`
+
+### Package Management
+- Use `uv` for dependency management
+- Follow uv best practices for lockfiles and environments
+
+### Git
+- Conventional commit messages preferred
+- PRs should reference issues when applicable
+- Keep PRs focused; split large changes
+
+## Support Philosophy
+
+- Many "bugs" are actually usage questions - redirect kindly to docs
+- Installation issues are the most common - we have guides for this
+- Cross-repo issues (sleap + sleap-nn) require careful triage

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -1,0 +1,204 @@
+# SLEAP Project
+
+## Overview
+
+SLEAP (Social LEAP Estimates Animal Poses) is a deep learning framework for multi-animal pose tracking. This repository is the main GUI application and CLI toolset that integrates with the sleap-nn neural network backend and sleap-io data utilities.
+
+SLEAP is a multi-animal pose tracking system consisting of three repositories that work together.
+
+### Repositories
+
+#### sleap (this repo)
+- **URL**: https://github.com/talmolab/sleap
+- **Purpose**: Main GUI application for labeling, training, and running inference
+- **Key components**:
+  - Qt-based GUI (`sleap/gui/`)
+  - CLI tools (`sleap-label`, `sleap-train`, `sleap-track`, etc.)
+  - Data structures for labels, skeletons, videos
+- **Docs**: https://sleap.ai
+
+#### sleap-nn
+- **URL**: https://github.com/talmolab/sleap-nn
+- **Purpose**: PyTorch neural network backend for training and inference
+- **Key components**:
+  - Model architectures (Single Instance, Top-Down, Bottom-Up, Multi-Class)
+  - Training pipelines
+  - Inference engines
+- **Docs**: https://nn.sleap.ai
+- **Python**: 3.11, 3.12, 3.13
+
+#### sleap-io
+- **URL**: https://github.com/talmolab/sleap-io
+- **Purpose**: Lightweight I/O utilities with minimal dependencies
+- **Key components**:
+  - File format readers/writers (SLEAP, NWB, DeepLabCut, etc.)
+  - Video backends (OpenCV, FFMPEG, PyAV)
+  - Data conversion utilities
+- **Docs**: https://io.sleap.ai
+- **Design philosophy**: Minimal dependencies, focused scope
+
+### Repository Interactions
+
+```
+┌─────────────────────────────────────────────────────┐
+│                      sleap                          │
+│                   (GUI + CLI)                       │
+│                                                     │
+│    Uses sleap-nn for training/inference             │
+│    Uses sleap-io for data loading/saving            │
+└──────────────┬─────────────────────┬────────────────┘
+               │                     │
+               ▼                     ▼
+┌──────────────────────┐   ┌──────────────────────────┐
+│      sleap-nn        │   │       sleap-io           │
+│  (neural networks)   │◄──│   (data I/O utilities)   │
+│                      │   │                          │
+│  Uses sleap-io for   │   │                          │
+│  data loading        │   │                          │
+└──────────────────────┘   └──────────────────────────┘
+```
+
+- **sleap** depends on both sleap-nn and sleap-io
+- **sleap-nn** depends on sleap-io for data loading
+- **sleap-io** is the foundational layer with minimal dependencies
+
+## Technology Stack
+
+- **Language**: Python 3.11, 3.12, 3.13
+- **Package Manager**: uv (with PyTorch index configurations)
+- **GUI**: PySide6 / QtPy
+- **Deep Learning**: sleap-nn (PyTorch backend)
+- **I/O**: sleap-io (minimal dependency I/O utilities)
+- **Data Processing**: NumPy, pandas, scipy, scikit-image, scikit-learn
+- **Visualization**: matplotlib, seaborn, opencv-python
+- **Video**: imageio, imageio-ffmpeg
+- **Configuration**: OmegaConf, PyYAML, attrs
+- **Testing**: pytest, pytest-cov, pytest-qt, pytest-xvfb
+- **Linting**: ruff (with black-compatible line length 88)
+- **Documentation**: mkdocs with mkdocs-material theme
+
+## Project Structure
+
+```
+sleap/
+├── sleap/
+│   ├── gui/                # PySide6-based GUI application
+│   ├── io/                 # Data I/O and conversion utilities
+│   ├── cli/                # Command-line interface implementations
+│   ├── nn/                 # Neural network training/inference interfaces
+│   ├── info/               # Inspection and diagnostic tools
+│   └── legacy_cli_adaptors # Backward compatibility layer
+├── tests/                  # Test suite with fixtures and data
+├── docs/                   # MkDocs documentation source
+├── openspec/               # OpenSpec specifications
+└── .claude/                # Claude Code configuration
+```
+
+## Conventions
+
+### Code Style
+- **Formatting**: Black-compatible (88 char line length), enforced via ruff
+- **Linting**: ruff with PEP8 compliance (select E, F, W rules)
+- **Type hints**: Encouraged for public APIs
+- **Docstrings**: Google-style format
+
+### Development Practices
+- **TDD**: Write tests first, then implementation
+- **Test location**: Tests mirror source structure in `tests/` directory
+- **Code coverage**: Aim for high coverage, tracked via codecov
+- **Dependencies**: Minimal where possible (follow sleap-io's philosophy)
+
+### Git Workflow
+- **Base branch**: `develop` (features merge here)
+- **Release branch**: `main` (stable releases)
+- **Feature branches**: Use format `name/descriptive-keyword` (e.g., `elizabeth/openspec-support-agent`)
+- **Commits**: Conventional commit messages preferred
+- **PRs**: Draft → Ready for review when tests pass and coverage is good
+- **Merge strategy**: Squash + merge into `develop`
+
+## CLI Commands
+
+SLEAP provides several command-line tools:
+
+| Command | Purpose |
+|---------|---------|
+| `sleap-label` | Launch GUI application |
+| `sleap-train` | Legacy training interface |
+| `sleap-track` | Legacy tracking interface |
+| `sleap-nn-train` | Training via sleap-nn backend |
+| `sleap-nn-track` | Tracking via sleap-nn backend |
+| `sleap-convert` | Convert between data formats |
+| `sleap-render` | Visualization and rendering |
+| `sleap-inspect` | Label file inspection |
+| `sleap-diagnostic` | System diagnostics |
+
+## Testing Strategy
+
+- **Framework**: pytest with extensions (pytest-cov, pytest-qt, pytest-xvfb)
+- **Test data**: Fixtures in `tests/data/` with various formats (HDF5, JSON, video)
+- **Coverage**: Tracked via codecov, aim to cover edge cases
+- **GUI testing**: Uses pytest-qt for Qt widget testing
+- **Headless testing**: pytest-xvfb for running GUI tests without display
+
+## Package Management with uv
+
+SLEAP uses uv with custom index configurations for PyTorch variants:
+
+- **CPU-only**: `extra = "nn-cpu"` → PyTorch CPU builds
+- **CUDA 11.8**: `extra = "nn-cuda118"` → PyTorch CUDA 11.8
+- **CUDA 12.8**: `extra = "nn-cuda128"` → PyTorch CUDA 12.8 (default)
+
+These extras are mutually exclusive (enforced via `tool.uv.conflicts`).
+
+## Error Handling
+
+- Actionable error messages for non-technical users
+- Validation at system boundaries (user input, file I/O)
+- Propagate errors to appropriate handling layer (GUI vs CLI)
+
+## Logging
+
+- Use of `rich` library for terminal output
+- GUI logging through Qt mechanisms
+- Diagnostic output via `sleap-diagnostic` command
+
+## Documentation
+
+- **Primary site**: https://sleap.ai
+- **Build system**: MkDocs with Material theme
+- **Jupyter integration**: mkdocs-jupyter for notebook embedding
+- **Versioning**: mike for multi-version docs
+- **API docs**: mkdocstrings for Python API reference
+
+## Related Repositories
+
+- **sleap-nn**: https://github.com/talmolab/sleap-nn (PyTorch backend)
+- **sleap-io**: https://github.com/talmolab/sleap-io (I/O utilities)
+
+## Common Support Issues
+
+### Installation
+- GPU/CUDA setup issues
+- Platform-specific problems (especially Windows)
+- Conda vs pip vs uv confusion
+
+### Training
+- Model config questions
+- GPU memory issues
+- Training not converging
+
+### Inference
+- Video format compatibility
+- Tracking quality issues
+- Export format questions
+
+### Cross-Repo Issues
+- sleap GUI + sleap-nn backend integration
+- sleap-io format compatibility with sleap and sleap-nn
+- Data pipeline issues spanning multiple repos
+
+## Community
+
+- **Issues**: GitHub Issues for bugs and feature requests
+- **Discussions**: GitHub Discussions (Help, Ideas, General)
+- **Code of Conduct**: See [code-of-conduct.md](../docs/code-of-conduct.md)


### PR DESCRIPTION
## Summary

Sets up OpenSpec infrastructure to enable spec-driven development workflow for the SLEAP project, starting with planning for a support agent system.

## What's Included

- **openspec/project.md**: Complete project overview covering:
  - SLEAP ecosystem (sleap, sleap-nn, sleap-io) and repository interactions
  - Technology stack (Python 3.11-3.13, uv, PySide6, pytest, ruff)
  - Development conventions (TDD, Google-style docstrings, git workflow)
  - Common support issues categorized by type
  
- **openspec/constitution.md**: Team principles including:
  - User-first design philosophy
  - Reproducibility and accessibility standards
  - Code standards and support philosophy
  
- **openspec/AGENTS.md**: Instructions for AI assistants on:
  - When to use OpenSpec (proposals, architecture changes, etc.)
  - Three-stage workflow (create → implement → archive)
  - Spec and proposal formatting
  - SLEAP-specific best practices

## Next Steps

This framework will enable us to:
1. Create proposals for the support agent system
2. Review and approve specifications before implementation
3. Follow TDD with clear acceptance criteria
4. Maintain authoritative specs that evolve with the codebase

## Test Plan

- [x] OpenSpec CLI installed and verified (`openspec --version`)
- [x] Directory structure follows OpenSpec conventions
- [x] AGENTS.md provides clear AI assistant instructions
- [x] project.md contains accurate SLEAP ecosystem information

🤖 Generated with [Claude Code](https://claude.com/claude-code)