### PR TITLE
Fix GUI error handling for preferences and training cancellation

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -64,12 +64,26 @@ def kill_process(pid: int):
     """Force kill a running process and any child processes.
 
     Args:
-        proc: A process ID.
+        pid: A process ID.
     """
-    proc_ = psutil.Process(pid)
+    try:
+        proc_ = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        # Process already exited, nothing to kill
+        return
+
     for subproc_ in proc_.children(recursive=True):
-        subproc_.kill()
-    proc_.kill()
+        try:
+            subproc_.kill()
+        except psutil.NoSuchProcess:
+            # Child process already exited
+            pass
+
+    try:
+        proc_.kill()
+    except psutil.NoSuchProcess:
+        # Process already exited (possibly due to children being killed)
+        pass
 
 
 @attr.s(auto_attribs=True)

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -59,7 +59,7 @@ class Preferences(object):
 
         if file_existed:
             try:
-                self._prefs = util.get_config_yaml(self._filename)
+                self._prefs = util.get_config_yaml(self._filename) or {}
                 logger.debug(f"Loaded preferences from {file_path}")
             except yaml.YAMLError as e:
                 logger.warning(


### PR DESCRIPTION
## Summary

- **Fix TypeError when preferences file is empty**: Handle the case where `yaml.load()` returns `None` for an empty preferences file by using `or {}` to fall back to an empty dict.

- **Fix NoSuchProcess error when canceling training**: Handle race condition in `kill_process()` where the training subprocess may exit between checking if it's running and attempting to kill it. This can occur when:
  - The "Stop Early" button sends a ZMQ stop command causing graceful exit
  - The training process finishes/crashes during Qt event processing
  - Killing child processes causes the parent to exit

## Test plan

- [ ] Verify empty preferences file doesn't cause TypeError on startup
- [ ] Verify canceling training doesn't raise NoSuchProcess error

🤖 Generated with [Claude Code](https://claude.com/claude-code)