### PR TITLE
Pass tracking_target_instance_count when post_connect_single_breaks enabled

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -327,6 +327,14 @@ class InferenceTask:
 
             if self.inference_params["tracking.post_connect_single_breaks"] == 1:
                 cli_args.extend(["--post_connect_single_breaks"])
+                # post_connect_single_breaks requires tracking_target_instance_count
+                if self.inference_params["tracking.max_tracks"] is not None:
+                    cli_args.extend(
+                        [
+                            "--tracking_target_instance_count",
+                            str(self.inference_params["tracking.max_tracks"]),
+                        ]
+                    )
 
             if self.inference_params["tracking.robust"] != 1.0:
                 cli_args.extend(["--scoring_reduction", "robust_quantile"])


### PR DESCRIPTION
## Summary

Fixes tracking post-processing by passing `--tracking_target_instance_count` when "Connect Single Track Breaks" is enabled.

## Problem

When calling `sleap-nn-track` with `--post_connect_single_breaks`, the `--tracking_target_instance_count` parameter must be explicitly set for the post-processing to work correctly. The SLEAP GUI was passing `--max_tracks N` but not `--tracking_target_instance_count N`.

These are distinct parameters in sleap-nn:
- `--max_tracks`: Limits track ID creation in the `local_queues` candidate method
- `--tracking_target_instance_count`: Target instance count for post-processing

## Fix

When `post_connect_single_breaks=True` AND `max_tracks` is set, also pass `--tracking_target_instance_count` with the same value.

## Test Plan

- [x] Tracking with "Connect Single Track Breaks" + "Max number of tracks" → CLI includes both flags
- [x] Tracking without max tracks set → does NOT pass `--tracking_target_instance_count`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)