### PR TITLE
Improve sleap doctor UX: add spinner and fix path truncation

### DIFF
--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -342,7 +342,7 @@ def doctor(output_json: bool) -> None:
         padding=(0, 2),
     )
     platform_table.add_column("Key", style="cyan")
-    platform_table.add_column("Value")
+    platform_table.add_column("Value", overflow="fold")
 
     platform_table.add_row("OS", f"{platform.system()} {platform.release()}")
     platform_table.add_row("Platform", platform.platform())
@@ -365,7 +365,7 @@ def doctor(output_json: bool) -> None:
         padding=(0, 2),
     )
     python_table.add_column("Key", style="cyan")
-    python_table.add_column("Value")
+    python_table.add_column("Value", overflow="fold")
 
     python_table.add_row("Version", sys.version.split()[0])
     python_table.add_row("Executable", sys.executable)
@@ -393,7 +393,7 @@ def doctor(output_json: bool) -> None:
             padding=(0, 2),
         )
         conda_table.add_column("Key", style="cyan")
-        conda_table.add_column("Value")
+        conda_table.add_column("Value", overflow="fold")
         conda_table.add_row("Environment", conda_info["environment"])
         conda_table.add_row("Prefix", conda_info["prefix"])
         console.print(conda_table)
@@ -410,7 +410,7 @@ def doctor(output_json: bool) -> None:
             padding=(0, 2),
         )
         uv_table.add_column("Key", style="cyan")
-        uv_table.add_column("Value")
+        uv_table.add_column("Value", overflow="fold")
         uv_table.add_row("Version", uv_info["version"])
         uv_table.add_row("Path", uv_info["path"])
         console.print(uv_table)
@@ -428,7 +428,7 @@ def doctor(output_json: bool) -> None:
         padding=(0, 2),
     )
     gpu_table.add_column("Key", style="cyan")
-    gpu_table.add_column("Value")
+    gpu_table.add_column("Value", overflow="fold")
 
     nvidia_driver = _get_nvidia_driver_version()
     if nvidia_driver:
@@ -443,8 +443,9 @@ def doctor(output_json: bool) -> None:
     else:
         gpu_table.add_row("NVIDIA Driver", "[dim]Not detected[/]")
 
-    # Get PyTorch info
-    pytorch_info = get_pytorch_info()
+    # Get PyTorch info (slow due to torch import - show spinner)
+    with console.status("[dim]Checking PyTorch...[/]", spinner="dots"):
+        pytorch_info = get_pytorch_info()
     if pytorch_info["installed"]:
         pytorch_str = f"v{pytorch_info['version']}"
         if pytorch_info["accelerator"] == "cuda":

--- a/sleap/system_info.py
+++ b/sleap/system_info.py
@@ -524,11 +524,10 @@ def _print_package_table(console: Console):
     table.add_column("Package", style="cyan")
     table.add_column("Version", style="white")
     table.add_column("Source", style="yellow")
-    table.add_column("Location", style="dim", overflow="ellipsis")
+    table.add_column("Location", style="dim", overflow="fold")
 
     packages = get_all_package_info()
     for pkg, info in packages.items():
-        location = _shorten_path(info["location"], 45)
-        table.add_row(pkg, info["version"], info["source"], location)
+        table.add_row(pkg, info["version"], info["source"], info["location"])
 
     console.print(table)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,31 @@ class TestCLIBasics:
         assert result.exit_code == 0
         assert "diagnostics" in result.output.lower()
 
+    def test_doctor_runs(self):
+        """Verify doctor command runs and produces output."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["doctor"])
+        assert result.exit_code == 0
+        # Check for expected sections in output
+        assert "Platform" in result.output
+        assert "Python" in result.output
+        assert "GPU" in result.output or "CUDA" in result.output
+        assert "Packages" in result.output
+
+    def test_doctor_json(self):
+        """Verify doctor --json outputs valid JSON."""
+        import json
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["doctor", "--json"])
+        assert result.exit_code == 0
+        # Should be valid JSON
+        data = json.loads(result.output)
+        assert "sleap_version" in data
+        assert "platform" in data
+        assert "python" in data
+        assert "packages" in data
+
 
 class TestSleapIoIntegration:
     """Tests for sleap-io CLI command integration.

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,0 +1,71 @@
+"""Tests for the SLEAP system_info module."""
+
+from io import StringIO
+
+from rich.console import Console
+
+from sleap.system_info import (
+    _print_package_table,
+    get_package_info,
+    get_all_package_info,
+)
+
+
+class TestPackageInfo:
+    """Tests for package info functions."""
+
+    def test_get_package_info_installed(self):
+        """Verify get_package_info returns info for installed packages."""
+        info = get_package_info("sleap")
+        assert info["version"] is not None
+        assert info["source"] in ("pip", "conda", "editable", "git", "local")
+
+    def test_get_package_info_not_installed(self):
+        """Verify get_package_info returns None version for missing packages."""
+        info = get_package_info("nonexistent-package-xyz")
+        assert info["version"] is None
+
+    def test_get_all_package_info(self):
+        """Verify get_all_package_info returns info for installed packages."""
+        packages = get_all_package_info()
+        assert "sleap" in packages
+        assert packages["sleap"]["version"] is not None
+
+
+class TestPackageTable:
+    """Tests for package table printing."""
+
+    def test_print_package_table(self):
+        """Verify _print_package_table prints a table with package info."""
+        # Create a console that writes to a string
+        output = StringIO()
+        console = Console(file=output, force_terminal=True, width=120)
+
+        _print_package_table(console)
+
+        result = output.getvalue()
+        # Check table structure
+        assert "Package" in result
+        assert "Version" in result
+        assert "Source" in result
+        assert "Location" in result
+        # Check that sleap is listed
+        assert "sleap" in result
+
+    def test_print_package_table_shows_full_paths(self):
+        """Verify package table shows full paths without truncation."""
+        output = StringIO()
+        # Use a wide console so paths don't need to wrap
+        console = Console(file=output, force_terminal=True, width=200)
+
+        _print_package_table(console)
+
+        result = output.getvalue()
+        # Check that paths are not truncated with "..."
+        # The old _shorten_path would add "..." prefix
+        lines_with_dots_prefix = [
+            line for line in result.split("\n") if "│ ..." in line
+        ]
+        assert len(lines_with_dots_prefix) == 0, (
+            "Paths should not be truncated with '...' prefix"
+        )


### PR DESCRIPTION
## Summary

- Add spinner during PyTorch import (~1.5s) showing "Checking PyTorch..." so users know the command hasn't hung
- Fix path truncation in `sleap doctor` tables by using `overflow="fold"` - long paths now wrap instead of being cut off with `…`
- Fix double-truncation in `_print_package_table()` by removing manual `_shorten_path()` call

## Test plan

- [ ] Run `sleap doctor` and verify spinner appears during PyTorch check
- [ ] Run `COLUMNS=60 sleap doctor` and verify paths wrap instead of truncating
- [ ] Run `sleap label --verbose` with narrow terminal and verify package locations wrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)