### PR TITLE
Update sleap-nn dependency to >=0.1.0a0 and add CUDA 13.0 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,19 +77,23 @@ jupyter = [
 ]
 
 nn = [
-    "sleap-nn[torch]>=0.0.4"
+    "sleap-nn[torch]>=0.1.0a0"
 ]
 
 nn-cpu = [
-    "sleap-nn[torch]>=0.0.4"
+    "sleap-nn[torch]>=0.1.0a0"
 ]
 
 nn-cuda128 = [
-    "sleap-nn[torch]>=0.0.4"
+    "sleap-nn[torch]>=0.1.0a0"
 ]
 
 nn-cuda118 = [
-    "sleap-nn[torch]>=0.0.4"
+    "sleap-nn[torch]>=0.1.0a0"
+]
+
+nn-cuda130 = [
+    "sleap-nn[torch]>=0.1.0a0"
 ]
 
 [dependency-groups]
@@ -128,7 +132,8 @@ conflicts = [
     [
         { extra = "nn-cpu" },
         { extra = "nn-cuda118" },
-        { extra = "nn-cuda128" }
+        { extra = "nn-cuda128" },
+        { extra = "nn-cuda130" }
     ]
 ]
 
@@ -137,6 +142,7 @@ sleap-nn = [
     { index = "pytorch-cpu", extra = "nn-cpu" },
     { index = "pytorch-cu118", extra = "nn-cuda118" },
     { index = "pytorch-cu128", extra = "nn-cuda128" },
+    { index = "pytorch-cu130", extra = "nn-cuda130" },
 ]
 markupsafe = { index = "pypi" }
 # For sleap-io dev, uncomment ONE of the following:
@@ -161,6 +167,12 @@ explicit = true
 name = "pytorch-cu128"
 url = "https://pypi.org/simple"
 extra-index-url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu130"
+url = "https://pypi.org/simple"
+extra-index-url = "https://download.pytorch.org/whl/cu130"
 explicit = true
 
 [[tool.uv.index]]

--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -238,7 +238,12 @@ class ConfigFileInfo:
 
             # otherwise try loading it from validation labels (much slower!)
             else:
-                filename = self._get_file_path("labels_gt.val.slp")
+                # Try new naming first, then legacy, then old sleap-nn naming
+                filename = (
+                    self._get_file_path("labels_gt.val.0.slp")  # sleap-nn v0.1.0+
+                    or self._get_file_path("labels_gt.val.slp")  # legacy SLEAP
+                    or self._get_file_path("labels_val_gt_0.slp")  # sleap-nn < v0.1.0
+                )
                 if filename is not None:
                     val_labels = load_file(filename)
                     if val_labels.skeletons:
@@ -314,10 +319,11 @@ class ConfigFileInfo:
         cache_key = (dset_name, split_name)
         if cache_key not in self._dset_len_cache:
             n = None
+            # Try new naming first, then legacy, then old sleap-nn naming
             filename = (
-                self._get_file_path(f"labels_gt.{split_name}.slp")
-                if self._get_file_path(f"labels_gt.{split_name}.slp")
-                else self._get_file_path(f"labels_{split_name}_gt_0.slp")
+                self._get_file_path(f"labels_gt.{split_name}.0.slp")  # v0.1.0+
+                or self._get_file_path(f"labels_gt.{split_name}.slp")  # legacy
+                or self._get_file_path(f"labels_{split_name}_gt_0.slp")  # < v0.1.0
             )
             if filename is not None:
                 with h5py.File(filename, "r") as f:
@@ -328,7 +334,11 @@ class ConfigFileInfo:
         return self._dset_len_cache[cache_key]
 
     def _get_metrics(self, split_name: Text):
-        metrics_path_nn = self._get_file_path(f"{split_name}_0_pred_metrics.npz")
+        # Try new naming first, then old sleap-nn naming
+        metrics_path_nn = (
+            self._get_file_path(f"metrics.{split_name}.0.npz")  # v0.1.0+
+            or self._get_file_path(f"{split_name}_0_pred_metrics.npz")  # < v0.1.0
+        )
 
         if metrics_path_nn is None:
             # Loading legacy metrics from SLEAP <= v1.4.1

--- a/sleap/info/labels.py
+++ b/sleap/info/labels.py
@@ -163,12 +163,18 @@ def describe_model(model_path, verbose=False):
 
     def describe_dataset(split_name):
         # Check whether the checkpoint files are sleap_nn or legacy sleap
-        # and load the labels accordingly
+        # and load the labels accordingly.
+        # Try new naming first, then legacy, then old sleap-nn naming
         labels = None
-        if os.path.exists(rel_path(f"labels_gt.{split_name}.slp")):
-            labels = labels_load_file(rel_path(f"labels_gt.{split_name}.slp"))
-        elif os.path.exists(rel_path(f"labels_{split_name}_gt_0.slp")):
-            labels = labels_load_file(rel_path(f"labels_{split_name}_gt_0.slp"))
+        gt_new = rel_path(f"labels_gt.{split_name}.0.slp")  # v0.1.0+
+        gt_legacy = rel_path(f"labels_gt.{split_name}.slp")  # legacy
+        gt_old = rel_path(f"labels_{split_name}_gt_0.slp")  # < v0.1.0
+        if os.path.exists(gt_new):
+            labels = labels_load_file(gt_new)
+        elif os.path.exists(gt_legacy):
+            labels = labels_load_file(gt_legacy)
+        elif os.path.exists(gt_old):
+            labels = labels_load_file(gt_old)
 
         if labels is not None:
             labeled_frames_user = [
@@ -181,12 +187,19 @@ def describe_model(model_path, verbose=False):
                 f"Frames: {len(labeled_frames_user)} / Instances: {len(user_instances)}"
             )
 
-        if os.path.exists(rel_path(f"metrics.{split_name}.npz")):
+        # Try new naming first, then old sleap-nn naming, then legacy naming
+        metrics_new = rel_path(f"metrics.{split_name}.0.npz")  # v0.1.0+
+        metrics_old = rel_path(f"{split_name}_0_pred_metrics.npz")  # < v0.1.0
+        metrics_legacy = rel_path(f"metrics.{split_name}.npz")  # legacy
+        if os.path.exists(metrics_new):
             print("Metrics:")
-            describe_metrics(rel_path(f"metrics.{split_name}.npz"), legacy=True)
-        elif os.path.exists(rel_path(f"{split_name}_0_pred_metrics.npz")):
+            describe_metrics(metrics_new, legacy=False)
+        elif os.path.exists(metrics_old):
             print("Metrics:")
-            describe_metrics(rel_path(f"{split_name}_0_pred_metrics.npz"), legacy=False)
+            describe_metrics(metrics_old, legacy=False)
+        elif os.path.exists(metrics_legacy):
+            print("Metrics:")
+            describe_metrics(metrics_legacy, legacy=True)
 
     print("=====")
     print("Training set:")

--- a/sleap/legacy_cli_adaptors.py
+++ b/sleap/legacy_cli_adaptors.py
@@ -226,26 +226,31 @@ def train_command(
                         / trainer.config.trainer_config.run_name
                     ).as_posix()
                     logger.info(f"Training labels path for index {index}: {ckpt_path}")
-                    data_paths[f"train_{index}"] = (
+                    # Use new sleap-nn v0.1.0+ naming convention:
+                    # labels_gt.{split}.{idx}.slp
+                    data_paths[f"train.{index}"] = (
                         Path(trainer.config.trainer_config.ckpt_dir)
                         / trainer.config.trainer_config.run_name
-                        / f"labels_train_gt_{index}.slp"
+                        / f"labels_gt.train.{index}.slp"
                     ).as_posix()
-                    data_paths[f"val_{index}"] = (
+                    data_paths[f"val.{index}"] = (
                         Path(trainer.config.trainer_config.ckpt_dir)
                         / trainer.config.trainer_config.run_name
-                        / f"labels_val_gt_{index}.slp"
+                        / f"labels_gt.val.{index}.slp"
                     ).as_posix()
 
                 if (
                     OmegaConf.select(config, "data_config.test_file_path", default=None)
                     is not None
                 ):
-                    data_paths["test"] = config.data_config.test_file_path
+                    # Test files use index 0 for consistency with new naming
+                    data_paths["test.0"] = config.data_config.test_file_path
 
                 for d_name, path in data_paths.items():
                     labels = sio.load_slp(path)
 
+                    # Use new sleap-nn v0.1.0+ naming convention:
+                    # labels_pr.{split}.{idx}.slp
                     pred_labels = predict(
                         data_path=path,
                         model_paths=[
@@ -257,7 +262,7 @@ def train_command(
                         device=trainer.trainer.strategy.root_device,
                         output_path=Path(trainer.config.trainer_config.ckpt_dir)
                         / trainer.config.trainer_config.run_name
-                        / f"pred_{d_name}.slp",
+                        / f"labels_pr.{d_name}.slp",
                         ensure_rgb=config.data_config.preprocessing.ensure_rgb,
                         ensure_grayscale=config.data_config.preprocessing.ensure_grayscale,
                     )
@@ -273,11 +278,13 @@ def train_command(
                         ground_truth_instances=labels, predicted_instances=pred_labels
                     )
                     metrics = evaluator.evaluate()
+                    # Use new sleap-nn v0.1.0+ naming convention:
+                    # metrics.{split}.{idx}.npz
                     np.savez(
                         (
                             Path(trainer.config.trainer_config.ckpt_dir)
                             / trainer.config.trainer_config.run_name
-                            / f"{d_name}_pred_metrics.npz"
+                            / f"metrics.{d_name}.npz"
                         ).as_posix(),
                         **metrics,
                     )


### PR DESCRIPTION
## Summary

- Update sleap-nn dependency from `>=0.0.4` to `>=0.1.0a0` for sleap v1.6.0a0 pre-release
- Add `nn-cuda130` optional extra for CUDA 13.0 support
- Update file loading to support new sleap-nn v0.1.0+ naming conventions with backwards compatibility
- Update legacy CLI adaptor to use new file naming for predictions/metrics

## Changes

### pyproject.toml
- Updated all `sleap-nn[torch]>=0.0.4` to `sleap-nn[torch]>=0.1.0a0`
- Added `nn-cuda130` optional extra
- Added `pytorch-cu130` to conflicts list
- Added `pytorch-cu130` uv index configuration
- Updated `[tool.uv.sources]` to include cu130 mapping

### sleap/gui/learning/configs.py
- Updated `skeleton` property to try new naming first: `labels_gt.{split}.0.slp`
- Updated `_get_dataset_len()` with new fallback chain
- Updated `_get_metrics()` to check `metrics.{split}.0.npz` first

### sleap/info/labels.py
- Updated `describe_dataset()` to check new naming patterns first
- Maintains backwards compatibility with legacy naming

### sleap/legacy_cli_adaptors.py
- Updated post-training evaluation to use new sleap-nn v0.1.0+ naming:
  - GT labels: `labels_gt.{split}.{idx}.slp`
  - Predictions: `labels_pr.{split}.{idx}.slp`
  - Metrics: `metrics.{split}.{idx}.npz`

## File Naming Convention (sleap-nn PR #408)

| Old Pattern | New Pattern |
|-------------|-------------|
| `labels_train_gt_0.slp` | `labels_gt.train.0.slp` |
| `labels_val_gt_0.slp` | `labels_gt.val.0.slp` |
| `pred_train_0.slp` | `labels_pr.train.0.slp` |
| `pred_val_0.slp` | `labels_pr.val.0.slp` |
| `train_0_pred_metrics.npz` | `metrics.train.0.npz` |
| `val_0_pred_metrics.npz` | `metrics.val.0.npz` |

## Backwards Compatibility

File loading uses fallback chains to maintain compatibility:
1. New sleap-nn v0.1.0+ naming (checked first)
2. Legacy SLEAP naming
3. Old sleap-nn < v0.1.0 naming

## Test plan

- [ ] New sleap-nn models load correctly (new naming)
- [ ] Old sleap-nn models still load (old naming)
- [ ] Legacy SLEAP models still load (legacy naming)
- [ ] Metrics display correctly for all formats
- [ ] Resume training works with new models
- [ ] GUI model browser shows correct info
- [ ] CUDA 13.0 installation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)