### PR TITLE
Fix analytics pinger by adding missing tf_version field

### DIFF
--- a/sleap/gui/web.py
+++ b/sleap/gui/web.py
@@ -156,6 +156,7 @@ def get_analytics_data() -> Dict[str, Any]:
     return {
         "sleap_version": sleap.__version__,
         "python_version": platform.python_version(),
+        "tf_version": "N/A",  # TensorFlow no longer bundled with GUI
         "conda_env": Path(os.environ.get("CONDA_PREFIX", "")).stem,
         "platform": platform.platform(),
     }


### PR DESCRIPTION
## Summary

- Fix analytics pinger that was silently failing since TensorFlow was removed from the package
- The backend at `https://analytics.sleap.ai/ping` requires a `tf_version` field
- Add `tf_version: "N/A"` to the analytics payload since TensorFlow is no longer bundled

## Background

In commit 08b6ede5 ("Remove `sleap.nn` and use `uv`"), the `tf_version` field was removed from `get_analytics_data()` when TensorFlow was unbundled. However, the analytics backend still requires this field, causing all pings to fail with HTTP 422:

```json
{"detail":[{"loc":["body","tf_version"],"msg":"field required","type":"value_error.missing"}]}
```

The error was masked because the try-except only catches `ConnectionError` and `Timeout`, not HTTP error responses.

## Test plan

- [x] Verified fix works by testing against analytics endpoint (returns 200 OK)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)