### PR TITLE
Add "Random sample (current video)" inference target option

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -45,7 +45,6 @@ frame and instances listed in data view table.
 """
 
 import os
-import random
 import re
 from logging import getLogger
 from pathlib import Path
@@ -1516,22 +1515,15 @@ class MainWindow(QMainWindow):
             for video in self.labels.videos
         }
 
+        # For random sample options, store candidate pools (all frames)
+        # Actual sampling is done in the dialog based on sample_count and exclusions
+        # This allows re-sampling when "skip user labeled" checkbox changes
         selection["random"] = {
-            video: remove_user_labeled(
-                video, random.sample(range(video.shape[0]), min(20, video.shape[0]))
-            )
-            for video in self.labels.videos
+            video: list(range(video.shape[0])) for video in self.labels.videos
         }
 
-        if len(self.labels.videos) > 1:
-            selection["random_video"] = {
-                current_video: remove_user_labeled(
-                    current_video,
-                    random.sample(
-                        range(current_video.shape[0]), min(20, current_video.shape[0])
-                    ),
-                )
-            }
+        # Always provide random_video option (current video sampling)
+        selection["random_video"] = {current_video: list(range(current_video.shape[0]))}
 
         if user_labeled_frames:
             selection["user"] = {

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -5,7 +5,7 @@ Dialogs for running training and/or inference in GUI.
 import shutil
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional, Text, cast
+from typing import Dict, List, Optional, Set, Text, cast
 
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -355,14 +355,33 @@ class LearningDialog(QtWidgets.QDialog):
                 frame_count=frame_count,
             )
 
+        # For random sample options, use sampling logic with default sample count
+        # The actual count will be updated when settings change
+        default_sample_count = 20
+
+        if "random_video" in self._frame_selection:
+            frame_count = self._sample_frames_from_pool(
+                self._frame_selection["random_video"],
+                default_sample_count,
+                exclude_user_labeled=False,
+            )
+            options["random_video"] = FrameTargetOption(
+                key="random_video",
+                label="Random sample (current video)",
+                description="Random frames from current video",
+                frame_count=frame_count,
+            )
+
         if "random" in self._frame_selection:
-            frame_count = self.count_total_frames_for_selection_option(
-                self._frame_selection["random"]
+            frame_count = self._sample_frames_from_pool(
+                self._frame_selection["random"],
+                default_sample_count,
+                exclude_user_labeled=False,
             )
             options["random"] = FrameTargetOption(
                 key="random",
-                label="Random sample",
-                description="Random frames for quick model check",
+                label="Random sample (all videos)",
+                description="Random frames from all videos",
                 frame_count=frame_count,
             )
 
@@ -456,8 +475,85 @@ class LearningDialog(QtWidgets.QDialog):
             )
 
     def _on_target_selection_changed(self):
-        """Track when user explicitly changes the frame target selection."""
+        """Track when user explicitly changes the frame target selection.
+
+        Also updates frame counts for random sample options based on current
+        settings (sample count spinbox, exclude user labeled checkbox).
+        """
         self._target_selection_user_changed = True
+        self._update_random_sample_frame_counts()
+
+    def _get_user_labeled_frame_indices(self, video: Video) -> Set[int]:
+        """Get set of frame indices that have user-labeled instances for a video."""
+        return {
+            lf.frame_idx for lf in self.labels.user_labeled_frames if lf.video == video
+        }
+
+    def _sample_frames_from_pool(
+        self,
+        candidate_pool: Dict[Video, List[int]],
+        sample_count: int,
+        exclude_user_labeled: bool,
+    ) -> int:
+        """Sample frames from a candidate pool and return the sampled count.
+
+        This implements the "filter then sample" approach, which maintains
+        the target sample count when possible (unlike "sample then filter").
+
+        Args:
+            candidate_pool: Dict mapping videos to lists of candidate frame indices.
+            sample_count: Target number of frames to sample.
+            exclude_user_labeled: If True, exclude user-labeled frames first.
+
+        Returns:
+            The actual number of frames that would be sampled.
+        """
+        total_sampled = 0
+
+        for video, candidates in candidate_pool.items():
+            if not candidates:
+                continue
+
+            # Convert to set for efficient filtering
+            available = set(candidates)
+
+            # Filter out user-labeled frames if requested
+            if exclude_user_labeled:
+                user_labeled = self._get_user_labeled_frame_indices(video)
+                available = available - user_labeled
+
+            # Sample up to sample_count from available frames
+            actual_sample_size = min(sample_count, len(available))
+            total_sampled += actual_sample_size
+
+        return total_sampled
+
+    def _update_random_sample_frame_counts(self):
+        """Update frame counts for random sample options based on current settings."""
+        if self._frame_selection is None:
+            return
+
+        selection = self.frame_target_selector.get_selection()
+        sample_count = selection.sample_count
+        exclude_user_labeled = selection.exclude_user_labeled
+
+        # Update random_video option
+        if "random_video" in self._frame_selection:
+            count = self._sample_frames_from_pool(
+                self._frame_selection["random_video"],
+                sample_count,
+                exclude_user_labeled,
+            )
+            self.frame_target_selector.update_option_frame_count("random_video", count)
+
+        # Update random (all videos) option
+        if "random" in self._frame_selection:
+            count = self._sample_frames_from_pool(
+                self._frame_selection["random"],
+                sample_count,
+                exclude_user_labeled,
+            )
+            self.frame_target_selector.update_option_frame_count("random", count)
 
     def connect_signals(self):
         """Connect valueChanged signals for pipeline and any existing tabs.
@@ -999,7 +1095,12 @@ class LearningDialog(QtWidgets.QDialog):
         """Get frames to predict based on user selection.
 
         Uses the new FrameTargetSelector widget for selection.
+
+        For random sample options (random, random_video), this method performs
+        the actual sampling based on sample_count and exclude_user_labeled settings.
         """
+        import random
+
         frames_to_predict = dict()
 
         if self._frame_selection is None:
@@ -1016,6 +1117,7 @@ class LearningDialog(QtWidgets.QDialog):
             "video": "video",
             "all_videos": "all_videos",
             "random": "random",
+            "random_video": "random_video",
             "suggestions": "suggestions",
             "user_labeled": "user",
             "predicted": "predicted",
@@ -1024,7 +1126,37 @@ class LearningDialog(QtWidgets.QDialog):
 
         frame_selection_key = key_map.get(target_key)
         if frame_selection_key and frame_selection_key in self._frame_selection:
-            frames_to_predict = self._frame_selection[frame_selection_key].copy()
+            candidate_frames = self._frame_selection[frame_selection_key].copy()
+
+            # For random sample options, perform actual sampling
+            if target_key in ("random", "random_video"):
+                sample_count = selection.sample_count
+                exclude_user_labeled = selection.exclude_user_labeled
+
+                frames_to_predict = {}
+                for video, candidates in candidate_frames.items():
+                    if not candidates:
+                        frames_to_predict[video] = []
+                        continue
+
+                    # Convert to set for efficient filtering
+                    available = set(candidates)
+
+                    # Filter out user-labeled frames if requested
+                    if exclude_user_labeled:
+                        user_labeled = self._get_user_labeled_frame_indices(video)
+                        available = available - user_labeled
+
+                    # Sample from available frames
+                    available_list = list(available)
+                    actual_sample_size = min(sample_count, len(available_list))
+                    if actual_sample_size > 0:
+                        sampled = random.sample(available_list, actual_sample_size)
+                        frames_to_predict[video] = sorted(sampled)
+                    else:
+                        frames_to_predict[video] = []
+            else:
+                frames_to_predict = candidate_frames
 
         return frames_to_predict
 

--- a/sleap/gui/widgets/frame_target_selector.py
+++ b/sleap/gui/widgets/frame_target_selector.py
@@ -25,6 +25,7 @@ from qtpy.QtWidgets import (
     QRadioButton,
     QButtonGroup,
     QComboBox,
+    QSpinBox,
 )
 
 
@@ -62,6 +63,7 @@ class FrameTargetSelection:
         exclude_predicted: Whether to skip already-predicted frames.
         prediction_mode: "add" (keep existing) or "replace" (overwrite).
         clear_all_first: Pre-action to clear all predictions before running.
+        sample_count: Number of frames for random sample options.
     """
 
     target_key: str = "frame"
@@ -69,6 +71,7 @@ class FrameTargetSelection:
     exclude_predicted: bool = False
     prediction_mode: str = "add"
     clear_all_first: bool = False
+    sample_count: int = 20
 
 
 class FrameTargetSelector(QWidget):
@@ -121,9 +124,15 @@ class FrameTargetSelector(QWidget):
             frame_count=0,
         ),
         FrameTargetOption(
+            key="random_video",
+            label="Random sample (current video)",
+            description="Random frames from current video",
+            frame_count=20,
+        ),
+        FrameTargetOption(
             key="random",
-            label="Random sample",
-            description="20 random frames for quick model check",
+            label="Random sample (all videos)",
+            description="Random frames from all videos",
             frame_count=20,
         ),
         FrameTargetOption(
@@ -177,7 +186,7 @@ class FrameTargetSelector(QWidget):
         target_layout = QVBoxLayout(self.target_group_box)
         target_layout.setSpacing(8)
 
-        # Row 1: Dropdown + description label (same row)
+        # Row 1: Dropdown + sample count spinbox + description label (same row)
         dropdown_row = QHBoxLayout()
         dropdown_row.setSpacing(12)
 
@@ -185,6 +194,18 @@ class FrameTargetSelector(QWidget):
         self.target_dropdown = QComboBox()
         self.target_dropdown.setMinimumWidth(150)
         dropdown_row.addWidget(self.target_dropdown)
+
+        # Sample count spinbox (only visible for random sample options)
+        self.sample_count_label = QLabel("Frames:")
+        self.sample_count_label.setStyleSheet("font-size: 11px;")
+        dropdown_row.addWidget(self.sample_count_label)
+
+        self.sample_count_spinbox = QSpinBox()
+        self.sample_count_spinbox.setRange(1, 1000)
+        self.sample_count_spinbox.setValue(20)
+        self.sample_count_spinbox.setMinimumWidth(60)
+        self.sample_count_spinbox.setStyleSheet("font-size: 11px;")
+        dropdown_row.addWidget(self.sample_count_spinbox)
 
         # Description label (shows description + frame count) - to the right
         self.description_label = QLabel()
@@ -247,9 +268,16 @@ class FrameTargetSelector(QWidget):
         self.skip_user_labeled_cb.stateChanged.connect(
             self._on_skip_user_labeled_changed
         )
+        self.sample_count_spinbox.valueChanged.connect(self._on_sample_count_changed)
 
     def _on_skip_user_labeled_changed(self, state):
         """Handle skip user labeled checkbox change."""
+        self._update_description()
+        self.valueChanged.emit()
+
+    def _on_sample_count_changed(self, value):
+        """Handle sample count spinbox change."""
+        self._update_description()
         self.valueChanged.emit()
 
     def _build_options_from_list(self, options: List[FrameTargetOption]):
@@ -308,14 +336,20 @@ class FrameTargetSelector(QWidget):
           would result in zero frames. Force off + disabled.
         - "nothing": No inference runs, so all filters are irrelevant. Disable all
           and force "Keep" for predictions.
+        - "random", "random_video": Show sample count spinbox.
         - All other targets: All filter combinations are valid.
         """
-        # Default: enable everything
+        # Default: enable everything, hide sample count spinbox
         self.skip_user_labeled_cb.setEnabled(True)
         self.predictions_label.setEnabled(True)
         self.predictions_clear_radio.setEnabled(True)
         self.predictions_replace_radio.setEnabled(True)
         self.predictions_keep_radio.setEnabled(True)
+
+        # Show sample count spinbox only for random sample options
+        is_random_sample = self._selected_key in ("random", "random_video")
+        self.sample_count_label.setVisible(is_random_sample)
+        self.sample_count_spinbox.setVisible(is_random_sample)
 
         if self._selected_key == "suggestions":
             # Suggestions already excludes user-labeled frames in sleap-nn
@@ -414,6 +448,7 @@ class FrameTargetSelector(QWidget):
             exclude_predicted=False,
             prediction_mode=prediction_mode,
             clear_all_first=clear_all_first,
+            sample_count=self.sample_count_spinbox.value(),
         )
 
     def set_selection(self, selection: FrameTargetSelection):
@@ -439,6 +474,9 @@ class FrameTargetSelector(QWidget):
         else:
             self.predictions_keep_radio.setChecked(True)
 
+        # Set sample count spinbox
+        self.sample_count_spinbox.setValue(selection.sample_count)
+
         self._update_description()
         self._apply_target_auto_configuration()
 
@@ -458,6 +496,7 @@ class FrameTargetSelector(QWidget):
             "_exclude_predicted": selection.exclude_predicted,
             "_prediction_mode": selection.prediction_mode,
             "_clear_all_first": selection.clear_all_first,
+            "_sample_count": selection.sample_count,
         }
 
     def get_mode(self) -> str:

--- a/tests/gui/widgets/test_frame_target_selector.py
+++ b/tests/gui/widgets/test_frame_target_selector.py
@@ -53,13 +53,13 @@ class TestFrameTargetSelectorInstantiation:
         assert inference_selector._mode == "inference"
         assert inference_selector.target_dropdown is not None
 
-    def test_training_mode_has_9_options(self, training_selector):
-        """Training mode should have 9 target options."""
-        assert training_selector.target_dropdown.count() == 9
+    def test_training_mode_has_10_options(self, training_selector):
+        """Training mode should have 10 target options."""
+        assert training_selector.target_dropdown.count() == 10
 
-    def test_inference_mode_has_8_options(self, inference_selector):
-        """Inference mode should have 8 target options (no 'nothing')."""
-        assert inference_selector.target_dropdown.count() == 8
+    def test_inference_mode_has_9_options(self, inference_selector):
+        """Inference mode should have 9 target options (no 'nothing')."""
+        assert inference_selector.target_dropdown.count() == 9
 
     def test_training_mode_includes_nothing(self, training_selector):
         """Training mode should include 'nothing' option."""
@@ -148,7 +148,8 @@ class TestTargetOptions:
             "clip": "Selected clip",
             "video": "Entire video",
             "all_videos": "All videos",
-            "random": "Random sample",
+            "random_video": "Random sample (current video)",
+            "random": "Random sample (all videos)",
             "suggestions": "Suggestions",
             "user_labeled": "User labeled",
             "predicted": "Frames with predictions",
@@ -448,10 +449,10 @@ class TestModeSwitching:
 
     def test_set_mode_training_to_inference(self, training_selector):
         """Switching from training to inference should remove 'nothing' option."""
-        assert training_selector.target_dropdown.count() == 9
+        assert training_selector.target_dropdown.count() == 10
         training_selector.set_mode("inference")
         assert training_selector._mode == "inference"
-        assert training_selector.target_dropdown.count() == 8
+        assert training_selector.target_dropdown.count() == 9
         options = [
             training_selector.target_dropdown.itemData(i)
             for i in range(training_selector.target_dropdown.count())
@@ -467,12 +468,12 @@ class TestModeSwitching:
         _options, not DEFAULT_OPTIONS. This is current behavior - if full
         restoration is needed, options should be reset from DEFAULT_OPTIONS.
         """
-        assert inference_selector.target_dropdown.count() == 8
+        assert inference_selector.target_dropdown.count() == 9
         inference_selector.set_mode("training")
         assert inference_selector._mode == "training"
-        # Options count stays 8 because 'nothing' was never in _options
+        # Options count stays 9 because 'nothing' was never in _options
         # (filtered during inference mode construction)
-        assert inference_selector.target_dropdown.count() == 8
+        assert inference_selector.target_dropdown.count() == 9
 
     def test_set_mode_same_mode_no_change(self, training_selector):
         """Setting same mode should be a no-op."""


### PR DESCRIPTION
## Summary
- Add new "Random sample (current video)" option to inference target dropdown for quick model testing on current video
- Add configurable sample count spinbox (1-1000, default 20) that appears when random sample options are selected
- Implement proper re-sampling when "Skip user labeled frames" is checked - maintains target count by sampling from filtered pool instead of subtracting
- Rename existing "Random sample" to "Random sample (all videos)" for clarity

## Changes
| File | Description |
|------|-------------|
| `sleap/gui/widgets/frame_target_selector.py` | Add `sample_count` field, spinbox UI, `random_video` option |
| `sleap/gui/learning/dialog.py` | Add sampling logic, `random_video` handling, frame count updates |
| `sleap/gui/app.py` | Always create `random_video` option, store candidate pools for deferred sampling |
| `tests/gui/widgets/test_frame_target_selector.py` | Update option counts (9→10 training, 8→9 inference) |

## Test plan
- [x] All 61 frame_target_selector tests pass
- [x] Manual testing with SLP file containing user-labeled frames
- [x] Verified frame count stays at 20 when "Skip user labeled" is checked (re-sampling works)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)