### PR TITLE
Add sleap-io v0.6.1 CLI commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "seaborn",
     "requests",
     "matplotlib",
-    "sleap-io[all]>=0.6.0,<0.7.0",
+    "sleap-io[all]>=0.6.1,<0.7.0",
 ]
 
 [tool.setuptools.dynamic]

--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -27,13 +27,21 @@ from rich.console import Console
 
 import sleap
 
-# Import sleap-io CLI commands for integration (requires sleap-io>=0.6.0)
+# Import sleap-io CLI commands for integration (requires sleap-io>=0.6.1)
 from sleap_io.io.cli import (
     show as sio_show,
     convert as sio_convert,
     split as sio_split,
+    unsplit as sio_unsplit,
+    merge as sio_merge,
     filenames as sio_filenames,
     render as sio_render,
+    fix as sio_fix,
+    embed as sio_embed,
+    unembed as sio_unembed,
+    trim as sio_trim,
+    reencode as sio_reencode,
+    transform as sio_transform,
 )
 
 
@@ -138,8 +146,12 @@ click.rich_click.COMMAND_GROUPS = {
     "sleap": [
         {"name": "Application", "commands": ["label", "doctor"]},
         {"name": "Data Inspection", "commands": ["show", "filenames"]},
-        {"name": "Data Transformation", "commands": ["convert", "split"]},
-        {"name": "Visualization", "commands": ["render"]},
+        {
+            "name": "Data Transformation",
+            "commands": ["convert", "split", "unsplit", "merge", "trim", "fix"],
+        },
+        {"name": "Frame Management", "commands": ["embed", "unembed"]},
+        {"name": "Video Processing", "commands": ["reencode", "transform", "render"]},
     ]
 }
 
@@ -1008,8 +1020,16 @@ def _format_doctor_plain(data: dict) -> str:
 cli.add_command(wrap_sio_command(sio_show), name="show")
 cli.add_command(wrap_sio_command(sio_convert), name="convert")
 cli.add_command(wrap_sio_command(sio_split), name="split")
+cli.add_command(wrap_sio_command(sio_unsplit), name="unsplit")
+cli.add_command(wrap_sio_command(sio_merge), name="merge")
 cli.add_command(wrap_sio_command(sio_filenames), name="filenames")
 cli.add_command(wrap_sio_command(sio_render), name="render")
+cli.add_command(wrap_sio_command(sio_fix), name="fix")
+cli.add_command(wrap_sio_command(sio_embed), name="embed")
+cli.add_command(wrap_sio_command(sio_unembed), name="unembed")
+cli.add_command(wrap_sio_command(sio_trim), name="trim")
+cli.add_command(wrap_sio_command(sio_reencode), name="reencode")
+cli.add_command(wrap_sio_command(sio_transform), name="transform")
 
 
 # =============================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,7 +163,21 @@ class TestSleapIoIntegration:
 
     def test_sleap_io_commands_are_registered(self):
         """Verify all sleap-io commands are registered on the CLI."""
-        expected_commands = ["show", "convert", "split", "filenames", "render"]
+        expected_commands = [
+            "show",
+            "convert",
+            "split",
+            "unsplit",
+            "merge",
+            "filenames",
+            "render",
+            "fix",
+            "embed",
+            "unembed",
+            "trim",
+            "reencode",
+            "transform",
+        ]
         registered_commands = list(cli.commands.keys())
 
         for cmd in expected_commands:
@@ -229,12 +243,85 @@ class TestSleapIoIntegration:
         # Native commands
         assert "label" in result.output
         assert "doctor" in result.output
-        # Inherited commands
+        # Inherited commands (original)
         assert "show" in result.output
         assert "convert" in result.output
         assert "split" in result.output
         assert "filenames" in result.output
         assert "render" in result.output
+        # Inherited commands (v0.6.1 additions)
+        assert "unsplit" in result.output
+        assert "merge" in result.output
+        assert "fix" in result.output
+        assert "embed" in result.output
+        assert "unembed" in result.output
+        assert "trim" in result.output
+        assert "reencode" in result.output
+        assert "transform" in result.output
+
+    def test_unsplit_command_registered(self):
+        """Verify unsplit command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["unsplit", "--help"])
+        assert result.exit_code == 0
+        assert "$ sleap unsplit" in result.output
+        assert "$ sio unsplit" not in result.output
+
+    def test_merge_command_registered(self):
+        """Verify merge command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["merge", "--help"])
+        assert result.exit_code == 0
+        assert "$ sleap merge" in result.output
+        assert "$ sio merge" not in result.output
+
+    def test_fix_command_registered(self):
+        """Verify fix command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["fix", "--help"])
+        assert result.exit_code == 0
+        assert "$ sleap fix" in result.output
+        assert "$ sio fix" not in result.output
+
+    def test_embed_command_registered(self):
+        """Verify embed command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["embed", "--help"])
+        assert result.exit_code == 0
+        assert "$ sleap embed" in result.output
+        assert "$ sio embed" not in result.output
+
+    def test_unembed_command_registered(self):
+        """Verify unembed command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["unembed", "--help"])
+        assert result.exit_code == 0
+        assert "$ sleap unembed" in result.output
+        assert "$ sio unembed" not in result.output
+
+    def test_trim_command_registered(self):
+        """Verify trim command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["trim", "--help"])
+        assert result.exit_code == 0
+        assert "$ sleap trim" in result.output
+        assert "$ sio trim" not in result.output
+
+    def test_reencode_command_registered(self):
+        """Verify reencode command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["reencode", "--help"])
+        assert result.exit_code == 0
+        assert "$ sleap reencode" in result.output
+        assert "$ sio reencode" not in result.output
+
+    def test_transform_command_registered(self):
+        """Verify transform command is available."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["transform", "--help"])
+        assert result.exit_code == 0
+        assert "$ sleap transform" in result.output
+        assert "$ sio transform" not in result.output
 
     def test_show_with_file(self, tmp_path):
         """Verify show command works with an actual file."""


### PR DESCRIPTION
## Summary

- Bump `sleap-io` minimum version from `>=0.6.0` to `>=0.6.1`
- Add 8 new CLI commands from sleap-io v0.6.1:
  - `merge` - Merge multiple labels files into one
  - `unsplit` - Reverse split operation by merging train/val/test files  
  - `fix` - Detect and repair common issues in labels files
  - `embed` - Embed video frames into labels file
  - `unembed` - Remove embedded frames and restore video references
  - `trim` - Trim video and labels to a frame range
  - `reencode` - Reencode video for improved seekability
  - `transform` - Transform video and adjust label coordinates (with automatic coordinate adjustment)

## Test plan

- [x] All 31 CLI tests pass locally
- [ ] CI passes on all platforms
- [ ] Manual verification: `sleap --help` shows all new commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)