### PR TITLE
Upgrade video rendering to use sleap-io API with live preview and non-blocking progress

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# SLEAP Development Guidelines for Claude
+
+## Package Management
+
+**Always use `uv` for package management.** Never use conda or pip directly.
+
+```bash
+# Sync environment with dependencies
+uv sync --extra nn
+
+# Install local packages (e.g., sleap-io in development)
+uv pip install "../sleap-io[all]"
+
+# Run Python in the uv environment
+uv run python script.py
+
+# Or activate the virtual environment
+source .venv/bin/activate
+python script.py
+```
+
+## Testing
+
+```bash
+# Run all tests
+uv run pytest
+
+# Run specific test file
+uv run pytest tests/test_specific.py
+
+# Run with coverage
+uv run pytest --cov=sleap
+```
+
+## Linting
+
+```bash
+# Run ruff for linting
+uv run ruff check .
+
+# Run ruff with auto-fix
+uv run ruff check --fix .
+```
+
+## Project Structure
+
+- `sleap/` - Main SLEAP package
+- `tests/` - Test suite
+- `docs/` - Documentation
+- `scratch/` - Investigation and prototype files (not part of main package)
+
+## Related Projects
+
+- `../sleap-io/` - sleap-io library (install with `uv pip install "../sleap-io[all]"`)
+- `../sleap-nn/` - sleap-nn neural network package

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -84,7 +84,6 @@ from sleap_io.model.instance import (
 )
 from sleap_io import Video
 from sleap_io import save_video
-from sleap.io.visuals import save_labeled_video
 from sleap.util import get_package_file
 from sleap_io.model.skeleton import Node, Skeleton
 from sleap.sleap_io_adaptors.skeleton_utils import (
@@ -1519,43 +1518,118 @@ class ExportVideoClip(AppCommand):
         return params
 
 
-class ExportLabeledClip(ExportVideoClip):
-    """Export a labeled video clip with labels and edges.
+class ExportLabeledClip(AppCommand):
+    """Export a labeled video clip with skeleton overlay.
 
-    This command is used to export a labeled video clip with labels and edges. It
-    inherits from the `ExportVideoClip` class and provides additional functionality for
-    exporting labeled videos.
+    Uses sleap-io's rendering API for high-quality video export with
+    real-time preview capabilities.
     """
 
     @classmethod
     def ask(cls, context: CommandContext, params: dict) -> bool:
-        """Ask the user for parameters to export a labeled video clip."""
-        params["form_name"] = "labeled_clip_form"
-        ok = super().ask(context, params)
-        return ok
+        """Show the render dialog and collect export parameters.
+
+        Args:
+            context: The command context.
+            params: Dictionary to store collected parameters.
+
+        Returns:
+            True if user confirmed, False if cancelled.
+        """
+        from sleap.gui.dialogs.render_clip import RenderClipDialog
+
+        labels = context.state["labels"]
+        video = context.state["video"]
+        frame_idx = context.state.get("frame_idx", None)
+
+        dialog = RenderClipDialog(
+            labels=labels,
+            video=video,
+            current_frame=frame_idx,
+            parent=context.app,
+        )
+
+        if not dialog.exec_():
+            return False
+
+        # Collect parameters from dialog
+        params["video_filename"] = dialog.get_output_path()
+        params["frame_indices"] = dialog.get_frame_indices()
+        export_params = dialog.get_export_params()
+
+        # Map dialog params to render params
+        params["fps"] = export_params.get("fps", 30)
+        params["crf"] = export_params.get("crf", 23)
+        params["scale"] = export_params.get("scale", 1.0)
+        params["color_by"] = export_params.get("color_by", "track")
+        params["palette"] = export_params.get("palette", "tableau10")
+        params["marker_shape"] = export_params.get("marker_shape", "circle")
+        params["marker_size"] = export_params.get("marker_size", 4.0)
+        params["line_width"] = export_params.get("line_width", 2.0)
+        params["alpha"] = export_params.get("alpha", 1.0)
+        params["show_nodes"] = export_params.get("show_nodes", True)
+        params["show_edges"] = export_params.get("show_edges", True)
+        params["background"] = export_params.get("background")
+        params["open_when_done"] = export_params.get("open_when_done", True)
+
+        return True
 
     @classmethod
-    def write_new_video(cls, context, params):
-        """Write a new annotated video using the parameters provided.
+    def do_action(cls, context: CommandContext, params: dict):
+        """Export the labeled video clip.
+
+        Args:
+            context: The command context.
+            params: Export parameters from ask().
+        """
+        cls.write_new_video(context, params)
+
+        if params.get("open_when_done", False):
+            open_file(params["video_filename"])
+
+    @classmethod
+    def write_new_video(cls, context: CommandContext, params: dict):
+        """Write annotated video using sleap-io rendering.
 
         Args:
             context: The command context.
             params: The parameters for the export.
         """
-        save_labeled_video(
-            filename=params["video_filename"],
-            labels=context.state["labels"],
-            video=context.state["video"],
-            frames=list(params["frames"]),
-            fps=params["fps"],
-            color_manager=params["color_manager"],
-            background=params["background"],
-            show_edges=params["show edges"],
-            edge_is_wedge=params["edge_is_wedge"],
-            marker_size=params["marker size"],
-            scale=params["scale"],
-            crop_size_xy=params["crop"],
-            gui_progress=params["gui_progress"],
+        import sleap_io as sio
+
+        labels = context.state["labels"]
+        video = context.state["video"]
+
+        # Build render parameters
+        render_params = {
+            "fps": params.get("fps", 30),
+            "crf": params.get("crf", 23),
+            "scale": params.get("scale", 1.0),
+            "color_by": params.get("color_by", "track"),
+            "palette": params.get("palette", "tableau10"),
+            "marker_shape": params.get("marker_shape", "circle"),
+            "marker_size": params.get("marker_size", 4.0),
+            "line_width": params.get("line_width", 2.0),
+            "alpha": params.get("alpha", 1.0),
+            "show_nodes": params.get("show_nodes", True),
+            "show_edges": params.get("show_edges", True),
+        }
+
+        # Add background if not "video"
+        if params.get("background"):
+            render_params["background"] = params["background"]
+
+        # Get frame indices
+        frame_inds = params.get("frame_indices", None)
+
+        # Render video using sleap-io
+        sio.render_video(
+            labels,
+            params["video_filename"],
+            video=video,
+            frame_inds=frame_inds,
+            show_progress=True,
+            **render_params,
         )
 
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1929,8 +1929,7 @@ def render_video_gui(
         win.setValue(current)
         pct = (current / total) * 100 if total > 0 else 0
         win.setLabelText(
-            f"Rendering video...<br>{current}/{total} frames "
-            f"(<b>{pct:.1f}%</b>)"
+            f"Rendering video...<br>{current}/{total} frames (<b>{pct:.1f}%</b>)"
         )
 
     def on_finished(fname):

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1588,20 +1588,61 @@ class ExportLabeledClip(AppCommand):
             context: The command context.
             params: Export parameters from ask().
         """
-        cls.write_new_video(context, params)
+        labels = context.state["labels"]
+        video = context.state["video"]
 
-        if params.get("open_when_done", False):
-            open_file(params["video_filename"])
+        # Build render parameters
+        render_params = {
+            "fps": params.get("fps", 30),
+            "crf": params.get("crf", 23),
+            "scale": params.get("scale", 1.0),
+            "color_by": params.get("color_by", "track"),
+            "palette": params.get("palette", "tableau10"),
+            "marker_shape": params.get("marker_shape", "circle"),
+            "marker_size": params.get("marker_size", 4.0),
+            "line_width": params.get("line_width", 2.0),
+            "alpha": params.get("alpha", 1.0),
+            "show_nodes": params.get("show_nodes", True),
+            "show_edges": params.get("show_edges", True),
+        }
+
+        # Add background if not "video"
+        if params.get("background"):
+            render_params["background"] = params["background"]
+
+        # Render with progress dialog (non-blocking)
+        render_video_gui(
+            labels=labels,
+            filename=params["video_filename"],
+            video=video,
+            frame_inds=params.get("frame_indices"),
+            render_params=render_params,
+            open_when_done=params.get("open_when_done", True),
+        )
 
     @classmethod
     def write_new_video(cls, context: CommandContext, params: dict):
         """Write annotated video using sleap-io rendering.
 
+        .. deprecated::
+            This method is deprecated. Use `render_video_gui()` for GUI rendering
+            with progress dialog, or call `sleap_io.render_video()` directly for
+            programmatic use.
+
         Args:
             context: The command context.
             params: The parameters for the export.
         """
+        import warnings
+
         import sleap_io as sio
+
+        warnings.warn(
+            "ExportLabeledClip.write_new_video() is deprecated. "
+            "Use render_video_gui() or sleap_io.render_video() directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         labels = context.state["labels"]
         video = context.state["video"]
@@ -1743,6 +1784,214 @@ class ExportPackageThread(QtCore.QThread):
                 self.cancelled.emit()
             else:
                 self.error.emit(str(e))
+
+
+class RenderVideoThread(QtCore.QThread):
+    """Background thread for rendering video without freezing GUI.
+
+    Uses sleap-io's render_video() with progress_callback for non-blocking rendering.
+    """
+
+    progress = QtCore.Signal(int, int)  # (current, total)
+    finished = QtCore.Signal(str)  # output filename
+    error = QtCore.Signal(str)  # error message
+    cancelled = QtCore.Signal()
+
+    def __init__(
+        self,
+        labels,
+        filename: str,
+        video,
+        frame_inds: list[int] | None,
+        render_params: dict,
+        parent=None,
+    ):
+        """Initialize the render video thread.
+
+        Args:
+            labels: Labels object to render.
+            filename: Output video path.
+            video: Video to render from.
+            frame_inds: Frame indices to render (None = all labeled).
+            render_params: Dict of rendering parameters for sio.render_video().
+            parent: Parent QObject.
+        """
+        super().__init__(parent)
+        self.labels = labels
+        self.filename = filename
+        self.video = video
+        self.frame_inds = frame_inds
+        self.render_params = render_params
+        self._cancelled = False
+
+    def cancel(self):
+        """Request cancellation of the render."""
+        self._cancelled = True
+
+    def run(self):
+        """Run the render in background thread."""
+        import sleap_io as sio
+
+        def on_progress(current, total):
+            """Progress callback for sio.render_video()."""
+            self.progress.emit(current, total)
+            # Return False to cancel rendering
+            return not self._cancelled
+
+        try:
+            sio.render_video(
+                self.labels,
+                self.filename,
+                video=self.video,
+                frame_inds=self.frame_inds,
+                progress_callback=on_progress,
+                show_progress=False,  # We handle progress ourselves
+                **self.render_params,
+            )
+
+            if self._cancelled:
+                # Clean up partial file on cancellation
+                if Path(self.filename).exists():
+                    os.remove(self.filename)
+                self.cancelled.emit()
+                return
+
+            self.finished.emit(self.filename)
+
+        except Exception as e:
+            # Check if this was a cancellation
+            is_cancelled = "cancel" in str(e).lower() or self._cancelled
+            if is_cancelled:
+                # Clean up partial file
+                if Path(self.filename).exists():
+                    os.remove(self.filename)
+                self.cancelled.emit()
+            else:
+                self.error.emit(str(e))
+
+
+def render_video_gui(
+    labels,
+    filename: str,
+    video,
+    frame_inds: list[int] | None,
+    render_params: dict,
+    open_when_done: bool = True,
+) -> str:
+    """Render video with progress dialog.
+
+    Args:
+        labels: Labels object to render.
+        filename: Output video path.
+        video: Video to render from.
+        frame_inds: Frame indices to render (None = all labeled).
+        render_params: Dict of rendering parameters for sio.render_video().
+        open_when_done: If True, open video after rendering.
+
+    Returns:
+        The filename if successful, "canceled" if canceled by user.
+    """
+    # Calculate total frames for progress
+    if frame_inds is not None:
+        total_frames = len(frame_inds)
+    else:
+        total_frames = len(
+            [lf for lf in labels.labeled_frames if video is None or lf.video == video]
+        )
+
+    # Create progress dialog
+    win = QtWidgets.QProgressDialog(
+        f"Rendering video...<br>0/{total_frames} frames", "Cancel", 0, total_frames
+    )
+    win.setWindowTitle("Rendering Video")
+    win.setWindowModality(QtCore.Qt.WindowModal)
+    win.setMinimumDuration(0)
+    win.setAutoClose(False)
+    win.setAutoReset(False)
+    win.setMinimumWidth(350)
+    win.show()
+    QtWidgets.QApplication.instance().processEvents()
+
+    # Track result
+    result = {"status": None, "filename": None, "error": None}
+
+    # Create worker thread
+    worker = RenderVideoThread(
+        labels=labels,
+        filename=filename,
+        video=video,
+        frame_inds=frame_inds,
+        render_params=render_params,
+    )
+
+    def on_progress(current, total):
+        win.setMaximum(total)
+        win.setValue(current)
+        pct = (current / total) * 100 if total > 0 else 0
+        win.setLabelText(
+            f"Rendering video...<br>{current}/{total} frames "
+            f"(<b>{pct:.1f}%</b>)"
+        )
+
+    def on_finished(fname):
+        result["status"] = "finished"
+        result["filename"] = fname
+
+    def on_cancelled():
+        result["status"] = "canceled"
+
+    def on_error(msg):
+        result["status"] = "error"
+        result["error"] = msg
+
+    # Connect signals
+    worker.progress.connect(on_progress)
+    worker.finished.connect(on_finished)
+    worker.cancelled.connect(on_cancelled)
+    worker.error.connect(on_error)
+
+    # Handle cancel button
+    win.canceled.connect(worker.cancel)
+
+    # Start the worker
+    worker.start()
+
+    # Process events while worker is running (keeps GUI responsive)
+    while worker.isRunning():
+        QtWidgets.QApplication.instance().processEvents()
+        worker.wait(10)  # Wait up to 10ms
+
+    # Ensure thread is fully terminated
+    worker.wait()
+
+    # Process any remaining events (including final signals from worker)
+    QtWidgets.QApplication.instance().processEvents()
+
+    # Clean up: disconnect signals and delete worker
+    worker.progress.disconnect()
+    worker.finished.disconnect()
+    worker.cancelled.disconnect()
+    worker.error.disconnect()
+    worker.deleteLater()
+
+    win.close()
+
+    # Handle result
+    if result["status"] == "finished":
+        if open_when_done:
+            open_file(result["filename"])
+        return result["filename"]
+    elif result["status"] == "canceled":
+        return "canceled"
+    elif result["status"] == "error":
+        QtWidgets.QMessageBox.critical(
+            None,
+            "Render Error",
+            f"Failed to render video:\n{result['error']}",
+        )
+        raise RuntimeError(result["error"])
+
+    return filename
 
 
 def export_dataset_gui(

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1542,10 +1542,16 @@ class ExportLabeledClip(AppCommand):
         video = context.state["video"]
         frame_idx = context.state.get("frame_idx", None)
 
+        # Get frame range if a clip is selected in main window
+        frame_range = None
+        if context.state["has_frame_range"]:
+            frame_range = tuple(context.state["frame_range"])
+
         dialog = RenderClipDialog(
             labels=labels,
             video=video,
             current_frame=frame_idx,
+            frame_range=frame_range,
             parent=context.app,
         )
 

--- a/sleap/gui/dialogs/render_clip.py
+++ b/sleap/gui/dialogs/render_clip.py
@@ -26,10 +26,16 @@ class RenderClipDialog(QtWidgets.QDialog):
 
     Usage from SLEAP GUI::
 
+        # Get frame range if clip is selected
+        frame_range = None
+        if context.state["has_frame_range"]:
+            frame_range = tuple(context.state["frame_range"])
+
         dialog = RenderClipDialog(
             labels=context.state["labels"],
             video=context.state["video"],
             current_frame=context.state["frame_idx"],
+            frame_range=frame_range,
             parent=context.app,
         )
         if dialog.exec_():
@@ -47,6 +53,7 @@ class RenderClipDialog(QtWidgets.QDialog):
         labels: "sio.Labels",
         video: "sio.Video | None" = None,
         current_frame: int | None = None,
+        frame_range: tuple[int, int] | None = None,
         parent: QtWidgets.QWidget | None = None,
     ):
         """Initialize the render clip dialog.
@@ -56,22 +63,43 @@ class RenderClipDialog(QtWidgets.QDialog):
             video: The video to render. If None, uses first video in labels.
             current_frame: Initial frame to show in preview. If None, uses
                 first labeled frame.
+            frame_range: Optional (start, end) tuple for initial frame range.
+                If provided, selects "Custom range" and sets start/end values.
+                This is typically from the main window's selected clip.
             parent: Parent widget.
         """
         super().__init__(parent)
         self.labels = labels
         self.video = video or (labels.videos[0] if labels.videos else None)
         self._current_frame = current_frame
+        self._initial_frame_range = frame_range
         self._output_path: str | None = None
 
         self._setup_ui()
         self._connect_signals()
+
+        # Initialize frame range from main window's selection
+        if frame_range is not None:
+            self._set_frame_range(frame_range)
 
         # Jump to current frame if specified
         if current_frame is not None:
             self._jump_to_frame(current_frame)
 
         self._update_preview()
+
+    def _set_frame_range(self, frame_range: tuple[int, int]):
+        """Set the frame range from an external selection (e.g., main window clip).
+
+        Args:
+            frame_range: (start, end) tuple of frame indices.
+        """
+        start, end = frame_range
+        # Select custom range mode
+        self.range_custom.setChecked(True)
+        # Set the start and end values
+        self.start_frame.setValue(start)
+        self.end_frame.setValue(end - 1)  # end is exclusive in context, make inclusive
 
     def _jump_to_frame(self, frame_idx: int):
         """Jump preview to a specific frame index."""
@@ -452,8 +480,13 @@ class RenderClipDialog(QtWidgets.QDialog):
             }
             self.scale.setValue(preset_scales.get(preset_text, 1.0))
 
-    def _get_render_params(self) -> dict:
-        """Get current render parameters from controls."""
+    def _get_render_params(self, for_preview: bool = True) -> dict:
+        """Get current render parameters from controls.
+
+        Args:
+            for_preview: If True, always use scale=1.0 for accurate preview.
+                If False, use the actual scale setting for export.
+        """
         params = {
             "color_by": self.color_by.currentText(),
             "palette": self.palette.currentText(),
@@ -470,8 +503,12 @@ class RenderClipDialog(QtWidgets.QDialog):
         if bg != "video":
             params["background"] = bg
 
-        # Scale for preview (use current scale setting)
-        params["scale"] = self.scale.value()
+        # Scale: always 1.0 for preview (accurate display), use setting for export
+        if for_preview:
+            # Preview always at full resolution for accurate display
+            params["scale"] = 1.0
+        else:
+            params["scale"] = self.scale.value()
 
         return params
 
@@ -518,7 +555,8 @@ class RenderClipDialog(QtWidgets.QDialog):
         Returns:
             Dictionary of parameters for `sio.render_video()`.
         """
-        params = self._get_render_params()
+        # Use actual scale setting for export (not preview's scale=1.0)
+        params = self._get_render_params(for_preview=False)
         params["fps"] = self.fps.value()
         params["crf"] = self.crf.value()
         params["open_when_done"] = self.open_when_done.isChecked()

--- a/sleap/gui/dialogs/render_clip.py
+++ b/sleap/gui/dialogs/render_clip.py
@@ -1,0 +1,555 @@
+"""Render Video Clip dialog with live preview using sleap-io.
+
+This dialog replaces the YAML-based FormBuilder approach for exporting
+labeled video clips, providing a pure Qt implementation with real-time
+preview capabilities using sleap-io's rendering API.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from qtpy import QtCore, QtWidgets
+
+from sleap.gui.widgets.rendering_preview import RenderingPreviewWidget
+
+if TYPE_CHECKING:
+    import sleap_io as sio
+
+
+class RenderClipDialog(QtWidgets.QDialog):
+    """Dialog for rendering video clips with live preview.
+
+    This dialog provides a pure Qt interface for configuring video rendering
+    options with real-time preview using sleap-io's `render_image()` function.
+
+    Usage from SLEAP GUI::
+
+        dialog = RenderClipDialog(
+            labels=context.state["labels"],
+            video=context.state["video"],
+            current_frame=context.state["frame_idx"],
+            parent=context.app,
+        )
+        if dialog.exec_():
+            params = dialog.get_export_params()
+            output_path = dialog.get_output_path()
+            # Call sio.render_video(...)
+
+    Attributes:
+        labels: The Labels object containing labeled frames.
+        video: The current video to render.
+    """
+
+    def __init__(
+        self,
+        labels: "sio.Labels",
+        video: "sio.Video | None" = None,
+        current_frame: int | None = None,
+        parent: QtWidgets.QWidget | None = None,
+    ):
+        """Initialize the render clip dialog.
+
+        Args:
+            labels: The Labels object containing labeled frames.
+            video: The video to render. If None, uses first video in labels.
+            current_frame: Initial frame to show in preview. If None, uses
+                first labeled frame.
+            parent: Parent widget.
+        """
+        super().__init__(parent)
+        self.labels = labels
+        self.video = video or (labels.videos[0] if labels.videos else None)
+        self._current_frame = current_frame
+        self._output_path: str | None = None
+
+        self._setup_ui()
+        self._connect_signals()
+
+        # Jump to current frame if specified
+        if current_frame is not None:
+            self._jump_to_frame(current_frame)
+
+        self._update_preview()
+
+    def _jump_to_frame(self, frame_idx: int):
+        """Jump preview to a specific frame index."""
+        self.preview.set_frame(frame_idx)
+
+    def _setup_ui(self):
+        """Build the dialog UI."""
+        self.setWindowTitle("Render Video Clip")
+        self.setMinimumSize(1000, 700)
+
+        main_layout = QtWidgets.QHBoxLayout(self)
+        main_layout.setSpacing(12)
+
+        # Left: Preview widget (2/3 width)
+        self.preview = RenderingPreviewWidget(self.labels, self.video)
+        main_layout.addWidget(self.preview, stretch=2)
+
+        # Right: Options panel (1/3 width)
+        options_panel = self._create_options_panel()
+        main_layout.addWidget(options_panel, stretch=1)
+
+    def _create_options_panel(self) -> QtWidgets.QWidget:
+        """Build the options panel with grouped controls."""
+        # Container for scroll + buttons
+        container = QtWidgets.QWidget()
+        container_layout = QtWidgets.QVBoxLayout(container)
+        container_layout.setContentsMargins(0, 0, 0, 0)
+        container_layout.setSpacing(8)
+
+        # Scrollable options area
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QtWidgets.QFrame.NoFrame)
+        scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
+
+        widget = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(widget)
+        layout.setSpacing(8)
+
+        # Video selection (for multi-video Labels)
+        if len(self.labels.videos) > 1:
+            layout.addWidget(self._create_video_selector_group())
+
+        # Frame Range
+        layout.addWidget(self._create_frame_range_group())
+
+        # Appearance
+        layout.addWidget(self._create_appearance_group())
+
+        # Quality
+        layout.addWidget(self._create_quality_group())
+
+        # Output
+        layout.addWidget(self._create_output_group())
+
+        # Spacer
+        layout.addStretch()
+
+        scroll.setWidget(widget)
+        container_layout.addWidget(scroll, stretch=1)
+
+        # Buttons (outside scroll area - always visible)
+        container_layout.addWidget(self._create_buttons())
+
+        return container
+
+    def _create_video_selector_group(self) -> QtWidgets.QGroupBox:
+        """Create video selection group (for multi-video Labels)."""
+        group = QtWidgets.QGroupBox("Video")
+        layout = QtWidgets.QFormLayout(group)
+
+        self.video_selector = QtWidgets.QComboBox()
+        for i, video in enumerate(self.labels.videos):
+            # Get video filename
+            name = getattr(video, "filename", None) or getattr(video, "backend", None)
+            if name:
+                name = os.path.basename(str(name))
+            else:
+                name = f"Video {i}"
+            n_frames = len(
+                [lf for lf in self.labels.labeled_frames if lf.video == video]
+            )
+            self.video_selector.addItem(f"{name} ({n_frames} labeled)", video)
+
+        # Select current video
+        if self.video in self.labels.videos:
+            self.video_selector.setCurrentIndex(self.labels.videos.index(self.video))
+
+        self.video_selector.currentIndexChanged.connect(self._on_video_changed)
+        layout.addRow("Source:", self.video_selector)
+
+        return group
+
+    def _on_video_changed(self, index: int):
+        """Handle video selection change."""
+        self.video = self.video_selector.itemData(index)
+        # Update preview widget
+        self.preview.video = self.video
+        self.preview._labeled_frame_indices = self.preview._get_labeled_frame_indices()
+        self.preview._update_slider_range()
+        if self.preview._labeled_frame_indices:
+            self.preview._current_frame_idx = self.preview._labeled_frame_indices[0]
+            self.preview.frame_slider.setValue(0)
+        self.preview._do_render()
+        # Update frame range limits
+        self._update_frame_range_limits()
+
+    def _update_frame_range_limits(self):
+        """Update frame range spinboxes based on current video."""
+        labeled_frames = [
+            lf.frame_idx
+            for lf in self.labels.labeled_frames
+            if self.video is None or lf.video == self.video
+        ]
+        if labeled_frames:
+            self.start_frame.setValue(min(labeled_frames))
+            self.end_frame.setValue(max(labeled_frames))
+            self.start_frame.setMaximum(max(labeled_frames))
+            self.end_frame.setMaximum(max(labeled_frames))
+
+    def _create_frame_range_group(self) -> QtWidgets.QGroupBox:
+        """Create frame range selection group."""
+        group = QtWidgets.QGroupBox("Frame Range")
+        layout = QtWidgets.QVBoxLayout(group)
+
+        # Radio buttons for range mode
+        self.range_all = QtWidgets.QRadioButton("All labeled frames")
+        self.range_all.setToolTip("Render all frames with labels")
+        self.range_all.setChecked(True)
+        layout.addWidget(self.range_all)
+
+        self.range_custom = QtWidgets.QRadioButton("Custom range:")
+        self.range_custom.setToolTip("Render a specific frame range")
+        layout.addWidget(self.range_custom)
+
+        # Custom range inputs
+        range_layout = QtWidgets.QHBoxLayout()
+        range_layout.setContentsMargins(20, 0, 0, 0)
+
+        self.start_frame = QtWidgets.QSpinBox()
+        self.start_frame.setRange(0, 999999)
+        self.start_frame.setEnabled(False)
+        range_layout.addWidget(QtWidgets.QLabel("Start:"))
+        range_layout.addWidget(self.start_frame)
+
+        self.end_frame = QtWidgets.QSpinBox()
+        self.end_frame.setRange(0, 999999)
+        self.end_frame.setEnabled(False)
+        range_layout.addWidget(QtWidgets.QLabel("End:"))
+        range_layout.addWidget(self.end_frame)
+
+        range_layout.addStretch()
+        layout.addLayout(range_layout)
+
+        # Connect range mode changes
+        self.range_custom.toggled.connect(self.start_frame.setEnabled)
+        self.range_custom.toggled.connect(self.end_frame.setEnabled)
+
+        # Set range based on labels
+        labeled_frames = [
+            lf.frame_idx
+            for lf in self.labels.labeled_frames
+            if self.video is None or lf.video == self.video
+        ]
+        if labeled_frames:
+            self.start_frame.setValue(min(labeled_frames))
+            self.end_frame.setValue(max(labeled_frames))
+            self.start_frame.setMaximum(max(labeled_frames))
+            self.end_frame.setMaximum(max(labeled_frames))
+
+        return group
+
+    def _create_appearance_group(self) -> QtWidgets.QGroupBox:
+        """Create appearance options group."""
+        group = QtWidgets.QGroupBox("Appearance")
+        layout = QtWidgets.QFormLayout(group)
+        layout.setFieldGrowthPolicy(QtWidgets.QFormLayout.ExpandingFieldsGrow)
+
+        # Color by
+        self.color_by = QtWidgets.QComboBox()
+        self.color_by.addItems(["track", "instance", "node"])
+        self.color_by.setToolTip(
+            "track: Consistent colors per tracked animal\n"
+            "instance: Unique colors per animal per frame\n"
+            "node: Unique colors per body part"
+        )
+        layout.addRow("Color by:", self.color_by)
+
+        # Palette
+        self.palette = QtWidgets.QComboBox()
+        palettes = [
+            "standard",
+            "distinct",
+            "rainbow",
+            "warm",
+            "cool",
+            "pastel",
+            "seaborn",
+            "tableau10",
+            "viridis",
+            "glasbey",
+            "glasbey_hv",
+            "glasbey_cool",
+            "glasbey_warm",
+        ]
+        self.palette.addItems(palettes)
+        self.palette.setCurrentText("tableau10")
+        self.palette.setToolTip("Color palette for instances/nodes")
+        layout.addRow("Palette:", self.palette)
+
+        # Marker shape
+        self.marker_shape = QtWidgets.QComboBox()
+        self.marker_shape.addItems(["circle", "square", "diamond", "triangle", "cross"])
+        self.marker_shape.setToolTip("Shape of node markers")
+        layout.addRow("Marker:", self.marker_shape)
+
+        # Marker size
+        self.marker_size = QtWidgets.QDoubleSpinBox()
+        self.marker_size.setRange(1.0, 30.0)
+        self.marker_size.setValue(4.0)
+        self.marker_size.setSingleStep(0.5)
+        self.marker_size.setToolTip("Size of node markers in pixels")
+        layout.addRow("Marker size:", self.marker_size)
+
+        # Line width
+        self.line_width = QtWidgets.QDoubleSpinBox()
+        self.line_width.setRange(0.5, 15.0)
+        self.line_width.setValue(2.0)
+        self.line_width.setSingleStep(0.5)
+        self.line_width.setToolTip("Width of skeleton edges in pixels")
+        layout.addRow("Line width:", self.line_width)
+
+        # Opacity
+        self.alpha = QtWidgets.QDoubleSpinBox()
+        self.alpha.setRange(0.1, 1.0)
+        self.alpha.setSingleStep(0.1)
+        self.alpha.setValue(1.0)
+        self.alpha.setToolTip("Opacity of skeleton overlay (0.1-1.0)")
+        layout.addRow("Opacity:", self.alpha)
+
+        # Show nodes/edges checkboxes
+        visibility_layout = QtWidgets.QHBoxLayout()
+        self.show_nodes = QtWidgets.QCheckBox("Nodes")
+        self.show_nodes.setChecked(True)
+        self.show_nodes.setToolTip("Show node markers")
+        self.show_edges = QtWidgets.QCheckBox("Edges")
+        self.show_edges.setChecked(True)
+        self.show_edges.setToolTip("Show skeleton edges")
+        visibility_layout.addWidget(self.show_nodes)
+        visibility_layout.addWidget(self.show_edges)
+        visibility_layout.addStretch()
+        layout.addRow("Show:", visibility_layout)
+
+        # Background
+        self.background = QtWidgets.QComboBox()
+        self.background.addItems(["video", "black", "white", "gray"])
+        self.background.setToolTip(
+            "Background for rendering\n"
+            "video: Use original video frames\n"
+            "black/white/gray: Solid color background"
+        )
+        layout.addRow("Background:", self.background)
+
+        return group
+
+    def _create_quality_group(self) -> QtWidgets.QGroupBox:
+        """Create quality/encoding options group."""
+        group = QtWidgets.QGroupBox("Quality")
+        layout = QtWidgets.QFormLayout(group)
+        layout.setFieldGrowthPolicy(QtWidgets.QFormLayout.ExpandingFieldsGrow)
+
+        # Preset
+        self.preset = QtWidgets.QComboBox()
+        self.preset.addItems(
+            ["preview (0.25x)", "draft (0.5x)", "final (1.0x)", "custom"]
+        )
+        self.preset.setCurrentText("final (1.0x)")
+        self.preset.setToolTip(
+            "Quality preset\n"
+            "preview: Fast, 0.25x resolution\n"
+            "draft: Medium, 0.5x resolution\n"
+            "final: Full resolution"
+        )
+        layout.addRow("Preset:", self.preset)
+
+        # Scale (only enabled for custom preset)
+        self.scale = QtWidgets.QDoubleSpinBox()
+        self.scale.setRange(0.1, 2.0)
+        self.scale.setValue(1.0)
+        self.scale.setSingleStep(0.1)
+        self.scale.setEnabled(False)
+        self.scale.setToolTip("Output scale factor (1.0 = original resolution)")
+        layout.addRow("Scale:", self.scale)
+
+        # CRF (video quality)
+        self.crf = QtWidgets.QSpinBox()
+        self.crf.setRange(2, 51)
+        self.crf.setValue(23)
+        self.crf.setToolTip(
+            "Video quality (CRF)\n"
+            "Lower = better quality, larger file\n"
+            "Recommended: 18-28"
+        )
+        layout.addRow("CRF:", self.crf)
+
+        # Connect preset to scale
+        self.preset.currentTextChanged.connect(self._on_preset_changed)
+
+        return group
+
+    def _create_output_group(self) -> QtWidgets.QGroupBox:
+        """Create output options group."""
+        group = QtWidgets.QGroupBox("Output")
+        layout = QtWidgets.QFormLayout(group)
+        layout.setFieldGrowthPolicy(QtWidgets.QFormLayout.ExpandingFieldsGrow)
+
+        # FPS
+        self.fps = QtWidgets.QSpinBox()
+        self.fps.setRange(1, 120)
+        self.fps.setValue(30)
+        self.fps.setToolTip("Output video frame rate")
+        layout.addRow("FPS:", self.fps)
+
+        # Open when done
+        self.open_when_done = QtWidgets.QCheckBox("Open video when done")
+        self.open_when_done.setChecked(True)
+        layout.addRow("", self.open_when_done)
+
+        return group
+
+    def _create_buttons(self) -> QtWidgets.QWidget:
+        """Create dialog buttons (fixed at bottom, outside scroll area)."""
+        widget = QtWidgets.QWidget()
+        layout = QtWidgets.QHBoxLayout(widget)
+        layout.setContentsMargins(0, 8, 0, 0)
+
+        layout.addStretch()
+
+        self.cancel_btn = QtWidgets.QPushButton("Cancel")
+        self.cancel_btn.clicked.connect(self.reject)
+        layout.addWidget(self.cancel_btn)
+
+        self.render_btn = QtWidgets.QPushButton("Render Video...")
+        self.render_btn.setDefault(True)
+        self.render_btn.clicked.connect(self._on_render)
+        layout.addWidget(self.render_btn)
+
+        return widget
+
+    def _connect_signals(self):
+        """Connect all control signals to preview updates."""
+        # Appearance controls
+        self.color_by.currentTextChanged.connect(self._update_preview)
+        self.palette.currentTextChanged.connect(self._update_preview)
+        self.marker_shape.currentTextChanged.connect(self._update_preview)
+        self.marker_size.valueChanged.connect(self._update_preview)
+        self.line_width.valueChanged.connect(self._update_preview)
+        self.alpha.valueChanged.connect(self._update_preview)
+        self.show_nodes.toggled.connect(self._update_preview)
+        self.show_edges.toggled.connect(self._update_preview)
+        self.background.currentTextChanged.connect(self._update_preview)
+
+        # Quality controls that affect preview
+        self.preset.currentTextChanged.connect(self._update_preview)
+        self.scale.valueChanged.connect(self._update_preview)
+
+    def _on_preset_changed(self, preset_text: str):
+        """Handle preset change - enable/disable scale spinbox."""
+        is_custom = preset_text == "custom"
+        self.scale.setEnabled(is_custom)
+
+        # Update scale value based on preset
+        if not is_custom:
+            preset_scales = {
+                "preview (0.25x)": 0.25,
+                "draft (0.5x)": 0.5,
+                "final (1.0x)": 1.0,
+            }
+            self.scale.setValue(preset_scales.get(preset_text, 1.0))
+
+    def _get_render_params(self) -> dict:
+        """Get current render parameters from controls."""
+        params = {
+            "color_by": self.color_by.currentText(),
+            "palette": self.palette.currentText(),
+            "marker_shape": self.marker_shape.currentText(),
+            "marker_size": self.marker_size.value(),
+            "line_width": self.line_width.value(),
+            "alpha": self.alpha.value(),
+            "show_nodes": self.show_nodes.isChecked(),
+            "show_edges": self.show_edges.isChecked(),
+        }
+
+        # Background
+        bg = self.background.currentText()
+        if bg != "video":
+            params["background"] = bg
+
+        # Scale for preview (use current scale setting)
+        params["scale"] = self.scale.value()
+
+        return params
+
+    def _update_preview(self):
+        """Update preview with current settings."""
+        params = self._get_render_params()
+        self.preview.set_render_params(**params)
+
+    def _on_render(self):
+        """Handle render button click - prompt for output file."""
+        # Generate default filename
+        default_name = "rendered_clip.mp4"
+        if self.video:
+            video_name = getattr(self.video, "filename", None) or getattr(
+                self.video, "backend", None
+            )
+            if video_name:
+                base = os.path.splitext(os.path.basename(str(video_name)))[0]
+                default_name = f"{base}_rendered.mp4"
+
+        filename, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self,
+            "Save Rendered Video",
+            default_name,
+            "MP4 Video (*.mp4);;All Files (*)",
+        )
+
+        if not filename:
+            return
+
+        if not filename.lower().endswith(".mp4"):
+            filename += ".mp4"
+
+        self._output_path = filename
+        self.accept()
+
+    def get_output_path(self) -> str | None:
+        """Get the selected output file path."""
+        return self._output_path
+
+    def get_export_params(self) -> dict:
+        """Get all export parameters.
+
+        Returns:
+            Dictionary of parameters for `sio.render_video()`.
+        """
+        params = self._get_render_params()
+        params["fps"] = self.fps.value()
+        params["crf"] = self.crf.value()
+        params["open_when_done"] = self.open_when_done.isChecked()
+
+        # Frame range
+        if self.range_custom.isChecked():
+            params["start"] = self.start_frame.value()
+            params["end"] = self.end_frame.value()
+
+        return params
+
+    def get_frame_indices(self) -> list[int]:
+        """Get list of frame indices to render.
+
+        Returns:
+            List of frame indices to include in the rendered video.
+        """
+        if self.range_all.isChecked():
+            # All labeled frames for current video
+            return [
+                lf.frame_idx
+                for lf in self.labels.labeled_frames
+                if self.video is None or lf.video == self.video
+            ]
+        else:
+            # Custom range - all labeled frames within range
+            start = self.start_frame.value()
+            end = self.end_frame.value()
+            return [
+                lf.frame_idx
+                for lf in self.labels.labeled_frames
+                if (self.video is None or lf.video == self.video)
+                and start <= lf.frame_idx <= end
+            ]

--- a/sleap/gui/widgets/rendering_preview.py
+++ b/sleap/gui/widgets/rendering_preview.py
@@ -1,0 +1,256 @@
+"""Widget for live preview of rendered frames using sleap-io.
+
+This module provides a preview widget that displays rendered frames using
+sleap-io's `render_image()` function, allowing real-time preview of
+rendering settings before exporting a video.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from qtpy import QtCore, QtGui, QtWidgets
+
+if TYPE_CHECKING:
+    import sleap_io as sio
+
+
+class RenderingPreviewWidget(QtWidgets.QWidget):
+    """Live preview of rendered frames using sleap-io.
+
+    This widget displays a rendered frame with the current render settings and
+    allows navigation through labeled frames. It uses sleap-io's `render_image()`
+    function for actual rendering.
+
+    Attributes:
+        labels: The Labels object containing labeled frames.
+        video: The video to render frames from.
+        frameChanged: Signal emitted when frame changes (int: frame index).
+    """
+
+    frameChanged = QtCore.Signal(int)
+
+    def __init__(
+        self,
+        labels: "sio.Labels",
+        video: "sio.Video | None" = None,
+        parent: QtWidgets.QWidget | None = None,
+    ):
+        """Initialize the rendering preview widget.
+
+        Args:
+            labels: The Labels object containing labeled frames.
+            video: The video to render. If None, uses first video in labels.
+            parent: Parent widget.
+        """
+        super().__init__(parent)
+        self.labels = labels
+        self.video = video or (labels.videos[0] if labels.videos else None)
+        self._current_frame_idx = 0
+        self._render_params: dict = {}
+        self._debounce_timer = QtCore.QTimer()
+        self._debounce_timer.setSingleShot(True)
+        self._debounce_timer.timeout.connect(self._do_render)
+
+        # Build list of labeled frame indices for this video
+        self._labeled_frame_indices = self._get_labeled_frame_indices()
+
+        self._setup_ui()
+        self._update_slider_range()
+
+        # Initial render
+        if self._labeled_frame_indices:
+            self._current_frame_idx = self._labeled_frame_indices[0]
+            self._do_render()
+
+    def _get_labeled_frame_indices(self) -> list[int]:
+        """Get sorted list of frame indices with labels for current video."""
+        if self.video is None:
+            return [lf.frame_idx for lf in self.labels.labeled_frames]
+        return sorted(
+            lf.frame_idx
+            for lf in self.labels.labeled_frames
+            if lf.video == self.video
+        )
+
+    def _setup_ui(self):
+        """Build the widget UI."""
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        # Preview image display
+        self.preview_label = QtWidgets.QLabel()
+        self.preview_label.setMinimumSize(400, 300)
+        self.preview_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.preview_label.setStyleSheet("background-color: #1a1a1a;")
+        self.preview_label.setSizePolicy(
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
+        )
+        layout.addWidget(self.preview_label, stretch=1)
+
+        # Frame navigation controls
+        nav_layout = QtWidgets.QHBoxLayout()
+        nav_layout.setContentsMargins(4, 4, 4, 4)
+
+        # Previous frame button
+        self.prev_btn = QtWidgets.QPushButton("<")
+        self.prev_btn.setFixedWidth(30)
+        self.prev_btn.setToolTip("Previous labeled frame")
+        self.prev_btn.clicked.connect(self._go_prev_frame)
+        nav_layout.addWidget(self.prev_btn)
+
+        # Frame slider
+        self.frame_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.frame_slider.setMinimum(0)
+        self.frame_slider.valueChanged.connect(self._on_slider_changed)
+        nav_layout.addWidget(self.frame_slider, stretch=1)
+
+        # Next frame button
+        self.next_btn = QtWidgets.QPushButton(">")
+        self.next_btn.setFixedWidth(30)
+        self.next_btn.setToolTip("Next labeled frame")
+        self.next_btn.clicked.connect(self._go_next_frame)
+        nav_layout.addWidget(self.next_btn)
+
+        # Frame label
+        self.frame_label = QtWidgets.QLabel("Frame: 0")
+        self.frame_label.setMinimumWidth(80)
+        nav_layout.addWidget(self.frame_label)
+
+        # Refresh button
+        self.refresh_btn = QtWidgets.QPushButton("Refresh")
+        self.refresh_btn.setToolTip("Re-render current frame")
+        self.refresh_btn.clicked.connect(self._do_render)
+        nav_layout.addWidget(self.refresh_btn)
+
+        layout.addLayout(nav_layout)
+
+    def _update_slider_range(self):
+        """Update slider to match labeled frames."""
+        n_frames = len(self._labeled_frame_indices)
+        self.frame_slider.setMaximum(max(0, n_frames - 1))
+        self.prev_btn.setEnabled(n_frames > 1)
+        self.next_btn.setEnabled(n_frames > 1)
+
+    def _on_slider_changed(self, slider_idx: int):
+        """Handle slider value change."""
+        if 0 <= slider_idx < len(self._labeled_frame_indices):
+            self._current_frame_idx = self._labeled_frame_indices[slider_idx]
+            self.frame_label.setText(f"Frame: {self._current_frame_idx}")
+            self._schedule_render()
+            self.frameChanged.emit(self._current_frame_idx)
+
+    def _go_prev_frame(self):
+        """Navigate to previous labeled frame."""
+        current_slider = self.frame_slider.value()
+        if current_slider > 0:
+            self.frame_slider.setValue(current_slider - 1)
+
+    def _go_next_frame(self):
+        """Navigate to next labeled frame."""
+        current_slider = self.frame_slider.value()
+        if current_slider < self.frame_slider.maximum():
+            self.frame_slider.setValue(current_slider + 1)
+
+    def set_render_params(self, **params):
+        """Update rendering parameters and refresh preview.
+
+        Args:
+            **params: Keyword arguments passed to `sio.render_image()`.
+        """
+        self._render_params = params
+        self._schedule_render()
+
+    def set_frame(self, frame_idx: int):
+        """Jump to a specific frame index.
+
+        Args:
+            frame_idx: Frame index to display.
+        """
+        if frame_idx in self._labeled_frame_indices:
+            slider_idx = self._labeled_frame_indices.index(frame_idx)
+            self.frame_slider.setValue(slider_idx)
+
+    def _schedule_render(self, delay_ms: int = 100):
+        """Schedule a debounced render.
+
+        Args:
+            delay_ms: Delay in milliseconds before rendering.
+        """
+        self._debounce_timer.start(delay_ms)
+
+    def _do_render(self):
+        """Render current frame with current settings."""
+        import sleap_io as sio
+
+        if not self._labeled_frame_indices:
+            self._show_no_frames_message()
+            return
+
+        # Find the labeled frame
+        lfs = self.labels.find(self.video, self._current_frame_idx)
+        if not lfs:
+            self._show_no_frames_message()
+            return
+
+        lf = lfs[0]
+
+        try:
+            # Render using sleap-io
+            img = sio.render_image(lf, **self._render_params)
+            self._display_image(img)
+        except Exception as e:
+            self._show_error_message(str(e))
+
+    def _display_image(self, img: np.ndarray):
+        """Convert numpy array to QPixmap and display.
+
+        Args:
+            img: Numpy array of image data (H, W, C).
+        """
+        # Ensure contiguous array
+        if not img.flags["C_CONTIGUOUS"]:
+            img = np.ascontiguousarray(img)
+
+        h, w = img.shape[:2]
+        c = img.shape[2] if img.ndim == 3 else 1
+
+        if c == 3:
+            # RGB
+            qimg = QtGui.QImage(img.data, w, h, w * c, QtGui.QImage.Format_RGB888)
+        elif c == 4:
+            # RGBA
+            qimg = QtGui.QImage(img.data, w, h, w * c, QtGui.QImage.Format_RGBA8888)
+        else:
+            # Grayscale
+            qimg = QtGui.QImage(img.data, w, h, w, QtGui.QImage.Format_Grayscale8)
+
+        pixmap = QtGui.QPixmap.fromImage(qimg)
+
+        # Scale to fit while maintaining aspect ratio
+        scaled = pixmap.scaled(
+            self.preview_label.size(),
+            QtCore.Qt.KeepAspectRatio,
+            QtCore.Qt.SmoothTransformation,
+        )
+        self.preview_label.setPixmap(scaled)
+
+    def _show_no_frames_message(self):
+        """Show message when no labeled frames available."""
+        self.preview_label.setText("No labeled frames")
+        self.preview_label.setStyleSheet("background-color: #1a1a1a; color: #888;")
+
+    def _show_error_message(self, error: str):
+        """Show error message.
+
+        Args:
+            error: Error message to display.
+        """
+        self.preview_label.setText(f"Render error:\n{error}")
+        self.preview_label.setStyleSheet("background-color: #1a1a1a; color: #f88;")
+
+    def resizeEvent(self, event):
+        """Re-render on resize to fit new size."""
+        super().resizeEvent(event)
+        self._schedule_render(delay_ms=200)

--- a/sleap/gui/widgets/rendering_preview.py
+++ b/sleap/gui/widgets/rendering_preview.py
@@ -69,9 +69,7 @@ class RenderingPreviewWidget(QtWidgets.QWidget):
         if self.video is None:
             return [lf.frame_idx for lf in self.labels.labeled_frames]
         return sorted(
-            lf.frame_idx
-            for lf in self.labels.labeled_frames
-            if lf.video == self.video
+            lf.frame_idx for lf in self.labels.labeled_frames if lf.video == self.video
         )
 
     def _setup_ui(self):

--- a/sleap/io/visuals.py
+++ b/sleap/io/visuals.py
@@ -1,10 +1,19 @@
 """
 Module for generating videos with visual annotation overlays.
+
+.. deprecated::
+    This module is deprecated. Use ``sleap_io.render_video()`` and
+    ``sleap_io.render_image()`` instead for improved rendering with
+    more customization options. See the sleap-io documentation for details.
+
+The legacy rendering code in this module is maintained for backwards
+compatibility but will be removed in a future release.
 """
 
 from __future__ import annotations
 
 import logging
+import warnings
 from collections import deque
 from queue import Queue, Empty
 from threading import Thread
@@ -31,6 +40,9 @@ logger = logging.getLogger(__name__)
 
 class VideoMarkerThread(Thread):
     """Annotate frame images (draw instances).
+
+    .. deprecated::
+        Use ``sleap_io.render_video()`` instead for improved rendering.
 
     Args:
         in_q: Queue with (list of frame indexes, ndarray of frame images).
@@ -59,6 +71,11 @@ class VideoMarkerThread(Thread):
         palette: str = "standard",
         distinctly_color: str = "instances",
     ):
+        warnings.warn(
+            "VideoMarkerThread is deprecated. Use sleap_io.render_video() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super(VideoMarkerThread, self).__init__()
         self.in_q = in_q
         self.out_q = out_q
@@ -438,6 +455,29 @@ def save_labeled_video(
 ):
     """Function to generate and save video with annotations.
 
+    .. deprecated::
+        Use ``sleap_io.render_video()`` instead for improved rendering with
+        more customization options including color schemes, marker shapes,
+        and real-time preview support.
+
+        Example migration::
+
+            import sleap_io as sio
+
+            # Old way (deprecated):
+            save_labeled_video(filename, labels, video, frames, fps=30)
+
+            # New way:
+            sio.render_video(
+                labels,
+                filename,
+                video=video,
+                frame_inds=frames,
+                fps=30,
+                color_by="track",
+                palette="tableau10",
+            )
+
     Args:
         filename: Output filename.
         labels: The dataset from which to get data.
@@ -461,6 +501,12 @@ def save_labeled_video(
     Returns:
         None.
     """
+    warnings.warn(
+        "save_labeled_video() is deprecated. Use sleap_io.render_video() instead "
+        "for improved rendering with more customization options.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     # Set up GUI progress dialog if requested
     progress_win = None
     canceled = False


### PR DESCRIPTION
## Summary

Upgrades the video rendering widget in the GUI to use sleap-io's rendering API (`sio.render_video()` and `sio.render_image()`), replacing the legacy OpenCV-based pipeline.

**Key improvements:**
- **Live preview**: Real-time preview of rendered frames with all style options
- **New styling options**: 12+ color palettes, 5 marker shapes, color by track/instance/node, alpha transparency
- **Non-blocking rendering**: Progress bar with cancel support - GUI stays responsive during export
- **Pure Qt dialog**: Replaces YAML FormBuilder with modern grouped controls and tooltips

## Changes

### New Files
- `sleap/gui/widgets/rendering_preview.py` - `RenderingPreviewWidget` for live preview
- `sleap/gui/dialogs/render_clip.py` - `RenderClipDialog` pure Qt dialog

### Modified Files
- `sleap/gui/commands.py`:
  - Updated `ExportLabeledClip` to use new dialog and `sio.render_video()`
  - Added `RenderVideoThread` for background rendering
  - Added `render_video_gui()` helper with progress dialog
- `sleap/io/visuals.py` - Added deprecation warnings to legacy rendering code

## Test plan

- [x] Preview updates live when changing style options
- [x] Video selector works for multi-video labels
- [x] Frame range initializes from selected clip
- [x] Progress bar shows frame count and percentage
- [x] Cancel button stops rendering and cleans up partial files
- [x] GUI remains responsive during long renders
- [x] Rendered video opens on completion (when enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)