### PR TITLE
Suppress frame error spam when scrubbing pkg.slp files

### DIFF
--- a/sleap/gui/widgets/video_worker.py
+++ b/sleap/gui/widgets/video_worker.py
@@ -130,7 +130,8 @@ class FrameLoaderThread(QThread):
                     print(f"[THREAD] Frame {frame_idx} was None")
 
         except Exception as e:
-            print(f"[THREAD] Error processing frame {frame_idx}: {e}")
+            if self.debug_mode:
+                print(f"[THREAD] Error processing frame {frame_idx}: {e}")
 
     def request_frame(self, video: sio.Video, frame_idx: int):
         """Request a frame to be loaded (called from main thread)."""


### PR DESCRIPTION
## Summary
- Guard frame processing error print with `debug_mode` check in `video_worker.py`
- Prevents terminal spam like `[THREAD] Error processing frame 211178: Frame index 211178 out of range.` when scrubbing through sparse video files
- Matches the pattern of all other prints in the file which are already guarded by `debug_mode`

## Test plan
- [ ] Open a `.pkg.slp` file and scrub through the seekbar rapidly
- [ ] Verify no error messages appear in terminal during normal use
- [ ] Enable debug mode and verify errors still appear when debugging is needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)