### PR TITLE
Add unified CLI with `sleap` command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dynamic = ["version", "readme"]
 dependencies = [
     "attrs",
+    "click>=8.0",
     "omegaconf",
     "imageio",
     "imageio-ffmpeg",
@@ -44,6 +45,7 @@ dependencies = [
     "pyzmq",
     "qtpy",
     "rich",
+    "rich-click>=1.8",
     "scikit-image",
     "scikit-learn",
     "scipy",
@@ -105,6 +107,7 @@ Documentation = "https://sleap.ai/"
 "Source Code" = "https://github.com/talmolab/sleap"
 
 [project.scripts]
+sleap = "sleap.cli:cli"
 sleap-convert = "sleap.io.convert:main"
 sleap-render = "sleap.io.visuals:main"
 sleap-label = "sleap.gui.app:main"
@@ -112,8 +115,8 @@ sleap-inspect = "sleap.info.labels:main"
 sleap-diagnostic = "sleap.diagnostic:main"
 sleap-train = "sleap.legacy_cli_adaptors:train_command"
 sleap-track = "sleap.legacy_cli_adaptors:track_command"
-sleap-nn-train = "sleap.cli:train"
-sleap-nn-track = "sleap.cli:track"
+sleap-nn-train = "sleap.nn_cli:train"
+sleap-nn-track = "sleap.nn_cli:track"
 # sleap-export = "sleap.legacy_cli_adaptors:export_cli"
 
 [tool.uv]

--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -1,502 +1,561 @@
-"""CLI commands for SLEAP-NN training and inference."""
+"""SLEAP Command-Line Interface.
 
-import logging
-from pathlib import Path
-
-import click
-from click import Command
-
-logger = logging.getLogger(__name__)
-
-
-class TrainCommand(Command):
-    """Custom command class that overrides help behavior for train command."""
-
-    def format_help(self, ctx, formatter):
-        """Override the help formatting to show custom training help."""
-        show_training_help()
-
-
-def show_training_help():
-    """Display training help information."""
-    help_text = """
-sleap-nn-train — Train SLEAP models from a config YAML file.
+This module provides the primary command-line interface for SLEAP using
+click and rich-click. The `sleap` command is the main entry point.
 
 Usage:
-  sleap-nn-train --config-dir <dir> --config-name <name> [overrides]
+    sleap                    Launch the GUI
+    sleap my_project.slp     Open project in GUI
+    sleap label [FILE]       Launch the GUI (explicit)
+    sleap doctor             Show system diagnostics
+    sleap --help             Show CLI help
 
-Common overrides:
-  trainer_config.max_epochs=100
-  trainer_config.batch_size=32
-
-Examples:
-  Start new run:
-    sleap-nn-train --config-dir /path/to/config_dir/ --config-name myrun
-  Resume 20 more epochs:
-    sleap-nn-train --config-dir /path/to/config_dir/ --config-name myrun \\
-      trainer_config.resume_ckpt_path=<path/to/ckpt> \\
-      trainer_config.max_epochs=20
-
-For a detailed list of all available config options, please refer to https://nn.sleap.ai/config/.
+Legacy CLIs (sleap-label, sleap-train, etc.) are maintained for backwards
+compatibility but the unified `sleap` command is preferred.
 """
-    click.echo(help_text)
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from typing import Any, Optional
+
+import rich_click as click
+from rich_click import RichHelpConfiguration, rich_config
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich import box
+
+import sleap
 
 
-@click.command(cls=TrainCommand)
-@click.option("--config-name", "-c", type=str, help="Configuration file name")
-@click.option(
-    "--config-dir", "-d", type=str, default=".", help="Configuration directory path"
-)
-@click.argument("overrides", nargs=-1, type=click.UNPROCESSED)
-def train(config_name, config_dir, overrides):
-    """Run training workflow with Hydra config overrides.
+# =============================================================================
+# DefaultGroup Implementation
+# =============================================================================
 
-    (From `sleap-nn`: `sleap-nn train`)
 
-    Examples:
-        sleap-nn-train --config-name myconfig --config-dir /path/to/config_dir/
-        sleap-nn-train -c myconfig -d /path/to/config_dir/ trainer_config.max_epochs=100
-        sleap-nn-train -c myconfig -d /path/to/config_dir/ +experiment=new_model
+class DefaultGroup(click.RichGroup):
+    """A Click group that invokes a default subcommand if none is specified.
+
+    Adapted from click-contrib/click-default-group for rich-click.
+
+    Key behaviors:
+    - `sleap` with no args -> invokes `label` command
+    - `sleap foo.slp` (unrecognized command) -> invokes `label foo.slp`
+    - `sleap doctor` -> invokes `doctor` command normally
+    - `sleap --help` -> shows group help
     """
-    # Import sleap-nn modules inside function
-    try:
-        from sleap_nn.train import run_training
-        from omegaconf import OmegaConf
-        import hydra
 
-        # Show help if no config name provided
-        if not config_name:
-            show_training_help()
-            return
+    ignore_unknown_options = True
 
-        # Initialize Hydra manually
-        # resolve the path to the config directory (hydra expects absolute path)
-        config_dir = Path(config_dir).resolve().as_posix()
-        with hydra.initialize_config_dir(config_dir=config_dir, version_base=None):
-            # Compose config with overrides
-            cfg = hydra.compose(config_name=config_name, overrides=list(overrides))
+    def __init__(
+        self,
+        *args: Any,
+        default: Optional[str] = None,
+        default_if_no_args: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.default_cmd_name = default
+        self.default_if_no_args = default_if_no_args
 
-            # Validate config
-            if not hasattr(cfg, "model_config") or not cfg.model_config:
-                click.echo(
-                    "No model config found! Use `sleap-nn-train --help` for more info."
-                )
-                raise click.Abort()
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        # If no args and we have a default, insert it
+        if not args and self.default_if_no_args and self.default_cmd_name:
+            args.insert(0, self.default_cmd_name)
+        return super().parse_args(ctx, args)
 
-            print("Input config:")
-            print("\n" + OmegaConf.to_yaml(cfg))
-            run_training(cfg)
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[click.Command]:
+        # First try normal command lookup
+        cmd = super().get_command(ctx, cmd_name)
+        if cmd is not None:
+            return cmd
+        # If command not found, we'll handle it in resolve_command
+        return None
 
-    except ImportError:
-        logger.error(
-            "sleap-nn is not installed. This appears to be a GUI-only installation. "
-            "To enable training, please install SLEAP with the 'nn' dependency. "
-            "See the installation guide: https://docs.sleap.ai/latest/installation/"
+    def resolve_command(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[Optional[str], Optional[click.Command], list[str]]:
+        try:
+            # Try to resolve normally first
+            cmd_name, cmd, remaining = super().resolve_command(ctx, args)
+
+            # If we found a real command, use it
+            if cmd is not None:
+                return cmd_name, cmd, remaining
+        except click.UsageError:
+            # No matching command found
+            pass
+
+        # No matching command - use the default and treat first arg as an argument
+        if self.default_cmd_name:
+            default_cmd = super().get_command(ctx, self.default_cmd_name)
+            if default_cmd:
+                return self.default_cmd_name, default_cmd, args
+
+        # Re-raise if we can't handle it
+        raise click.UsageError(
+            f"No such command '{args[0]}'." if args else "No command specified."
         )
 
 
-@click.command()
-@click.option(
-    "--data_path",
-    "-i",
-    type=str,
-    required=True,
-    help="Path to data to predict on. Can be a labels (.slp) file or video format.",
-)
-@click.option(
-    "--model_paths",
-    "-m",
-    multiple=True,
-    help="Path to trained model directory (with training_config.json). "
-    "Multiple models can be specified, each preceded by --model_paths.",
-)
-@click.option(
-    "--output_path",
-    "-o",
-    type=str,
-    default=None,
-    help="The output filename for predicted data. "
-    "If not provided, defaults to '[data_path].slp'.",
-)
-@click.option(
-    "--device",
-    "-d",
-    type=str,
-    default="auto",
-    help="Device on which torch.Tensor will be allocated. "
-    "One of ('cpu', 'cuda', 'mps', 'auto'). Default: 'auto' "
-    "(based on available backend). If `cuda` is available, "
-    "you could also use `cuda:0` to specify the device.",
-)
-@click.option(
-    "--batch_size",
-    "-b",
-    type=int,
-    default=4,
-    help="Number of frames to predict at a time. "
-    "Larger values result in faster inference speeds, but require more memory.",
-)
-@click.option(
-    "--tracking",
-    "-t",
-    is_flag=True,
-    default=False,
-    help="If True, runs tracking on the predicted instances.",
-)
-@click.option(
-    "-n",
-    "--max_instances",
-    type=int,
-    default=None,
-    help="Limit maximum number of instances in multi-instance models. "
-    "Not available for ID models. Defaults to None.",
-)
-@click.option(
-    "--backbone_ckpt_path",
-    type=str,
-    default=None,
-    help="To run inference on any `.ckpt` other than `best.ckpt` from the "
-    "`model_paths` dir, the path to the `.ckpt` file should be passed here.",
-)
-@click.option(
-    "--head_ckpt_path",
-    type=str,
-    default=None,
-    help="Path to `.ckpt` file if a different set of head layer weights are to be used."
-    "If `None`, the `best.ckpt` from `model_paths` dir is used "
-    "(or the ckpt from `backbone_ckpt_path` if provided).",
-)
-@click.option(
-    "--max_height",
-    type=int,
-    default=None,
-    help="Maximum height the image should be padded to. "
-    "If not provided, the values from the training config are used.",
-)
-@click.option(
-    "--max_width",
-    type=int,
-    default=None,
-    help="Maximum width the image should be padded to. "
-    "If not provided, the values from the training config are used.",
-)
-@click.option(
-    "--input_scale",
-    type=float,
-    default=None,
-    help="Scale factor to apply to the input image. "
-    "If not provided, the values from the training config are used.",
-)
-@click.option(
-    "--ensure_rgb",
-    is_flag=True,
-    default=False,
-    help="True if the input image should have 3 channels (RGB image). "
-    "If input has only one channel when this is set to `True`, then the images "
-    "from single-channel is replicated along the channel axis. If the image has "
-    "three channels and this is set to False, then we retain the three channels.",
-)
-@click.option(
-    "--ensure_grayscale",
-    is_flag=True,
-    default=False,
-    help="True if the input image should only have a single channel. "
-    "If input has three channels (RGB) and this is set to True, then we convert "
-    "the image to grayscale (single-channel) image. If the source image has only "
-    "1 channel and this is set to False, then we retain the single channel input.",
-)
-@click.option(
-    "--anchor_part",
-    type=str,
-    default=None,
-    help="The node name to use as the anchor for the centroid. "
-    "If not provided, the anchor part in the `training_config.yaml` is used.",
-)
-@click.option(
-    "--only_labeled_frames",
-    is_flag=True,
-    default=False,
-    help="Only run inference on user labeled frames when running on labels dataset. "
-    "This is useful for generating predictions to compare against ground truth.",
-)
-@click.option(
-    "--only_suggested_frames",
-    is_flag=True,
-    default=False,
-    help="Only run inference on unlabeled suggested frames when running on"
-    "labels dataset.This is useful for generating predictions for initialization.",
-)
-@click.option(
-    "--no_empty_frames",
-    is_flag=True,
-    default=False,
-    help=("Clear empty frames that did not have predictions before saving to output."),
-)
-@click.option(
-    "--video_index",
-    type=int,
-    default=None,
-    help="Integer index of video in .slp file to predict on. "
-    "To be used with an .slp path as an alternative to specifying the video path.",
-)
-@click.option(
-    "--video_dataset", type=str, default=None, help="The dataset for HDF5 videos."
-)
-@click.option(
-    "--video_input_format",
-    type=str,
-    default="channels_last",
-    help="The input_format for HDF5 videos.",
-)
-@click.option(
-    "--frames",
-    type=str,
-    default="",
-    help="List of frames to predict when running on a video. Can be specified as a "
-    "comma separated list (e.g. 1,2,3) or a range separated by hyphen "
-    "(e.g., 1-3, for 1,2,3). If not provided, defaults to predicting on entire "
-    "video.",
-)
-@click.option(
-    "--integral_patch_size",
-    type=int,
-    default=5,
-    help="Size of patches to crop around each rough peak as an integer scalar. "
-    "Default: 5.",
-)
-@click.option(
-    "--max_edge_length_ratio",
-    type=float,
-    default=0.25,
-    help="The maximum expected length of a connected pair of points as a fraction of "
-    "the image size. Candidate connections longer than this length will be "
-    "penalized during matching. Default: 0.25.",
-)
-@click.option(
-    "--dist_penalty_weight",
-    type=float,
-    default=1.0,
-    help="A coefficient to scale weight of the distance penalty as a scalar float. "
-    "Set to values greater than 1.0 to enforce the distance penalty more strictly."
-    "Default: 1.0.",
-)
-@click.option(
-    "--n_points",
-    type=int,
-    default=10,
-    help="Number of points to sample along the line integral. Default: 10.",
-)
-@click.option(
-    "--min_instance_peaks",
-    type=float,
-    default=0,
-    help="Min number of peaks instance should have to be considered a real instance."
-    "Instances with fewer peaks than this will be discarded "
-    "(useful for filtering spurious detections). Default: 0.",
-)
-@click.option(
-    "--min_line_scores",
-    type=float,
-    default=0.25,
-    help="Minimum line score (between -1 and 1) required to form a match between "
-    "candidate point pairs. Useful for rejecting spurious detections when"
-    "there are no better ones. Default: 0.25.",
-)
-@click.option(
-    "--queue_maxsize",
-    type=int,
-    default=8,
-    help="Maximum size of the frame buffer queue.",
-)
-@click.option(
-    "--crop_size",
-    type=int,
-    default=None,
-    help="Crop size. If not provided, the crop size from training_config.yaml is used.",
-)
-@click.option(
-    "--peak_threshold",
-    type=float,
-    default=0.2,
-    help="Minimum confidence map value to consider a peak as valid.",
-)
-@click.option(
-    "--integral_refinement",
-    type=str,
-    default="integral",
-    help="If `None`, returns the grid-aligned peaks with no refinement. "
-    "If `'integral'`, peaks will be refined with integral regression. "
-    "Default: 'integral'.",
-)
-@click.option(
-    "--tracking_window_size",
-    type=int,
-    default=5,
-    help="Number of frames to look for in the candidate instances to match with the "
-    "current detections.",
-)
-@click.option(
-    "--min_new_track_points",
-    type=int,
-    default=0,
-    help="We won't spawn a new track for an instance with fewer than this many points.",
-)
-@click.option(
-    "--candidates_method",
-    type=str,
-    default="fixed_window",
-    help="Either of `fixed_window` or `local_queues`. In fixed window method, "
-    "candidates from the last `window_size` frames. In local queues, last "
-    "`window_size` instances for each track ID is considered for matching against "
-    "the current detection.",
-)
-@click.option(
-    "--min_match_points",
-    type=int,
-    default=0,
-    help="Minimum non-NaN points for match candidates.",
-)
-@click.option(
-    "--features",
-    type=str,
-    default="keypoints",
-    help="Feature representation for the candidates to update current detections. "
-    "One of [`keypoints`, `centroids`, `bboxes`, `image`].",
-)
-@click.option(
-    "--scoring_method",
-    type=str,
-    default="oks",
-    help="Method to compute association score between features from the current frame "
-    "and previous tracks. options:[`oks`, `cosine_sim`, `iou`, `euclidean_dist`].",
-)
-@click.option(
-    "--scoring_reduction",
-    type=str,
-    default="mean",
-    help="Method to aggregate multiple scores if there are several detections"
-    "associated with the same track. One of [`mean`, `max`, `robust_quantile`].",
-)
-@click.option(
-    "--robust_best_instance",
-    type=float,
-    default=1.0,
-    help="If the value is between 0 and 1 (excluded), use a robust quantile similarity "
-    "score for the track. If the value is 1, use the max similarity (non-robust). "
-    "For selecting a robust score, 0.95 is a good value.",
-)
-@click.option(
-    "--track_matching_method",
-    type=str,
-    default="hungarian",
-    help="Track matching algorithm. One of `hungarian`, `greedy`.",
-)
-@click.option(
-    "--max_tracks",
-    type=int,
-    default=None,
-    help="Maximum number of new tracks to be created to avoid redundant tracks. "
-    "(only for local queues candidate)",
-)
-@click.option(
-    "--use_flow",
-    is_flag=True,
-    default=False,
-    help="If True, `FlowShiftTracker` is used, where the poses are matched using "
-    "optical flow shifts.",
-)
-@click.option(
-    "--of_img_scale",
-    type=float,
-    default=1.0,
-    help="Factor to scale the images by when computing optical flow. Decrease this to "
-    "increase performance at the cost of finer accuracy. Sometimes decreasing the "
-    "image scale can improve performance with fast movements.",
-)
-@click.option(
-    "--of_window_size",
-    type=int,
-    default=21,
-    help="Optical flow window size to consider at each pyramid scale level.",
-)
-@click.option(
-    "--of_max_levels",
-    type=int,
-    default=3,
-    help="Number of pyramid scale levels to consider. This is different from the scale "
-    "parameter, which determines the initial image scaling.",
-)
-@click.option(
-    "--post_connect_single_breaks",
-    is_flag=True,
-    default=False,
-    help="If True and `max_tracks` is not None with local queues candidate method, "
-    "connects track breaks when exactly one track is lost and exactly"
-    "one new track is spawned in the frame.",
-)
-@click.option(
-    "--tracking_target_instance_count",
-    type=int,
-    default=0,
-    help="Target number of instances to track per frame. (default: 0)",
-)
-@click.option(
-    "--tracking_pre_cull_to_target",
-    type=int,
-    default=0,
-    help=(
-        "If non-zero and target_instance_count is also non-zero, then cull instances "
-        "over target count per frame *before* tracking. (default: 0)"
-    ),
-)
-@click.option(
-    "--tracking_pre_cull_iou_threshold",
-    type=float,
-    default=0,
-    help=(
-        "If non-zero and pre_cull_to_target also set, then use IOU threshold to remove "
-        "overlapping instances over count *before* tracking. (default: 0)"
-    ),
-)
-@click.option(
-    "--tracking_clean_instance_count",
-    type=int,
-    default=0,
-    help="Target number of instances to clean *after* tracking. (default: 0)",
-)
-@click.option(
-    "--tracking_clean_iou_threshold",
-    type=float,
-    default=0,
-    help="IOU to use when culling instances *after* tracking. (default: 0)",
-)
-def track(**kwargs):
-    """Run Inference and Tracking workflow.
+# =============================================================================
+# CLI Configuration
+# =============================================================================
 
-    (From `sleap-nn`: `sleap-nn track`)
+# SLEAP brand colors (from sleap.system_info)
+SLEAP_TEAL = "#1abc9c"
+SLEAP_BLUE = "#3498db"
+SLEAP_PURPLE = "#9b59b6"
+SLEAP_ORANGE = "#e67e22"
+
+# Configure rich-click with solarized-slim theme
+SLEAP_HELP_CONFIG = RichHelpConfiguration(
+    theme="solarized-slim",
+    header_text=f"[bold {SLEAP_TEAL}]SLEAP[/] - Social LEAP Estimates Animal Poses",
+    footer_text=(
+        "[dim]Docs: https://docs.sleap.ai | "
+        "Support: https://github.com/talmolab/sleap/discussions[/]"
+    ),
+    text_markup="rich",
+    show_arguments=True,
+)
+
+
+# =============================================================================
+# Main CLI Group
+# =============================================================================
+
+
+@click.group(
+    cls=DefaultGroup,
+    default="label",
+    default_if_no_args=True,
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@rich_config(help_config=SLEAP_HELP_CONFIG)
+@click.version_option(version=sleap.__version__, prog_name="sleap")
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """SLEAP: A deep learning framework for multi-animal pose tracking.
+
+    Run [bold cyan]sleap[/] without arguments to launch the GUI.
+
+    [dim]Examples:[/]
+      sleap                    Launch the GUI
+      sleap my_project.slp     Open project in GUI
+      sleap doctor             Show system diagnostics
     """
-    # Import sleap-nn modules inside function
-    try:
-        from sleap_nn.predict import run_inference, frame_list
+    pass
 
-        # Convert model_paths from tuple to list
-        if "model_paths" in kwargs and kwargs["model_paths"]:
-            kwargs["model_paths"] = list(kwargs["model_paths"])
-        else:
-            kwargs["model_paths"] = None
 
-        # Convert frames string to list
-        if "frames" in kwargs and kwargs["frames"]:
-            kwargs["frames"] = frame_list(kwargs["frames"])
-        else:
-            kwargs["frames"] = None
+# =============================================================================
+# Label Command (GUI Launcher)
+# =============================================================================
 
-        # Call the original function
-        return run_inference(**kwargs)
 
-    except ImportError:
-        logger.error(
-            "sleap-nn is not installed. This appears to be a GUI-only installation. "
-            "To enable training, please install SLEAP with the 'nn' dependency. "
-            "See the installation guide: https://docs.sleap.ai/latest/installation/"
+@cli.command(context_settings={"help_option_names": ["-h", "--help"]})
+@rich_config(help_config=SLEAP_HELP_CONFIG)
+@click.argument(
+    "labels_path",
+    required=False,
+    type=click.Path(exists=False),
+    metavar="[LABELS.slp]",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    help="Show detailed startup information including GPU status.",
+)
+@click.option(
+    "--reset",
+    is_flag=True,
+    help="Reset GUI preferences to defaults.",
+)
+@click.option(
+    "--no-usage-data",
+    is_flag=True,
+    help="Disable anonymous usage data collection.",
+)
+@click.option(
+    "--nonnative",
+    is_flag=True,
+    help="Use non-native file dialogs.",
+)
+@click.option(
+    "--profiling",
+    is_flag=True,
+    help="Enable performance profiling.",
+)
+def label(
+    labels_path: Optional[str],
+    verbose: bool,
+    reset: bool,
+    no_usage_data: bool,
+    nonnative: bool,
+    profiling: bool,
+) -> None:
+    """Launch the SLEAP labeling GUI.
+
+    Optionally open a labels file (.slp) directly.
+
+    [dim]Examples:[/]
+      sleap label                      Launch empty GUI
+      sleap label my_project.slp       Open existing project
+      sleap my_project.slp             Same as above (shorthand)
+    """
+    # Build args list for the existing GUI main function
+    args = []
+
+    if labels_path:
+        args.append(labels_path)
+    if verbose:
+        args.append("--verbose")
+    if reset:
+        args.append("--reset")
+    if no_usage_data:
+        args.append("--no-usage-data")
+    if nonnative:
+        args.append("--nonnative")
+    if profiling:
+        args.append("--profiling")
+
+    # Import and call the existing GUI launcher
+    from sleap.gui.app import main as gui_main
+
+    gui_main(args=args if args else None)
+
+
+# =============================================================================
+# Doctor Command (System Diagnostics)
+# =============================================================================
+
+
+@cli.command(context_settings={"help_option_names": ["-h", "--help"]})
+@rich_config(help_config=SLEAP_HELP_CONFIG)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Output diagnostics as JSON for programmatic use.",
+)
+def doctor(output_json: bool) -> None:
+    """Show system diagnostics for troubleshooting.
+
+    Displays detailed information about your system configuration,
+    including Python environment, GPU status, and package versions.
+
+    This output is designed to be copy-pasted when reporting issues.
+
+    [dim]Examples:[/]
+      sleap doctor           Show diagnostics
+      sleap doctor --json    Output as JSON
+    """
+    from sleap.system_info import (
+        get_all_package_info,
+        get_pytorch_info,
+        _get_nvidia_driver_version,
+    )
+
+    if output_json:
+        _doctor_json()
+        return
+
+    console = Console()
+
+    console.print()
+    console.print(
+        Panel(
+            f"[bold {SLEAP_TEAL}]SLEAP System Diagnostics[/]",
+            border_style=SLEAP_TEAL,
+            padding=(0, 2),
         )
+    )
+    console.print()
+
+    # -------------------------------------------------------------------------
+    # Platform Information
+    # -------------------------------------------------------------------------
+    platform_table = Table(
+        title="Platform",
+        show_header=False,
+        box=box.SIMPLE,
+        title_style=f"bold {SLEAP_BLUE}",
+        border_style="dim",
+        padding=(0, 2),
+    )
+    platform_table.add_column("Key", style="cyan")
+    platform_table.add_column("Value")
+
+    platform_table.add_row("OS", f"{platform.system()} {platform.release()}")
+    platform_table.add_row("Platform", platform.platform())
+    platform_table.add_row("Machine", platform.machine())
+    processor = platform.processor()
+    platform_table.add_row("Processor", processor if processor else "N/A")
+
+    console.print(platform_table)
+    console.print()
+
+    # -------------------------------------------------------------------------
+    # Python Information
+    # -------------------------------------------------------------------------
+    python_table = Table(
+        title="Python",
+        show_header=False,
+        box=box.SIMPLE,
+        title_style=f"bold {SLEAP_BLUE}",
+        border_style="dim",
+        padding=(0, 2),
+    )
+    python_table.add_column("Key", style="cyan")
+    python_table.add_column("Value")
+
+    python_table.add_row("Version", sys.version.split()[0])
+    python_table.add_row("Executable", sys.executable)
+    python_table.add_row("Prefix", sys.prefix)
+
+    # Virtual environment detection
+    venv = os.environ.get("VIRTUAL_ENV")
+    if venv:
+        python_table.add_row("Virtual Env", venv)
+
+    console.print(python_table)
+    console.print()
+
+    # -------------------------------------------------------------------------
+    # Conda / UV Information
+    # -------------------------------------------------------------------------
+    conda_info = _get_conda_info()
+    if conda_info:
+        conda_table = Table(
+            title="Conda",
+            show_header=False,
+            box=box.SIMPLE,
+            title_style=f"bold {SLEAP_BLUE}",
+            border_style="dim",
+            padding=(0, 2),
+        )
+        conda_table.add_column("Key", style="cyan")
+        conda_table.add_column("Value")
+        conda_table.add_row("Environment", conda_info["environment"])
+        conda_table.add_row("Prefix", conda_info["prefix"])
+        console.print(conda_table)
+        console.print()
+
+    uv_info = _get_uv_info()
+    if uv_info:
+        uv_table = Table(
+            title="UV",
+            show_header=False,
+            box=box.SIMPLE,
+            title_style=f"bold {SLEAP_BLUE}",
+            border_style="dim",
+            padding=(0, 2),
+        )
+        uv_table.add_column("Key", style="cyan")
+        uv_table.add_column("Value")
+        uv_table.add_row("Version", uv_info["version"])
+        uv_table.add_row("Path", uv_info["path"])
+        console.print(uv_table)
+        console.print()
+
+    # -------------------------------------------------------------------------
+    # GPU / CUDA Information
+    # -------------------------------------------------------------------------
+    gpu_table = Table(
+        title="GPU / CUDA",
+        show_header=False,
+        box=box.SIMPLE,
+        title_style=f"bold {SLEAP_BLUE}",
+        border_style="dim",
+        padding=(0, 2),
+    )
+    gpu_table.add_column("Key", style="cyan")
+    gpu_table.add_column("Value")
+
+    nvidia_driver = _get_nvidia_driver_version()
+    if nvidia_driver:
+        gpu_table.add_row("NVIDIA Driver", nvidia_driver)
+
+        gpus = _get_nvidia_gpu_info()
+        for i, gpu in enumerate(gpus):
+            gpu_table.add_row(
+                f"GPU {i}",
+                f"{gpu['name']} ({gpu['memory_free']} free / {gpu['memory_total']})",
+            )
+    else:
+        gpu_table.add_row("NVIDIA Driver", "[dim]Not detected[/]")
+
+    # Get PyTorch info
+    pytorch_info = get_pytorch_info()
+    if pytorch_info["installed"]:
+        pytorch_str = f"v{pytorch_info['version']}"
+        if pytorch_info["accelerator"] == "cuda":
+            pytorch_str += f" (CUDA {pytorch_info['cuda_version']})"
+        elif pytorch_info["accelerator"] == "mps":
+            pytorch_str += " (MPS)"
+        else:
+            pytorch_str += " (CPU)"
+        gpu_table.add_row("PyTorch", pytorch_str)
+    else:
+        gpu_table.add_row("PyTorch", "[dim]Not installed[/]")
+
+    console.print(gpu_table)
+    console.print()
+
+    # -------------------------------------------------------------------------
+    # Package Versions
+    # -------------------------------------------------------------------------
+    packages_table = Table(
+        title="Packages",
+        show_header=True,
+        header_style=f"bold {SLEAP_TEAL}",
+        box=box.SIMPLE,
+        title_style=f"bold {SLEAP_BLUE}",
+        border_style="dim",
+        padding=(0, 2),
+    )
+    packages_table.add_column("Package", style="cyan")
+    packages_table.add_column("Version")
+    packages_table.add_column("Source", style="dim")
+
+    packages = get_all_package_info()
+    for pkg_name, info in packages.items():
+        packages_table.add_row(pkg_name, info["version"], info["source"])
+
+    console.print(packages_table)
+    console.print()
+
+    # -------------------------------------------------------------------------
+    # Footer
+    # -------------------------------------------------------------------------
+    console.print(
+        Panel(
+            "[dim]Copy this output when reporting issues at:\n"
+            "https://github.com/talmolab/sleap/issues[/]",
+            border_style="dim",
+            padding=(0, 2),
+        )
+    )
+    console.print()
+
+
+def _doctor_json() -> None:
+    """Output diagnostics as JSON."""
+    import json
+
+    from sleap.system_info import (
+        get_all_package_info,
+        get_pytorch_info,
+        _get_nvidia_driver_version,
+    )
+
+    data = {
+        "sleap_version": sleap.__version__,
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+        },
+        "python": {
+            "version": sys.version.split()[0],
+            "executable": sys.executable,
+            "prefix": sys.prefix,
+            "virtual_env": os.environ.get("VIRTUAL_ENV"),
+        },
+        "conda": _get_conda_info(),
+        "uv": _get_uv_info(),
+        "gpu": {
+            "nvidia_driver": _get_nvidia_driver_version(),
+            "gpus": _get_nvidia_gpu_info(),
+        },
+        "pytorch": get_pytorch_info(),
+        "packages": get_all_package_info(),
+    }
+
+    print(json.dumps(data, indent=2))
+
+
+def _get_conda_info() -> Optional[dict[str, str]]:
+    """Get conda environment information."""
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    conda_env = os.environ.get("CONDA_DEFAULT_ENV")
+    if conda_prefix:
+        return {
+            "environment": conda_env or "base",
+            "prefix": conda_prefix,
+        }
+    return None
+
+
+def _get_uv_info() -> Optional[dict[str, str]]:
+    """Get uv information if available."""
+    uv_path = shutil.which("uv")
+    if not uv_path:
+        return None
+    try:
+        result = subprocess.run(
+            ["uv", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return {
+                "version": result.stdout.strip(),
+                "path": uv_path,
+            }
+    except Exception:
+        pass
+    return None
+
+
+def _get_nvidia_gpu_info() -> list[dict[str, str]]:
+    """Get NVIDIA GPU information."""
+    if not shutil.which("nvidia-smi"):
+        return []
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name,memory.total,memory.free,utilization.gpu",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            gpus = []
+            for line in result.stdout.strip().split("\n"):
+                if line:
+                    parts = [p.strip() for p in line.split(",")]
+                    if len(parts) >= 4:
+                        gpus.append(
+                            {
+                                "name": parts[0],
+                                "memory_total": f"{parts[1]} MB",
+                                "memory_free": f"{parts[2]} MB",
+                                "utilization": f"{parts[3]}%",
+                            }
+                        )
+            return gpus
+    except Exception:
+        pass
+    return []
+
+
+# =============================================================================
+# Entry Point
+# =============================================================================
+
+if __name__ == "__main__":
+    cli()

--- a/sleap/nn_cli.py
+++ b/sleap/nn_cli.py
@@ -1,0 +1,502 @@
+"""CLI commands for SLEAP-NN training and inference."""
+
+import logging
+from pathlib import Path
+
+import click
+from click import Command
+
+logger = logging.getLogger(__name__)
+
+
+class TrainCommand(Command):
+    """Custom command class that overrides help behavior for train command."""
+
+    def format_help(self, ctx, formatter):
+        """Override the help formatting to show custom training help."""
+        show_training_help()
+
+
+def show_training_help():
+    """Display training help information."""
+    help_text = """
+sleap-nn-train — Train SLEAP models from a config YAML file.
+
+Usage:
+  sleap-nn-train --config-dir <dir> --config-name <name> [overrides]
+
+Common overrides:
+  trainer_config.max_epochs=100
+  trainer_config.batch_size=32
+
+Examples:
+  Start new run:
+    sleap-nn-train --config-dir /path/to/config_dir/ --config-name myrun
+  Resume 20 more epochs:
+    sleap-nn-train --config-dir /path/to/config_dir/ --config-name myrun \\
+      trainer_config.resume_ckpt_path=<path/to/ckpt> \\
+      trainer_config.max_epochs=20
+
+For a detailed list of all available config options, please refer to https://nn.sleap.ai/config/.
+"""
+    click.echo(help_text)
+
+
+@click.command(cls=TrainCommand)
+@click.option("--config-name", "-c", type=str, help="Configuration file name")
+@click.option(
+    "--config-dir", "-d", type=str, default=".", help="Configuration directory path"
+)
+@click.argument("overrides", nargs=-1, type=click.UNPROCESSED)
+def train(config_name, config_dir, overrides):
+    """Run training workflow with Hydra config overrides.
+
+    (From `sleap-nn`: `sleap-nn train`)
+
+    Examples:
+        sleap-nn-train --config-name myconfig --config-dir /path/to/config_dir/
+        sleap-nn-train -c myconfig -d /path/to/config_dir/ trainer_config.max_epochs=100
+        sleap-nn-train -c myconfig -d /path/to/config_dir/ +experiment=new_model
+    """
+    # Import sleap-nn modules inside function
+    try:
+        from sleap_nn.train import run_training
+        from omegaconf import OmegaConf
+        import hydra
+
+        # Show help if no config name provided
+        if not config_name:
+            show_training_help()
+            return
+
+        # Initialize Hydra manually
+        # resolve the path to the config directory (hydra expects absolute path)
+        config_dir = Path(config_dir).resolve().as_posix()
+        with hydra.initialize_config_dir(config_dir=config_dir, version_base=None):
+            # Compose config with overrides
+            cfg = hydra.compose(config_name=config_name, overrides=list(overrides))
+
+            # Validate config
+            if not hasattr(cfg, "model_config") or not cfg.model_config:
+                click.echo(
+                    "No model config found! Use `sleap-nn-train --help` for more info."
+                )
+                raise click.Abort()
+
+            print("Input config:")
+            print("\n" + OmegaConf.to_yaml(cfg))
+            run_training(cfg)
+
+    except ImportError:
+        logger.error(
+            "sleap-nn is not installed. This appears to be a GUI-only installation. "
+            "To enable training, please install SLEAP with the 'nn' dependency. "
+            "See the installation guide: https://docs.sleap.ai/latest/installation/"
+        )
+
+
+@click.command()
+@click.option(
+    "--data_path",
+    "-i",
+    type=str,
+    required=True,
+    help="Path to data to predict on. Can be a labels (.slp) file or video format.",
+)
+@click.option(
+    "--model_paths",
+    "-m",
+    multiple=True,
+    help="Path to trained model directory (with training_config.json). "
+    "Multiple models can be specified, each preceded by --model_paths.",
+)
+@click.option(
+    "--output_path",
+    "-o",
+    type=str,
+    default=None,
+    help="The output filename for predicted data. "
+    "If not provided, defaults to '[data_path].slp'.",
+)
+@click.option(
+    "--device",
+    "-d",
+    type=str,
+    default="auto",
+    help="Device on which torch.Tensor will be allocated. "
+    "One of ('cpu', 'cuda', 'mps', 'auto'). Default: 'auto' "
+    "(based on available backend). If `cuda` is available, "
+    "you could also use `cuda:0` to specify the device.",
+)
+@click.option(
+    "--batch_size",
+    "-b",
+    type=int,
+    default=4,
+    help="Number of frames to predict at a time. "
+    "Larger values result in faster inference speeds, but require more memory.",
+)
+@click.option(
+    "--tracking",
+    "-t",
+    is_flag=True,
+    default=False,
+    help="If True, runs tracking on the predicted instances.",
+)
+@click.option(
+    "-n",
+    "--max_instances",
+    type=int,
+    default=None,
+    help="Limit maximum number of instances in multi-instance models. "
+    "Not available for ID models. Defaults to None.",
+)
+@click.option(
+    "--backbone_ckpt_path",
+    type=str,
+    default=None,
+    help="To run inference on any `.ckpt` other than `best.ckpt` from the "
+    "`model_paths` dir, the path to the `.ckpt` file should be passed here.",
+)
+@click.option(
+    "--head_ckpt_path",
+    type=str,
+    default=None,
+    help="Path to `.ckpt` file if a different set of head layer weights are to be used."
+    "If `None`, the `best.ckpt` from `model_paths` dir is used "
+    "(or the ckpt from `backbone_ckpt_path` if provided).",
+)
+@click.option(
+    "--max_height",
+    type=int,
+    default=None,
+    help="Maximum height the image should be padded to. "
+    "If not provided, the values from the training config are used.",
+)
+@click.option(
+    "--max_width",
+    type=int,
+    default=None,
+    help="Maximum width the image should be padded to. "
+    "If not provided, the values from the training config are used.",
+)
+@click.option(
+    "--input_scale",
+    type=float,
+    default=None,
+    help="Scale factor to apply to the input image. "
+    "If not provided, the values from the training config are used.",
+)
+@click.option(
+    "--ensure_rgb",
+    is_flag=True,
+    default=False,
+    help="True if the input image should have 3 channels (RGB image). "
+    "If input has only one channel when this is set to `True`, then the images "
+    "from single-channel is replicated along the channel axis. If the image has "
+    "three channels and this is set to False, then we retain the three channels.",
+)
+@click.option(
+    "--ensure_grayscale",
+    is_flag=True,
+    default=False,
+    help="True if the input image should only have a single channel. "
+    "If input has three channels (RGB) and this is set to True, then we convert "
+    "the image to grayscale (single-channel) image. If the source image has only "
+    "1 channel and this is set to False, then we retain the single channel input.",
+)
+@click.option(
+    "--anchor_part",
+    type=str,
+    default=None,
+    help="The node name to use as the anchor for the centroid. "
+    "If not provided, the anchor part in the `training_config.yaml` is used.",
+)
+@click.option(
+    "--only_labeled_frames",
+    is_flag=True,
+    default=False,
+    help="Only run inference on user labeled frames when running on labels dataset. "
+    "This is useful for generating predictions to compare against ground truth.",
+)
+@click.option(
+    "--only_suggested_frames",
+    is_flag=True,
+    default=False,
+    help="Only run inference on unlabeled suggested frames when running on"
+    "labels dataset.This is useful for generating predictions for initialization.",
+)
+@click.option(
+    "--no_empty_frames",
+    is_flag=True,
+    default=False,
+    help=("Clear empty frames that did not have predictions before saving to output."),
+)
+@click.option(
+    "--video_index",
+    type=int,
+    default=None,
+    help="Integer index of video in .slp file to predict on. "
+    "To be used with an .slp path as an alternative to specifying the video path.",
+)
+@click.option(
+    "--video_dataset", type=str, default=None, help="The dataset for HDF5 videos."
+)
+@click.option(
+    "--video_input_format",
+    type=str,
+    default="channels_last",
+    help="The input_format for HDF5 videos.",
+)
+@click.option(
+    "--frames",
+    type=str,
+    default="",
+    help="List of frames to predict when running on a video. Can be specified as a "
+    "comma separated list (e.g. 1,2,3) or a range separated by hyphen "
+    "(e.g., 1-3, for 1,2,3). If not provided, defaults to predicting on entire "
+    "video.",
+)
+@click.option(
+    "--integral_patch_size",
+    type=int,
+    default=5,
+    help="Size of patches to crop around each rough peak as an integer scalar. "
+    "Default: 5.",
+)
+@click.option(
+    "--max_edge_length_ratio",
+    type=float,
+    default=0.25,
+    help="The maximum expected length of a connected pair of points as a fraction of "
+    "the image size. Candidate connections longer than this length will be "
+    "penalized during matching. Default: 0.25.",
+)
+@click.option(
+    "--dist_penalty_weight",
+    type=float,
+    default=1.0,
+    help="A coefficient to scale weight of the distance penalty as a scalar float. "
+    "Set to values greater than 1.0 to enforce the distance penalty more strictly."
+    "Default: 1.0.",
+)
+@click.option(
+    "--n_points",
+    type=int,
+    default=10,
+    help="Number of points to sample along the line integral. Default: 10.",
+)
+@click.option(
+    "--min_instance_peaks",
+    type=float,
+    default=0,
+    help="Min number of peaks instance should have to be considered a real instance."
+    "Instances with fewer peaks than this will be discarded "
+    "(useful for filtering spurious detections). Default: 0.",
+)
+@click.option(
+    "--min_line_scores",
+    type=float,
+    default=0.25,
+    help="Minimum line score (between -1 and 1) required to form a match between "
+    "candidate point pairs. Useful for rejecting spurious detections when"
+    "there are no better ones. Default: 0.25.",
+)
+@click.option(
+    "--queue_maxsize",
+    type=int,
+    default=8,
+    help="Maximum size of the frame buffer queue.",
+)
+@click.option(
+    "--crop_size",
+    type=int,
+    default=None,
+    help="Crop size. If not provided, the crop size from training_config.yaml is used.",
+)
+@click.option(
+    "--peak_threshold",
+    type=float,
+    default=0.2,
+    help="Minimum confidence map value to consider a peak as valid.",
+)
+@click.option(
+    "--integral_refinement",
+    type=str,
+    default="integral",
+    help="If `None`, returns the grid-aligned peaks with no refinement. "
+    "If `'integral'`, peaks will be refined with integral regression. "
+    "Default: 'integral'.",
+)
+@click.option(
+    "--tracking_window_size",
+    type=int,
+    default=5,
+    help="Number of frames to look for in the candidate instances to match with the "
+    "current detections.",
+)
+@click.option(
+    "--min_new_track_points",
+    type=int,
+    default=0,
+    help="We won't spawn a new track for an instance with fewer than this many points.",
+)
+@click.option(
+    "--candidates_method",
+    type=str,
+    default="fixed_window",
+    help="Either of `fixed_window` or `local_queues`. In fixed window method, "
+    "candidates from the last `window_size` frames. In local queues, last "
+    "`window_size` instances for each track ID is considered for matching against "
+    "the current detection.",
+)
+@click.option(
+    "--min_match_points",
+    type=int,
+    default=0,
+    help="Minimum non-NaN points for match candidates.",
+)
+@click.option(
+    "--features",
+    type=str,
+    default="keypoints",
+    help="Feature representation for the candidates to update current detections. "
+    "One of [`keypoints`, `centroids`, `bboxes`, `image`].",
+)
+@click.option(
+    "--scoring_method",
+    type=str,
+    default="oks",
+    help="Method to compute association score between features from the current frame "
+    "and previous tracks. options:[`oks`, `cosine_sim`, `iou`, `euclidean_dist`].",
+)
+@click.option(
+    "--scoring_reduction",
+    type=str,
+    default="mean",
+    help="Method to aggregate multiple scores if there are several detections"
+    "associated with the same track. One of [`mean`, `max`, `robust_quantile`].",
+)
+@click.option(
+    "--robust_best_instance",
+    type=float,
+    default=1.0,
+    help="If the value is between 0 and 1 (excluded), use a robust quantile similarity "
+    "score for the track. If the value is 1, use the max similarity (non-robust). "
+    "For selecting a robust score, 0.95 is a good value.",
+)
+@click.option(
+    "--track_matching_method",
+    type=str,
+    default="hungarian",
+    help="Track matching algorithm. One of `hungarian`, `greedy`.",
+)
+@click.option(
+    "--max_tracks",
+    type=int,
+    default=None,
+    help="Maximum number of new tracks to be created to avoid redundant tracks. "
+    "(only for local queues candidate)",
+)
+@click.option(
+    "--use_flow",
+    is_flag=True,
+    default=False,
+    help="If True, `FlowShiftTracker` is used, where the poses are matched using "
+    "optical flow shifts.",
+)
+@click.option(
+    "--of_img_scale",
+    type=float,
+    default=1.0,
+    help="Factor to scale the images by when computing optical flow. Decrease this to "
+    "increase performance at the cost of finer accuracy. Sometimes decreasing the "
+    "image scale can improve performance with fast movements.",
+)
+@click.option(
+    "--of_window_size",
+    type=int,
+    default=21,
+    help="Optical flow window size to consider at each pyramid scale level.",
+)
+@click.option(
+    "--of_max_levels",
+    type=int,
+    default=3,
+    help="Number of pyramid scale levels to consider. This is different from the scale "
+    "parameter, which determines the initial image scaling.",
+)
+@click.option(
+    "--post_connect_single_breaks",
+    is_flag=True,
+    default=False,
+    help="If True and `max_tracks` is not None with local queues candidate method, "
+    "connects track breaks when exactly one track is lost and exactly"
+    "one new track is spawned in the frame.",
+)
+@click.option(
+    "--tracking_target_instance_count",
+    type=int,
+    default=0,
+    help="Target number of instances to track per frame. (default: 0)",
+)
+@click.option(
+    "--tracking_pre_cull_to_target",
+    type=int,
+    default=0,
+    help=(
+        "If non-zero and target_instance_count is also non-zero, then cull instances "
+        "over target count per frame *before* tracking. (default: 0)"
+    ),
+)
+@click.option(
+    "--tracking_pre_cull_iou_threshold",
+    type=float,
+    default=0,
+    help=(
+        "If non-zero and pre_cull_to_target also set, then use IOU threshold to remove "
+        "overlapping instances over count *before* tracking. (default: 0)"
+    ),
+)
+@click.option(
+    "--tracking_clean_instance_count",
+    type=int,
+    default=0,
+    help="Target number of instances to clean *after* tracking. (default: 0)",
+)
+@click.option(
+    "--tracking_clean_iou_threshold",
+    type=float,
+    default=0,
+    help="IOU to use when culling instances *after* tracking. (default: 0)",
+)
+def track(**kwargs):
+    """Run Inference and Tracking workflow.
+
+    (From `sleap-nn`: `sleap-nn track`)
+    """
+    # Import sleap-nn modules inside function
+    try:
+        from sleap_nn.predict import run_inference, frame_list
+
+        # Convert model_paths from tuple to list
+        if "model_paths" in kwargs and kwargs["model_paths"]:
+            kwargs["model_paths"] = list(kwargs["model_paths"])
+        else:
+            kwargs["model_paths"] = None
+
+        # Convert frames string to list
+        if "frames" in kwargs and kwargs["frames"]:
+            kwargs["frames"] = frame_list(kwargs["frames"])
+        else:
+            kwargs["frames"] = None
+
+        # Call the original function
+        return run_inference(**kwargs)
+
+    except ImportError:
+        logger.error(
+            "sleap-nn is not installed. This appears to be a GUI-only installation. "
+            "To enable training, please install SLEAP with the 'nn' dependency. "
+            "See the installation guide: https://docs.sleap.ai/latest/installation/"
+        )


### PR DESCRIPTION
## Summary
- Adds new unified `sleap` CLI as the primary entry point
- `sleap` / `sleap label [FILE]` - Launch GUI (default command)
- `sleap doctor` - System diagnostics for troubleshooting
- `sleap doctor --json` - JSON output for scripting

## Features
- **DefaultGroup pattern**: `sleap file.slp` automatically routes to `sleap label file.slp`
- **solarized-slim theme** via rich-click for clean, professional formatting
- **Comprehensive doctor command** with platform, Python, conda/uv, GPU, and package info

## Changes
- `sleap/cli.py` - New unified CLI implementation
- `sleap/nn_cli.py` - Moved sleap-nn commands here (was cli.py)
- `pyproject.toml` - Added `click`, `rich-click` deps and `sleap` entry point

## Test plan
- [ ] `sleap --help` shows group help
- [ ] `sleap` launches GUI
- [ ] `sleap label` launches GUI
- [ ] `sleap my_file.slp` launches GUI with file
- [ ] `sleap doctor` shows system diagnostics
- [ ] `sleap doctor --json` outputs valid JSON
- [ ] Legacy CLIs still work (`sleap-label`, `sleap-train`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)