### PR TITLE
Fix training config form not pre-populating from selected config

### DIFF
--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -516,6 +516,12 @@ class TrainingConfigFilesWidget(FieldComboWidget):
         finally:
             self.blockSignals(False)
 
+        # After update completes, trigger config load for the selected item.
+        # This ensures the form is populated with the selected config's values.
+        selected = self.getSelectedConfigInfo()
+        if selected is not None:
+            self.onConfigSelection.emit(selected)
+
     @property
     def _menu_cfg_idx_offset(self):
         if (


### PR DESCRIPTION
## Summary

- Fixes training config form not pre-populating values from selected config in dropdown
- The config would appear selected but form showed default values (e.g., Output Stride: 1 instead of 4)

## Root Cause

When `TrainingConfigFilesWidget.update()` populates the dropdown:
1. Signals are blocked during `set_options()` to prevent cascade of multiple `currentIndexChanged` signals as items are added
2. But after completion, no signal was emitted for the final selected config
3. Result: Config appeared selected but `acceptSelectedConfigInfo()` was never called, so form showed defaults

## Fix

Added signal emission after `update()` completes (`configs.py:519-523`):

```python
# After update completes, trigger config load for the selected item.
# This ensures the form is populated with the selected config's values.
selected = self.getSelectedConfigInfo()
if selected is not None:
    self.onConfigSelection.emit(selected)
```

This ensures:
- Cascade prevention during `set_options()` is preserved (signals still blocked)
- One signal is emitted after update for the final selected config
- Form is populated with correct values from the selected config

## Test plan

- [ ] Open training dialog for bottom-up pipeline
- [ ] Verify config is auto-selected in dropdown and form shows its values (not defaults)
- [ ] If no trained models exist, verify template config is loaded
- [ ] Select different configs from dropdown, verify form updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)