### PR TITLE
Fix docs workflow race condition with concurrency group

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - develop
 
+# Ensure only one docs deployment runs at a time to prevent gh-pages push conflicts
+concurrency:
+  group: docs-deployment
+  cancel-in-progress: false
 
 jobs:
   docs:


### PR DESCRIPTION
## Summary
- Adds a `concurrency` group to the docs workflow to prevent race conditions when multiple docs deployments run simultaneously
- Fixes the issue where the docs build failed after v1.6.0a1 pre-release due to gh-pages push conflicts

## Problem
When a release and push to develop happen simultaneously (e.g., when merging a version bump PR and creating a release), both trigger the docs workflow. Without concurrency control, both workflows try to push to the `gh-pages` branch at the same time, causing one to fail with:

```
! [rejected] gh-pages -> gh-pages (fetch first)
error: failed to push some refs to 'https://github.com/talmolab/sleap'
```

This was observed after the v1.6.0a1 pre-release (see [failed run](https://github.com/talmolab/sleap/actions/runs/20968303355)).

## Solution
Add a concurrency group that queues docs deployments so only one runs at a time:

```yaml
concurrency:
  group: docs-deployment
  cancel-in-progress: false
```

Using `cancel-in-progress: false` ensures both deployments eventually succeed rather than canceling one.

## Test plan
- [ ] Verify PR preview docs build succeeds
- [ ] After merge, verify docs workflow succeeds on develop push

🤖 Generated with [Claude Code](https://claude.com/claude-code)