### PR TITLE
Move dev dependencies to PEP 735 dependency-groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv sync --extra dev --extra nn-cpu
+        uv sync --extra nn-cpu
 
     - name: Run ruff checks
       run: |
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra dev --extra nn-cpu
+          uv sync --extra nn-cpu
           # uv pip install PySide6==6.7.3  # exit code 139
           # uv pip install PySide6==6.8.1.1  # exit code 139
           # uv pip install PySide6==6.8.3  # exit code 139

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra dev --extra nn-cpu --extra docs
+          uv sync --extra nn-cpu --extra docs
 
       - name: Print environment info
         run: |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -199,41 +199,42 @@ cd sleap
 === "Windows/Linux (CUDA)"
     ```bash
     # CUDA 12.8
-    uv sync --extra dev --extra nn-cuda128 --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv sync --extra nn-cuda128 --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
 
     # CUDA 11.8
-    uv sync --extra dev --extra nn-cuda118 --index https://download.pytorch.org/whl/cu118 --index https://pypi.org/simple
+    uv sync --extra nn-cuda118 --index https://download.pytorch.org/whl/cu118 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux (CPU)"
     ```bash
-    uv sync --extra dev --extra nn-cpu --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv sync --extra nn-cpu --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```bash
-    uv sync --extra dev --extra nn-cpu --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv sync --extra nn-cpu --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "GUI Only"
     ```bash
-    uv sync --extra dev
+    uv sync
     ```
 
-!!! note "SLEAP `uv sync` Extras"
-    The `uv sync` comes with the following **extras** (for local builds):
+!!! note "SLEAP `uv sync` Extras and Dependency Groups"
+    `uv sync` automatically installs the **dev** dependency group (pytest, ruff, etc.) for development.
+
+    The following **extras** are also available:
 
     - **nn-cpu**: Installs `sleap-nn` with the default torch-cpu backend.
     - **nn-cuda118**: Installs `sleap-nn` with the torch CUDA 11.8.
     - **nn-cuda128**: Installs `sleap-nn` with the torch CUDA 12.8.
-    - **dev**: Installs all development tools for testing.
     - **docs**: Installs all documentation-related dependencies (e.g., mkdocs).
     - **jupyter**: Installs all Jupyter and JupyterLab dependencies.
 
 !!! tip "Upgrading All Dependencies"
     To ensure you have the latest versions of all dependencies, use the `--upgrade` flag with `uv sync`:
     ```bash
-    uv sync --extra dev --upgrade
+    uv sync --upgrade
     ```
     This will upgrade all installed packages in your environment to the latest available versions compatible with your `pyproject.toml`.
 
@@ -257,27 +258,27 @@ To update all dependencies (including `sleap-nn` and `sleap-io`) when working fr
 
 === "Windows/Linux (CUDA 12.8)"
     ```bash
-    uv sync --extra dev --extra nn-cuda128 --upgrade --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv sync --extra nn-cuda128 --upgrade --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux (CUDA 11.8)"
     ```bash
-    uv sync --extra dev --extra nn-cuda118 --upgrade --index https://download.pytorch.org/whl/cu118 --index https://pypi.org/simple
+    uv sync --extra nn-cuda118 --upgrade --index https://download.pytorch.org/whl/cu118 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux (CPU)"
     ```bash
-    uv sync --extra dev --extra nn-cpu --upgrade --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv sync --extra nn-cpu --upgrade --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```bash
-    uv sync --extra dev --extra nn-cpu --upgrade --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv sync --extra nn-cpu --upgrade --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "GUI Only"
     ```bash
-    uv sync --extra dev --upgrade
+    uv sync --upgrade
     ```
 
 !!! info "Updating Local Editable Dependencies"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,14 +60,6 @@ version = {attr = "sleap.version.__version__"}
 readme = {file = ["README.md"], content-type="text/markdown"}
 
 [project.optional-dependencies]
-dev = [
-    "pytest",
-    "pytest-cov",
-    "pytest-qt>=4.4.0",
-    "pytest-xvfb",
-    "ruff",
-]
-
 docs = [
     "mkdocs",
     "mkdocs-material",
@@ -98,6 +90,16 @@ nn-cuda128 = [
 
 nn-cuda118 = [
     "sleap-nn[torch]>=0.0.4"
+]
+
+[dependency-groups]
+# PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv`)
+dev = [
+    "pytest",
+    "pytest-cov",
+    "pytest-qt>=4.4.0",
+    "pytest-xvfb",
+    "ruff",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- Migrate dev dependencies from `[project.optional-dependencies]` to `[dependency-groups]` following PEP 735
- With this change, `uv sync` automatically installs the dev dependency group without needing `--extra dev`
- Update CI workflows and installation docs accordingly

## Test plan
- [ ] Verify CI passes (lint + tests)
- [ ] Verify `uv sync` installs dev dependencies automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)