### PR TITLE
Add sleap-io CLI command inheritance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ outputs/
 plan/
 scratch/
 tmp/
+# Playwright MCP artifacts
+.playwright-mcp/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "seaborn",
     "requests",
     "matplotlib",
-    "sleap-io[all]>=0.5.7",
+    "sleap-io[all]>=0.6.0",  # CLI commands added in 0.6.0
 ]
 
 [tool.setuptools.dynamic]

--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -32,6 +32,20 @@ from rich import box
 
 import sleap
 
+# Import sleap-io CLI commands for integration
+try:
+    from sleap_io.io.cli import (
+        show as sio_show,
+        convert as sio_convert,
+        split as sio_split,
+        filenames as sio_filenames,
+        render as sio_render,
+    )
+
+    _HAS_SLEAP_IO_CLI = True
+except ImportError:
+    _HAS_SLEAP_IO_CLI = False
+
 
 # =============================================================================
 # DefaultGroup Implementation
@@ -124,6 +138,48 @@ SLEAP_HELP_CONFIG = RichHelpConfiguration(
     text_markup="rich",
     show_arguments=True,
 )
+
+# Command organization for help display
+click.rich_click.COMMAND_GROUPS = {
+    "sleap": [
+        {"name": "Application", "commands": ["label", "doctor"]},
+        {"name": "Data Inspection", "commands": ["show", "filenames"]},
+        {"name": "Data Transformation", "commands": ["convert", "split"]},
+        {"name": "Visualization", "commands": ["render"]},
+    ]
+}
+
+
+def wrap_sio_command(sio_cmd: click.Command) -> click.Command:
+    """Wrap a sleap-io CLI command with SLEAP branding.
+
+    This creates a new command that:
+    1. Has the same parameters as the original command
+    2. Uses SLEAP's rich-click configuration for help formatting
+    3. Replaces 'sio' with 'sleap' in help text examples
+
+    Args:
+        sio_cmd: A Click Command object from sleap-io.
+
+    Returns:
+        A new Command object with SLEAP branding applied.
+    """
+    import copy
+
+    # Deep copy to avoid modifying the original
+    new_cmd = copy.copy(sio_cmd)
+
+    # Replace examples in help text
+    if new_cmd.help:
+        new_cmd.help = new_cmd.help.replace("$ sio ", "$ sleap ")
+        # Also replace any "sio" command references in the docs
+        new_cmd.help = new_cmd.help.replace("[bold]sio[/]", "[bold]sleap[/]")
+
+    # Apply SLEAP's rich-click configuration
+    # RichCommand stores config in _rich_config attribute
+    new_cmd._rich_config = SLEAP_HELP_CONFIG
+
+    return new_cmd
 
 
 # =============================================================================
@@ -551,6 +607,19 @@ def _get_nvidia_gpu_info() -> list[dict[str, str]]:
     except Exception:
         pass
     return []
+
+
+# =============================================================================
+# sleap-io Commands (Inherited)
+# =============================================================================
+
+if _HAS_SLEAP_IO_CLI:
+    # Add wrapped sleap-io commands to the CLI group
+    cli.add_command(wrap_sio_command(sio_show), name="show")
+    cli.add_command(wrap_sio_command(sio_convert), name="convert")
+    cli.add_command(wrap_sio_command(sio_split), name="split")
+    cli.add_command(wrap_sio_command(sio_filenames), name="filenames")
+    cli.add_command(wrap_sio_command(sio_render), name="render")
 
 
 # =============================================================================

--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -32,19 +32,14 @@ from rich import box
 
 import sleap
 
-# Import sleap-io CLI commands for integration
-try:
-    from sleap_io.io.cli import (
-        show as sio_show,
-        convert as sio_convert,
-        split as sio_split,
-        filenames as sio_filenames,
-        render as sio_render,
-    )
-
-    _HAS_SLEAP_IO_CLI = True
-except ImportError:
-    _HAS_SLEAP_IO_CLI = False
+# Import sleap-io CLI commands for integration (requires sleap-io>=0.6.0)
+from sleap_io.io.cli import (
+    show as sio_show,
+    convert as sio_convert,
+    split as sio_split,
+    filenames as sio_filenames,
+    render as sio_render,
+)
 
 
 # =============================================================================
@@ -613,13 +608,12 @@ def _get_nvidia_gpu_info() -> list[dict[str, str]]:
 # sleap-io Commands (Inherited)
 # =============================================================================
 
-if _HAS_SLEAP_IO_CLI:
-    # Add wrapped sleap-io commands to the CLI group
-    cli.add_command(wrap_sio_command(sio_show), name="show")
-    cli.add_command(wrap_sio_command(sio_convert), name="convert")
-    cli.add_command(wrap_sio_command(sio_split), name="split")
-    cli.add_command(wrap_sio_command(sio_filenames), name="filenames")
-    cli.add_command(wrap_sio_command(sio_render), name="render")
+# Add wrapped sleap-io commands to the CLI group
+cli.add_command(wrap_sio_command(sio_show), name="show")
+cli.add_command(wrap_sio_command(sio_convert), name="convert")
+cli.add_command(wrap_sio_command(sio_split), name="split")
+cli.add_command(wrap_sio_command(sio_filenames), name="filenames")
+cli.add_command(wrap_sio_command(sio_render), name="render")
 
 
 # =============================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ This module tests the main CLI entry point and sleap-io command integration.
 import pytest
 from click.testing import CliRunner
 
-from sleap.cli import cli, _HAS_SLEAP_IO_CLI
+from sleap.cli import cli
 
 
 class TestCLIBasics:
@@ -43,9 +43,45 @@ class TestCLIBasics:
         assert "diagnostics" in result.output.lower()
 
 
-@pytest.mark.skipif(not _HAS_SLEAP_IO_CLI, reason="sleap-io CLI not available")
 class TestSleapIoIntegration:
-    """Tests for sleap-io CLI command integration."""
+    """Tests for sleap-io CLI command integration.
+
+    These tests verify that sleap-io commands are properly inherited and branded.
+    Requires sleap-io>=0.6.0 which is enforced via version fencing in pyproject.toml.
+    """
+
+    def test_sleap_io_commands_are_registered(self):
+        """Verify all sleap-io commands are registered on the CLI.
+
+        This test explicitly checks that the commands exist as Click command
+        objects, catching cases where the import might have failed silently.
+        """
+        expected_commands = ["show", "convert", "split", "filenames", "render"]
+        registered_commands = list(cli.commands.keys())
+
+        for cmd in expected_commands:
+            assert cmd in registered_commands, (
+                f"Command '{cmd}' not found in CLI. "
+                f"Available commands: {registered_commands}. "
+                "This likely means sleap-io>=0.6.0 is not installed correctly."
+            )
+
+    def test_sleap_io_version_has_cli(self):
+        """Verify installed sleap-io version includes CLI commands.
+
+        This test imports directly from sleap-io to verify the CLI module exists.
+        """
+        # This import should not fail if sleap-io>=0.6.0 is installed
+        from sleap_io.io.cli import show, convert, split, filenames, render
+
+        # Verify they are Click commands
+        import click
+
+        assert isinstance(show, click.Command)
+        assert isinstance(convert, click.Command)
+        assert isinstance(split, click.Command)
+        assert isinstance(filenames, click.Command)
+        assert isinstance(render, click.Command)
 
     def test_show_command_registered(self):
         """Verify show command is available."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,41 +47,18 @@ class TestSleapIoIntegration:
     """Tests for sleap-io CLI command integration.
 
     These tests verify that sleap-io commands are properly inherited and branded.
-    Requires sleap-io>=0.6.0 which is enforced via version fencing in pyproject.toml.
     """
 
     def test_sleap_io_commands_are_registered(self):
-        """Verify all sleap-io commands are registered on the CLI.
-
-        This test explicitly checks that the commands exist as Click command
-        objects, catching cases where the import might have failed silently.
-        """
+        """Verify all sleap-io commands are registered on the CLI."""
         expected_commands = ["show", "convert", "split", "filenames", "render"]
         registered_commands = list(cli.commands.keys())
 
         for cmd in expected_commands:
             assert cmd in registered_commands, (
                 f"Command '{cmd}' not found in CLI. "
-                f"Available commands: {registered_commands}. "
-                "This likely means sleap-io>=0.6.0 is not installed correctly."
+                f"Available commands: {registered_commands}."
             )
-
-    def test_sleap_io_version_has_cli(self):
-        """Verify installed sleap-io version includes CLI commands.
-
-        This test imports directly from sleap-io to verify the CLI module exists.
-        """
-        # This import should not fail if sleap-io>=0.6.0 is installed
-        from sleap_io.io.cli import show, convert, split, filenames, render
-
-        # Verify they are Click commands
-        import click
-
-        assert isinstance(show, click.Command)
-        assert isinstance(convert, click.Command)
-        assert isinstance(split, click.Command)
-        assert isinstance(filenames, click.Command)
-        assert isinstance(render, click.Command)
 
     def test_show_command_registered(self):
         """Verify show command is available."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,142 @@
+"""Tests for the SLEAP CLI module.
+
+This module tests the main CLI entry point and sleap-io command integration.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from sleap.cli import cli, _HAS_SLEAP_IO_CLI
+
+
+class TestCLIBasics:
+    """Tests for basic CLI functionality."""
+
+    def test_cli_help(self):
+        """Verify main CLI help displays correctly."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "SLEAP" in result.output
+        assert "label" in result.output
+        assert "doctor" in result.output
+
+    def test_cli_version(self):
+        """Verify version flag works."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--version"])
+        assert result.exit_code == 0
+        assert "sleap" in result.output.lower()
+
+    def test_label_help(self):
+        """Verify label command help displays correctly."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["label", "--help"])
+        assert result.exit_code == 0
+        assert "Launch the SLEAP labeling GUI" in result.output
+
+    def test_doctor_help(self):
+        """Verify doctor command help displays correctly."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["doctor", "--help"])
+        assert result.exit_code == 0
+        assert "diagnostics" in result.output.lower()
+
+
+@pytest.mark.skipif(not _HAS_SLEAP_IO_CLI, reason="sleap-io CLI not available")
+class TestSleapIoIntegration:
+    """Tests for sleap-io CLI command integration."""
+
+    def test_show_command_registered(self):
+        """Verify show command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["show", "--help"])
+        assert result.exit_code == 0
+        assert "Print labels file summary" in result.output
+
+    def test_show_help_has_sleap_branding(self):
+        """Verify show help uses sleap, not sio, in examples."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["show", "--help"])
+        assert "$ sleap show" in result.output
+        assert "$ sio show" not in result.output
+
+    def test_convert_command_registered(self):
+        """Verify convert command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["convert", "--help"])
+        assert result.exit_code == 0
+        assert "Convert between pose data formats" in result.output
+
+    def test_convert_help_has_sleap_branding(self):
+        """Verify convert help uses sleap, not sio, in examples."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["convert", "--help"])
+        assert "$ sleap convert" in result.output
+        assert "$ sio convert" not in result.output
+
+    def test_split_command_registered(self):
+        """Verify split command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["split", "--help"])
+        assert result.exit_code == 0
+        assert "Split labels" in result.output or "train/val/test" in result.output
+
+    def test_filenames_command_registered(self):
+        """Verify filenames command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["filenames", "--help"])
+        assert result.exit_code == 0
+        assert "video" in result.output.lower()
+
+    def test_render_command_registered(self):
+        """Verify render command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["render", "--help"])
+        assert result.exit_code == 0
+        assert "Render" in result.output
+
+    def test_main_help_shows_all_commands(self):
+        """Verify main help lists all commands."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        # Native commands
+        assert "label" in result.output
+        assert "doctor" in result.output
+        # Inherited commands
+        assert "show" in result.output
+        assert "convert" in result.output
+        assert "split" in result.output
+        assert "filenames" in result.output
+        assert "render" in result.output
+
+    def test_show_with_file(self, tmp_path):
+        """Verify show command works with an actual file."""
+        # Create a minimal labels file using sleap-io
+        from sleap_io import Labels, Skeleton
+
+        skeleton = Skeleton(["A", "B"])
+        labels = Labels(skeletons=[skeleton])
+        labels_path = tmp_path / "test.slp"
+        labels.save(str(labels_path))
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["show", str(labels_path)])
+        assert result.exit_code == 0
+        assert "test.slp" in result.output
+
+
+class TestDefaultGroupBehavior:
+    """Tests for DefaultGroup functionality."""
+
+    def test_unrecognized_command_falls_back_to_label(self):
+        """Verify unrecognized commands fall back to label."""
+        runner = CliRunner()
+        # This should try to open "nonexistent.slp" with the label command
+        # It will fail because the file doesn't exist, but the error should
+        # come from the label command, not a "command not found" error
+        result = runner.invoke(cli, ["nonexistent.slp"])
+        # The label command should be invoked (might fail for other reasons)
+        # We mainly check it doesn't say "No such command"
+        assert "No such command" not in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,6 @@
 This module tests the main CLI entry point and sleap-io command integration.
 """
 
-import pytest
 from click.testing import CliRunner
 
 from sleap.cli import cli


### PR DESCRIPTION
## Summary

Integrate 5 CLI commands from sleap-io (`show`, `convert`, `split`, `filenames`, `render`) into the `sleap` CLI using a dynamic command wrapper approach. Commands are wrapped with SLEAP branding and have their help text examples rebranded from `$ sio` to `$ sleap`.

## Changes

### `sleap/cli.py`
- Add `wrap_sio_command()` function that wraps sleap-io commands with SLEAP's `RichHelpConfiguration`
- Register 5 commands: `show`, `convert`, `split`, `filenames`, `render`
- Configure `COMMAND_GROUPS` to organize help into Application, Data Inspection, Data Transformation, and Visualization sections

### `tests/test_cli.py`
- Add 15 integration tests covering:
  - Command registration and availability
  - Help text branding (`sleap` instead of `sio`)
  - Basic command execution
  - DefaultGroup behavior (falling back to `label` command)

## Example

```bash
# Before: had to use sio command
$ sio show labels.slp

# After: can use sleap command with SLEAP branding
$ sleap show labels.slp
$ sleap show --help  # Shows SLEAP-branded help with `sleap show` examples
```

## Test plan

- [x] All 15 CLI tests pass locally
- [ ] CI passes on all platforms
- [ ] Manual verification: `sleap show --help` displays SLEAP branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)