### PR TITLE
Improve training config dialog UX

### DIFF
--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -9,6 +9,12 @@ data:
   label: Overfit Mode (train=val)
   name: data_config.use_same_data_for_val
   type: bool
+- default: null
+  help: Random seed for reproducible train/validation data splits. Leave empty (Auto) for random seed each run.
+  label: Random Seed
+  name: trainer_config.seed
+  type: optional_int
+  none_label: Auto
 - default: 1.0
   help: Rescaling factor applied to input images before training. Values less than 1.0 downsample the image (e.g., 0.5 reduces dimensions by half), which reduces memory usage and speeds up training at the cost of spatial resolution. Set to 1.0 to use original image resolution. Note that crop size and sigma values are relative to the scaled image.
   label: Input Scaling
@@ -23,7 +29,8 @@ data:
   name: data_config.preprocessing.crop_size
   type: optional_int
   none_label: Auto
-  range: 0,832
+  range: 32,1024
+  step: 32
 
 model:
 - default: unet

--- a/sleap/gui/dialogs/formbuilder.py
+++ b/sleap/gui/dialogs/formbuilder.py
@@ -481,6 +481,11 @@ class FormBuilderLayout(QtWidgets.QFormLayout):
                 min, max = 0, item["default"] * 10
                 field.setRange(min, max)
 
+            # Support step size for spinbox (useful for crop_size which should be
+            # divisible by max_stride, typically 32)
+            if "step" in item.keys():
+                field.setSingleStep(int(item["step"]))
+
             field.setValue(item["default"])
             if item.get("default_disabled", False):
                 field.setToNone()
@@ -769,6 +774,9 @@ class OptionalSpinWidget(QtWidgets.QWidget):
 
     def updateState(self, valueChanged=True):
         self.spin_widget.setDisabled(self.check_widget.isChecked())
+        # Force visual refresh to ensure spinbox displays correctly after
+        # enable/disable state change (fixes display not updating on some platforms)
+        self.spin_widget.repaint()
         if valueChanged:
             self.valueChanged.emit()
 
@@ -807,13 +815,28 @@ class OptionalSpinWidget(QtWidgets.QWidget):
                 val = self.noneVal
 
         is_none = self.isNoneVal(val)
+
+        # Block signals temporarily to avoid multiple valueChanged emissions
+        # and ensure state is consistent before any signals fire
+        self.check_widget.blockSignals(True)
+        self.spin_widget.blockSignals(True)
+
         self.check_widget.setChecked(is_none)
         if not is_none:
+            # Enable spinbox before setting value to ensure proper display
+            self.spin_widget.setEnabled(True)
             self.spin_widget.setValue(val)
+
+        self.check_widget.blockSignals(False)
+        self.spin_widget.blockSignals(False)
+
         self.updateState(valueChanged=False)
 
     def setRange(self, min, max):
         self.spin_widget.setRange(min, max)
+
+    def setSingleStep(self, step):
+        self.spin_widget.setSingleStep(step)
 
 
 class FieldComboWidget(QtWidgets.QComboBox):

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -71,6 +71,11 @@ class LearningDialog(QtWidgets.QDialog):
         int, int, int
     )  # video_idx, frame_idx, instance_idx
 
+    # Class-level cache for pipeline tab form state.
+    # Persists across dialog sessions so values are restored after Cancel.
+    # Key: (mode, labels_filename, tab_name), Value: form data dict
+    _cached_tab_state: Dict[tuple, dict] = {}
+
     def __init__(
         self,
         mode: Text,
@@ -256,6 +261,20 @@ class LearningDialog(QtWidgets.QDialog):
         # Defer minimum width update to after event processing completes
         # to ensure layout is fully computed
         QtCore.QTimer.singleShot(0, self._update_minimum_width)
+
+    def closeEvent(self, event):
+        """Handle dialog close event.
+
+        Saves current form state for all pipeline tabs before closing.
+        This allows values to persist across Cancel operations - when the
+        dialog is reopened, the cached values are restored.
+        """
+        # Save form state for all initialized tabs
+        for tab_name, tab_widget in self.tabs.items():
+            cache_key = (self.mode, self.labels_filename, tab_name)
+            LearningDialog._cached_tab_state[cache_key] = tab_widget.get_all_form_data()
+
+        super().closeEvent(event)
 
     def update_file_lists(self):
         """Update config file lists for all currently shown tabs.
@@ -638,6 +657,12 @@ class LearningDialog(QtWidgets.QDialog):
 
             # Update file list for the newly created tab
             widget.update_file_list()
+
+            # Restore cached form state if available (persists across Cancel)
+            cache_key = (self.mode, self.labels_filename, head_name)
+            if cache_key in LearningDialog._cached_tab_state:
+                cached_data = LearningDialog._cached_tab_state[cache_key]
+                widget.set_fields_from_key_val_dict(cached_data)
 
         return self.tabs[head_name]
 
@@ -1943,8 +1968,16 @@ class TrainingEditorWidget(QtWidgets.QWidget):
 
         cfg = cfg_info.config
         key_val_dict = get_keyval_dict_from_omegaconf(cfg)
-        if key_val_dict.get("trainer_config.trainer_devices") == "auto":
-            key_val_dict["trainer_config.trainer_devices"] = None
+
+        # Filter out system-specific settings that should come from preferences,
+        # not from the training profile. These are machine-specific (GPU count,
+        # workers) and should default to "auto" regardless of what the profile says.
+        system_specific_keys = [
+            "trainer_config.trainer_devices",
+            "trainer_config.train_data_loader.num_workers",
+        ]
+        for key in system_specific_keys:
+            key_val_dict.pop(key, None)
 
         # Clear run_name - it should be auto-generated for new training runs.
         # This prevents old run_name from base config from leaking through.

--- a/sleap/training_profiles/baseline.centroid.yaml
+++ b/sleap/training_profiles/baseline.centroid.yaml
@@ -33,8 +33,8 @@ data_config:
       brightness_max: 2.0
       brightness_p: 0.0
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
+      rotation_min: -180.0
+      rotation_max: 180.0
       scale_min: 0.9
       scale_max: 1.1
       translate_width: 0.0

--- a/sleap/training_profiles/baseline.multi_class_bottomup.yaml
+++ b/sleap/training_profiles/baseline.multi_class_bottomup.yaml
@@ -33,8 +33,8 @@ data_config:
       brightness_max: 1.1
       brightness_p: 0.0
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
+      rotation_min: -180.0
+      rotation_max: 180.0
       scale_min: 1.0
       scale_max: 1.0
       translate_width: 0.0

--- a/sleap/training_profiles/baseline.multi_class_topdown.yaml
+++ b/sleap/training_profiles/baseline.multi_class_topdown.yaml
@@ -33,8 +33,8 @@ data_config:
       brightness_max: 1.1
       brightness_p: 0.0
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
+      rotation_min: -180.0
+      rotation_max: 180.0
       scale_min: 1.0
       scale_max: 1.0
       translate_width: 0.0

--- a/sleap/training_profiles/baseline_large_rf.bottomup.yaml
+++ b/sleap/training_profiles/baseline_large_rf.bottomup.yaml
@@ -33,8 +33,8 @@ data_config:
       brightness_max: 2.0
       brightness_p: 0.0
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
+      rotation_min: -180.0
+      rotation_max: 180.0
       scale_min: 0.9
       scale_max: 1.1
       translate_width: 0.0

--- a/sleap/training_profiles/baseline_large_rf.single.yaml
+++ b/sleap/training_profiles/baseline_large_rf.single.yaml
@@ -33,8 +33,8 @@ data_config:
       brightness_max: 2.0
       brightness_p: 0.0
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
+      rotation_min: -180.0
+      rotation_max: 180.0
       scale_min: 0.9
       scale_max: 1.1
       translate_width: 0.0

--- a/sleap/training_profiles/baseline_large_rf.topdown.yaml
+++ b/sleap/training_profiles/baseline_large_rf.topdown.yaml
@@ -33,8 +33,8 @@ data_config:
       brightness_max: 2.0
       brightness_p: 0.0
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
+      rotation_min: -180.0
+      rotation_max: 180.0
       scale_min: 0.9
       scale_max: 1.1
       translate_width: 0.0

--- a/sleap/training_profiles/baseline_medium_rf.bottomup.yaml
+++ b/sleap/training_profiles/baseline_medium_rf.bottomup.yaml
@@ -33,8 +33,8 @@ data_config:
       brightness_max: 2.0
       brightness_p: 0.0
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
+      rotation_min: -180.0
+      rotation_max: 180.0
       scale_min: 0.9
       scale_max: 1.1
       translate_width: 0.0

--- a/sleap/training_profiles/baseline_medium_rf.single.yaml
+++ b/sleap/training_profiles/baseline_medium_rf.single.yaml
@@ -33,8 +33,8 @@ data_config:
       brightness_max: 2.0
       brightness_p: 0.0
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
+      rotation_min: -180.0
+      rotation_max: 180.0
       scale_min: 0.9
       scale_max: 1.1
       translate_width: 0.0

--- a/sleap/training_profiles/baseline_medium_rf.topdown.yaml
+++ b/sleap/training_profiles/baseline_medium_rf.topdown.yaml
@@ -33,8 +33,8 @@ data_config:
       brightness_max: 2.0
       brightness_p: 0.0
     geometric:
-      rotation_min: -15.0
-      rotation_max: 15.0
+      rotation_min: -180.0
+      rotation_max: 180.0
       scale_min: 0.9
       scale_max: 1.1
       translate_width: 0.0


### PR DESCRIPTION
## Summary

Multiple UX fixes for the training configuration dialog:

- **Devices/workers as preferences**: Filter system-specific settings (trainer_devices, num_workers) from profile configs so they always default to "auto" from user preferences, not from the profile
- **Crop size widget fix**: Fix display not updating when unchecking Auto by blocking signals during setValue and forcing repaint
- **Crop size step**: Add step support to OptionalSpinWidget and set crop size range to 32-1024 with step of 32 (max stride aligned)
- **Form state persistence**: Add class-level cache to LearningDialog that saves pipeline tab form state on close and restores on reopen, so values persist after Cancel
- **Default rotation**: Update all 9 baseline profiles from ±15° to ±180° rotation augmentation
- **Seed exposure**: Add Random Seed field (trainer_config.seed) to training config UI for reproducible train/val splits

## Test plan

- [x] Qt screenshot tests verify all changes work correctly
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)