### PR TITLE
Add --exclude_user_labeled flag to sleap-nn-track CLI shim

### DIFF
--- a/sleap/nn_cli.py
+++ b/sleap/nn_cli.py
@@ -227,6 +227,13 @@ def train(config_name, config_dir, overrides):
     "labels dataset.This is useful for generating predictions for initialization.",
 )
 @click.option(
+    "--exclude_user_labeled",
+    is_flag=True,
+    default=False,
+    help="Skip frames that have user-labeled instances. Useful when predicting on "
+    "entire video but skipping already-labeled frames.",
+)
+@click.option(
     "--no_empty_frames",
     is_flag=True,
     default=False,


### PR DESCRIPTION
## Summary
- Adds missing `--exclude_user_labeled` CLI option to the `sleap-nn-track` shim in `sleap/nn_cli.py`
- This flag was added to sleap-nn 0.1.0a0 but was never upstreamed to SLEAP's CLI wrapper

## Context
Running inference with "Skip user labeled frames" enabled from the GUI resulted in:
```
Error: No such option: --exclude_user_labeled
```

The GUI correctly adds `--exclude_user_labeled` to the CLI args (`sleap/gui/learning/runners.py:320-321`), but the shim was missing the corresponding click option.

## Test plan
- [x] `sleap-nn-track --help` now shows `--exclude_user_labeled` option
- [x] All 253 related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)