### PR TITLE
Fix WandB checkbox being re-enabled when not logged in

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -36,6 +36,7 @@ from sleap.gui.widgets.frame_target_selector import (
     FrameTargetSelection,
 )
 from sleap.gui.learning.main_tab import MainTabWidget
+from sleap.gui.learning.wandb_utils import check_wandb_login_status
 
 # List of fields which should show list of skeleton nodes
 NODE_LIST_FIELDS = [
@@ -749,37 +750,42 @@ class LearningDialog(QtWidgets.QDialog):
                     defaults_to_apply["_ensure_channels"] = "grayscale"
 
                 # WandB settings from previous config (except run_name)
-                use_wandb = OmegaConf.select(
-                    cfg, "trainer_config.use_wandb", default=None
-                )
-                if use_wandb is not None:
-                    defaults_to_apply["trainer_config.use_wandb"] = use_wandb
-
-                wandb_entity = OmegaConf.select(
-                    cfg, "trainer_config.wandb.entity", default=None
-                )
-                if wandb_entity:
-                    defaults_to_apply["trainer_config.wandb.entity"] = wandb_entity
-
-                wandb_project = OmegaConf.select(
-                    cfg, "trainer_config.wandb.project", default=None
-                )
-                if wandb_project:
-                    defaults_to_apply["trainer_config.wandb.project"] = wandb_project
-
-                wandb_group = OmegaConf.select(
-                    cfg, "trainer_config.wandb.group", default=None
-                )
-                if wandb_group:
-                    defaults_to_apply["trainer_config.wandb.group"] = wandb_group
-
-                save_viz = OmegaConf.select(
-                    cfg, "trainer_config.wandb.save_viz_imgs_wandb", default=None
-                )
-                if save_viz is not None:
-                    defaults_to_apply["trainer_config.wandb.save_viz_imgs_wandb"] = (
-                        save_viz
+                # Only apply if user is logged in to prevent enabling wandb
+                # when credentials are not available (which would trigger an
+                # interactive login prompt that stalls training)
+                is_wandb_logged_in, _, _ = check_wandb_login_status()
+                if is_wandb_logged_in:
+                    use_wandb = OmegaConf.select(
+                        cfg, "trainer_config.use_wandb", default=None
                     )
+                    if use_wandb is not None:
+                        defaults_to_apply["trainer_config.use_wandb"] = use_wandb
+
+                    wandb_entity = OmegaConf.select(
+                        cfg, "trainer_config.wandb.entity", default=None
+                    )
+                    if wandb_entity:
+                        defaults_to_apply["trainer_config.wandb.entity"] = wandb_entity
+
+                    wandb_project = OmegaConf.select(
+                        cfg, "trainer_config.wandb.project", default=None
+                    )
+                    if wandb_project:
+                        defaults_to_apply["trainer_config.wandb.project"] = wandb_project
+
+                    wandb_group = OmegaConf.select(
+                        cfg, "trainer_config.wandb.group", default=None
+                    )
+                    if wandb_group:
+                        defaults_to_apply["trainer_config.wandb.group"] = wandb_group
+
+                    save_viz = OmegaConf.select(
+                        cfg, "trainer_config.wandb.save_viz_imgs_wandb", default=None
+                    )
+                    if save_viz is not None:
+                        defaults_to_apply["trainer_config.wandb.save_viz_imgs_wandb"] = (
+                            save_viz
+                        )
 
         if not used_trained_config:
             # No trained config - use video channel analysis for image conversion

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -771,7 +771,9 @@ class LearningDialog(QtWidgets.QDialog):
                         cfg, "trainer_config.wandb.project", default=None
                     )
                     if wandb_project:
-                        defaults_to_apply["trainer_config.wandb.project"] = wandb_project
+                        defaults_to_apply["trainer_config.wandb.project"] = (
+                            wandb_project
+                        )
 
                     wandb_group = OmegaConf.select(
                         cfg, "trainer_config.wandb.group", default=None
@@ -783,9 +785,8 @@ class LearningDialog(QtWidgets.QDialog):
                         cfg, "trainer_config.wandb.save_viz_imgs_wandb", default=None
                     )
                     if save_viz is not None:
-                        defaults_to_apply["trainer_config.wandb.save_viz_imgs_wandb"] = (
-                            save_viz
-                        )
+                        key = "trainer_config.wandb.save_viz_imgs_wandb"
+                        defaults_to_apply[key] = save_viz
 
         if not used_trained_config:
             # No trained config - use video channel analysis for image conversion


### PR DESCRIPTION
## Summary

- Fixes WandB "Enable" checkbox being re-checked from previous config defaults when user is not logged in
- Prevents sleap-nn from triggering interactive login prompt that stalls training

## Problem

When opening the training dialog with a previous config that had WandB enabled:
1. `MainTabWidget._update_wandb_status()` correctly detected not-logged-in state and unchecked the checkbox
2. `LearningDialog._apply_pipeline_defaults()` then loaded `use_wandb=True` from the previous config and re-checked it
3. User clicks "Run" with checkbox enabled but fields disabled (confusing state)
4. sleap-nn starts with `use_wandb=True`, triggering `wandb.login()` interactive prompt
5. Training appears stalled if user doesn't notice the terminal prompt

## Solution

Check WandB login status before applying WandB settings from previous configs in `_apply_pipeline_defaults()`. If not logged in, the WandB settings are simply not applied, keeping the checkbox in the correct unchecked state.

## Test plan

- [ ] Open training dialog when NOT logged into WandB
- [ ] Select a pipeline that has a previous config with `use_wandb=True`
- [ ] Verify "Enable WandB" checkbox remains unchecked
- [ ] Verify WandB fields remain disabled
- [ ] Run training and verify no interactive login prompt appears

🤖 Generated with [Claude Code](https://claude.ai/code)