### PR TITLE
Add Claude Code skills for investigation and Qt testing

### DIFF
--- a/.claude/skills/investigation/SKILL.md
+++ b/.claude/skills/investigation/SKILL.md
@@ -1,33 +1,67 @@
 ---
 name: investigation
-description: Scaffolds a template for a small investigation for empirical experimentation. Use when the user asks for an investigation, experiment or research to support making design decisions, assess performance or try out a new idea that requires data or an MVP.
+description: >
+  Scaffolds a structured investigation in scratch/ for empirical research and documentation.
+  Use when the user says "start an investigation" or wants to: trace code paths or data flow
+  ("trace from X to Y", "what touches X", "follow the wiring"), document system architecture
+  comprehensively ("document how the system works", "archeology"), investigate bugs
+  ("figure out why X happens"), explore technical feasibility ("can we do X?"), or explore
+  design options ("explore the API", "gather context", "design alternatives").
+  Creates dated folder with README. NOT for simple code questions or single-file searches.
 ---
 
 # Set up an investigation
 
 ## Instructions
 
-1. Create a folder in `{REPO_ROOT}/scratch/` with the format `{YYYY-MM-DD}-{descriptive-name}`. You will mainly work inside this folder.
-2. Create a `README.md` in this folder where you will:
-   1. Describe the task.
-   2. Take background notes for context.
-   3. Create a task list for progress tracking.
-   4. Summarize results and outcomes.
-3. Create scripts and testing data files in this folder to conduct an empirical investigation.
-4. For multi-step investigations with sub-experiments, consider generating individual markdown files to take interediate notes.
-5. The `README.md` should contain actionable findings to support a subsequent implementation or design decision.
+1. Create a folder in `{REPO_ROOT}/scratch/` with the format `{YYYY-MM-DD}-{descriptive-name}`.
+2. Create a `README.md` in this folder with: task description, background context, task checklist. Update with findings as you progress.
+3. Create scripts and data files as needed for empirical work.
+4. For complex investigations, split into sub-documents as patterns emerge.
 
-## Best practices
-- Both for this library and other ones, it's worth writing a simple script or calling the library interactively to list its members or try out different constructions to explore the API and document it in a markdown file called `API.md`.
-- Generate figures when applicable (e.g., plots, data visualizations) and reference them inline in the markdown files.
-- Always use `uv` with self-contained dependencies when using Python.
-- When you need a local web server, use `npx serve -p 8080 --cors --no-clipboard &` (run in background to avoid blocking).
-- Prefer self-contained HTML+JS pages (without React if possible) and use Playwright MCP for rendering screenshots.
-- Use subagents whenever possible to save context and delegate tasks in parallel.
+## Investigation Patterns
 
-## Important: Scratch work is gitignored
-The `scratch/` directory is in `.gitignore` and will NOT be committed. When distilling findings into PRs:
-- Do NOT assume local scratch notes will be checked in
-- Include all relevant information inline in PR descriptions or code comments
-- Copy key findings, code snippets, benchmark results, or data directly into the PR
-- The PR should be self-contained and not rely on scratch files for context
+These are common patterns, not rigid categories. Most investigations blend multiple patterns.
+
+**Tracing** - "trace from X to Y", "what touches X", "follow the wiring"
+- Follow call stack or data flow from a focal component to its connections
+- Can trace forward (X → where does it go?) or backward (what leads to X?)
+- Useful for: assessing impact of changes, understanding coupling
+
+**System Architecture Archeology** - "document how the system works", "archeology"
+- Comprehensive documentation of an entire system or flow for reusable reference
+- Start from entry points, trace through all layers, document relationships exhaustively
+- For complex systems, consider numbered sub-documents (01-cli.md, 02-data.md, etc.)
+
+**Bug Investigation** - "figure out why X happens", "this is broken"
+- Reproduce → trace root cause → propose fix
+- For cross-repo bugs, consider per-repo task breakdowns
+
+**Technical Exploration** - "can we do X?", "is this possible?", "figure out how to"
+- Feasibility testing with proof-of-concept scripts
+- Document what works AND what doesn't
+
+**Design Research** - "explore the API", "gather context", "design alternatives"
+- Understand systems and constraints before building
+- Compare alternatives, document trade-offs
+- Include visual artifacts (mockups, screenshots) when relevant
+- For iterative decisions, use numbered "Design Questions" (DQ1, DQ2...) to structure review
+
+## Best Practices
+
+- Use `uv` with inline dependencies for standalone scripts; for scripts importing local project code, use `python` directly (or `uv run python` if env not activated)
+- Use subagents for parallel exploration to save context
+- Write small scripts to explore APIs interactively
+- Generate figures/diagrams and reference inline in markdown
+- For web servers: `npx serve -p 8080 --cors --no-clipboard &`
+- For screenshots: use Playwright MCP for web, Qt's grab() for GUI
+- For external package API review: clone to `scratch/repos/` for direct source access
+
+## Important: Scratch is Gitignored
+
+The `scratch/` directory is in `.gitignore` and will NOT be committed.
+
+- NEVER delete anything from scratch - it doesn't need cleanup
+- When distilling findings into PRs, include all relevant info inline
+- Copy key findings, code, and data directly into PR descriptions
+- PRs must be self-contained; don't reference scratch files

--- a/.claude/skills/investigation/SKILL.md
+++ b/.claude/skills/investigation/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: investigation
+description: Scaffolds a template for a small investigation for empirical experimentation. Use when the user asks for an investigation, experiment or research to support making design decisions, assess performance or try out a new idea that requires data or an MVP.
+---
+
+# Set up an investigation
+
+## Instructions
+
+1. Create a folder in `{REPO_ROOT}/scratch/` with the format `{YYYY-MM-DD}-{descriptive-name}`. You will mainly work inside this folder.
+2. Create a `README.md` in this folder where you will:
+   1. Describe the task.
+   2. Take background notes for context.
+   3. Create a task list for progress tracking.
+   4. Summarize results and outcomes.
+3. Create scripts and testing data files in this folder to conduct an empirical investigation.
+4. For multi-step investigations with sub-experiments, consider generating individual markdown files to take interediate notes.
+5. The `README.md` should contain actionable findings to support a subsequent implementation or design decision.
+
+## Best practices
+- Both for this library and other ones, it's worth writing a simple script or calling the library interactively to list its members or try out different constructions to explore the API and document it in a markdown file called `API.md`.
+- Generate figures when applicable (e.g., plots, data visualizations) and reference them inline in the markdown files.
+- Always use `uv` with self-contained dependencies when using Python.
+- When you need a local web server, use `npx serve -p 8080 --cors --no-clipboard &` (run in background to avoid blocking).
+- Prefer self-contained HTML+JS pages (without React if possible) and use Playwright MCP for rendering screenshots.
+- Use subagents whenever possible to save context and delegate tasks in parallel.
+
+## Important: Scratch work is gitignored
+The `scratch/` directory is in `.gitignore` and will NOT be committed. When distilling findings into PRs:
+- Do NOT assume local scratch notes will be checked in
+- Include all relevant information inline in PR descriptions or code comments
+- Copy key findings, code snippets, benchmark results, or data directly into the PR
+- The PR should be self-contained and not rely on scratch files for context

--- a/.claude/skills/qt-testing/SKILL.md
+++ b/.claude/skills/qt-testing/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: qt-testing
+description: Capture and visually inspect Qt GUI widgets using screenshots. Use when asked to verify GUI rendering, test widget appearance, check layouts, or visually inspect any PySide6/Qt component. Enables Claude to "see" Qt interfaces by capturing offscreen screenshots and analyzing them with vision.
+---
+
+# Qt GUI Testing
+
+Capture screenshots of Qt widgets for visual inspection without displaying windows on screen.
+
+## Quick Start
+
+```python
+# Capture any widget
+from scripts.qt_capture import capture_widget
+path = capture_widget(my_widget, "description_here")
+# Then read the screenshot with the Read tool
+```
+
+## Core Script
+
+Run `scripts/qt_capture.py` or import `capture_widget` from it:
+
+```bash
+# Standalone test
+uv run --with PySide6 python .claude/skills/qt-testing/scripts/qt_capture.py
+```
+
+## Output Location
+
+All screenshots save to: `scratch/.qt-screenshots/`
+
+Naming: `{YYYY-MM-DD.HH-MM-SS}_{description}.png`
+
+## Workflow
+
+1. Create/obtain the widget to test
+2. Call `capture_widget(widget, "description")`
+3. Read the saved screenshot with the Read tool
+4. Analyze with vision to verify correctness
+
+## Interaction Pattern
+
+To interact with widgets (click buttons, etc.):
+
+```python
+# Find widget at coordinates (from vision analysis)
+target = widget.childAt(x, y)
+
+# Trigger it directly (not mouse events)
+if hasattr(target, 'click'):
+    target.click()
+    QApplication.processEvents()
+
+# Capture result
+capture_widget(widget, "after_click")
+```
+
+## Example: Test a Dialog
+
+```python
+import sys
+from PySide6.QtWidgets import QApplication
+from sleap.gui.learning.dialog import TrainingEditorDialog
+
+# Add skill scripts to path
+sys.path.insert(0, ".claude/skills/qt-testing")
+from scripts.qt_capture import capture_widget, init_qt
+
+app = init_qt()
+dialog = TrainingEditorDialog()
+path = capture_widget(dialog, "training_dialog")
+dialog.close()
+print(f"Inspect: {path}")
+```
+
+## Key Points
+
+- Uses `Qt.WA_DontShowOnScreen` - no window popup
+- Renders identically to on-screen display (verified)
+- Call `processEvents()` after interactions before capture
+- Use `childAt(x, y)` to map vision coordinates to widgets
+- Direct method calls (`.click()`) work; simulated mouse events don't

--- a/.claude/skills/qt-testing/scripts/qt_capture.py
+++ b/.claude/skills/qt-testing/scripts/qt_capture.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+"""Qt widget screenshot capture utility.
+
+Captures screenshots of Qt widgets without displaying them on screen.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+from PySide6.QtWidgets import QApplication, QWidget
+from PySide6.QtCore import Qt
+
+# Output directory
+OUTPUT_DIR = Path("scratch/.qt-screenshots")
+
+
+def init_qt() -> QApplication:
+    """Initialize Qt application (required once per process)."""
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication(sys.argv)
+    return app
+
+
+def timestamp() -> str:
+    """Generate timestamp for filename."""
+    return datetime.now().strftime("%Y-%m-%d.%H-%M-%S")
+
+
+def capture_widget(
+    widget: QWidget,
+    description: str,
+    output_dir: Optional[Path] = None,
+) -> Path:
+    """
+    Capture a screenshot of a widget without displaying it on screen.
+
+    Args:
+        widget: The QWidget to capture
+        description: Short description for filename (use underscores, no spaces)
+        output_dir: Override output directory (default: scratch/.qt-screenshots)
+
+    Returns:
+        Path to saved screenshot
+    """
+    out = output_dir or OUTPUT_DIR
+    out.mkdir(parents=True, exist_ok=True)
+
+    # Configure for invisible rendering
+    widget.setAttribute(Qt.WA_DontShowOnScreen, True)
+    widget.show()
+    QApplication.processEvents()
+
+    # Capture
+    pixmap = widget.grab()
+    if pixmap.isNull():
+        raise RuntimeError("Failed to capture widget - pixmap is null")
+
+    # Save with timestamp
+    desc_clean = description.replace(" ", "_").replace("/", "-")
+    filename = f"{timestamp()}_{desc_clean}.png"
+    filepath = out / filename
+
+    if not pixmap.save(str(filepath)):
+        raise RuntimeError(f"Failed to save screenshot to {filepath}")
+
+    # Don't close - caller may want to interact further
+    widget.hide()
+
+    return filepath
+
+
+def capture_and_click(
+    widget: QWidget,
+    x: int,
+    y: int,
+    description: str,
+) -> tuple[Path, Optional[QWidget]]:
+    """
+    Click at coordinates and capture the result.
+
+    Args:
+        widget: Parent widget
+        x, y: Coordinates to click (in widget coordinate space)
+        description: Description for filename
+
+    Returns:
+        Tuple of (screenshot path, clicked widget or None)
+    """
+    widget.setAttribute(Qt.WA_DontShowOnScreen, True)
+    widget.show()
+    QApplication.processEvents()
+
+    # Find and click widget at coordinates
+    target = widget.childAt(x, y)
+    if target is not None:
+        if hasattr(target, "click"):
+            target.click()
+        elif hasattr(target, "toggle"):
+            target.toggle()
+        QApplication.processEvents()
+
+    # Capture result
+    path = capture_widget(widget, description)
+    return path, target
+
+
+# Self-test when run directly
+if __name__ == "__main__":
+    from PySide6.QtWidgets import QPushButton, QVBoxLayout, QLabel
+
+    app = init_qt()
+
+    # Create test widget
+    widget = QWidget()
+    widget.setWindowTitle("Qt Capture Test")
+    widget.setFixedSize(300, 150)
+
+    layout = QVBoxLayout(widget)
+    layout.addWidget(QLabel("Qt Capture Test Widget"))
+    btn = QPushButton("Test Button")
+    layout.addWidget(btn)
+
+    # Capture it
+    path = capture_widget(widget, "self_test")
+    print(f"Captured: {path}")
+
+    widget.close()
+    print("Self-test complete!")


### PR DESCRIPTION
## Summary

Adds two Claude Code skills for development workflow:

- **Investigation skill**: Scaffolds empirical investigations in `scratch/` directory for design decisions, performance assessments, and prototyping
- **Qt testing skill**: Enables Claude to capture and visually inspect Qt GUI widgets using offscreen screenshots

## Changes

- `.claude/skills/investigation/SKILL.md` - Investigation skill with trigger phrases and patterns
- `.claude/skills/qt-testing/SKILL.md` - Qt testing skill definition
- `.claude/skills/qt-testing/scripts/qt_capture.py` - Screenshot capture utilities

## Test Plan

- [x] Investigation skill triggers on "start an investigation"
- [x] Qt testing skill captures widgets correctly with `WA_DontShowOnScreen`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)