### PR TITLE
Bump version to 1.6.0a0

### DIFF
--- a/sleap/version.py
+++ b/sleap/version.py
@@ -11,7 +11,7 @@ For example, if you set the version to X.Y.Z, then the tag should be "vX.Y.Z".
 Must be a semver string, "aN" should be appended for alpha releases.
 """
 
-__version__ = "1.5.2"
+__version__ = "1.6.0a0"
 
 
 def versions():


### PR DESCRIPTION
## Summary
- Bumps version from 1.5.2 to 1.6.0a0 (alpha release)

## Test plan
- [x] Verified `sleap.version.__version__` returns `1.6.0a0`
- [ ] pyproject.toml pulls version dynamically via `version = {attr = "sleap.version.__version__"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)