### PR TITLE
feat: Add PR-local docs preview deployment

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,99 @@
+# PR-local documentation preview deployment
+# Each PR gets its own isolated preview at https://docs.sleap.ai/pr/{number}/
+# This prevents parallel PRs from clobbering each other's docs
+name: Docs - PR Preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+    paths:
+      - "sleap/**"
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/pr-preview.yml"
+
+# Per-PR concurrency: each PR gets its own group, allowing parallel PR previews
+# cancel-in-progress: true means new pushes to the same PR cancel previous builds
+concurrency:
+  group: pr-preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write       # To push to gh-pages branch
+  pull-requests: write  # To post comments on PRs
+
+jobs:
+  deploy:
+    name: Deploy Preview
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --extra nn-cpu --extra docs
+
+      - name: Build docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uv run mkdocs build --site-dir _site
+
+      - name: Deploy PR Preview
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: _site
+          target-folder: pr/${{ github.event.number }}
+          commit-message: "Deploy PR #${{ github.event.number }} preview"
+
+      - name: Comment on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          message: |
+            ## Docs Preview
+
+            | | |
+            |---|---|
+            | **Preview URL** | https://docs.sleap.ai/pr/${{ github.event.number }}/ |
+            | **Commit** | `${{ github.event.pull_request.head.sha }}` |
+
+            _This preview will be removed when the PR is closed._
+
+  cleanup:
+    name: Cleanup Preview
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Remove PR preview
+        run: |
+          if [ -d "pr/${{ github.event.number }}" ]; then
+            rm -rf "pr/${{ github.event.number }}"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -A
+            git commit -m "Remove PR #${{ github.event.number }} preview" || echo "Nothing to commit"
+            git push
+          else
+            echo "Preview directory pr/${{ github.event.number }} does not exist"
+          fi
+
+      - name: Comment on PR (cleanup)
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          message: |
+            ## Docs Preview
+
+            Preview has been removed.

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history for diff computation
 
       - name: Setup UV
         uses: astral-sh/setup-uv@v6
@@ -43,6 +45,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run mkdocs build --site-dir _site
+
+      - name: Get changed files and generate links
+        id: changed-pages
+        env:
+          BASE_URL: https://docs.sleap.ai/pr/${{ github.event.number }}/
+        run: |
+          # Get list of changed files in this PR (docs-relevant paths only)
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD -- \
+            'docs/**' 'sleap/**' 'mkdocs.yml' '.github/workflows/pr-preview.yml' \
+            2>/dev/null || echo "")
+
+          # Convert to space-separated args
+          FILES_ARGS=$(echo "$CHANGED_FILES" | tr '\n' ' ')
+
+          # Run the script to generate markdown links
+          RESULT=$(python scripts/get_changed_docs_urls.py "$BASE_URL" $FILES_ARGS)
+
+          # Extract markdown from JSON result (handle multiline)
+          MARKDOWN=$(echo "$RESULT" | python -c "import sys, json; print(json.load(sys.stdin)['markdown'])")
+
+          # Use heredoc for multiline output
+          echo "links<<EOF" >> $GITHUB_OUTPUT
+          echo "$MARKDOWN" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Deploy PR Preview
         uses: JamesIves/github-pages-deploy-action@v4
@@ -63,6 +89,8 @@ jobs:
             |---|---|
             | **Preview URL** | https://docs.sleap.ai/pr/${{ github.event.number }}/ |
             | **Commit** | `${{ github.event.pull_request.head.sha }}` |
+
+            ${{ steps.changed-pages.outputs.links }}
 
             _This preview will be removed when the PR is closed._
 

--- a/docs/assets/stylesheets/extra.css
+++ b/docs/assets/stylesheets/extra.css
@@ -1,4 +1,32 @@
-.md-typeset .admonition, 
-.md-typeset details { 
+.md-typeset .admonition,
+.md-typeset details {
     font-size: inherit; /* Ensures it matches the surrounding text */
+}
+
+/* Markdown source link button - positioned in top-right like Material action buttons */
+.md-source-file {
+    float: right;
+    margin: 0 0 0.5em 0.5em;
+}
+
+.md-source-file a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2em;
+    height: 2em;
+    border-radius: 0.2em;
+    color: var(--md-default-fg-color--light);
+    transition: color 0.25s, background-color 0.25s;
+}
+
+.md-source-file a:hover {
+    color: var(--md-accent-fg-color);
+    background-color: var(--md-accent-fg-color--transparent);
+}
+
+.md-source-file svg {
+    width: 1.2em;
+    height: 1.2em;
+    fill: currentColor;
 }

--- a/hooks/copy_source_markdown.py
+++ b/hooks/copy_source_markdown.py
@@ -1,0 +1,92 @@
+"""MkDocs hook to publish markdown sources alongside HTML pages.
+
+This hook does two things:
+1. Copies markdown source files to the build output for direct access via URLs like:
+       https://docs.sleap.ai/{version}/guides/overview.md
+2. Injects a "View page source" link at the top of each page pointing to the local
+   markdown file (useful for LLM context).
+
+The hook runs during the build process to modify pages and copy source files.
+"""
+
+import shutil
+from pathlib import Path
+
+
+def on_page_content(html: str, page, config, files) -> str:  # noqa: ARG001
+    """Inject a link to the markdown source at the top of the page.
+
+    Args:
+        html: The rendered HTML content of the page.
+        page: The MkDocs page object with source file info.
+        config: MkDocs config object.
+        files: Collection of files in the docs.
+
+    Returns:
+        Modified HTML with the source link injected.
+    """
+    # Get the source file path relative to docs_dir
+    src_path = Path(page.file.src_path)  # e.g., "guides/overview.md" or "index.md"
+
+    # Calculate a relative URL to the markdown source
+    # MkDocs generates directory-style URLs:
+    #   - install.md -> /install/index.html
+    #   - guides/overview.md -> /guides/overview/index.html
+    #   - guides/index.md -> /guides/index.html
+    #   - index.md -> /index.html
+    # The markdown files are copied to the same relative path in site_dir:
+    #   - install.md -> /install.md
+    #   - guides/overview.md -> /guides/overview.md
+    # So we use relative paths that work from the page's URL:
+    if src_path.name == "index.md":
+        # index.md pages: source is in the same directory
+        md_url = "index.md"
+    else:
+        # Non-index pages: source is one level up (../filename.md)
+        md_url = f"../{src_path.name}"
+
+    # Create a subtle link block at the top of the content
+    # SVG is a document icon from Material Design Icons
+    svg_icon = (
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">'
+        '<path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 '
+        '2-2V8l-6-6m4 18H6V4h7v5h5v11M13 9V3.5L18.5 9H13Z"/></svg>'
+    )
+    source_link = (
+        f'<div class="md-source-file">'
+        f'<a href="{md_url}" title="View markdown source" class="md-icon">'
+        f"{svg_icon}</a></div>\n"
+    )
+
+    return source_link + html
+
+
+def on_post_build(config, **kwargs):  # noqa: ARG001
+    """Copy markdown source files to the build output after site generation.
+
+    Args:
+        config: MkDocs config object containing docs_dir and site_dir paths.
+        **kwargs: Additional keyword arguments passed by MkDocs (unused).
+    """
+    docs_dir = Path(config["docs_dir"])
+    site_dir = Path(config["site_dir"])
+
+    # Track how many files were copied for logging
+    copied_count = 0
+
+    # Find all markdown files in the docs directory
+    for md_file in docs_dir.rglob("*.md"):
+        # Get the relative path from docs_dir
+        rel_path = md_file.relative_to(docs_dir)
+
+        # Determine destination path in site_dir
+        dest_path = site_dir / rel_path
+
+        # Ensure the destination directory exists
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Copy the markdown file
+        shutil.copy2(md_file, dest_path)
+        copied_count += 1
+
+    print(f"Copied {copied_count} markdown source files to output directory")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,11 @@
 site_name: SLEAP Documentation
 site_url: https://docs.sleap.ai/
 repo_url: https://github.com/talmolab/sleap
+edit_uri: edit/develop/docs/
+
+# Custom hooks
+hooks:
+  - hooks/copy_source_markdown.py  # Publish .md sources alongside HTML
 
 theme:
   name: material

--- a/scripts/get_changed_docs_urls.py
+++ b/scripts/get_changed_docs_urls.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Map changed files from a PR to their corresponding docs preview URLs.
+
+This script is used by the PR preview workflow to generate direct links to
+the specific documentation pages that changed.
+
+Usage:
+    python scripts/get_changed_docs_urls.py <base_url> [file1] [file2] ...
+
+Example:
+    python scripts/get_changed_docs_urls.py <base_url> docs/install.md
+
+Output:
+    JSON object with categorized changes::
+
+        {"pages": [...], "api_affected": true, "config_changed": true}
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def file_to_docs_url(file_path: str, base_url: str) -> dict | None:
+    """Convert a docs file path to its preview URL.
+
+    Args:
+        file_path: Path to the changed file (e.g., "docs/guides/overview.md")
+        base_url: Base URL for the preview (e.g., "https://docs.sleap.ai/pr/123/")
+
+    Returns:
+        Dict with file, url, and title if the file is a docs page, else None.
+    """
+    path = Path(file_path)
+
+    # Only process docs markdown files
+    if not file_path.startswith("docs/") or path.suffix != ".md":
+        return None
+
+    # Get the relative path within docs/
+    rel_path = path.relative_to("docs")
+
+    # Convert to URL path following MkDocs conventions:
+    # - index.md -> /
+    # - foo.md -> /foo/
+    # - foo/bar.md -> /foo/bar/
+    # - foo/index.md -> /foo/
+    if rel_path.name == "index.md":
+        # index.md files map to their parent directory
+        url_path = str(rel_path.parent)
+        if url_path == ".":
+            url_path = ""
+    else:
+        # Other .md files map to a directory with their stem
+        url_path = str(rel_path.with_suffix(""))
+
+    # Ensure base_url ends with /
+    if not base_url.endswith("/"):
+        base_url += "/"
+
+    # Build the full URL
+    if url_path:
+        full_url = f"{base_url}{url_path}/"
+    else:
+        full_url = base_url
+
+    # Generate a friendly title from the file name
+    title = rel_path.name
+
+    return {"file": file_path, "url": full_url, "title": title}
+
+
+def categorize_changes(files: list[str], base_url: str) -> dict:
+    """Categorize changed files into docs pages and other changes.
+
+    Args:
+        files: List of changed file paths
+        base_url: Base URL for the preview
+
+    Returns:
+        Dict with pages, api_affected, and config_changed keys.
+    """
+    pages = []
+    api_affected = False
+    config_changed = False
+
+    for file_path in files:
+        # Check for API-affecting changes (sleap package)
+        if file_path.startswith("sleap/"):
+            api_affected = True
+            continue
+
+        # Check for config changes
+        if file_path in ("mkdocs.yml", ".github/workflows/pr-preview.yml"):
+            config_changed = True
+            continue
+
+        # Try to map to a docs URL
+        page_info = file_to_docs_url(file_path, base_url)
+        if page_info:
+            pages.append(page_info)
+
+    return {
+        "pages": pages,
+        "api_affected": api_affected,
+        "config_changed": config_changed,
+    }
+
+
+def format_markdown_links(result: dict, base_url: str) -> str:
+    """Format the categorized changes as markdown links.
+
+    Args:
+        result: Output from categorize_changes()
+        base_url: Base URL for the preview
+
+    Returns:
+        Markdown formatted string with links
+    """
+    lines = []
+
+    # Add page links
+    if result["pages"]:
+        lines.append("**Changed pages:**")
+        for page in result["pages"]:
+            lines.append(f"- [{page['title']}]({page['url']})")
+
+    # Add API reference note
+    if result["api_affected"]:
+        lines.append("")
+        lines.append(
+            f"**API changes detected** - [View API Reference]({base_url}api/)"
+        )
+
+    # Add config change note
+    if result["config_changed"]:
+        lines.append("")
+        lines.append("_Configuration files changed - full rebuild performed._")
+
+    # If no specific pages but config/API changed, just note it
+    if not result["pages"] and not result["api_affected"] and result["config_changed"]:
+        lines.append("_Only configuration files changed._")
+
+    return "\n".join(lines) if lines else "_No documentation pages directly changed._"
+
+
+def main():
+    """CLI entry point for the script."""
+    if len(sys.argv) < 2:
+        print(
+            "Usage: get_changed_docs_urls.py <base_url> [file1] [file2] ...",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    base_url = sys.argv[1]
+    files = sys.argv[2:] if len(sys.argv) > 2 else []
+
+    result = categorize_changes(files, base_url)
+
+    # Output as JSON for workflow parsing
+    output = {
+        **result,
+        "markdown": format_markdown_links(result, base_url),
+    }
+    print(json.dumps(output))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR implements PR-local documentation previews to prevent parallel PRs from clobbering each other's docs on the shared `dev` version.

**Key Changes:**
- New `pr-preview.yml` workflow deploys each PR to an isolated subdirectory (`pr/{number}/`)
- Each PR gets its own preview URL at `https://docs.sleap.ai/pr/{number}/`
- Automatic cleanup when PRs are closed
- Sticky PR comments show preview URL and update on each push
- **Direct links to changed pages**: PR comments include links to specific documentation pages that changed
- **Published markdown sources**: Source `.md` files are accessible directly via URLs (e.g., `https://docs.sleap.ai/dev/guides/overview.md`) with a "View markdown source" button on each page

## How It Works

| Event | Previous Behavior | New Behavior |
|-------|-------------------|--------------|
| PR opened/updated | No preview | Deploy to `pr/{number}/` (isolated) |
| PR closed | N/A | Automatically removes `pr/{number}/` |
| Main branch push | Deploy to `dev/` | Deploy to `dev/` (unchanged) |
| Release published | Deploy to `v{X.Y.Z}/` | Deploy to `v{X.Y.Z}/` (unchanged) |

## URL Structure

```
https://docs.sleap.ai/
├── dev/             # Main branch docs (via mike)
├── v1.4.0/          # Release docs (via mike)
├── latest -> v1.4.0 # Alias
└── pr/
    ├── 123/         # PR #123 preview
    └── 456/         # PR #456 preview
```

## Example PR Comment

After this change, PR preview comments will look like:

```markdown
## Docs Preview

| | |
|---|---|
| **Preview URL** | https://docs.sleap.ai/pr/123/ |
| **Commit** | `abc1234` |

**Changed pages:**
- [overview.md](https://docs.sleap.ai/pr/123/guides/overview/)
- [install.md](https://docs.sleap.ai/pr/123/installation/)

**API changes detected** - [View API Reference](https://docs.sleap.ai/pr/123/api/)

_This preview will be removed when the PR is closed._
```

## New Files

- `.github/workflows/pr-preview.yml` - PR preview workflow
- `scripts/get_changed_docs_urls.py` - Script to map changed files to docs URLs
- `hooks/copy_source_markdown.py` - MkDocs hook to publish markdown sources

## Test Plan

- [x] Verify this PR triggers the new `pr-preview.yml` workflow
- [x] Verify preview is deployed to `https://docs.sleap.ai/pr/2550/`
- [x] Verify sticky comment is posted with preview URL
- [x] Verify production docs at `https://docs.sleap.ai/` are unaffected
- [ ] Verify changed page links appear in PR comment
- [ ] Verify markdown source button appears on docs pages
- [ ] After merging: verify preview is cleaned up

## Safety

- Production docs remain unaffected (mike only writes to version directories)
- Release and main branch deployment unchanged
- PR previews are isolated in `pr/` subdirectory

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)