### PR TITLE
Fix training/inference dialog minimum width and WandB login state

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -217,6 +217,42 @@ class LearningDialog(QtWidgets.QDialog):
         # Set the dialog's dimensions
         self.resize(int(target_width), int(target_height))
 
+        # Note: minimum width is set dynamically in _update_minimum_width()
+        # after tabs are added, since TrainingEditorWidget tabs may be wider
+        # than the main tab.
+
+    def _update_minimum_width(self):
+        """Update dialog minimum width based on tab content.
+
+        Called after tabs are added/changed to ensure the dialog cannot be
+        resized smaller than its content requires. This is especially important
+        on Windows 11 where Qt doesn't always propagate minimum size constraints
+        from child widgets through scroll areas.
+        """
+        # Get minimum width from the tab widget which accounts for all tabs
+        # Use sizeHint as it reflects the preferred size including all content
+        tab_width = self.tab_widget.sizeHint().width()
+
+        # Add margins for dialog layout and window frame decorations
+        # The scroll area and content layout add some padding
+        min_width = tab_width + 40
+
+        # Floor at the main tab's requirement as a safety minimum
+        min_width = max(min_width, MainTabWidget.BOX_MIN_WIDTH + 50)
+
+        self.setMinimumWidth(min_width)
+
+    def showEvent(self, event):
+        """Handle dialog show event.
+
+        Updates minimum width after the dialog is shown and layout is computed.
+        This ensures accurate size calculations on all platforms.
+        """
+        super().showEvent(event)
+        # Defer minimum width update to after event processing completes
+        # to ensure layout is fully computed
+        QtCore.QTimer.singleShot(0, self._update_minimum_width)
+
     def update_file_lists(self):
         """Update config file lists for all currently shown tabs.
 
@@ -815,6 +851,10 @@ class LearningDialog(QtWidgets.QDialog):
 
             # Apply defaults from previous trained config or video analysis
             self._apply_pipeline_defaults(pipeline)
+
+            # Update minimum width after tabs change (if dialog is visible)
+            if self.isVisible():
+                self._update_minimum_width()
 
         self.current_pipeline = pipeline
 

--- a/sleap/gui/learning/main_tab.py
+++ b/sleap/gui/learning/main_tab.py
@@ -1238,6 +1238,16 @@ class MainTabWidget(QWidget):
         if not hasattr(self, "_api_key_status_label"):
             return
 
+        # WandB option fields to enable/disable based on login status
+        wandb_option_fields = [
+            "trainer_config.use_wandb",
+            "trainer_config.wandb.save_viz_imgs_wandb",
+            "trainer_config.wandb.entity",
+            "trainer_config.wandb.project",
+            "trainer_config.wandb.prv_runid",
+            "trainer_config.wandb.group",
+        ]
+
         if is_logged_in:
             # Show logged in status
             if auth_source == "WANDB_API_KEY environment variable":
@@ -1253,6 +1263,12 @@ class MainTabWidget(QWidget):
                 self._wandb_copy_btn.setVisible(False)
             if hasattr(self, "_wandb_refresh_btn"):
                 self._wandb_refresh_btn.setVisible(False)
+
+            # Enable WandB option fields when logged in
+            for field_name in wandb_option_fields:
+                field = self._fields.get(field_name)
+                if field is not None:
+                    field.setEnabled(True)
 
             # Update hidden API key field
             api_key_field = self._fields.get("trainer_config.wandb.api_key")
@@ -1273,6 +1289,12 @@ class MainTabWidget(QWidget):
                 self._wandb_copy_btn.setVisible(True)
             if hasattr(self, "_wandb_refresh_btn"):
                 self._wandb_refresh_btn.setVisible(True)
+
+            # Disable WandB option fields when not logged in
+            for field_name in wandb_option_fields:
+                field = self._fields.get(field_name)
+                if field is not None:
+                    field.setEnabled(False)
 
             # Clear any placeholder
             self._wandb_api_key_placeholder = None


### PR DESCRIPTION
## Summary
- Fix dialog minimum width to prevent content clipping on Windows 11 by dynamically computing width from tab content
- Disable WandB options when user is not logged in to WandB

## Test plan
- [ ] Open training dialog on Windows 11, verify window cannot be resized smaller than content
- [ ] Open training dialog without WandB login, verify WandB options are disabled
- [ ] Login to WandB, click refresh, verify options become enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)