### PR TITLE
Add progress dialog and completion notification for package export

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1593,9 +1593,14 @@ class ExportPackageThread(QtCore.QThread):
         else:
             export_target = self.filename
 
+        # Deep copy labels to avoid mutation by sleap-io's embed_frames().
+        # sleap-io replaces video references in-place with embedded versions,
+        # which would break subsequent exports from the same Labels object.
+        labels_copy = deepcopy(self.labels)
+
         try:
             save_file(
-                self.labels,
+                labels_copy,
                 export_target,
                 format="slp",
                 embed=self.embed_option,

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -70,6 +70,12 @@ from sleap.gui.dialogs.frame_range import FrameRangeDialog
 from sleap.gui.state import GuiState
 from sleap.gui.suggestions import VideoFrameSuggestions
 from sleap_io import LabeledFrame, Labels, save_file, SuggestionFrame
+
+try:
+    from sleap_io.io.slp import ExportCancelled
+except ImportError:
+    # Fallback for older sleap-io versions without ExportCancelled
+    ExportCancelled = None
 from sleap_io.model.instance import (
     Instance,
     PredictedInstance,
@@ -1530,6 +1536,107 @@ class ExportLabeledClip(ExportVideoClip):
         )
 
 
+class ExportPackageThread(QtCore.QThread):
+    """Background thread for exporting labels package without freezing GUI."""
+
+    progress = QtCore.Signal(int, int)  # (current, total)
+    finished = QtCore.Signal(str)  # filename
+    error = QtCore.Signal(str)  # error message
+    cancelled = QtCore.Signal()
+
+    def __init__(
+        self,
+        labels: Labels,
+        filename: str,
+        embed_option: str,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.labels = labels
+        self.filename = filename
+        self.embed_option = embed_option
+        self._cancelled = False
+
+    def cancel(self):
+        """Request cancellation of the export."""
+        self._cancelled = True
+
+    def _needs_temp_file(self) -> bool:
+        """Check if we need to use a temp file to avoid overwriting source.
+
+        Returns True if any video in the labels references the output filename,
+        which would cause errors if we delete the file before reading frames.
+        """
+        output_path = Path(self.filename).resolve()
+        if not output_path.exists():
+            return False
+
+        for video in self.labels.videos:
+            video_path = Path(video.filename).resolve()
+            if video_path == output_path:
+                return True
+        return False
+
+    def run(self):
+        """Run the export in background thread."""
+
+        def on_progress(current, total):
+            self.progress.emit(current, total)
+            return not self._cancelled
+
+        # Check if we need to use a temp file to avoid overwriting source
+        use_temp = self._needs_temp_file()
+        if use_temp:
+            # Write to temp file first, then rename
+            temp_filename = self.filename + ".tmp"
+            export_target = temp_filename
+        else:
+            export_target = self.filename
+
+        try:
+            save_file(
+                self.labels,
+                export_target,
+                format="slp",
+                embed=self.embed_option,
+                progress_callback=on_progress,
+            )
+
+            if self._cancelled:
+                # Clean up on cancellation
+                if Path(export_target).exists():
+                    os.remove(export_target)
+                self.cancelled.emit()
+                return
+
+            # If we used a temp file, replace the original
+            if use_temp:
+                if Path(self.filename).exists():
+                    os.remove(self.filename)
+                os.rename(export_target, self.filename)
+
+            self.finished.emit(self.filename)
+
+        except Exception as e:
+            # Clean up temp file if it exists
+            if use_temp and Path(export_target).exists():
+                os.remove(export_target)
+
+            # Check if this was a cancellation
+            is_cancelled = (
+                (ExportCancelled is not None and isinstance(e, ExportCancelled))
+                or "cancel" in str(e).lower()
+                or self._cancelled
+            )
+            if is_cancelled:
+                # Clean up partial file
+                if Path(self.filename).exists():
+                    os.remove(self.filename)
+                self.cancelled.emit()
+            else:
+                self.error.emit(str(e))
+
+
 def export_dataset_gui(
     labels: Labels,
     filename: str,
@@ -1550,42 +1657,159 @@ def export_dataset_gui(
         verbose: If `True`, display progress dialog. Defaults to `True`.
         as_package: If `True`, save as a package (saves image data instead of
             referencing video). Defaults to `True`.
+
+    Returns:
+        The filename if successful, "canceled" if canceled by user.
     """
-    if verbose:
-        win = QtWidgets.QProgressDialog(
-            "Exporting dataset with frame images...", "Cancel", 0, 1
-        )
-
-    def update_progress(n, n_total):
-        if win.wasCanceled():
-            return False
-        win.setMaximum(n_total)
-        win.setValue(n)
-        win.setLabelText(
-            f"Exporting dataset with frame images...<br>{n}/{n_total} "
-            f"(<b>{(n / n_total) * 100:.1f}%</b>)"
-        )
-        QtWidgets.QApplication.instance().processEvents()
-        return True
-
     embed_option = "all" if all_labeled else "user+suggestions" if suggested else "user"
-    save_file(
-        labels,
-        filename,
-        format="slp",
-        embed=embed_option if as_package else False,
-        # progress_callback=update_progress if verbose else None, #TODO
+
+    if not verbose:
+        # Non-verbose mode: run synchronously without GUI
+        save_file(
+            labels,
+            filename,
+            format="slp",
+            embed=embed_option if as_package else False,
+        )
+        return filename
+
+    # Create progress dialog
+    win = QtWidgets.QProgressDialog(
+        "Exporting dataset with frame images...", "Cancel", 0, 1
+    )
+    win.setWindowModality(QtCore.Qt.WindowModal)
+    win.setMinimumDuration(0)
+    win.setAutoClose(False)
+    win.setAutoReset(False)
+    win.show()
+    QtWidgets.QApplication.instance().processEvents()
+
+    # Track result
+    result = {"status": None, "filename": None, "error": None}
+
+    # Create worker thread
+    worker = ExportPackageThread(
+        labels=labels,
+        filename=filename,
+        embed_option=embed_option if as_package else False,
     )
 
-    if verbose:
-        if win.wasCanceled():
-            # Delete output if saving was canceled.
-            os.remove(filename)
-            return "canceled"
+    def on_progress(current, total):
+        win.setMaximum(total)
+        win.setValue(current)
+        win.setLabelText(
+            f"Exporting dataset with frame images...<br>{current}/{total} "
+            f"(<b>{(current / total) * 100:.1f}%</b>)"
+        )
 
-        win.hide()
+    def on_finished(fname):
+        result["status"] = "finished"
+        result["filename"] = fname
+
+    def on_cancelled():
+        result["status"] = "canceled"
+
+    def on_error(msg):
+        result["status"] = "error"
+        result["error"] = msg
+
+    # Connect signals
+    worker.progress.connect(on_progress)
+    worker.finished.connect(on_finished)
+    worker.cancelled.connect(on_cancelled)
+    worker.error.connect(on_error)
+
+    # Handle cancel button
+    win.canceled.connect(worker.cancel)
+
+    # Start the worker
+    worker.start()
+
+    # Process events while worker is running (keeps GUI responsive)
+    while worker.isRunning():
+        QtWidgets.QApplication.instance().processEvents()
+        worker.wait(10)  # Wait up to 10ms
+
+    # Ensure thread is fully terminated
+    worker.wait()
+
+    # Process any remaining events (including final signals from worker)
+    QtWidgets.QApplication.instance().processEvents()
+
+    # Clean up: disconnect signals and delete worker to prevent dangling references
+    worker.progress.disconnect()
+    worker.finished.disconnect()
+    worker.cancelled.disconnect()
+    worker.error.disconnect()
+    worker.deleteLater()
+
+    win.close()
+
+    # Handle result
+    if result["status"] == "finished":
+        _show_export_complete_dialog(result["filename"])
+        return result["filename"]
+    elif result["status"] == "canceled":
+        return "canceled"
+    elif result["status"] == "error":
+        QtWidgets.QMessageBox.critical(
+            None,
+            "Export Error",
+            f"Failed to export labels package:\n{result['error']}",
+        )
+        raise RuntimeError(result["error"])
 
     return filename
+
+
+def _show_export_complete_dialog(filepath: str):
+    """Show a dialog after export completes with options to open folder or copy path.
+
+    Args:
+        filepath: The path to the exported file.
+    """
+    msg = QtWidgets.QMessageBox()
+    msg.setWindowTitle("Export Complete")
+    msg.setIcon(QtWidgets.QMessageBox.Information)
+    msg.setText("Labels package exported successfully.")
+    msg.setInformativeText(filepath)
+
+    # Add custom buttons
+    open_folder_btn = msg.addButton("Open Folder", QtWidgets.QMessageBox.ActionRole)
+    copy_path_btn = msg.addButton("Copy Path", QtWidgets.QMessageBox.ActionRole)
+    ok_btn = msg.addButton(QtWidgets.QMessageBox.Ok)
+
+    msg.setDefaultButton(ok_btn)
+    msg.exec()
+
+    clicked = msg.clickedButton()
+    if clicked == open_folder_btn:
+        reveal_file(filepath)
+    elif clicked == copy_path_btn:
+        QtWidgets.QApplication.clipboard().setText(filepath)
+
+
+def reveal_file(filepath: str):
+    """Open the file explorer with the given file selected/revealed.
+
+    Similar to `open_file()` but reveals the file in its containing folder
+    rather than opening it with the default application.
+
+    Args:
+        filepath: The path to the file to reveal.
+    """
+    filepath = Path(filepath).resolve()
+
+    if sys.platform == "win32":
+        # Windows: use explorer /select, to highlight the file
+        # Note: the comma after /select is required
+        subprocess.Popen(["explorer", "/select,", str(filepath)])
+    elif sys.platform == "darwin":
+        # macOS: use open -R to reveal in Finder
+        subprocess.Popen(["open", "-R", str(filepath)])
+    else:
+        # Linux: xdg-open doesn't support file selection, open parent folder
+        subprocess.Popen(["xdg-open", str(filepath.parent)])
 
 
 class ExportDatasetWithImages(AppCommand):


### PR DESCRIPTION
## Summary

- Enable progress dialog and completion notification for "Export Labels Package..." command
- Previously the progress dialog was created but never updated (callback was commented out)
- Now shows real-time progress during frame embedding with cancel support
- Shows completion dialog with convenient actions after export finishes
- **Export runs in a background thread** to prevent GUI freezing during slow I/O

## Changes

### `sleap/gui/commands.py`

**`ExportPackageThread`** (new class)
- QThread subclass that runs the export in background
- Emits `progress(current, total)`, `finished(filename)`, `cancelled()`, `error(msg)` signals
- Handles `ExportCancelled` exception and partial file cleanup
- `_needs_temp_file()`: Detects when overwriting source file, uses temp file to avoid read errors
- Deep copies Labels before export to avoid mutation issues

**`export_dataset_gui()`**
- Enable `progress_callback` parameter (was commented out with `#TODO`)
- Create worker thread and connect signals
- Process Qt events while waiting for thread (keeps GUI responsive)
- Proper thread cleanup: `wait()`, disconnect signals, `deleteLater()`
- Handle result based on thread signals

**`_show_export_complete_dialog()`** (new)
- Shows "Export Complete" message with file path
- Three buttons:
  - **Open Folder**: Opens file explorer with the exported file selected
  - **Copy Path**: Copies file path to clipboard
  - **OK**: Dismisses dialog

**`reveal_file()`** (new)
- Cross-platform helper to reveal a file in the system file explorer
- Windows: `explorer /select,<path>`
- macOS: `open -R <path>`
- Linux: `xdg-open <parent>`

**`ExportCancelled` import**
- Imports from `sleap_io.io.slp` with fallback for older versions

## Why QThread?

The export can be slow when loading frames from network storage or slow disks. Without threading:
- A single frame taking 10 seconds to load would freeze the GUI for 10 seconds
- The Cancel button would be unresponsive during that time

With the QThread approach:
- GUI remains fully responsive at all times
- Cancel button works immediately
- Progress updates appear as soon as frames complete

## Bug Fixes

1. **Completion dialog not appearing**: Fixed race condition where signal wasn't processed before checking result - added `processEvents()` after while loop

2. **Overwriting existing .pkg.slp fails**: When exporting to a file that's also the source, sleap-io would delete it before reading frames. Fixed by detecting this case and using a temp file, then renaming on success.

3. **App won't quit after export**: Fixed by properly cleaning up worker thread - `wait()`, disconnect signals, and `deleteLater()`

4. **Repeated exports fail with "Frame index out of range"**: sleap-io's `embed_frames()` mutates the Labels object in-place, replacing video references with embedded versions pointing to the exported `.pkg.slp` file. On subsequent exports, frame indices would be invalid since embedded videos have sparse indexing. Fixed by deep copying Labels before export.

## Dependencies

Requires [sleap-io PR #283](https://github.com/talmolab/sleap-io/pull/283) for `progress_callback` support.

## Test plan

- [x] Export a labels package and verify progress dialog appears and updates
- [x] Verify GUI remains responsive during export (can move/resize window)
- [x] Cancel during export and verify partial file is deleted
- [x] Complete export and verify completion dialog appears
- [x] Test "Open Folder" button opens explorer with file selected
- [x] Test "Copy Path" button copies path to clipboard
- [x] Test "OK" button dismisses dialog
- [x] Test overwriting existing .pkg.slp file works
- [x] Test app quits cleanly after export
- [x] Export multiple times in a row without closing the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)