### PR TITLE
Fix 'Delete All Predictions...' deleting user instances in multi-video projects

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -118,6 +118,7 @@ from sleap.sleap_io_adaptors.lf_labels_utils import (
     remove_track,
     remove_video,
     remove_all_tracks,
+    videos_match,
 )
 
 # Indicates whether we support multiple project windows (i.e., "open" opens new window)
@@ -3274,7 +3275,7 @@ class RemoveSuggestion(EditCommand):
         if selected_frame is not None:
             for sug_idx, suggestion in enumerate(context.labels.suggestions):
                 if (
-                    suggestion.video.matches_content(selected_frame.video)
+                    videos_match(suggestion.video, selected_frame.video)
                     and suggestion.frame_idx == selected_frame.frame_idx
                 ):
                     context.labels.suggestions.pop(sug_idx)

--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -108,12 +108,32 @@ def remove_all_tracks(labels: Labels):
     return labels
 
 
+def videos_match(video1: Video, video2: Video) -> bool:
+    """Check if two videos are the same video object.
+
+    This uses object identity instead of video.matches_content() because
+    matches_content() only compares shape and backend type, which can cause
+    different videos with the same dimensions to incorrectly match.
+
+    For operations within a single Labels object, we should use object identity
+    to ensure we're comparing the exact same video object.
+
+    Args:
+        video1: First video to compare
+        video2: Second video to compare
+
+    Returns:
+        True if the videos are the same object
+    """
+    return video1 is video2
+
+
 def remove_frames(labels: Labels, frames: List[LabeledFrame]):
     """Remove a list of frames from the labels dataset."""
     for lf in frames:
         for lf_idx, lab_fr in enumerate(labels):
             if (
-                lab_fr.video.matches_content(lf.video)
+                videos_match(lab_fr.video, lf.video)
                 and lab_fr.frame_idx == lf.frame_idx
             ):
                 labels_pop(labels, lf_idx)
@@ -172,19 +192,19 @@ def remove_video(labels: Labels, video: Video):
     # Remove labeled frames for this video (iterate backwards to avoid index issues)
     for lf_idx in reversed(range(len(labels.labeled_frames))):
         lf = labels.labeled_frames[lf_idx]
-        if lf.video.matches_content(video):
+        if videos_match(lf.video, video):
             labels_pop(labels, lf_idx)
 
     # Remove video from videos list (iterate backwards to avoid index issues)
     for vid_idx in reversed(range(len(labels.videos))):
         vid = labels.videos[vid_idx]
-        if video == vid:
+        if videos_match(video, vid):
             labels.videos.pop(vid_idx)
 
         # Remove any suggestions for this video
         if hasattr(labels, "suggestions"):
             labels.suggestions = [
-                s for s in labels.suggestions if not s.video.matches_content(video)
+                s for s in labels.suggestions if not videos_match(s.video, video)
             ]
 
 

--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -109,23 +109,28 @@ def remove_all_tracks(labels: Labels):
 
 
 def videos_match(video1: Video, video2: Video) -> bool:
-    """Check if two videos are the same video object.
+    """Check if two videos represent the same video.
 
-    This uses object identity instead of video.matches_content() because
-    matches_content() only compares shape and backend type, which can cause
-    different videos with the same dimensions to incorrectly match.
+    This combines matches_content() (shape and backend type) with matches_path()
+    (filename comparison) to correctly identify matching videos while handling:
 
-    For operations within a single Labels object, we should use object identity
-    to ensure we're comparing the exact same video object.
+    1. Different video files with same dimensions (e.g., 1-frame .tif files)
+       -> Returns False (different paths)
+    2. Same video file with different object IDs (e.g., after deserialization)
+       -> Returns True (same content AND same path)
+
+    Using matches_content() alone would incorrectly match different videos
+    with the same shape. Using object identity alone would fail to match
+    the same video after deserialization.
 
     Args:
         video1: First video to compare
         video2: Second video to compare
 
     Returns:
-        True if the videos are the same object
+        True if the videos have matching content AND matching file paths
     """
-    return video1 is video2
+    return video1.matches_content(video2) and video1.matches_path(video2, strict=True)
 
 
 def remove_frames(labels: Labels, frames: List[LabeledFrame]):


### PR DESCRIPTION
  ## Summary
  - Fixed bug where "Delete All Predictions..." menu item deleted user-labeled instances in multi-video projects
  - Root cause: `video.matches_content()` returns True for ALL videos with the same dimensions (shape and backend type), causing `remove_frames()` to remove frames from all videos instead of just the target
  - `remove_frames()` on videos w/ ImageVideo backend and 1 frame (`.tif`): frame to remove is idx 0 -> `remove_frames()` checks video shape & backend type + labeled frame idx (0 for .tif ImageVideos) -> call `labels_pop()`
  - soln: compare content AND path w/ [sleap-io `matches_path()` function](https://io.sleap.ai/latest/model/?h=matches_path#sleap_io.Video)

  ## Test plan
  - [ ] Open a multi-video project with both user instances and predictions
  - [ ] Use "Labels > Delete All Predictions..."
  - [ ] Verify only predictions are deleted, user instances are preserved
  - [ ] Verify frames with only user instances remain in the project

  🤖 Generated with [Claude Code](https://claude.com/claude-code)