### PR TITLE
Fix delete unused tracks crash with untracked instances

### DIFF
--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -156,7 +156,8 @@ def remove_unused_tracks(labels: Labels):
     used_tracks = set()
     for lf in labels:
         for inst in lf.instances:
-            used_tracks.add(inst.track.name)
+            if inst.track is not None:
+                used_tracks.add(inst.track.name)
 
     # Remove set difference from tracks in Labels
     tracks_to_remove = all_tracks - used_tracks


### PR DESCRIPTION
## Summary

Fixes crash when using Tracks → Delete Multiple Tracks → Unused with instances that have no track assigned.

## Problem

`remove_unused_tracks()` in `lf_labels_utils.py` assumed every instance has a track, but instances can be untracked (`inst.track = None`), causing `AttributeError: 'NoneType' object has no attribute 'name'`.

## Fix

Added None check before accessing `inst.track.name`:

```python
for inst in lf.instances:
    if inst.track is not None:
        used_tracks.add(inst.track.name)
```

## Test Plan

- [x] Tracks → Delete Multiple Tracks → Unused no longer crashes with untracked instances

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)