### PR TITLE
Fix docs versioning to not set pre-releases as latest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,12 +41,19 @@ jobs:
             git config --global user.name "github-actions[bot]"
             git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Build and upload docs (release)
-        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+      - name: Build and upload docs (stable release)
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' && !github.event.release.prerelease }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
             uv run mike deploy --update-aliases --allow-empty --push "${{ github.event.release.tag_name }}" latest
+
+      - name: Build and upload docs (pre-release)
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' && github.event.release.prerelease }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            uv run mike deploy --allow-empty --push "${{ github.event.release.tag_name }}"
 
       - name: Build and upload docs (dev)
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary

- Fixes an issue where pre-release documentation would become the default at `docs.sleap.ai`
- Splits release docs deployment into stable and pre-release steps
- Pre-releases are now deployed without the `latest` alias

## Problem

The current `docs.yml` workflow deploys ALL releases (including pre-releases) with the `latest` alias:

```yaml
- name: Build and upload docs (release)
  if: github.event_name == 'release' && github.event.action == 'published'
  run: |
    uv run mike deploy --update-aliases --push "$TAG" latest
```

This means when `v1.6.0a0` is released:
1. New docs are built at `/v1.6.0a0/`
2. The `latest` alias moves from `v1.5.2` to `v1.6.0a0`
3. **Users visiting `docs.sleap.ai` see pre-release docs by default**

## Solution

Split the release step into two conditional steps:

1. **Stable releases** (`!github.event.release.prerelease`):
   - Deploy with `latest` alias
   - Becomes the default at `docs.sleap.ai`

2. **Pre-releases** (`github.event.release.prerelease`):
   - Deploy WITHOUT `latest` alias
   - Accessible at `/vX.Y.ZaN/` only

## After this change

When `v1.6.0a0` is released (marked as pre-release on GitHub):
```
docs.sleap.ai/          → redirects to /latest/
docs.sleap.ai/latest/   → v1.5.2 (STABLE - unchanged!)
docs.sleap.ai/dev/      → develop branch
docs.sleap.ai/v1.6.0a0/ → pre-release docs (accessible, not default)
```

## Test plan

- [ ] Merge this PR
- [ ] Create a test pre-release (e.g., `v1.6.0a0`) with "This is a pre-release" checkbox checked
- [ ] Verify docs are deployed to `/v1.6.0a0/` without updating `latest`
- [ ] Verify `docs.sleap.ai` still shows v1.5.2

## Related

This is a prerequisite for the v1.6.0a0 pre-release. See investigation: `scratch/2026-01-10-release-pipeline-investigation/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
