### PR TITLE
Fix WandB checkbox state and add run URL display

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -865,8 +865,9 @@ class LearningDialog(QtWidgets.QDialog):
 
     def merge_pipeline_and_head_config_data(self, head_name, head_data, pipeline_data):
         for key, val in pipeline_data.items():
-            # if key.starts_with("_"):
-            #     continue
+            # Skip GUI-only fields (not part of sleap-nn config schema)
+            if key.startswith("gui."):
+                continue
             if key.startswith("model_config.head_configs."):
                 key_scope = key.split(".")
                 if key_scope[2] != head_name:

--- a/sleap/gui/learning/main_tab.py
+++ b/sleap/gui/learning/main_tab.py
@@ -879,9 +879,15 @@ class MainTabWidget(QWidget):
 
         row1.addSpacing(12)
 
-        upload_viz = QCheckBox("Upload Viz to WandB")
+        upload_viz = QCheckBox("Upload Viz")
         self._fields["trainer_config.wandb.save_viz_imgs_wandb"] = upload_viz
         row1.addWidget(upload_viz)
+
+        row1.addSpacing(12)
+
+        open_in_browser = QCheckBox("Open in browser")
+        self._fields["gui.wandb_open_in_browser"] = open_in_browser
+        row1.addWidget(open_in_browser)
 
         row1.addStretch()
         layout.addLayout(row1)
@@ -1242,6 +1248,7 @@ class MainTabWidget(QWidget):
         wandb_option_fields = [
             "trainer_config.use_wandb",
             "trainer_config.wandb.save_viz_imgs_wandb",
+            "gui.wandb_open_in_browser",
             "trainer_config.wandb.entity",
             "trainer_config.wandb.project",
             "trainer_config.wandb.prv_runid",
@@ -1301,6 +1308,7 @@ class MainTabWidget(QWidget):
             checkbox_fields = [
                 "trainer_config.use_wandb",
                 "trainer_config.wandb.save_viz_imgs_wandb",
+                "gui.wandb_open_in_browser",
             ]
             for field_name in checkbox_fields:
                 field = self._fields.get(field_name)

--- a/sleap/gui/learning/main_tab.py
+++ b/sleap/gui/learning/main_tab.py
@@ -1296,6 +1296,17 @@ class MainTabWidget(QWidget):
                 if field is not None:
                     field.setEnabled(False)
 
+            # Also uncheck the wandb-related checkboxes to prevent
+            # wandb being enabled in config when not logged in
+            checkbox_fields = [
+                "trainer_config.use_wandb",
+                "trainer_config.wandb.save_viz_imgs_wandb",
+            ]
+            for field_name in checkbox_fields:
+                field = self._fields.get(field_name)
+                if field is not None and isinstance(field, QCheckBox):
+                    field.setChecked(False)
+
             # Clear any placeholder
             self._wandb_api_key_placeholder = None
             api_key_field = self._fields.get("trainer_config.wandb.api_key")

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -724,8 +724,11 @@ def run_gui_training(
         zmq_ports["controller_port"] = inference_params.get("controller_port", 9000)
         zmq_ports["publish_port"] = inference_params.get("publish_port", 9001)
 
+        # Get WandB auto-open setting from inference params (GUI-only setting)
+        auto_open_wandb = inference_params.get("gui.wandb_open_in_browser", False)
+
         # Open training monitor window
-        win = LossViewer(zmq_ports=zmq_ports)
+        win = LossViewer(zmq_ports=zmq_ports, auto_open_wandb=auto_open_wandb)
 
         # Reassign the values in the inference parameters in case the ports were changed
         inference_params["controller_port"] = win.zmq_ports["controller_port"]

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -591,6 +591,7 @@ class LossViewer(QtWidgets.QMainWindow):
         zmq_ports: Dict = None,
         zmq_context: Optional[zmq.Context] = None,
         show_controller=True,
+        auto_open_wandb: bool = False,
         parent=None,
     ):
         super().__init__(parent)
@@ -599,6 +600,9 @@ class LossViewer(QtWidgets.QMainWindow):
         self.stop_button = None
         self.cancel_button = None
         self.canceled = False
+        self.auto_open_wandb = auto_open_wandb
+        self.wandb_url: Optional[str] = None
+        self._wandb_label: Optional[QtWidgets.QLabel] = None
 
         # Set up ZMQ ports for communication.
         zmq_ports = zmq_ports or dict()
@@ -725,6 +729,12 @@ class LossViewer(QtWidgets.QMainWindow):
             control_layout.addWidget(self.batches_to_show_field)
 
             control_layout.addStretch(1)
+
+            # WandB URL label (hidden until URL is received)
+            self._wandb_label = QtWidgets.QLabel()
+            self._wandb_label.setOpenExternalLinks(True)
+            self._wandb_label.setVisible(False)
+            control_layout.addWidget(self._wandb_label)
 
             self.stop_button = QtWidgets.QPushButton("Stop Early")
             self.stop_button.clicked.connect(self._stop)
@@ -894,6 +904,11 @@ class LossViewer(QtWidgets.QMainWindow):
             if msg["event"] == "train_begin":
                 self._set_start_time(perf_counter())
                 self.current_job_output_type = msg["what"]
+
+                # Handle WandB URL if present
+                wandb_url = msg.get("wandb_url")
+                if wandb_url:
+                    self._on_wandb_url_received(wandb_url)
 
             # Make sure message matches current training job.
             if msg.get("what", "") == self.current_job_output_type:
@@ -1111,6 +1126,26 @@ class LossViewer(QtWidgets.QMainWindow):
         if not self.ctx_given and self.ctx is not None:
             self.ctx.term()
             self.ctx = None
+
+    def _on_wandb_url_received(self, url: str):
+        """Handle received WandB run URL.
+
+        Args:
+            url: The WandB run URL.
+        """
+        import webbrowser
+
+        self.wandb_url = url
+        logger.info(f"WandB run URL: {url}")
+
+        # Update the clickable label
+        if self._wandb_label is not None:
+            self._wandb_label.setText(f'<a href="{url}">WandB Run</a>')
+            self._wandb_label.setVisible(True)
+
+        # Auto-open in browser if enabled
+        if self.auto_open_wandb:
+            webbrowser.open(url)
 
     def _set_end(self):
         """Mark the end of the run."""


### PR DESCRIPTION
## Summary

- Fix WandB checkbox values not being unchecked when not logged in (was causing interactive prompt during training)
- Add "Open in browser" checkbox to auto-launch WandB dashboard when training starts
- Display clickable WandB run link in training monitor window
- Rename "Upload Viz to WandB" to "Upload Viz" for brevity

## Changes

### Bug Fix
When not logged into WandB, the checkboxes were only **disabled** but not **unchecked**, causing `use_wandb: true` to be included in the config. This led to an interactive WandB login prompt blocking training initialization.

### New Feature
- Added "Open in browser" checkbox next to "Upload Viz" in the WandB section
- When checked and WandB is enabled, automatically opens the WandB run dashboard in the browser when training starts
- Also displays a clickable "WandB Run" link in the training monitor control bar

## Test plan
- [ ] Start training with WandB enabled and "Open in browser" checked - browser should open
- [ ] Start training with WandB enabled but "Open in browser" unchecked - no browser, but link appears in monitor
- [ ] Log out of WandB and verify all WandB checkboxes are unchecked and disabled
- [ ] Verify training starts without interactive prompt when not logged into WandB

🤖 Generated with [Claude Code](https://claude.com/claude-code)