### PR TITLE
Housekeeping: Python 3.13 default and sleap-support skill

### DIFF
--- a/.claude/skills/investigation/SKILL.md
+++ b/.claude/skills/investigation/SKILL.md
@@ -14,7 +14,10 @@ description: >
 
 ## Instructions
 
-1. Create a folder in `{REPO_ROOT}/scratch/` with the format `{YYYY-MM-DD}-{descriptive-name}`.
+1. Create a folder in `{REPO_ROOT}/scratch/` with the format `{YYYY-MM-DD}-{descriptive-name}`:
+   ```bash
+   mkdir scratch/$(uv run python -c "import datetime; print(datetime.date.today().isoformat())")-{descriptive-name}
+   ```
 2. Create a `README.md` in this folder with: task description, background context, task checklist. Update with findings as you progress.
 3. Create scripts and data files as needed for empirical work.
 4. For complex investigations, split into sub-documents as patterns emerge.

--- a/.claude/skills/sleap-support/SKILL.md
+++ b/.claude/skills/sleap-support/SKILL.md
@@ -1,0 +1,309 @@
+---
+name: sleap-support
+description: >
+  Handle SLEAP GitHub support workflow for issues and discussions. Use when
+  the user says "support", provides a GitHub issue/discussion number like "#2512",
+  or asks to investigate a user report from talmolab/sleap. Scaffolds investigation
+  folders, downloads posts with images, analyzes problems, and drafts friendly responses.
+---
+
+# SLEAP Support Workflow
+
+Handle GitHub issues and discussions from `talmolab/sleap` with a systematic investigation process.
+
+## Quick Start
+
+When given an issue/discussion number:
+
+```bash
+# Check both issues AND discussions (users often post in wrong category)
+gh issue view 2512 --repo talmolab/sleap --json number,title,body,author,createdAt,comments 2>/dev/null || \
+gh api repos/talmolab/sleap/discussions/2512 2>/dev/null
+```
+
+## Workflow Steps
+
+### 1. Create Investigation Folder
+
+First, check if an investigation already exists:
+
+```bash
+ls -d scratch/*-*2512* 2>/dev/null || echo "No existing investigation"
+```
+
+If none exists, create one:
+
+```bash
+mkdir -p scratch/$(date +%Y-%m-%d)-{issue|discussion}-2512-{short-description}
+```
+
+### 2. Fetch Post Content
+
+**For Issues:**
+```bash
+gh issue view NUMBER --repo talmolab/sleap --json number,title,body,author,createdAt,comments,labels > scratch/.../issue.json
+```
+
+**For Discussions:**
+```bash
+gh api repos/talmolab/sleap/discussions/NUMBER > scratch/.../discussion.json
+```
+
+### 3. Download Images
+
+Extract image URLs from the post body and download:
+
+```bash
+# Parse markdown image links: ![alt](url)
+grep -oP '!\[.*?\]\(\K[^)]+' scratch/.../issue.json | while read url; do
+  wget -P scratch/.../images/ "$url"
+done
+```
+
+### 4. Create USER_POST.md
+
+Convert the JSON to readable markdown with inline images:
+
+```markdown
+# Issue/Discussion #NUMBER: Title
+
+**Author**: @username
+**Created**: YYYY-MM-DD
+**Platform**: (extract from post if mentioned)
+**SLEAP Version**: (extract from post if mentioned)
+
+## Original Post
+
+[post body with images referenced inline]
+
+## Comments
+
+[any replies]
+```
+
+### 5. Write Investigation README
+
+Create `scratch/.../README.md`:
+
+```markdown
+# Investigation: Issue/Discussion #NUMBER
+
+**Date**: YYYY-MM-DD
+**Post**: https://github.com/talmolab/sleap/{issues|discussions}/NUMBER
+**Author**: @username
+**Type**: Bug Report | Usage Question | Feature Request
+
+## Summary
+
+[1-2 sentence summary of the issue]
+
+## Key Information
+
+- **Platform**: Windows/macOS/Linux
+- **SLEAP Version**: X.Y.Z
+- **GPU**: (if relevant)
+- **Dataset**: (if described)
+
+## Preliminary Analysis
+
+[Initial thoughts on what might be happening]
+
+## Areas to Investigate
+
+- [ ] Check area 1
+- [ ] Check area 2
+
+## Files
+
+- `USER_POST.md` - Original post content
+- `images/` - Downloaded screenshots
+- `RESPONSE_DRAFT.md` - Draft response (when ready)
+```
+
+### 6. Check Release History First
+
+**Before deep investigation, check if the issue was already fixed:**
+
+```bash
+# Get user's SLEAP version from their post (look for sleap doctor output or sleap.__version__)
+USER_VERSION="1.4.0"  # example
+
+# Check sleap releases for fixes
+gh release list --repo talmolab/sleap --limit 20
+gh release view v1.5.0 --repo talmolab/sleap --json body -q '.body' | grep -i "fix"
+
+# For sleap-io issues
+gh release list --repo talmolab/sleap-io --limit 10
+gh release view v0.6.0 --repo talmolab/sleap-io --json body -q '.body'
+
+# For sleap-nn/training issues
+gh release list --repo talmolab/sleap-nn --limit 10
+gh release view v0.2.0 --repo talmolab/sleap-nn --json body -q '.body'
+```
+
+**If a fix exists in a newer version:**
+- Response should guide user to upgrade
+- Include the specific version with the fix
+- Mention what was fixed (link to PR/issue if available)
+
+**If investigating an unfixed bug:**
+- Checkout the user's version to see their actual code:
+
+```bash
+# Clone repos if not present
+[ -d scratch/repos/sleap-io ] || gh repo clone talmolab/sleap-io scratch/repos/sleap-io
+[ -d scratch/repos/sleap-nn ] || gh repo clone talmolab/sleap-nn scratch/repos/sleap-nn
+
+# Checkout user's version
+cd scratch/repos/sleap-io && git fetch --tags && git checkout v0.5.0
+cd scratch/repos/sleap-nn && git fetch --tags && git checkout v0.1.5
+
+# Now you're looking at the code they're actually running
+```
+
+**Use `git blame` to find potential culprits:**
+
+```bash
+# Find when a suspicious function was last changed
+git blame -L 50,100 sleap/io/main.py
+
+# Check if a line was changed recently
+git log --oneline -5 -- path/to/file.py
+
+# Find the commit that introduced a specific change
+git log -S "function_name" --oneline
+```
+
+### 7. Analyze and Reproduce
+
+Determine the issue type:
+
+**Usage Question**: Check if documentation covers this. Common topics:
+- Model configuration (skeleton, training params)
+- Multi-animal vs single-animal tracking
+- Inference and tracking settings
+- Data format questions
+
+**Bug Report**: Try to reproduce. Check:
+- Version-specific issues
+- Platform-specific behavior
+- GPU/CUDA compatibility
+- Data corruption signs
+
+**Feature Request**: Note for tracking, no immediate action needed.
+
+### 8. Determine Data Needs
+
+**When to request SLP file:**
+- Inference/tracking issues that can't be diagnosed from logs
+- "Labels not showing" or display issues
+- Merging or import problems
+- Corruption or data loss reports
+
+**Suggest upload to `https://slp.sh`** - our SLP file sharing service.
+
+**If SLP provided:** Download and analyze:
+```bash
+sio show path/to/file.slp --summary
+sio show path/to/file.slp --videos
+sio show path/to/file.slp --skeleton
+```
+
+### 9. Draft Response
+
+Create `RESPONSE_DRAFT.md` following this structure:
+
+```markdown
+Hi @{username},
+
+Thanks for the post!
+
+[Restate understanding: "If I understand correctly, you're seeing X when you try to Y..."]
+
+[Provide solution OR request more info]
+
+[If requesting info, give EXPLICIT instructions:]
+- Use `sleap doctor` CLI for diagnostics
+- Provide copy-paste terminal commands
+- Assume non-technical user
+
+Let us know if that works for you!
+
+Cheers,
+
+:heart: Talmo & Claude :robot:
+
+<details>
+<summary><b>Extended technical analysis</b></summary>
+
+[Detailed investigation notes, code traces, version checks]
+
+</details>
+```
+
+## Response Tone Guidelines
+
+- **Opening**: Bright and positive ("Thanks for the post!", "Great question!")
+- **Body**: Clear, concise, non-technical language
+- **Instructions**: Step-by-step, assume terminal newbie
+- **Closing**: Encouraging ("Let us know if that works for you!")
+- **Signature**: `:heart: Talmo & Claude :robot:`
+
+## When Requesting User Actions
+
+**Terminal commands must be copy-paste ready:**
+
+```bash
+# Good - one-liner, no environment activation needed
+sleap doctor
+
+# Good - uses uvx for isolated execution
+uvx sio show your_file.slp --summary
+
+# Bad - assumes environment knowledge
+source activate sleap && python -c "import sleap; print(sleap.__version__)"
+```
+
+## Related Repositories
+
+**For data/I/O issues** - Check `talmolab/sleap-io`:
+- Local: `../sleap-io` (preferred)
+- Clone if needed: `gh repo clone talmolab/sleap-io scratch/repos/sleap-io`
+- Key docs: `sleap-io/docs/examples.md`, `sleap-io/docs/formats/SLP.md`
+- CLI: `sio show --help` for inspection commands
+
+**For training/inference issues** - Check `talmolab/sleap-nn`:
+- Local: `../sleap-nn` (preferred)
+- Clone if needed: `gh repo clone talmolab/sleap-nn scratch/repos/sleap-nn`
+- Topics: Model configs, training params, evaluation metrics, tracking
+
+## Common Patterns
+
+### Instance Duplication
+- Check track assignment logic
+- Look for ID switching during tracking
+- May need `sleap-track` with different settings
+
+### Training Issues
+- GPU memory: suggest reducing batch size
+- Loss not decreasing: check learning rate, augmentation
+- NaN losses: data normalization issues
+
+### Import/Export Issues
+- Format compatibility (H5 vs SLP versions)
+- Missing video paths
+- Skeleton definition mismatches
+
+### GUI Issues
+- Qt/PySide6 version conflicts
+- Display scaling on high-DPI
+- Video codec issues
+
+## Confirmation Before Posting
+
+**ALWAYS** confirm with the developer before posting:
+1. Show the full draft response
+2. Ask: "Does this look good to post?"
+3. Wait for explicit approval
+
+**Never post automatically** - support responses represent the project.

--- a/.claude/skills/sleap-support/gh-commands.md
+++ b/.claude/skills/sleap-support/gh-commands.md
@@ -1,0 +1,115 @@
+# GitHub CLI Commands Reference
+
+Quick reference for `gh` commands used in support workflow.
+
+## Fetching Issues
+
+```bash
+# Get issue with all details
+gh issue view NUMBER --repo talmolab/sleap --json number,title,body,author,createdAt,comments,labels,state
+
+# Get issue body only (for quick reading)
+gh issue view NUMBER --repo talmolab/sleap --json body -q '.body'
+
+# Get issue comments
+gh issue view NUMBER --repo talmolab/sleap --json comments -q '.comments[].body'
+
+# List recent issues
+gh issue list --repo talmolab/sleap --limit 10 --json number,title,author,createdAt
+```
+
+## Fetching Discussions
+
+```bash
+# Get discussion details
+gh api repos/talmolab/sleap/discussions/NUMBER
+
+# Get discussion body
+gh api repos/talmolab/sleap/discussions/NUMBER -q '.body'
+
+# Get discussion comments
+gh api repos/talmolab/sleap/discussions/NUMBER -q '.comments.nodes[].body'
+
+# List recent discussions
+gh api repos/talmolab/sleap/discussions --jq '.[] | {number, title, author: .user.login}'
+```
+
+## Posting Replies
+
+**Issues:**
+```bash
+gh issue comment NUMBER --repo talmolab/sleap --body "Your response here"
+
+# Or from file
+gh issue comment NUMBER --repo talmolab/sleap --body-file RESPONSE_DRAFT.md
+```
+
+**Discussions:**
+```bash
+# Need to use API for discussions
+gh api repos/talmolab/sleap/discussions/NUMBER/comments -X POST -f body="Your response"
+```
+
+## Searching
+
+```bash
+# Search issues by keyword
+gh issue list --repo talmolab/sleap --search "keyword" --json number,title
+
+# Search with labels
+gh issue list --repo talmolab/sleap --label "bug" --json number,title
+
+# Search discussions
+gh api repos/talmolab/sleap/discussions -q '.[] | select(.title | test("keyword"; "i")) | {number, title}'
+```
+
+## Checking Both Issues AND Discussions
+
+Users often post in the wrong category. Always check both:
+
+```bash
+# Try issue first, fall back to discussion
+gh issue view NUMBER --repo talmolab/sleap 2>/dev/null || \
+gh api repos/talmolab/sleap/discussions/NUMBER 2>/dev/null || \
+echo "Not found as issue or discussion"
+```
+
+## Downloading Images
+
+Images in posts use GitHub's CDN format:
+```
+https://user-images.githubusercontent.com/...
+https://github.com/user-attachments/assets/...
+```
+
+Download all images from a post:
+```bash
+# Extract and download image URLs
+grep -oE 'https://[^)]+\.(png|jpg|jpeg|gif)' post.md | while read url; do
+  wget -q -P images/ "$url"
+done
+```
+
+## Labels
+
+Common labels in talmolab/sleap:
+- `bug` - Bug reports
+- `enhancement` - Feature requests
+- `question` - Usage questions
+- `documentation` - Doc improvements needed
+- `good first issue` - Beginner-friendly
+
+Add a label:
+```bash
+gh issue edit NUMBER --repo talmolab/sleap --add-label "label-name"
+```
+
+## Closing Issues
+
+```bash
+# Close with comment
+gh issue close NUMBER --repo talmolab/sleap --comment "Closing as resolved. Feel free to reopen if needed!"
+
+# Close as not planned
+gh issue close NUMBER --repo talmolab/sleap --reason "not planned" --comment "Thanks for the suggestion!"
+```

--- a/.claude/skills/sleap-support/response-templates.md
+++ b/.claude/skills/sleap-support/response-templates.md
@@ -1,0 +1,159 @@
+# Response Templates
+
+## Opening Lines
+
+Use variety - pick one that fits the context:
+
+**For questions:**
+- "Thanks for the post!"
+- "Great question!"
+- "Thanks for reaching out!"
+
+**For bug reports:**
+- "Thanks for the detailed report!"
+- "Thanks for flagging this!"
+- "Appreciate you reporting this!"
+
+**For feature requests:**
+- "Thanks for the suggestion!"
+- "Interesting idea!"
+
+## Requesting More Information
+
+### Need SLP File
+
+```markdown
+To help diagnose this, it would be helpful to see your project file. Could you upload your `.slp` file to https://slp.sh and share the link here?
+
+This is our secure file sharing service - files are automatically deleted after 7 days.
+```
+
+### Need System Info
+
+```markdown
+Could you share the output of `sleap doctor`? You can run this in a terminal:
+
+1. Open a terminal (Command Prompt on Windows, Terminal on Mac/Linux)
+2. Type `sleap doctor` and press Enter
+3. Copy-paste the output here
+
+This will help us understand your setup!
+```
+
+### Need Error Logs
+
+```markdown
+Could you share the full error message? If you're running from the GUI:
+
+1. Open SLEAP from a terminal instead of clicking the icon
+2. On Windows: Open Command Prompt, type `sleap-label`, press Enter
+3. On Mac/Linux: Open Terminal, type `sleap-label`, press Enter
+4. Reproduce the error
+5. Copy-paste any red text from the terminal here
+```
+
+### Need Video Info
+
+```markdown
+Could you tell us more about your video?
+
+1. What format is it? (mp4, avi, etc.)
+2. How long is it? (minutes/hours)
+3. What resolution? (you can check this by right-clicking the file → Properties → Details on Windows)
+```
+
+## Common Solutions
+
+### GPU Memory Issues
+
+```markdown
+This looks like a GPU memory issue! Try reducing the batch size:
+
+1. In the training dialog, look for "Batch Size"
+2. Try halving it (e.g., if it's 4, try 2)
+3. If that still fails, try 1
+
+Smaller batch sizes use less GPU memory but may train a bit slower.
+```
+
+### Multi-Animal Tracking
+
+```markdown
+For multi-animal projects, make sure you're using the correct tracking method:
+
+1. After inference, go to `Predict` → `Run Tracking...`
+2. Try the "Simple" tracker first
+3. If that doesn't work well, try "Flow" tracker for animals that move smoothly
+
+The tracker connects detections across frames - without it, you'll see different track IDs each frame!
+```
+
+### Missing Labels After Import
+
+```markdown
+If labels aren't showing after import, the skeleton might not match:
+
+1. Go to `Skeleton` menu → check that nodes and edges match your data
+2. If they don't match, you may need to re-import with the correct skeleton
+
+You can check your file's skeleton with:
+```bash
+uvx sio show your_file.slp --skeleton
+```
+```
+
+## Closing Lines
+
+**Standard:**
+```markdown
+Let us know if that works for you!
+
+Cheers,
+
+:heart: Talmo & Claude :robot:
+```
+
+**If uncertain about solution:**
+```markdown
+Let us know if this helps or if you're still running into issues!
+
+Cheers,
+
+:heart: Talmo & Claude :robot:
+```
+
+**If they need to try something:**
+```markdown
+Give that a try and let us know how it goes!
+
+Cheers,
+
+:heart: Talmo & Claude :robot:
+```
+
+## Technical Details Section
+
+Always include this at the end:
+
+```markdown
+<details>
+<summary><b>Extended technical analysis</b></summary>
+
+## Investigation Notes
+
+- [What you checked]
+- [What you found]
+- [Relevant code paths]
+
+## Relevant Files
+
+- `sleap/path/to/file.py:123` - [what it does]
+
+## Version Info
+
+- Reported version: X.Y.Z
+- Current version: A.B.C
+- Relevant changes: [if any]
+
+</details>
+```

--- a/.claude/skills/sleap-support/troubleshooting-patterns.md
+++ b/.claude/skills/sleap-support/troubleshooting-patterns.md
@@ -1,0 +1,345 @@
+# Troubleshooting Patterns
+
+Quick reference for common issues and diagnostic steps.
+
+## Training Issues
+
+### Loss Not Decreasing
+
+**Symptoms**: Training runs but loss stays flat or increases
+
+**Diagnostics**:
+1. Check learning rate (too high?)
+2. Check data augmentation (too aggressive?)
+3. Check labels (are they correct?)
+
+**Common fixes**:
+- Reduce learning rate by 10x
+- Disable rotation augmentation initially
+- Verify skeleton is correct
+
+### NaN Loss
+
+**Symptoms**: Loss becomes NaN early in training
+
+**Diagnostics**:
+1. Check for empty frames (no labels)
+2. Check image normalization
+3. Check for corrupted images
+
+**Common fixes**:
+- Remove frames with no instances
+- Check video codec compatibility
+
+### Out of Memory (OOM)
+
+**Symptoms**: CUDA out of memory error
+
+**Diagnostics**:
+```bash
+# Check GPU memory
+nvidia-smi
+```
+
+**Common fixes**:
+- Reduce batch size
+- Reduce input scale
+- Use smaller backbone
+
+## Inference Issues
+
+### No Predictions
+
+**Symptoms**: Model runs but no instances detected
+
+**Diagnostics**:
+1. Check confidence threshold
+2. Check model was trained on similar data
+3. Check input resolution matches training
+
+**Common fixes**:
+- Lower confidence threshold in inference settings
+- Retrain with more diverse data
+
+### Instance Duplication
+
+**Symptoms**: Same animal gets multiple instances
+
+**Diagnostics**:
+1. Check NMS threshold
+2. Check centroid model predictions
+3. Review tracking settings
+
+**Common fixes**:
+- Increase NMS threshold
+- Use tracking to merge duplicates
+- Check multi-animal vs single-animal settings
+
+### Track ID Switching
+
+**Symptoms**: Animal identities swap between frames
+
+**Diagnostics**:
+1. Check tracker settings
+2. Check for occlusions in video
+3. Review prediction confidence
+
+**Common fixes**:
+- Try different tracker (Simple → Flow)
+- Increase tracking window
+- Manual correction in GUI
+
+## GUI Issues
+
+### SLEAP Won't Start
+
+**Symptoms**: Nothing happens or immediate crash
+
+**Diagnostics**:
+```bash
+# Run from terminal to see errors
+sleap-label
+```
+
+**Common causes**:
+- Qt/PySide6 conflicts
+- Missing dependencies
+- Corrupted installation
+
+**Fixes**:
+- Reinstall following the [installation guide](https://sleap.ai/installation.html)
+- Check Python version compatibility
+- Run `sleap doctor` to verify environment
+
+### Video Won't Load
+
+**Symptoms**: Error when opening video
+
+**Diagnostics**:
+```bash
+# Check video info
+ffprobe video.mp4
+```
+
+**Common causes**:
+- Unsupported codec
+- Corrupted file
+- Path with special characters
+
+**Fixes**:
+- Re-encode video: `ffmpeg -i input.mp4 -c:v libx264 output.mp4`
+- Move to path without spaces/special chars
+
+### Display Issues
+
+**Symptoms**: UI elements too small/large, rendering problems
+
+**Common causes**:
+- High-DPI scaling issues
+- OpenGL driver problems
+
+**Fixes**:
+- Set environment variable: `QT_SCALE_FACTOR=1.5`
+- Update graphics drivers
+
+## Data Issues
+
+### Can't Open SLP File
+
+**Symptoms**: Error loading project
+
+**Diagnostics**:
+```bash
+uvx sio show file.slp --summary
+```
+
+**Common causes**:
+- File corruption
+- Version incompatibility
+- Missing video files
+
+**Fixes**:
+- Try loading with `fix_videos=True`
+- Check video paths match
+
+### Missing Labels
+
+**Symptoms**: Labels exist but don't display
+
+**Diagnostics**:
+1. Check skeleton matches
+2. Check frame indices
+3. Check instance visibility
+
+**Fixes**:
+- Verify skeleton: `uvx sio show file.slp --skeleton`
+- Check track visibility in GUI
+
+### Merge Conflicts
+
+**Symptoms**: Issues when merging SLP files
+
+**Diagnostics**:
+```bash
+# Compare skeletons
+uvx sio show file1.slp --skeleton
+uvx sio show file2.slp --skeleton
+```
+
+**Common causes**:
+- Different skeleton definitions
+- Overlapping frame ranges
+- Different video sources
+
+**Fixes**:
+- Ensure identical skeletons before merge
+- Use sleap-io merge with conflict resolution
+
+## Version-Specific Issues
+
+### Upgrading from v1.2 to v1.3+
+
+- HDF5 format changed
+- Need to re-export old projects
+
+### Python 3.11+ Compatibility
+
+- Some dependencies may have issues
+- Check dependency versions
+
+### GPU/CUDA Issues
+
+**Diagnostics**:
+```bash
+# Check GPU availability (sleap doctor reports this)
+sleap doctor
+
+# Check NVIDIA driver
+nvidia-smi
+```
+
+**Common fixes**:
+- Ensure CUDA toolkit matches TensorFlow version
+- Check cuDNN installation
+- See [GPU setup guide](https://sleap.ai/installation.html#gpu-support)
+
+## Version-Aware Investigation
+
+**IMPORTANT**: Before diving deep into investigation, always check if the issue was already fixed.
+
+### Step 1: Identify User's Versions
+
+Look in the user's post for version information:
+- `sleap doctor` output (preferred - contains all relevant info)
+- `sleap.__version__` output
+- Error tracebacks mentioning package paths
+
+If version info is missing, request `sleap doctor` output from the user.
+
+### Step 2: Check Release Notes for Fixes
+
+```bash
+# SLEAP main package releases
+gh release list --repo talmolab/sleap --limit 20
+
+# View specific release notes
+gh release view v1.5.0 --repo talmolab/sleap
+
+# Search release notes for keywords
+gh release view v1.5.0 --repo talmolab/sleap --json body -q '.body' | grep -i "fix\|bug\|issue"
+
+# sleap-io releases (data I/O issues)
+gh release list --repo talmolab/sleap-io --limit 10
+gh release view v0.6.0 --repo talmolab/sleap-io
+
+# sleap-nn releases (training/inference issues)
+gh release list --repo talmolab/sleap-nn --limit 10
+gh release view v0.2.0 --repo talmolab/sleap-nn
+```
+
+### Step 3: Match User's Version to Code
+
+If the user's version is older, checkout that version to see their actual code:
+
+```bash
+# Ensure repos are cloned
+[ -d scratch/repos/sleap-io ] || gh repo clone talmolab/sleap-io scratch/repos/sleap-io
+[ -d scratch/repos/sleap-nn ] || gh repo clone talmolab/sleap-nn scratch/repos/sleap-nn
+
+# Checkout user's sleap-io version
+cd scratch/repos/sleap-io
+git fetch --tags
+git checkout v0.5.0  # user's version
+
+# Checkout user's sleap-nn version
+cd scratch/repos/sleap-nn
+git fetch --tags
+git checkout v0.1.5  # user's version
+
+# Return to sleap main repo
+cd /home/talmo/code/sleap
+```
+
+### Step 4: Use Git Blame to Find Culprits
+
+When you've identified a suspicious code region:
+
+```bash
+# Blame specific lines
+git blame -L 50,100 path/to/file.py
+
+# Show who changed a function recently
+git log --oneline -10 -- path/to/file.py
+
+# Find commits that added/removed a string
+git log -S "suspicious_function" --oneline
+
+# Find commits touching a pattern
+git log -G "regex_pattern" --oneline -- path/to/file.py
+
+# Show the diff for a specific commit
+git show COMMIT_HASH --stat
+git show COMMIT_HASH -- path/to/file.py
+```
+
+### Step 5: Compare Versions
+
+```bash
+# See what changed between user's version and current
+git diff v1.4.0..HEAD -- path/to/file.py
+
+# List commits between versions
+git log --oneline v1.4.0..HEAD -- path/to/file.py
+
+# Find when a bug was introduced (bisect conceptually)
+git log --oneline --all -- path/to/file.py | head -20
+```
+
+### Response Scenarios
+
+**Best case - Already fixed:**
+```markdown
+Good news! This issue was fixed in version X.Y.Z (PR #123).
+
+To fix this, upgrade to the latest version of SLEAP. You can verify your current version with:
+\`\`\`bash
+sleap doctor
+\`\`\`
+
+See the [installation guide](https://sleap.ai/installation.html) for upgrade instructions for your setup.
+
+Let us know if that resolves it!
+```
+
+**Issue exists in their version:**
+```markdown
+I checked the code for version X.Y.Z and I can see the issue.
+This appears to be caused by [explanation].
+
+[Solution or workaround]
+```
+
+**Need to backport a fix:**
+- Note the specific commit that fixed it
+- Check if it can be cleanly cherry-picked
+- Consider releasing a patch version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup UV
       uses: astral-sh/setup-uv@v6
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: Install dependencies
       run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,22 +2,31 @@
 
 ## Package Management
 
-**Always use `uv` for package management.** Never use conda or pip directly.
+- **Always use `uv` for python commands and environment management.**
+- Never use `conda` or `pip`.
+- Do not call `python` directly, use `uv run python`.
+
+### Basic usage
+We manage our dependencies in `pyproject.toml` and will only edit the versions or add dependencies very sparingly and with a lot of careful planning.
 
 ```bash
-# Sync environment with dependencies
+# Sync environment with dependencies (this removes packages installed with `uv pip install`)
 uv sync --extra nn
-
-# Install local packages (e.g., sleap-io in development)
-uv pip install "../sleap-io[all]"
 
 # Run Python in the uv environment
 uv run python script.py
 
-# Or activate the virtual environment
-source .venv/bin/activate
-python script.py
+# Install local packages (e.g., for sleap-io or sleap-nn development)
+uv pip install -e "../sleap-io[all]"
+uv pip install -e "../sleap-nn[torch]" --torch-backend=auto
+
+# Only when trying out new packages or pulling something in for an experiment
+uv pip install XYZ
 ```
+
+### Reference for `uv`
+- When looking up `uv` command syntax, use `uv --help`, `uv sync --help`, etc.
+- For advanced usage, like resolution mechanics, refer to the docs in `scratch/repos/uv/docs`. If it doesn't exist, use `gh` to clone `astral-sh/uv` into that folder.
 
 ## Testing
 
@@ -51,5 +60,9 @@ uv run ruff check --fix .
 
 ## Related Projects
 
-- `../sleap-io/` - sleap-io library (install with `uv pip install "../sleap-io[all]"`)
+- `../sleap-io/` - sleap-io library
+  - data backend, data model, I/O backends, merging, labels project (.slp) manipulation, advanced workflows like filtering, rendering or embedding
+  - If not available locally in `../sleap-io` (typical local dev setup), use `gh` to clone `talmolab/sleap-io` in `scratch/repos/sleap-io` to have a local copy to read for reference.
 - `../sleap-nn/` - sleap-nn neural network package
+  - neural network backend, training, inference, evaluation metrics, tracking, model configuration, hyperparameters
+  - If not available locally in `../sleap-nn` (typical local dev setup), use `gh` to clone `talmolab/sleap-nn` to `scratch/repos/sleap-nn` to have a local copy to read for reference.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -87,20 +87,20 @@ Choose your platform (Windows and Linux commands are the same):
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn]" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn]" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn]" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn]" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv tool install --python 3.12 "sleap[nn]"
+    uv tool install --python 3.13 "sleap[nn]"
     ```
 
-**What does `[nn]` mean?** The `[nn]` installs neural network dependencies (PyTorch) for training models. If you only need to view and annotate data (no training), you can omit it: `uv tool install --python 3.12 sleap`
+**What does `[nn]` mean?** The `[nn]` installs neural network dependencies (PyTorch) for training models. If you only need to view and annotate data (no training), you can omit it: `uv tool install --python 3.13 sleap`
 
 **Expected output:**
 ```
@@ -144,17 +144,17 @@ To test new features before official release, you can install pre-release versio
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]" --prerelease allow --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv tool install --force --python 3.13 "sleap[nn]" --prerelease allow --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]" --prerelease allow --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv tool install --force --python 3.13 "sleap[nn]" --prerelease allow --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]" --prerelease allow
+    uv tool install --force --python 3.13 "sleap[nn]" --prerelease allow
     ```
 
 ### Install a Specific Version
@@ -163,17 +163,17 @@ Pin to an exact version for reproducibility or to test a specific release:
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]==1.6.0a0" --prerelease allow --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --prerelease allow --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]==1.6.0a0" --prerelease allow --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --prerelease allow --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]==1.6.0a0" --prerelease allow
+    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --prerelease allow
     ```
 
 ### Pin Dependency Versions
@@ -182,17 +182,17 @@ For full reproducibility, you can explicitly pin the versions of `sleap-io` and 
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]==1.6.0a0" --with "sleap-io==0.6.0" --with "sleap-nn==0.1.0a0" --prerelease allow --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --with "sleap-io==0.6.0" --with "sleap-nn==0.1.0a0" --prerelease allow --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]==1.6.0a0" --with "sleap-io==0.6.0" --with "sleap-nn==0.1.0a0" --prerelease allow --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --with "sleap-io==0.6.0" --with "sleap-nn==0.1.0a0" --prerelease allow --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]==1.6.0a0" --with "sleap-io==0.6.0" --with "sleap-nn==0.1.0a0" --prerelease allow
+    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --with "sleap-io==0.6.0" --with "sleap-nn==0.1.0a0" --prerelease allow
     ```
 
 !!! info "Version compatibility"
@@ -212,17 +212,17 @@ If you encounter issues with a pre-release, rollback to the latest stable versio
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]==1.5.2" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv tool install --force --python 3.13 "sleap[nn]==1.5.2" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]==1.5.2" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv tool install --force --python 3.13 "sleap[nn]==1.5.2" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv tool install --force --python 3.12 "sleap[nn]==1.5.2"
+    uv tool install --force --python 3.13 "sleap[nn]==1.5.2"
     ```
 
 ### CUDA 13.0 Support
@@ -230,7 +230,7 @@ If you encounter issues with a pre-release, rollback to the latest stable versio
 Starting with v1.6.0, SLEAP supports CUDA 13.0 for the latest NVIDIA GPUs:
 
 ```
-uv tool install --force --python 3.12 "sleap[nn]" --prerelease allow --index https://download.pytorch.org/whl/cu130 --index https://pypi.org/simple
+uv tool install --force --python 3.13 "sleap[nn]" --prerelease allow --index https://download.pytorch.org/whl/cu130 --index https://pypi.org/simple
 ```
 
 ---
@@ -257,17 +257,17 @@ If you need to train models, include the `[nn]` extra:
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uvx --python 3.12 --from "sleap[nn]" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple sleap
+    uvx --python 3.13 --from "sleap[nn]" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple sleap
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uvx --python 3.12 --from "sleap[nn]" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple sleap
+    uvx --python 3.13 --from "sleap[nn]" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple sleap
     ```
 
 === "macOS"
     ```
-    uvx --python 3.12 --from "sleap[nn]" sleap
+    uvx --python 3.13 --from "sleap[nn]" sleap
     ```
 
 ---
@@ -291,17 +291,17 @@ Replace `BRANCH` with the branch name (e.g., `fix/video-loading`) or `develop` f
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv tool install --python 3.12 "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH"
+    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH"
     ```
 
 ### Testing a branch in `sleap-io`
@@ -310,17 +310,17 @@ Install SLEAP from PyPI but override `sleap-io` with a git version:
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv tool install --python 3.12 "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH"
+    uv tool install --python 3.13 "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH"
     ```
 
 ### Testing a branch in `sleap-nn`
@@ -329,17 +329,17 @@ Install SLEAP from PyPI but override `sleap-nn` with a git version:
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv tool install --python 3.12 "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH"
+    uv tool install --python 3.13 "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH"
     ```
 
 ### Testing everything from develop
@@ -348,17 +348,17 @@ Install the latest development version of all three packages:
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@develop" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@develop" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@develop" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@develop" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv tool install --python 3.12 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@develop" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@develop" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@develop" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@develop" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv tool install --python 3.12 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@develop" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@develop"
+    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@develop" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@develop"
     ```
 
 ### Pinning to a specific commit
@@ -366,7 +366,7 @@ Install the latest development version of all three packages:
 For reproducibility, you can install from a specific commit hash instead of a branch:
 
 ```
-uv tool install --python 3.12 "sleap[nn] @ git+https://github.com/talmolab/sleap@abc123def"
+uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@abc123def"
 ```
 
 ---
@@ -396,17 +396,17 @@ Then install dependencies:
 
 === "Windows/Linux with NVIDIA GPU"
     ```
-    uv sync --python 3.12 --extra dev --extra nn-cuda128 --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
+    uv sync --python 3.13 --extra dev --extra nn-cuda128 --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
     ```
 
 === "Windows/Linux without GPU"
     ```
-    uv sync --python 3.12 --extra dev --extra nn-cpu --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
+    uv sync --python 3.13 --extra dev --extra nn-cpu --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
     ```
 
 === "macOS"
     ```
-    uv sync --python 3.12 --extra dev --extra nn-cpu
+    uv sync --python 3.13 --extra dev --extra nn-cpu
     ```
 
 ### Running Commands
@@ -487,7 +487,7 @@ The [Install SLEAP](#install-sleap) and [Development Setup](#development-setup) 
 
 ```bash
 # Create and activate a conda environment
-conda create -n sleap python=3.12
+conda create -n sleap python=3.13
 conda activate sleap
 
 # Install uv inside the conda environment
@@ -509,8 +509,8 @@ conda deactivate
 Then install Python via uv:
 
 ```bash
-uv python install 3.12
-uv python pin 3.12
+uv python install 3.13
+uv python pin 3.13
 ```
 
 Now you can use any of the installation methods above without conda interference.
@@ -534,7 +534,7 @@ Set-ExecutionPolicy RemoteSigned
 
 ### Python version errors
 
-Always include `--python 3.12` in your commands. Python 3.14 is not yet supported.
+Always include `--python 3.13` in your commands. Python 3.14 is not yet supported.
 
 ### Installation seems stuck
 


### PR DESCRIPTION
## Summary

- **Bump default Python version from 3.12 to 3.13** in CI lint job and installation docs (3.12 remains supported)
- **Update CLAUDE.md** with expanded dev guidelines: clearer uv usage patterns, explicit pip/conda prohibitions, related project details
- **Add sleap-support Claude skill** for GitHub issue/discussion support workflow

## Test plan

- [ ] CI passes with Python 3.13
- [ ] Installation docs render correctly
- [ ] sleap-support skill loads in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)