### PR TITLE
Training GUI QOL improvements

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -214,13 +214,11 @@ training:
 - type: text
   text: '<b>Data Pipeline framework options</b>'
 
-- default: 'torch_dataset'
-  help: Framework to create the data loaders. (When using torch_dataset,
-    num_workers in trainer_config should be set to 0 as multiprocessing
-    doesn't work with pickling video backends.)
+- default: 'Standard'
+  help: 'Framework for loading training data. Standard: Loads images directly from video (use num_workers=0). Cache in Memory: Pre-loads images into RAM for faster training. Cache to Disk: Saves images to disk for reuse across runs.'
   label: Data Pipeline Framework
-  name: data_config.data_pipeline_fw
-  options: 'torch_dataset,torch_dataset_cache_img_memory,torch_dataset_cache_img_disk'
+  name: _data_pipeline_fw
+  options: 'Standard,Cache in Memory,Cache to Disk'
   type: list
 
 - type: text
@@ -262,6 +260,12 @@ training:
   type: optional_string
   default: null
   help: Grouping within the project.
+
+- name: trainer_config.wandb.save_viz_imgs_wandb
+  label: Upload Visualization Images to WandB
+  type: bool
+  default: false
+  help: If True, sample predictions saved during training will also be uploaded to WandB. Requires both "Enable WandB for logging" and "Visualize Predictions During Training" to be enabled.
 
 
 - type: text

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -283,26 +283,10 @@ training:
   help: Grouping within the project.
 
 - name: trainer_config.wandb.save_viz_imgs_wandb
-  label: Upload Visualization Images to WandB
+  label: Upload Viz to WandB
   type: bool
   default: false
   help: If True, sample predictions saved during training will also be uploaded to WandB. Requires both "Enable WandB for logging" and "Visualize Predictions During Training" to be enabled.
-
-
-- type: text
-  text: '<b>ZMQ Options</b>'
-
-- name: trainer_config.zmq.controller_port
-  label: Controller Port
-  type: int
-  default: 9000
-  range: 1024,65535
-
-- name: trainer_config.zmq.publish_port
-  label: Publish Port
-  type: int
-  default: 9001
-  range: 1024,65535
 
 - type: text
   text: '<b>Output Options</b>'
@@ -335,14 +319,16 @@ training:
   type: bool
 
 - name: trainer_config.visualize_preds_during_training
-  label: Visualize Predictions During Training
+  label: Visualize Predictions
   type: bool
   default: true
+  help: If True, sample predictions will be saved during training for visual inspection.
 
 - name: trainer_config.keep_viz
-  label: Keep Prediction Visualization Images After Training
+  label: Keep Viz Images
   type: bool
   default: false
+  help: If True, keep prediction visualization images after training completes. Otherwise they are deleted.
 
 - name: _predict_frames
   label: Predict On

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -212,14 +212,35 @@ training:
   type: list
 
 - type: text
-  text: '<b>Data Pipeline framework options</b>'
+  text: '<b>Data Pipeline and Hardware Options</b>'
 
-- default: 'Standard'
-  help: 'Framework for loading training data. Standard: Loads images directly from video (use num_workers=0). Cache in Memory: Pre-loads images into RAM for faster training. Cache to Disk: Saves images to disk for reuse across runs.'
+- default: 'Cache in Memory'
+  help: 'Data loading strategy. Stream: Reads frames directly from video as needed (set workers=0). Cache in Memory: Pre-loads all frames into RAM for faster training (recommended). Cache to Disk: Saves frames to disk for reuse across training runs.'
   label: Data Pipeline Framework
   name: _data_pipeline_fw
-  options: 'Standard,Cache in Memory,Cache to Disk'
+  options: 'Stream (no caching),Cache in Memory,Cache to Disk'
   type: list
+
+- name: trainer_config.train_data_loader.num_workers
+  label: Data Loader Workers
+  type: int
+  default: 0
+  range: 0,16
+  help: Number of subprocesses for data loading. Use 0 for "Stream" mode to avoid race conditions. Use 2-4 with caching modes for faster loading.
+
+- name: trainer_config.trainer_devices
+  label: Number of GPU Devices
+  type: optional_int
+  default: null
+  none_label: Auto
+  help: Number of GPU devices to train on. "Auto" detects available GPUs.
+
+- name: trainer_config.trainer_accelerator
+  label: Device Accelerator
+  type: list
+  default: "auto"
+  options: auto,cuda,cpu,mps
+  help: Hardware accelerator for training. "auto" uses CUDA if available, otherwise CPU. Use "mps" for Apple Silicon Macs.
 
 - type: text
   text: '<b>WandB options</b>'

--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -234,38 +234,34 @@ training:
 
 - name: trainer_config.wandb.entity
   label:  Entity Name
-  type: string
+  type: optional_string
   default: null
+  help: Account name (username or organization).
 
 - name: trainer_config.wandb.project
   label:  Project Name
-  type: string
+  type: optional_string
   default: null
-
-- name: trainer_config.wandb.name
-  label:  Run Name
-  type: string
-  default: null
+  help: Name for the group of runs.
 
 - name: trainer_config.wandb.api_key
-  label: WandBAPI Key
-  type: string
+  label: WandB API Key
+  type: optional_string
   default: null
-  help: WandB API Key. You could also set it in your terminal by exporting the WANDB_API_KEY environment variable.
-    Or `wandb.login()` in your Python shell.
+  help: WandB API Key. From https://wandb.ai/authorize. You could also set it in your terminal by exporting the WANDB_API_KEY environment variable or `wandb.login()` in your Python shell.
   hidden: true
 
 - name: trainer_config.wandb.prv_runid
   label: Previous Run ID
-  type: string
+  type: optional_string
   default: null
-  help: Previous run ID if you want to resume training from a previous run. If None, a new run will be created.
+  help: Previous run ID if this is a continuation of a previous run that was stopped.
 
 - name: trainer_config.wandb.group
   label: Group Name
-  type: string
+  type: optional_string
   default: null
-  help: Group name if you want to group runs together.
+  help: Grouping within the project.
 
 
 - type: text
@@ -286,11 +282,11 @@ training:
 - type: text
   text: '<b>Output Options</b>'
 
-- default: ''
+- default: null
   help: String to set as the run name. ckpts are saved to {Runs folder}/{Run name}. If None, it will be auto-generated {trainer_config.ckpt_dir}/{time_stamp}_{head_name}_n={num_samples}.
   label: Run Name
   name: trainer_config.run_name
-  type: string
+  type: optional_string
 - default: models
   help: 'Path to the folder that run data should be stored in. All the data for a
     single run are stored in the path: "{Runs folder}/{Run name}". Non-existing folders will be created

--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -449,28 +449,6 @@ optimization:
   name: trainer_config.train_data_loader.batch_size
   type: int
   range: 1,512
-- default: 0
-  help: Number of subprocesses to use for data loading. 0 means that the data will be loaded in the main process.
-    This can help improve data loading speed. However, when using `data_pipeline_fw` as `torch_dataset`, i.e., when
-    not caching the data samples, then the number of workers should be set to 0 to avoid race conditions. If using caching,
-    then set number of workers to a value greater than 0. (Start with 2 and increase if needed)
-  label: Number of workers
-  name: trainer_config.train_data_loader.num_workers
-  type: int
-  range: 0,16
-- default: null
-  help: Number of devices to train on (int), or "auto" to select automatically. 
-  label: Number of GPU devices
-  name: trainer_config.trainer_devices
-  type: optional_int
-  none_label: Auto
-- default: "auto"
-  help: Accelerator to use for training. "auto" means "cuda" if GPUs are available, otherwise "cpu".
-    For mac, "mps" can be used for Apple Silicon.
-  label: Device Accelerator
-  name: trainer_config.trainer_accelerator
-  type: list
-  options: auto,cuda,cpu,mps
 - default: 100
   help: Maximum number of epochs to train for. Training can be stopped manually or automatically if early stopping is enabled and a plateau is detected.
   label: Epochs

--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -1,9 +1,14 @@
 data:
 - default: 0.1
-  help: Fraction of labeled frames to use as a validation set.
+  help: Fraction of labeled frames to use as a validation set. Ignored if "Overfit Mode" is enabled.
   label: Validation fraction
   name: data_config.validation_fraction
   type: double
+- default: false
+  help: If enabled, the same data will be used for both training and validation (train = val). This is useful for intentional overfitting on small datasets (fewer than 10 labeled frames) to test model capacity.
+  label: Overfit Mode (train=val)
+  name: data_config.use_same_data_for_val
+  type: bool
 - default: 1.0
   help: ''
   label: Input Scaling

--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -341,22 +341,17 @@ model:
   type: stacked
 augmentation:
 # Geometric augmentations
-- default: true
-  help: Enable random rotation augmentation. Rotation is applied independently with 100% probability when enabled.
+- default: "±180°"
+  help: "Rotation augmentation range. Off: disabled. ±15°: for side-view cameras where upside-down would be unnatural. ±180°: for top-view/overhead cameras where all orientations are valid."
   label: Rotation
-  name: _rotation_enabled
-  type: bool
-- default: -180
-  help: Minimum rotation angle in degrees in [-180, 180].
-  label: Rotation Min Angle
-  name: data_config.augmentation_config.geometric.rotation_min
-  range: -180,180
-  type: double
-- default: 180
-  help: Maximum rotation angle in degrees in [-180, 180].
-  label: Rotation Max Angle
-  name: data_config.augmentation_config.geometric.rotation_max
-  range: -180,180
+  name: _rotation_preset
+  type: list
+  options: "Off,±15°,±180°,Custom"
+- default: 45
+  help: Custom symmetric rotation range in degrees. Images will be rotated randomly between -X and +X degrees. Only used when "Custom" is selected above.
+  label: Custom Rotation (±)
+  name: _rotation_custom_angle
+  range: 1,180
   type: double
 - default: false
   help: Enable random scaling augmentation. Scaling is applied independently with 100% probability when enabled.

--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -340,11 +340,12 @@ model:
     options: 1,2,4,8,16,32,64
   type: stacked
 augmentation:
-- default: 0.0
-  help: Probabibility to apply rotational and scale augmentation.
-  label: Affine probability
-  name: data_config.augmentation_config.geometric.affine_p
-  type: float
+# Geometric augmentations
+- default: true
+  help: Enable random rotation augmentation. Rotation is applied independently with 100% probability when enabled.
+  label: Rotation
+  name: _rotation_enabled
+  type: bool
 - default: -180
   help: Minimum rotation angle in degrees in [-180, 180].
   label: Rotation Min Angle
@@ -357,6 +358,11 @@ augmentation:
   name: data_config.augmentation_config.geometric.rotation_max
   range: -180,180
   type: double
+- default: false
+  help: Enable random scaling augmentation. Scaling is applied independently with 100% probability when enabled.
+  label: Scale
+  name: _scale_enabled
+  type: bool
 - default: 0.9
   help: Minimum scaling factor.
   label: Scale Min
@@ -367,45 +373,44 @@ augmentation:
   label: Scale Max
   name: data_config.augmentation_config.geometric.scale_max
   type: double
-- default: 0.0
-  help: Probabibility to apply uniformly distributed noise augmentation.
-  label: Uniform Noise probability
-  name: data_config.augmentation_config.intensity.uniform_noise_p
-  type: float
+# Intensity augmentations
+- default: false
+  help: Enable uniformly distributed noise augmentation.
+  label: Uniform Noise
+  name: _uniform_noise_enabled
+  type: bool
 - default: 0.0
   help: Minimum value to add.
   range: 0.0, 1.0
   label: Uniform Noise Min Val
   name: data_config.augmentation_config.intensity.uniform_noise_min
   type: double
-- default: 1.0
+- default: 0.1
   range: 0.0, 1.0
   help: Maximum value to add.
   label: Uniform Noise Max Val
   name: data_config.augmentation_config.intensity.uniform_noise_max
   type: double
+- default: false
+  help: Enable normally distributed noise augmentation. This is applied independently to each pixel.
+  label: Gaussian Noise
+  name: _gaussian_noise_enabled
+  type: bool
 - default: 0.0
-  help: Probabibility to apply normally distributed noise augmentation.
-    This is applied independently to each pixel.
-  label: Gaussian Noise probability
-  name: data_config.augmentation_config.intensity.gaussian_noise_p
-  type: float
-- default: 5.0
   help: Mean of the distribution to sample from.
   label: Gaussian Noise Mean
   name: data_config.augmentation_config.intensity.gaussian_noise_mean
   type: double
-- default: 1.0
+- default: 0.04
   help: Standard deviation of the distribution to sample from.
   label: Gaussian Noise Stddev
   name: data_config.augmentation_config.intensity.gaussian_noise_std
   type: double
-- default: 0.0
-  help: Probabibility to apply gamma constrast adjustment to the image. This scales
-    all pixel values by `x ** gamma` where `x` is the pixel value in the [0, 1] range.
-  label: Contrast probability
-  name: data_config.augmentation_config.intensity.contrast_p
-  type: float
+- default: false
+  help: Enable gamma contrast adjustment. This scales all pixel values by x^gamma where x is in [0, 1].
+  label: Contrast
+  name: _contrast_enabled
+  type: bool
 - default: 0.5
   help: Minimum gamma to use for augmentation. Reasonable values are in [0.5, 2.0].
   label: Contrast Min Gamma
@@ -416,19 +421,17 @@ augmentation:
   label: Contrast Max Gamma
   name: data_config.augmentation_config.intensity.contrast_max
   type: double
-- default: 0.0
-  help: If True, the image brightness will be augmented. This adjustment simply adds
-      the same value to all pixels in the image to simulate broadfield illumination
-      change.
-  label: Brightness probability
-  name: data_config.augmentation_config.intensity.brightness_p
-  type: float
+- default: false
+  help: Enable brightness augmentation. This adds the same value to all pixels to simulate illumination change.
+  label: Brightness
+  name: _brightness_enabled
+  type: bool
 - default: 0.0
   help: Minimum value to add to all pixels.
   label: Brightness Min Val
   name: data_config.augmentation_config.intensity.brightness_min
   type: double
-- default: 1.0
+- default: 0.2
   help: Maximum value to add to all pixels.
   label: Brightness Max Val
   name: data_config.augmentation_config.intensity.brightness_max

--- a/sleap/gui/config_utils.py
+++ b/sleap/gui/config_utils.py
@@ -155,6 +155,45 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict):
         "trainer_config.train_data_loader.num_workers"
     ]
 
+    # Transform augmentation checkboxes to probability values
+    # Geometric augmentations use new independent probability params (rotation_p, scale_p)
+    if "_rotation_enabled" in key_val_dict:
+        rotation_enabled = key_val_dict["_rotation_enabled"]
+        key_val_dict["data_config.augmentation_config.geometric.rotation_p"] = (
+            1.0 if rotation_enabled else None
+        )
+
+    if "_scale_enabled" in key_val_dict:
+        scale_enabled = key_val_dict["_scale_enabled"]
+        key_val_dict["data_config.augmentation_config.geometric.scale_p"] = (
+            1.0 if scale_enabled else None
+        )
+
+    # Intensity augmentations use legacy probability params
+    if "_uniform_noise_enabled" in key_val_dict:
+        uniform_noise_enabled = key_val_dict["_uniform_noise_enabled"]
+        key_val_dict["data_config.augmentation_config.intensity.uniform_noise_p"] = (
+            1.0 if uniform_noise_enabled else 0.0
+        )
+
+    if "_gaussian_noise_enabled" in key_val_dict:
+        gaussian_noise_enabled = key_val_dict["_gaussian_noise_enabled"]
+        key_val_dict["data_config.augmentation_config.intensity.gaussian_noise_p"] = (
+            1.0 if gaussian_noise_enabled else 0.0
+        )
+
+    if "_contrast_enabled" in key_val_dict:
+        contrast_enabled = key_val_dict["_contrast_enabled"]
+        key_val_dict["data_config.augmentation_config.intensity.contrast_p"] = (
+            1.0 if contrast_enabled else 0.0
+        )
+
+    if "_brightness_enabled" in key_val_dict:
+        brightness_enabled = key_val_dict["_brightness_enabled"]
+        key_val_dict["data_config.augmentation_config.intensity.brightness_p"] = (
+            1.0 if brightness_enabled else 0.0
+        )
+
 
 def get_skeleton_from_config(skeleton_config: OmegaConf):
     """Create Sleap-io Skeleton objects from config.

--- a/sleap/gui/config_utils.py
+++ b/sleap/gui/config_utils.py
@@ -122,6 +122,18 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict):
         key_val_dict["data_config.preprocessing.ensure_rgb"] = ensure_rgb
         key_val_dict["data_config.preprocessing.ensure_grayscale"] = ensure_grayscale
 
+    # Map friendly data pipeline names to sleap-nn enum values
+    if "_data_pipeline_fw" in key_val_dict:
+        pipeline_map = {
+            "Standard": "torch_dataset",
+            "Cache in Memory": "torch_dataset_cache_img_memory",
+            "Cache to Disk": "torch_dataset_cache_img_disk",
+        }
+        friendly_name = key_val_dict["_data_pipeline_fw"]
+        key_val_dict["data_config.data_pipeline_fw"] = pipeline_map.get(
+            friendly_name, "torch_dataset"
+        )
+
     # Overwrite backbone strides with stride from head.
     backbone_name = find_backbone_name_from_key_val_dict(key_val_dict)
     if backbone_name is not None:

--- a/sleap/gui/config_utils.py
+++ b/sleap/gui/config_utils.py
@@ -125,13 +125,13 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict):
     # Map friendly data pipeline names to sleap-nn enum values
     if "_data_pipeline_fw" in key_val_dict:
         pipeline_map = {
-            "Standard": "torch_dataset",
+            "Stream (no caching)": "torch_dataset",
             "Cache in Memory": "torch_dataset_cache_img_memory",
             "Cache to Disk": "torch_dataset_cache_img_disk",
         }
         friendly_name = key_val_dict["_data_pipeline_fw"]
         key_val_dict["data_config.data_pipeline_fw"] = pipeline_map.get(
-            friendly_name, "torch_dataset"
+            friendly_name, "torch_dataset_cache_img_memory"
         )
 
     # Overwrite backbone strides with stride from head.
@@ -155,8 +155,8 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict):
         "trainer_config.train_data_loader.num_workers"
     ]
 
-    # Transform augmentation checkboxes to probability values
-    # Geometric augmentations use new independent probability params (rotation_p, scale_p)
+    # Transform augmentation checkboxes to probability values.
+    # Geometric augmentations use new independent probability params from sleap-nn.
     if "_rotation_enabled" in key_val_dict:
         rotation_enabled = key_val_dict["_rotation_enabled"]
         key_val_dict["data_config.augmentation_config.geometric.rotation_p"] = (

--- a/sleap/gui/config_utils.py
+++ b/sleap/gui/config_utils.py
@@ -155,13 +155,28 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict):
         "trainer_config.train_data_loader.num_workers"
     ]
 
-    # Transform augmentation checkboxes to probability values.
+    # Transform augmentation checkboxes/presets to probability values.
     # Geometric augmentations use new independent probability params from sleap-nn.
-    if "_rotation_enabled" in key_val_dict:
-        rotation_enabled = key_val_dict["_rotation_enabled"]
-        key_val_dict["data_config.augmentation_config.geometric.rotation_p"] = (
-            1.0 if rotation_enabled else None
-        )
+
+    # Handle rotation preset dropdown
+    if "_rotation_preset" in key_val_dict:
+        preset = key_val_dict["_rotation_preset"]
+        if preset == "Off":
+            key_val_dict["data_config.augmentation_config.geometric.rotation_p"] = None
+        else:
+            key_val_dict["data_config.augmentation_config.geometric.rotation_p"] = 1.0
+            # Determine angle from preset or custom value
+            preset_angles = {"±15°": 15, "±180°": 180}
+            if preset in preset_angles:
+                angle = preset_angles[preset]
+            else:  # Custom
+                angle = key_val_dict.get("_rotation_custom_angle", 45)
+            key_val_dict[
+                "data_config.augmentation_config.geometric.rotation_min"
+            ] = -angle
+            key_val_dict["data_config.augmentation_config.geometric.rotation_max"] = (
+                angle
+            )
 
     if "_scale_enabled" in key_val_dict:
         scale_enabled = key_val_dict["_scale_enabled"]

--- a/sleap/gui/dialogs/formbuilder.py
+++ b/sleap/gui/dialogs/formbuilder.py
@@ -400,6 +400,8 @@ class FormBuilderLayout(QtWidgets.QFormLayout):
             val = int(val)
         elif widget.property("field_data_type").startswith("file_"):
             val = None if val == "None" else val
+        elif widget.property("field_data_type") == "optional_string":
+            val = None if val == "" else val
         return val
 
     def build_form(self, items_to_create: List[Dict[Text, Any]]):

--- a/sleap/gui/dialogs/formbuilder.py
+++ b/sleap/gui/dialogs/formbuilder.py
@@ -363,9 +363,9 @@ class FormBuilderLayout(QtWidgets.QFormLayout):
         elif hasattr(widget, "setValue"):
             widget.setValue(val)
         elif hasattr(widget, "currentText"):
-            widget.setCurrentText(str(val))
+            widget.setCurrentText(str(val) if val is not None else "")
         elif hasattr(widget, "text"):
-            widget.setText(str(val))
+            widget.setText(str(val) if val is not None else "")
         else:
             print(f"don't know how to set value for {widget}")
         # for macOS we need to call repaint (bug in Qt?)

--- a/sleap/gui/dialogs/formbuilder.py
+++ b/sleap/gui/dialogs/formbuilder.py
@@ -66,7 +66,7 @@ class YamlFormWidget(QtWidgets.QGroupBox):
     ):
         super(YamlFormWidget, self).__init__(*args, **kwargs)
 
-        with open(yaml_file, "r") as form_yaml:
+        with open(yaml_file, "r", encoding="utf-8") as form_yaml:
             items_to_create = yaml.load(form_yaml, Loader=yaml.SafeLoader)
 
         self.which_form = which_form

--- a/sleap/gui/dialogs/formbuilder.py
+++ b/sleap/gui/dialogs/formbuilder.py
@@ -253,6 +253,9 @@ class FormBuilderLayout(QtWidgets.QFormLayout):
     ):
         super(FormBuilderLayout, self).__init__(*args, **kwargs)
 
+        # Reduce vertical spacing between form rows for more compact layout
+        self.setVerticalSpacing(6)
+
         self.form_text_widget = None
 
         self.buttons = dict()
@@ -524,6 +527,7 @@ class FormBuilderLayout(QtWidgets.QFormLayout):
         # string
         elif item["type"] in ("string", "optional_string"):
             field = QtWidgets.QLineEdit()
+            field.setMaximumWidth(400)  # Prevent text fields from stretching too wide
             val = item.get("default", "")
             val = "" if val is None else val
             field.setText(str(val))
@@ -631,6 +635,10 @@ class StackBuilderWidget(QtWidgets.QWidget):
         multi_layout.setFormAlignment(QtCore.Qt.AlignLeft | QtCore.Qt.AlignTop)
         self.combo_box = QtWidgets.QComboBox()
         self.stacked_widget = ResizingStackedWidget()
+        # Prevent stacked widget from expanding vertically
+        self.stacked_widget.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+        )
 
         self.combo_box.activated.connect(self.switch_to_idx)
 
@@ -646,6 +654,10 @@ class StackBuilderWidget(QtWidgets.QWidget):
 
             page_widget = QtWidgets.QGroupBox()
             page_widget.setLayout(self.page_layouts[page])
+            # Prevent vertical expansion - only take space needed for content
+            page_widget.setSizePolicy(
+                QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
+            )
 
             self.stacked_widget.addWidget(page_widget)
 

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1187,6 +1187,7 @@ class TrainingEditorWidget(QtWidgets.QWidget):
 
         col1_layout.addWidget(self.form_widgets["data"])
         col1_layout.addWidget(self.form_widgets["optimization"])
+        self.form_widgets["augmentation"].setMaximumWidth(255)
         col2_layout.addWidget(self.form_widgets["augmentation"])
         col3_layout.addWidget(self.form_widgets["model"])
 
@@ -1198,10 +1199,19 @@ class TrainingEditorWidget(QtWidgets.QWidget):
 
         col_layout = QtWidgets.QHBoxLayout()
         if col0_layout:
-            col_layout.addWidget(self._layout_widget(col0_layout))
-        col_layout.addWidget(self._layout_widget(col1_layout))
-        col_layout.addWidget(self._layout_widget(col2_layout))
-        col_layout.addWidget(self._layout_widget(col3_layout))
+            col_layout.addWidget(
+                self._layout_widget(col0_layout), stretch=0, alignment=QtCore.Qt.AlignTop
+            )
+        col_layout.addWidget(
+            self._layout_widget(col1_layout), stretch=0, alignment=QtCore.Qt.AlignTop
+        )
+        col_layout.addWidget(
+            self._layout_widget(col2_layout), stretch=0, alignment=QtCore.Qt.AlignTop
+        )
+        col_layout.addWidget(
+            self._layout_widget(col3_layout), stretch=0, alignment=QtCore.Qt.AlignTop
+        )
+        col_layout.addStretch(1)  # Push columns left, absorb extra space
 
         # If we have an object which gets a list of config files,
         # then we'll show a menu to allow selection from the list.

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -22,6 +22,11 @@ from sleap.gui.config_utils import (
 from sleap.gui.dialogs.filedialog import FileDialog
 from sleap.gui.dialogs.formbuilder import YamlFormWidget
 from sleap.gui.learning import receptivefield, runners, configs
+from sleap.gui.learning.wandb_utils import (
+    check_wandb_login_status,
+    get_wandb_api_key_help_text,
+)
+from sleap.prefs import prefs
 from sleap.gui.learning.configs import TrainingConfigsGetter
 from sleap.sleap_io_adaptors.skeleton_utils import (
     cycles,
@@ -976,6 +981,10 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
 
         self.setLayout(self.form_widget.form_layout)
 
+        # Load saved WandB preferences and update API key help text
+        if mode == "training":
+            self._init_wandb_settings()
+
     @property
     def fields(self):
         return self.form_widget.fields
@@ -988,7 +997,9 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
         self.form_widget.set_message()
 
     def get_form_data(self):
-        return self.form_widget.get_form_data()
+        data = self.form_widget.get_form_data()
+        self._save_wandb_preferences(data)
+        return data
 
     def set_form_data(self, data):
         self.form_widget.set_form_data(data)
@@ -1033,6 +1044,51 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
 
         self.pipeline_field.setValue(val)
         self.emitPipeline()
+
+    def _init_wandb_settings(self):
+        """Initialize WandB settings from preferences and update API key help text."""
+        # Load saved WandB preferences
+        wandb_prefs = {
+            "trainer_config.wandb.entity": prefs["wandb entity"],
+            "trainer_config.wandb.project": prefs["wandb project"],
+            "trainer_config.wandb.group": prefs["wandb group"],
+        }
+        # Only set values that are not None
+        wandb_prefs = {k: v for k, v in wandb_prefs.items() if v is not None}
+        if wandb_prefs:
+            self.form_widget.set_form_data(wandb_prefs)
+
+        # Update API key help text based on login status
+        try:
+            is_logged_in, auth_source = check_wandb_login_status()
+            if is_logged_in:
+                api_key_field = self.form_widget.fields.get(
+                    "trainer_config.wandb.api_key"
+                )
+                if api_key_field is not None:
+                    help_text = get_wandb_api_key_help_text(is_logged_in, auth_source)
+                    api_key_field.setToolTip(help_text)
+        except Exception:
+            # Don't fail if wandb check fails
+            pass
+
+    def _save_wandb_preferences(self, form_data: dict):
+        """Save WandB settings to preferences for persistence across sessions."""
+        # Map form field names to preference keys
+        pref_mapping = {
+            "trainer_config.wandb.entity": "wandb entity",
+            "trainer_config.wandb.project": "wandb project",
+            "trainer_config.wandb.group": "wandb group",
+        }
+        changed = False
+        for form_key, pref_key in pref_mapping.items():
+            if form_key in form_data:
+                value = form_data[form_key]
+                if prefs[pref_key] != value:
+                    prefs[pref_key] = value
+                    changed = True
+        if changed:
+            prefs.save()
 
 
 class TrainingEditorWidget(QtWidgets.QWidget):

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -90,6 +90,7 @@ class LearningDialog(QtWidgets.QDialog):
         self.skeleton = skeleton
 
         self._frame_selection = None
+        self._predict_frames_user_changed = False  # Track if user changed this session
 
         self.current_pipeline = ""
 
@@ -172,6 +173,12 @@ class LearningDialog(QtWidgets.QDialog):
         self.pipeline_form_widget.emitPipeline()
 
         self.connect_signals()
+
+        # Track when user explicitly changes predict frames option
+        if "_predict_frames" in self.pipeline_form_widget.fields:
+            self.pipeline_form_widget.fields["_predict_frames"].valueChanged.connect(
+                self._on_predict_frames_changed
+            )
 
         # Connect actions for buttons
         self.copy_button.clicked.connect(self.copy)
@@ -270,15 +277,9 @@ class LearningDialog(QtWidgets.QDialog):
                 )
 
             # Build list of options
-            # Priority for default (lowest to highest):
-            #   "nothing" (if training)
-            #   "current frame" (if inference)
-            #   "suggested frames" (if available)
-            #   "selected clip" (if available)
             if self.mode != "inference":
                 prediction_options.append("nothing")
             prediction_options.append("current frame")
-            default_option = "nothing" if self.mode != "inference" else "current frame"
 
             option = f"random frames ({total_random} total frames)"
             prediction_options.append(option)
@@ -287,10 +288,10 @@ class LearningDialog(QtWidgets.QDialog):
                 option = f"random frames in current video ({random_video} frames)"
                 prediction_options.append(option)
 
-            if total_suggestions > 0:
+            has_suggestions = total_suggestions > 0
+            if has_suggestions:
                 option = f"suggested frames ({total_suggestions} total frames)"
                 prediction_options.append(option)
-                default_option = option
 
             if total_user > 0:
                 option = f"user labeled frames ({total_user} total frames)"
@@ -299,16 +300,108 @@ class LearningDialog(QtWidgets.QDialog):
             if clip_length > 0:
                 option = f"selected clip ({clip_length} frames)"
                 prediction_options.append(option)
-                default_option = option
 
             prediction_options.append(f"entire current video ({video_length} frames)")
 
             if len(self.labels.videos) > 1:
                 prediction_options.append(f"all videos ({all_videos_length} frames)")
 
+            # Determine default based on precedence rules:
+            # 1. If user changed this session -> preserve current selection
+            # 2. If suggestions exist -> default to "suggested frames"
+            # 3. If no suggestions -> use persisted preference (fallback if invalid)
+            if self._predict_frames_user_changed:
+                # Try to preserve user's current selection
+                current = self.pipeline_form_widget.fields["_predict_frames"].value()
+                current_normalized = self._normalize_predict_option(current)
+                # Find matching option in new list
+                default_option = None
+                for opt in prediction_options:
+                    if self._normalize_predict_option(opt) == current_normalized:
+                        default_option = opt
+                        break
+                if default_option is None:
+                    # Current selection no longer available, use precedence rules
+                    default_option = self._get_predict_frames_default(
+                        has_suggestions, prediction_options
+                    )
+            else:
+                default_option = self._get_predict_frames_default(
+                    has_suggestions, prediction_options
+                )
+
             self.pipeline_form_widget.fields["_predict_frames"].set_options(
                 prediction_options, default_option
             )
+
+    def _on_predict_frames_changed(self):
+        """Track when user explicitly changes the predict frames option."""
+        self._predict_frames_user_changed = True
+
+    @staticmethod
+    def _normalize_predict_option(option: str) -> str:
+        """Extract base option type from dynamic option string.
+
+        E.g., "random frames (123 total frames)" -> "random frames"
+        """
+        if option.startswith("nothing"):
+            return "nothing"
+        elif option.startswith("current frame"):
+            return "current frame"
+        elif option.startswith("random frames in current video"):
+            return "random frames in current video"
+        elif option.startswith("random frames"):
+            return "random frames"
+        elif option.startswith("suggested frames"):
+            return "suggested frames"
+        elif option.startswith("user labeled frames"):
+            return "user labeled frames"
+        elif option.startswith("selected clip"):
+            return "selected clip"
+        elif option.startswith("entire current video"):
+            return "entire current video"
+        elif option.startswith("all videos"):
+            return "all videos"
+        return option
+
+    def _get_predict_frames_default(
+        self, has_suggestions: bool, prediction_options: list
+    ) -> str:
+        """Determine default predict frames option based on precedence rules.
+
+        Precedence:
+        1. If user explicitly changed this session -> keep their choice (elsewhere)
+        2. If suggestions exist -> "suggested frames"
+        3. If no suggestions -> use persisted pref (fallback if invalid)
+        """
+        # If suggestions exist, always default to suggested frames
+        if has_suggestions:
+            for opt in prediction_options:
+                if opt.startswith("suggested frames"):
+                    return opt
+
+        # No suggestions: use persisted preference
+        saved_pref = prefs["training predict on"]
+
+        # Find matching option in available options
+        for opt in prediction_options:
+            if self._normalize_predict_option(opt) == saved_pref:
+                return opt
+
+        # Fallback: "nothing" for training, "current frame" for inference
+        return "nothing" if self.mode != "inference" else "current frame"
+
+    def _save_predict_frames_preference(self):
+        """Save the current predict frames selection to preferences."""
+        if "_predict_frames" not in self.pipeline_form_widget.fields:
+            return
+
+        current = self.pipeline_form_widget.fields["_predict_frames"].value()
+        normalized = self._normalize_predict_option(current)
+
+        if prefs["training predict on"] != normalized:
+            prefs["training predict on"] = normalized
+            prefs.save()
 
     def connect_signals(self):
         self.pipeline_form_widget.valueChanged.connect(self.on_tab_data_change)
@@ -755,6 +848,8 @@ class LearningDialog(QtWidgets.QDialog):
 
     def run(self):
         """Run with current dialog settings."""
+        # Save predict frames preference before running
+        self._save_predict_frames_preference()
 
         pipeline_form_data = self.pipeline_form_widget.get_form_data()
 
@@ -985,6 +1080,7 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
         self._wandb_api_key_placeholder = None
         if mode == "training":
             self._init_wandb_settings()
+            self._init_training_settings()
 
     @property
     def fields(self):
@@ -1005,6 +1101,7 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
             if api_key == self._wandb_api_key_placeholder:
                 data["trainer_config.wandb.api_key"] = None
         self._save_wandb_preferences(data)
+        self._save_training_preferences(data)
         return data
 
     def set_form_data(self, data):
@@ -1097,6 +1194,31 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
             "trainer_config.wandb.project": "wandb project",
             "trainer_config.wandb.group": "wandb group",
             "trainer_config.wandb.save_viz_imgs_wandb": "wandb save viz images",
+        }
+        changed = False
+        for form_key, pref_key in pref_mapping.items():
+            if form_key in form_data:
+                value = form_data[form_key]
+                if prefs[pref_key] != value:
+                    prefs[pref_key] = value
+                    changed = True
+        if changed:
+            prefs.save()
+
+    def _init_training_settings(self):
+        """Initialize training pipeline settings from preferences."""
+        # Note: _predict_frames is handled at LearningDialog level due to
+        # dynamic options and precedence rules (suggestions > saved pref)
+        training_prefs = {
+            "_ensure_channels": prefs["training image conversion"],
+        }
+        self.form_widget.set_form_data(training_prefs)
+
+    def _save_training_preferences(self, form_data: dict):
+        """Save training pipeline settings to preferences."""
+        # Note: _predict_frames is handled at LearningDialog level
+        pref_mapping = {
+            "_ensure_channels": "training image conversion",
         }
         changed = False
         for form_key, pref_key in pref_mapping.items():

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1073,24 +1073,20 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
             self.form_widget.set_form_data(wandb_prefs)
 
         # Update API key field based on login status
-        try:
-            is_logged_in, auth_source = check_wandb_login_status()
-            if is_logged_in:
-                api_key_field = self.form_widget.fields.get(
-                    "trainer_config.wandb.api_key"
+        is_logged_in, auth_source = check_wandb_login_status()
+        if is_logged_in:
+            api_key_field = self.form_widget.fields.get(
+                "trainer_config.wandb.api_key"
+            )
+            if api_key_field is not None:
+                # Set placeholder to indicate already authenticated
+                placeholder = f"(using {auth_source})"
+                api_key_field.setText(placeholder)
+                api_key_field.setToolTip(
+                    get_wandb_api_key_help_text(is_logged_in, auth_source)
                 )
-                if api_key_field is not None:
-                    # Set placeholder to indicate already authenticated
-                    placeholder = f"(using {auth_source})"
-                    api_key_field.setText(placeholder)
-                    api_key_field.setToolTip(
-                        get_wandb_api_key_help_text(is_logged_in, auth_source)
-                    )
-                    # Store placeholder so we can strip it on form read
-                    self._wandb_api_key_placeholder = placeholder
-        except Exception:
-            # Don't fail if wandb check fails
-            pass
+                # Store placeholder so we can strip it on form read
+                self._wandb_api_key_placeholder = placeholder
 
     def _save_wandb_preferences(self, form_data: dict):
         """Save WandB settings to preferences for persistence across sessions."""

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1164,6 +1164,9 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         self.form_widgets["model"].valueChanged.connect(self.update_receptive_field)
         self.form_widgets["data"].valueChanged.connect(self.update_receptive_field)
 
+        # Connect overfit mode checkbox to disable validation fraction
+        self._setup_overfit_mode_toggle()
+
         if hasattr(skeleton, "node_names"):
             for field_name in NODE_LIST_FIELDS:
                 form_name = field_name.split(".")[0]
@@ -1296,6 +1299,26 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         # has changed so that it can activate/update the "user" config
         # if self._cfg_list_widget:
         #     self._set_user_config()
+
+    def _setup_overfit_mode_toggle(self):
+        """Connect overfit mode checkbox to disable validation fraction.
+
+        Follows the same pattern as OptionalSpinWidget.updateState().
+        """
+        data_form = self.form_widgets["data"]
+        overfit_field_name = "data_config.use_same_data_for_val"
+        val_frac_field_name = "data_config.validation_fraction"
+
+        overfit_checkbox = data_form.fields.get(overfit_field_name)
+        val_frac_widget = data_form.fields.get(val_frac_field_name)
+
+        if overfit_checkbox is not None and val_frac_widget is not None:
+
+            def update_state():
+                val_frac_widget.setDisabled(overfit_checkbox.isChecked())
+
+            overfit_checkbox.stateChanged.connect(update_state)
+            update_state()
 
     def acceptSelectedConfigInfo(self, cfg_info: configs.ConfigFileInfo):
         self._load_config(cfg_info)

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1172,9 +1172,7 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
         # Update API key field based on login status
         is_logged_in, auth_source = check_wandb_login_status()
         if is_logged_in:
-            api_key_field = self.form_widget.fields.get(
-                "trainer_config.wandb.api_key"
-            )
+            api_key_field = self.form_widget.fields.get("trainer_config.wandb.api_key")
             if api_key_field is not None:
                 # Set placeholder to indicate already authenticated
                 placeholder = f"(using {auth_source})"
@@ -1211,7 +1209,17 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
         # dynamic options and precedence rules (suggestions > saved pref)
         training_prefs = {
             "_ensure_channels": prefs["training image conversion"],
+            "_data_pipeline_fw": prefs["training data pipeline framework"],
+            "trainer_config.train_data_loader.num_workers": prefs[
+                "training num workers"
+            ],
+            "trainer_config.trainer_accelerator": prefs["training accelerator"],
         }
+        # trainer_devices is optional_int - only set if not None
+        if prefs["training num devices"] is not None:
+            training_prefs["trainer_config.trainer_devices"] = prefs[
+                "training num devices"
+            ]
         self.form_widget.set_form_data(training_prefs)
 
     def _save_training_preferences(self, form_data: dict):
@@ -1219,6 +1227,10 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
         # Note: _predict_frames is handled at LearningDialog level
         pref_mapping = {
             "_ensure_channels": "training image conversion",
+            "_data_pipeline_fw": "training data pipeline framework",
+            "trainer_config.train_data_loader.num_workers": "training num workers",
+            "trainer_config.trainer_devices": "training num devices",
+            "trainer_config.trainer_accelerator": "training accelerator",
         }
         changed = False
         for form_key, pref_key in pref_mapping.items():

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -145,23 +145,23 @@ class LearningDialog(QtWidgets.QDialog):
         self.message_widget = QtWidgets.QLabel("")
 
         # Layout for entire dialog
+        # Tabs and message go inside scroll area
         content_widget = QtWidgets.QWidget()
         content_layout = QtWidgets.QVBoxLayout(content_widget)
-
         content_layout.addWidget(self.tab_widget)
         content_layout.addWidget(self.message_widget)
-        content_layout.addWidget(buttons_layout_widget)
 
-        # Create the QScrollArea.
+        # Create the QScrollArea for tabs only
         scroll_area = QtWidgets.QScrollArea()
         scroll_area.setWidgetResizable(True)
         scroll_area.setWidget(content_widget)
-
         scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
         scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
 
+        # Main layout: scroll area + buttons (buttons always visible at bottom)
         layout = QtWidgets.QVBoxLayout(self)
         layout.addWidget(scroll_area)
+        layout.addWidget(buttons_layout_widget)
 
         self.adjust_initial_size()
 
@@ -191,8 +191,9 @@ class LearningDialog(QtWidgets.QDialog):
         # Get screen size
         screen = QtGui.QGuiApplication.primaryScreen().availableGeometry()
 
-        max_width = 1860
-        max_height = 1150
+        # Reduced from 1860x1150 to fit compact layout better
+        max_width = 1130
+        max_height = 860
         margin = 0.10
 
         # Calculate target width and height
@@ -1063,6 +1064,20 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
     updatePipeline = QtCore.Signal(str)
     valueChanged = QtCore.Signal()
 
+    # Fields to place in the right column (WandB options)
+    RIGHT_COLUMN_FIELDS = {
+        "trainer_config.use_wandb",
+        "trainer_config.wandb.entity",
+        "trainer_config.wandb.project",
+        "trainer_config.wandb.api_key",
+        "trainer_config.wandb.prv_runid",
+        "trainer_config.wandb.group",
+        "trainer_config.wandb.save_viz_imgs_wandb",
+    }
+
+    # Section headers to place in right column
+    RIGHT_COLUMN_HEADERS = {"WandB options"}
+
     def __init__(
         self, mode: Text, skeleton: Optional["Skeleton"] = None, *args, **kwargs
     ):
@@ -1085,13 +1100,120 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
 
         self.form_widget.form_layout.valueChanged.connect(self.valueChanged)
 
-        self.setLayout(self.form_widget.form_layout)
+        # Build two-column layout for training mode
+        if mode == "training":
+            self._build_two_column_layout()
+        else:
+            self.setLayout(self.form_widget.form_layout)
 
         # Load saved WandB preferences and update API key field
         self._wandb_api_key_placeholder = None
         if mode == "training":
             self._init_wandb_settings()
             self._init_training_settings()
+
+    def _build_two_column_layout(self):
+        """Reorganize the pipeline form into a two-column layout.
+
+        The pipeline stacked widget stays at the top (full width).
+        Left column: Input Data, Data Pipeline/Hardware, Output options
+        Right column: WandB options, ZMQ options
+        """
+        form_layout = self.form_widget.form_layout
+
+        # Create main layout
+        main_layout = QtWidgets.QVBoxLayout()
+        main_layout.setContentsMargins(0, 0, 0, 0)
+
+        # Create two-column layout for settings
+        columns_layout = QtWidgets.QHBoxLayout()
+        left_column = QtWidgets.QFormLayout()
+        right_column = QtWidgets.QFormLayout()
+        left_column.setVerticalSpacing(6)
+        right_column.setVerticalSpacing(6)
+
+        # Track which column we're adding to based on section headers
+        current_column = left_column
+        pipeline_widget = None
+
+        # Iterate through all rows in the form
+        row_count = form_layout.rowCount()
+        for i in range(row_count):
+            # Get the label and field for this row
+            label_item = form_layout.itemAt(i, QtWidgets.QFormLayout.LabelRole)
+            field_item = form_layout.itemAt(i, QtWidgets.QFormLayout.FieldRole)
+
+            if field_item is None:
+                continue
+
+            field_widget = field_item.widget()
+            if field_widget is None:
+                continue
+
+            # Check if this is the pipeline stacked widget
+            field_name = field_widget.objectName()
+            if field_name == "_pipeline":
+                pipeline_widget = field_widget
+                continue
+
+            # Check if this is a section header (QLabel with bold text)
+            if isinstance(field_widget, QtWidgets.QLabel):
+                header_text = field_widget.text()
+                # Check for section headers and switch columns if needed
+                for header in self.RIGHT_COLUMN_HEADERS:
+                    if header in header_text:
+                        current_column = right_column
+                        break
+                else:
+                    # Not a right column header
+                    if "Input Data" in header_text or "Data Pipeline" in header_text or "Output" in header_text:
+                        current_column = left_column
+
+                # Add the header to the current column
+                current_column.addRow(field_widget)
+                continue
+
+            # Check if this field belongs in right column
+            if field_name in self.RIGHT_COLUMN_FIELDS:
+                target_column = right_column
+            else:
+                target_column = current_column
+
+            # Get the label text
+            label_text = ""
+            if label_item:
+                label_widget = label_item.widget()
+                if label_widget:
+                    label_text = label_widget.text()
+
+            # Add to target column
+            if label_text:
+                target_column.addRow(label_text, field_widget)
+            else:
+                target_column.addRow(field_widget)
+
+        # Wrap columns in widgets for alignment
+        left_widget = QtWidgets.QWidget()
+        left_widget.setLayout(left_column)
+        right_widget = QtWidgets.QWidget()
+        right_widget.setLayout(right_column)
+
+        columns_layout.addWidget(left_widget, stretch=1, alignment=QtCore.Qt.AlignTop)
+        columns_layout.addWidget(right_widget, stretch=1, alignment=QtCore.Qt.AlignTop)
+
+        # Add pipeline widget at top if found (no stretch - only takes needed space)
+        if pipeline_widget:
+            main_layout.addWidget(pipeline_widget, stretch=0)
+
+        # Add columns (no stretch - only takes needed space)
+        columns_widget = QtWidgets.QWidget()
+        columns_widget.setLayout(columns_layout)
+        main_layout.addWidget(columns_widget, stretch=0)
+
+        # Push everything to top, extra space goes to bottom
+        main_layout.addStretch(1)
+
+        self.setLayout(main_layout)
 
     @property
     def fields(self):
@@ -1315,6 +1437,9 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         # Connect rotation preset dropdown to enable/disable custom angle field
         self._setup_rotation_preset_toggle()
 
+        # Connect augmentation checkboxes to show/hide their parameter fields
+        self._setup_augmentation_param_toggles()
+
         if hasattr(skeleton, "node_names"):
             for field_name in NODE_LIST_FIELDS:
                 form_name = field_name.split(".")[0]
@@ -1486,6 +1611,70 @@ class TrainingEditorWidget(QtWidgets.QWidget):
 
             preset_field.valueChanged.connect(update_state)
             update_state()  # Set initial state
+
+    def _setup_augmentation_param_toggles(self):
+        """Connect augmentation checkboxes to show/hide their parameter fields.
+
+        When an augmentation checkbox is unchecked, its parameter fields are hidden
+        to reduce visual clutter. The fields are shown when the checkbox is checked.
+        """
+        aug_form = self.form_widgets["augmentation"]
+        form_layout = aug_form.form_layout
+
+        # Define which checkbox controls which parameter fields
+        toggle_groups = {
+            "_scale_enabled": [
+                "data_config.augmentation_config.geometric.scale_min",
+                "data_config.augmentation_config.geometric.scale_max",
+            ],
+            "_uniform_noise_enabled": [
+                "data_config.augmentation_config.intensity.uniform_noise_min",
+                "data_config.augmentation_config.intensity.uniform_noise_max",
+            ],
+            "_gaussian_noise_enabled": [
+                "data_config.augmentation_config.intensity.gaussian_noise_mean",
+                "data_config.augmentation_config.intensity.gaussian_noise_std",
+            ],
+            "_contrast_enabled": [
+                "data_config.augmentation_config.intensity.contrast_min",
+                "data_config.augmentation_config.intensity.contrast_max",
+            ],
+            "_brightness_enabled": [
+                "data_config.augmentation_config.intensity.brightness_min",
+                "data_config.augmentation_config.intensity.brightness_max",
+            ],
+        }
+
+        for checkbox_name, param_fields in toggle_groups.items():
+            checkbox = aug_form.fields.get(checkbox_name)
+            if checkbox is None:
+                continue
+
+            # Collect the parameter field widgets and their labels
+            param_widgets = []
+            for field_name in param_fields:
+                field = aug_form.fields.get(field_name)
+                if field is not None:
+                    # Get the label for this field from the form layout
+                    label = form_layout.labelForField(field)
+                    param_widgets.append((field, label))
+
+            if not param_widgets:
+                continue
+
+            # Create update function that captures the widgets
+            def make_update_visibility(widgets):
+                def update_visibility(state):
+                    visible = bool(state)
+                    for field, label in widgets:
+                        field.setVisible(visible)
+                        if label is not None:
+                            label.setVisible(visible)
+                return update_visibility
+
+            update_fn = make_update_visibility(param_widgets)
+            checkbox.stateChanged.connect(update_fn)
+            update_fn(checkbox.isChecked())  # Set initial state
 
     def acceptSelectedConfigInfo(self, cfg_info: configs.ConfigFileInfo):
         self._load_config(cfg_info)

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -507,8 +507,13 @@ class LearningDialog(QtWidgets.QDialog):
 
             self.update_tabs_from_tab(source_data)
 
-            # Update pipeline tab
-            self.pipeline_form_widget.set_form_data(source_data)
+            # Update pipeline tab, but filter out run_name to prevent cross-tab
+            # contamination (each head has its own run_name from its base config,
+            # but the pipeline run_name should remain independent)
+            pipeline_data = {
+                k: v for k, v in source_data.items() if k != "trainer_config.run_name"
+            }
+            self.pipeline_form_widget.set_form_data(pipeline_data)
 
         self._validate_pipeline()
 
@@ -648,6 +653,12 @@ class LearningDialog(QtWidgets.QDialog):
                         get_keyval_dict_from_omegaconf(trained_cfg_info.config),
                         tab_cfg_key_val_dict,
                     )
+
+                # Clear wandb.name for new training runs (not resume) so sleap-nn
+                # will default it to the new run_name. The wandb.name field is not
+                # in the GUI form, so old values from base configs would persist.
+                if not self.tabs[tab_name].resume_training:
+                    loaded_cfg_scoped["trainer_config.wandb.name"] = None
 
                 # Deserialize merged dict to object
                 cfg = get_omegaconf_from_gui_form(loaded_cfg_scoped)
@@ -1537,6 +1548,11 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         key_val_dict = get_keyval_dict_from_omegaconf(cfg)
         if key_val_dict.get("trainer_config.trainer_devices") == "auto":
             key_val_dict["trainer_config.trainer_devices"] = None
+
+        # Clear run_name - it should be auto-generated for new training runs.
+        # This prevents old run_name from base config from leaking through.
+        key_val_dict["trainer_config.run_name"] = None
+
         self.set_fields_from_key_val_dict(key_val_dict)
 
     # def _set_user_config(self):
@@ -1697,6 +1713,11 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         else:
             trained_config_info.config.model_config.pretrained_backbone_weights = None
             trained_config_info.config.model_config.pretrained_head_weights = None
+
+        # Always clear wandb.name so sleap-nn will default it to the new run_name.
+        # "Use Trained Model Weights" means use pretrained weights for initialization,
+        # not resume the same wandb logging run.
+        trained_config_info.config.trainer_config.wandb.name = None
 
         return trained_config_info
 

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -981,7 +981,8 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
 
         self.setLayout(self.form_widget.form_layout)
 
-        # Load saved WandB preferences and update API key help text
+        # Load saved WandB preferences and update API key field
+        self._wandb_api_key_placeholder = None
         if mode == "training":
             self._init_wandb_settings()
 
@@ -998,6 +999,11 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
 
     def get_form_data(self):
         data = self.form_widget.get_form_data()
+        # Strip placeholder from API key if user didn't change it
+        api_key = data.get("trainer_config.wandb.api_key")
+        if api_key and self._wandb_api_key_placeholder:
+            if api_key == self._wandb_api_key_placeholder:
+                data["trainer_config.wandb.api_key"] = None
         self._save_wandb_preferences(data)
         return data
 
@@ -1047,18 +1053,26 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
 
     def _init_wandb_settings(self):
         """Initialize WandB settings from preferences and update API key help text."""
-        # Load saved WandB preferences
+        # Load saved WandB preferences (bools always set, strings only if not None)
         wandb_prefs = {
+            "trainer_config.use_wandb": prefs["wandb enabled"],
             "trainer_config.wandb.entity": prefs["wandb entity"],
             "trainer_config.wandb.project": prefs["wandb project"],
             "trainer_config.wandb.group": prefs["wandb group"],
+            "trainer_config.wandb.save_viz_imgs_wandb": prefs["wandb save viz images"],
         }
-        # Only set values that are not None
-        wandb_prefs = {k: v for k, v in wandb_prefs.items() if v is not None}
+        # Filter out None values for optional string fields
+        wandb_prefs = {
+            k: v
+            for k, v in wandb_prefs.items()
+            if v is not None
+            or k
+            in ("trainer_config.use_wandb", "trainer_config.wandb.save_viz_imgs_wandb")
+        }
         if wandb_prefs:
             self.form_widget.set_form_data(wandb_prefs)
 
-        # Update API key help text based on login status
+        # Update API key field based on login status
         try:
             is_logged_in, auth_source = check_wandb_login_status()
             if is_logged_in:
@@ -1066,19 +1080,27 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
                     "trainer_config.wandb.api_key"
                 )
                 if api_key_field is not None:
-                    help_text = get_wandb_api_key_help_text(is_logged_in, auth_source)
-                    api_key_field.setToolTip(help_text)
+                    # Set placeholder to indicate already authenticated
+                    placeholder = f"(using {auth_source})"
+                    api_key_field.setText(placeholder)
+                    api_key_field.setToolTip(
+                        get_wandb_api_key_help_text(is_logged_in, auth_source)
+                    )
+                    # Store placeholder so we can strip it on form read
+                    self._wandb_api_key_placeholder = placeholder
         except Exception:
             # Don't fail if wandb check fails
             pass
 
     def _save_wandb_preferences(self, form_data: dict):
         """Save WandB settings to preferences for persistence across sessions."""
-        # Map form field names to preference keys
+        # Map form field names to preference keys (API key excluded for security)
         pref_mapping = {
+            "trainer_config.use_wandb": "wandb enabled",
             "trainer_config.wandb.entity": "wandb entity",
             "trainer_config.wandb.project": "wandb project",
             "trainer_config.wandb.group": "wandb group",
+            "trainer_config.wandb.save_viz_imgs_wandb": "wandb save viz images",
         }
         changed = False
         for form_key, pref_key in pref_mapping.items():
@@ -1200,7 +1222,9 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         col_layout = QtWidgets.QHBoxLayout()
         if col0_layout:
             col_layout.addWidget(
-                self._layout_widget(col0_layout), stretch=0, alignment=QtCore.Qt.AlignTop
+                self._layout_widget(col0_layout),
+                stretch=0,
+                alignment=QtCore.Qt.AlignTop,
             )
         col_layout.addWidget(
             self._layout_widget(col1_layout), stretch=0, alignment=QtCore.Qt.AlignTop

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1312,6 +1312,9 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         # Connect overfit mode checkbox to disable validation fraction
         self._setup_overfit_mode_toggle()
 
+        # Connect rotation preset dropdown to enable/disable custom angle field
+        self._setup_rotation_preset_toggle()
+
         if hasattr(skeleton, "node_names"):
             for field_name in NODE_LIST_FIELDS:
                 form_name = field_name.split(".")[0]
@@ -1465,6 +1468,25 @@ class TrainingEditorWidget(QtWidgets.QWidget):
             overfit_checkbox.stateChanged.connect(update_state)
             update_state()
 
+    def _setup_rotation_preset_toggle(self):
+        """Connect rotation preset dropdown to enable/disable custom angle field.
+
+        When a preset (Off, ±15°, ±180°) is selected, the custom angle field is
+        disabled. When "Custom" is selected, the field is enabled.
+        """
+        aug_form = self.form_widgets["augmentation"]
+        preset_field = aug_form.fields.get("_rotation_preset")
+        custom_field = aug_form.fields.get("_rotation_custom_angle")
+
+        if preset_field is not None and custom_field is not None:
+
+            def update_state():
+                is_custom = preset_field.value() == "Custom"
+                custom_field.setEnabled(is_custom)
+
+            preset_field.valueChanged.connect(update_state)
+            update_state()  # Set initial state
+
     def acceptSelectedConfigInfo(self, cfg_info: configs.ConfigFileInfo):
         self._load_config(cfg_info)
 
@@ -1552,6 +1574,31 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         # Clear run_name - it should be auto-generated for new training runs.
         # This prevents old run_name from base config from leaking through.
         key_val_dict["trainer_config.run_name"] = None
+
+        # Reverse-map rotation_min/rotation_max to _rotation_preset dropdown
+        rot_min = key_val_dict.get(
+            "data_config.augmentation_config.geometric.rotation_min"
+        )
+        rot_max = key_val_dict.get(
+            "data_config.augmentation_config.geometric.rotation_max"
+        )
+        rot_p = key_val_dict.get("data_config.augmentation_config.geometric.rotation_p")
+        if rot_p is None or rot_p == 0:
+            key_val_dict["_rotation_preset"] = "Off"
+        elif rot_min is not None and rot_max is not None:
+            # Check for symmetric presets
+            if rot_min == -15 and rot_max == 15:
+                key_val_dict["_rotation_preset"] = "±15°"
+            elif rot_min == -180 and rot_max == 180:
+                key_val_dict["_rotation_preset"] = "±180°"
+            elif rot_min == -rot_max:
+                # Symmetric but custom angle
+                key_val_dict["_rotation_preset"] = "Custom"
+                key_val_dict["_rotation_custom_angle"] = rot_max
+            else:
+                # Asymmetric (rare) - use Custom with max as angle
+                key_val_dict["_rotation_preset"] = "Custom"
+                key_val_dict["_rotation_custom_angle"] = max(abs(rot_min), abs(rot_max))
 
         self.set_fields_from_key_val_dict(key_val_dict)
 

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1166,7 +1166,11 @@ class TrainingPipelineWidget(QtWidgets.QWidget):
                         break
                 else:
                     # Not a right column header
-                    if "Input Data" in header_text or "Data Pipeline" in header_text or "Output" in header_text:
+                    if (
+                        "Input Data" in header_text
+                        or "Data Pipeline" in header_text
+                        or "Output" in header_text
+                    ):
                         current_column = left_column
 
                 # Add the header to the current column
@@ -1670,6 +1674,7 @@ class TrainingEditorWidget(QtWidgets.QWidget):
                         field.setVisible(visible)
                         if label is not None:
                             label.setVisible(visible)
+
                 return update_visibility
 
             update_fn = make_update_visibility(param_widgets)

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -812,6 +812,7 @@ def run_gui_training(
                         "the error."
                     ).exec_()
                 trained_job_paths[model_type] = None
+                break  # Don't continue to next model if this one failed
 
     if gui:
         # close training monitor window

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -38,22 +38,24 @@ def get_timestamp() -> Text:
 def setup_new_run_folder(
     config: OmegaConf, base_run_name: Optional[Text] = None
 ) -> Text:
-    """Create a new run folder from config."""
+    """Create a new run folder from config.
+
+    Args:
+        config: Training configuration with trainer_config.save_ckpt and ckpt_dir.
+        base_run_name: Optional suffix to append (e.g., "centroid.n=10").
+
+    Returns:
+        Path to the new run folder, or None if save_ckpt is False.
+    """
     run_path = None
     if config.trainer_config.save_ckpt:
-        # Auto-generate run name suffix.
+        # Generate fresh run name: YYMMDD_HHMMSS.{base_run_name}
         run_name = get_timestamp()
         if isinstance(base_run_name, str):
             run_name = run_name + "." + base_run_name
 
-        # Prepend existing run_name if it's valid (not None or "None")
-        if config.trainer_config.run_name and config.trainer_config.run_name != "None":
-            cfg_run_name = config.trainer_config.run_name + "_" + run_name
-        else:
-            cfg_run_name = run_name
-
-        # Build run path.
-        run_path = (Path(config.trainer_config.ckpt_dir) / cfg_run_name).as_posix()
+        # Build run path (always use fresh name, don't prepend old run_name)
+        run_path = (Path(config.trainer_config.ckpt_dir) / run_name).as_posix()
 
     return run_path
 

--- a/sleap/gui/learning/wandb_utils.py
+++ b/sleap/gui/learning/wandb_utils.py
@@ -1,0 +1,52 @@
+"""Utilities for WandB integration in SLEAP GUI."""
+
+import os
+from typing import Optional, Tuple
+
+
+def check_wandb_login_status() -> Tuple[bool, Optional[str]]:
+    """Check if wandb is logged in and return status info.
+
+    Returns:
+        Tuple of (is_logged_in, status_message).
+        status_message describes how the user is authenticated (env var, cached, etc.)
+    """
+    # Check environment variable first
+    env_key = os.environ.get("WANDB_API_KEY")
+    if env_key:
+        return True, "WANDB_API_KEY environment variable"
+
+    # Try to check wandb cached credentials
+    try:
+        import wandb
+
+        # wandb.login(verify=True) returns True if already logged in
+        # This checks cached credentials without prompting
+        if wandb.login(verify=True):
+            return True, "cached wandb credentials"
+    except Exception:
+        pass
+
+    return False, None
+
+
+def get_wandb_api_key_help_text(is_logged_in: bool, auth_source: Optional[str]) -> str:
+    """Generate help text for the WandB API key field based on login status.
+
+    Args:
+        is_logged_in: Whether wandb is currently authenticated.
+        auth_source: Description of how the user is authenticated.
+
+    Returns:
+        Help text string for the API key field.
+    """
+    base_help = (
+        "WandB API Key. From https://wandb.ai/authorize. "
+        "You could also set it in your terminal by exporting the WANDB_API_KEY "
+        "environment variable or `wandb login` in your shell."
+    )
+
+    if is_logged_in and auth_source:
+        return f"{base_help} (Already authenticated via {auth_source} - can leave blank)"
+
+    return base_help

--- a/sleap/gui/learning/wandb_utils.py
+++ b/sleap/gui/learning/wandb_utils.py
@@ -23,12 +23,14 @@ def check_wandb_login_status() -> Tuple[bool, Optional[str]]:
     try:
         import netrc
 
-        netrc_path = Path.home() / ("_netrc" if os.name == "nt" else ".netrc")
-        if netrc_path.exists():
-            nrc = netrc.netrc(str(netrc_path))
-            auth = nrc.authenticators("api.wandb.ai")
-            if auth and auth[2]:  # (login, account, password) - password is API key
-                return True, "cached credentials (~/.netrc)"
+        # Try both .netrc and _netrc (Windows can use either)
+        for netrc_name in (".netrc", "_netrc"):
+            netrc_path = Path.home() / netrc_name
+            if netrc_path.exists():
+                nrc = netrc.netrc(str(netrc_path))
+                auth = nrc.authenticators("api.wandb.ai")
+                if auth and auth[2]:  # (login, account, password) - password is API key
+                    return True, "cached credentials (~/.netrc)"
     except Exception:
         pass
 

--- a/sleap/gui/learning/wandb_utils.py
+++ b/sleap/gui/learning/wandb_utils.py
@@ -1,29 +1,34 @@
 """Utilities for WandB integration in SLEAP GUI."""
 
 import os
+from pathlib import Path
 from typing import Optional, Tuple
 
 
 def check_wandb_login_status() -> Tuple[bool, Optional[str]]:
     """Check if wandb is logged in and return status info.
 
+    This function checks for cached credentials without calling wandb.login(),
+    which would be slow and print messages to stdout.
+
     Returns:
-        Tuple of (is_logged_in, status_message).
-        status_message describes how the user is authenticated (env var, cached, etc.)
+        Tuple of (is_logged_in, auth_source).
+        auth_source describes how the user is authenticated (env var, netrc, etc.)
     """
-    # Check environment variable first
-    env_key = os.environ.get("WANDB_API_KEY")
-    if env_key:
+    # Check environment variable first (fastest)
+    if os.environ.get("WANDB_API_KEY"):
         return True, "WANDB_API_KEY environment variable"
 
-    # Try to check wandb cached credentials
+    # Check netrc file for cached credentials (wandb stores keys here)
     try:
-        import wandb
+        import netrc
 
-        # wandb.login(verify=True) returns True if already logged in
-        # This checks cached credentials without prompting
-        if wandb.login(verify=True):
-            return True, "cached wandb credentials"
+        netrc_path = Path.home() / ("_netrc" if os.name == "nt" else ".netrc")
+        if netrc_path.exists():
+            nrc = netrc.netrc(str(netrc_path))
+            auth = nrc.authenticators("api.wandb.ai")
+            if auth and auth[2]:  # (login, account, password) - password is API key
+                return True, "cached credentials (~/.netrc)"
     except Exception:
         pass
 
@@ -47,6 +52,8 @@ def get_wandb_api_key_help_text(is_logged_in: bool, auth_source: Optional[str]) 
     )
 
     if is_logged_in and auth_source:
-        return f"{base_help} (Already authenticated via {auth_source} - can leave blank)"
+        return (
+            f"{base_help} (Already authenticated via {auth_source} - can leave blank)"
+        )
 
     return base_help

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -46,6 +46,10 @@ class Preferences(object):
         # Training pipeline settings
         "training image conversion": "",  # '', 'RGB', or 'grayscale'
         "training predict on": "current frame",  # 'current frame' or 'random frames'
+        "training data pipeline framework": "Cache in Memory",
+        "training num workers": 0,
+        "training num devices": None,  # None = auto-detect
+        "training accelerator": "auto",
     }
     _filename = "preferences.yaml"
 

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -43,6 +43,9 @@ class Preferences(object):
         "wandb project": None,
         "wandb group": None,
         "wandb save viz images": False,
+        # Training pipeline settings
+        "training image conversion": "",  # '', 'RGB', or 'grayscale'
+        "training predict on": "current frame",  # 'current frame' or 'random frames'
     }
     _filename = "preferences.yaml"
 


### PR DESCRIPTION
## Summary

Comprehensive quality-of-life improvements for the training configuration GUI.

> **Note**: Replaces #2508 which was closed when its base branch was merged.

## Changes

### WandB Integration
- Expose `save_viz_imgs_wandb` option for uploading training visualizations
- Persist WandB settings across sessions (entity, project, group, enabled, save viz)
- Auto-detect wandb login status via netrc (fast, silent, no network call)
- Show authentication status in API key field placeholder

### Training Form UX
- **Augmentation simplification**: Replace probability sliders with on/off checkboxes
- **Rotation presets**: Dropdown with Off, ±15°, ±180°, Custom (one click vs editing two fields)
- **Overfit mode**: Checkbox for `use_same_data_for_val` (train=val for small datasets)
- **Hardware settings**: Moved from per-model to pipeline tab (num_workers, devices, accelerator)
- **Data pipeline**: Friendly names (Stream, Cache in Memory, Cache to Disk)

### Layout & Sizing
- Dialog reduced from 1860x1150 to 1130x860 (fits 1280x720 screens)
- Two-column Pipeline tab layout
- Augmentation params hidden when disabled
- Buttons always visible (outside scroll area)

### Bug Fixes
- Fix optional string fields exporting as `""` instead of `None`
- Fix `None` values displaying as "None" in text fields
- Fix multi-stage training abort (stop if first model fails)
- Fix run_name/wandb.name inheritance from base configs
- Fix UTF-8 encoding for YAML forms on Windows

### Settings Persistence
- All training pipeline settings persist across sessions
- Smart defaults: "suggested frames" for new users, saved preference for experienced users

## Test Plan

- [x] WandB settings persist across dialog open/close
- [x] Augmentation checkboxes toggle params correctly
- [x] Rotation dropdown works with all presets
- [x] Overfit mode disables validation fraction
- [x] Dialog fits on smaller screens
- [x] Multi-stage training aborts on first failure
- [x] Run folder names are clean (no old run_name prefix)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)