### PR TITLE
Add Delete Predictions on User-Labeled Frames feature

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -826,6 +826,12 @@ class MainWindow(QMainWindow):
             "Delete Predictions beyond Frame Limit...",
             self.commands.deleteFrameLimitPredictions,
         )
+        add_menu_item(
+            labelMenu,
+            "delete user frame predictions",
+            "Delete Predictions on User-Labeled Frames...",
+            self.commands.deleteUserFramePredictions,
+        )
 
         ### Tracks Menu ###
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -97,6 +97,7 @@ from sleap.sleap_io_adaptors.lf_labels_utils import (
     load_labels_video_search,
     clear_suggestion,
     get_instances_to_show,
+    get_predictions_on_user_frames,
 )
 from sleap.sleap_io_adaptors.video_utils import get_last_frame_idx
 
@@ -543,6 +544,10 @@ class CommandContext:
     def deleteFrameLimitPredictions(self):
         """Gui for deleting instances beyond some frame number."""
         self.execute(DeleteFrameLimitPredictions)
+
+    def deleteUserFramePredictions(self):
+        """Gui for deleting predictions on frames with user instances."""
+        self.execute(DeleteUserFramePredictions)
 
     def completeInstanceNodes(self, instance: Instance):
         """Adds missing nodes to given instance."""
@@ -2885,6 +2890,56 @@ class DeleteFrameLimitPredictions(InstanceDeleteCommand):
             params["min_frame_idx"] = results["min_frame_idx"]
             params["max_frame_idx"] = results["max_frame_idx"]
             return super().ask(context, params)
+
+
+class DeleteUserFramePredictions(InstanceDeleteCommand):
+    """Delete predictions on frames that have user instances.
+
+    This command cleans up predictions that were merged into frames that already
+    have user labels, which causes both to be displayed in the GUI (confusing UX).
+
+    Two modes are supported:
+    - Unlinked only (default): Delete predictions not linked via any user instance's
+      `from_predicted` attribute. These are the "orphan" predictions causing duplicates.
+    - All predictions: Delete all predictions on user-labeled frames.
+    """
+
+    @staticmethod
+    def get_frame_instance_list(context: CommandContext, params: dict):
+        video = (
+            context.state["video"] if params.get("current_video_only", True) else None
+        )
+        unlinked_only = params.get("unlinked_only", True)
+
+        return get_predictions_on_user_frames(
+            labels=context.labels,
+            video=video,
+            unlinked_only=unlinked_only,
+        )
+
+    @classmethod
+    def ask(cls, context: CommandContext, params: dict) -> bool:
+        from sleap.gui.dialogs.delete import DeleteUserFramePredictionsDialog
+
+        dialog = DeleteUserFramePredictionsDialog(context)
+        if not dialog.exec_():
+            return False
+
+        params["current_video_only"] = dialog.current_video_only
+        params["unlinked_only"] = dialog.unlinked_only
+
+        lf_inst_list = cls.get_frame_instance_list(context, params)
+        params["lf_instance_list"] = lf_inst_list
+
+        if len(lf_inst_list) == 0:
+            QtWidgets.QMessageBox.information(
+                context.app,
+                "No predictions to delete",
+                "No predictions found on user-labeled frames matching the criteria.",
+            )
+            return False
+
+        return cls._confirm_deletion(context, lf_inst_list)
 
 
 class TransposeInstances(EditCommand):

--- a/sleap/gui/dialogs/delete.py
+++ b/sleap/gui/dialogs/delete.py
@@ -225,6 +225,93 @@ class DeleteDialog(QtWidgets.QDialog):
         self.context.changestack_push("delete instances")
 
 
+class DeleteUserFramePredictionsDialog(QtWidgets.QDialog):
+    """Dialog for deleting predictions on frames with user instances.
+
+    This dialog allows users to clean up predictions that were merged into
+    frames that already have user labels, which causes both to be displayed.
+
+    Args:
+        context: The `CommandContext` from which this dialog is being shown.
+    """
+
+    def __init__(self, context: "CommandContext", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.context = context
+        self.setWindowTitle("Delete Predictions on User-Labeled Frames")
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        # Description
+        desc_label = QtWidgets.QLabel(
+            "Delete predictions on frames that already have user-labeled instances.\n"
+            "This cleans up duplicate instances that appear when predictions are\n"
+            "merged into frames with existing user labels."
+        )
+        desc_label.setWordWrap(True)
+        layout.addWidget(desc_label)
+
+        layout.addSpacing(10)
+
+        # Scope group
+        scope_group = QtWidgets.QGroupBox("Scope")
+        scope_layout = QtWidgets.QVBoxLayout(scope_group)
+        self.current_video_radio = QtWidgets.QRadioButton("Current video only")
+        self.all_videos_radio = QtWidgets.QRadioButton("All videos")
+        self.current_video_radio.setChecked(True)
+        scope_layout.addWidget(self.current_video_radio)
+        scope_layout.addWidget(self.all_videos_radio)
+        layout.addWidget(scope_group)
+
+        # Mode group
+        mode_group = QtWidgets.QGroupBox("What to delete")
+        mode_layout = QtWidgets.QVBoxLayout(mode_group)
+
+        self.unlinked_radio = QtWidgets.QRadioButton(
+            "Unlinked predictions only (visible duplicates)"
+        )
+        self.unlinked_radio.setToolTip(
+            "Delete predictions that are NOT linked to any user instance via\n"
+            "'from_predicted'. These are the predictions that appear as duplicates\n"
+            "in the GUI alongside user instances."
+        )
+
+        self.all_radio = QtWidgets.QRadioButton(
+            "All predictions on user-labeled frames"
+        )
+        self.all_radio.setToolTip(
+            "Delete ALL predictions on frames with user instances, including\n"
+            "those that are linked to user instances (hidden from display)."
+        )
+
+        self.unlinked_radio.setChecked(True)
+        mode_layout.addWidget(self.unlinked_radio)
+        mode_layout.addWidget(self.all_radio)
+        layout.addWidget(mode_group)
+
+        layout.addSpacing(10)
+
+        # Buttons
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Cancel | QtWidgets.QDialogButtonBox.Ok
+        )
+        buttons.button(QtWidgets.QDialogButtonBox.Ok).setText("Delete")
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    @property
+    def current_video_only(self) -> bool:
+        """Whether to limit deletion to current video only."""
+        return self.current_video_radio.isChecked()
+
+    @property
+    def unlinked_only(self) -> bool:
+        """Whether to only delete unlinked (orphan) predictions."""
+        return self.unlinked_radio.isChecked()
+
+
 if __name__ == "__main__":
     app = QtWidgets.QApplication([])
 

--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -1503,3 +1503,69 @@ def labels_add_instance(labels: Labels, frame: LabeledFrame, instance):
     else:
         # Fallback if instances is not a list
         frame.instances = list(frame.instances) + [instance]
+
+
+def get_predictions_on_user_frames(
+    labels: Labels,
+    video: Optional[Video] = None,
+    unlinked_only: bool = True,
+) -> List[tuple]:
+    """Find predictions on frames that have user instances.
+
+    This is useful for cleaning up predictions that were merged into frames
+    that already have user labels, which causes both to be displayed in the GUI.
+
+    Args:
+        labels: The Labels object to search.
+        video: Optional video to limit search. If None, searches all videos.
+        unlinked_only: If True (default), only return predictions not linked
+            via any user instance's `from_predicted` attribute. These are the
+            "orphan" predictions that cause duplicate display in the GUI.
+            If False, return all predictions on user-labeled frames.
+
+    Returns:
+        List of (LabeledFrame, PredictedInstance) tuples for predictions
+        that match the criteria.
+    """
+    result = []
+
+    for lf in labels:
+        # Skip if filtering by video and this isn't the target video
+        if video is not None and lf.video != video:
+            continue
+
+        # Skip frames without user instances
+        if not hasattr(lf, "has_user_instances") or not lf.has_user_instances:
+            continue
+
+        # Separate user instances and predictions
+        user_instances = []
+        predictions = []
+        for inst in lf.instances:
+            if isinstance(inst, PredictedInstance):
+                predictions.append(inst)
+            else:
+                user_instances.append(inst)
+
+        # Skip if no predictions on this frame
+        if not predictions:
+            continue
+
+        if unlinked_only:
+            # Find predictions that are linked (referenced by from_predicted)
+            linked_predictions = {
+                inst.from_predicted
+                for inst in user_instances
+                if getattr(inst, "from_predicted", None) is not None
+            }
+
+            # Only include unlinked predictions
+            for pred in predictions:
+                if pred not in linked_predictions:
+                    result.append((lf, pred))
+        else:
+            # Include all predictions on user-labeled frames
+            for pred in predictions:
+                result.append((lf, pred))
+
+    return result


### PR DESCRIPTION
## Summary

Adds a new Labels menu option to delete predictions on frames that already have user-labeled instances. This cleans up duplicate instances that appear when predictions are merged into frames with existing user labels.

## Problem

When predictions are merged into frames that already have user labels (via ad hoc prediction merges or full-video inference), both the user instances AND the unlinked predictions are displayed in the GUI, creating confusing duplicate instances.

## Solution

New menu item: **Labels → Delete Predictions on User-Labeled Frames...**

Two modes supported:
- **Unlinked only** (default): Delete predictions not linked via `from_predicted` - these are the visible duplicates
- **All predictions**: Delete ALL predictions on user-labeled frames for complete cleanup

Scope options:
- Current video only
- All videos

## Changes

- `sleap/sleap_io_adaptors/lf_labels_utils.py`: Add `get_predictions_on_user_frames()` helper
- `sleap/gui/commands.py`: Add `DeleteUserFramePredictions` command class
- `sleap/gui/dialogs/delete.py`: Add `DeleteUserFramePredictionsDialog`
- `sleap/gui/app.py`: Add menu item after other prediction deletion options

## Test Plan

- [x] Menu item appears in Labels menu
- [x] Dialog shows scope and mode options
- [x] "No predictions found" info message when none exist
- [x] Unlinked predictions deleted correctly
- [x] "All predictions" mode deletes both linked and unlinked

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)