### PR TITLE
Fix export training package zmq config error

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -554,10 +554,6 @@ def write_pipeline_files(
                     f"--config-dir . "
                     f"trainer_config.ckpt_dir={Path(ckpt_path).parent.as_posix()} "
                     f"trainer_config.run_name={Path(ckpt_path).name} "
-                    f"trainer_config.zmq.controller_port="
-                    f"{cfg_info.config.trainer_config.zmq.controller_port} "
-                    f"trainer_config.zmq.publish_port="
-                    f"{cfg_info.config.trainer_config.zmq.publish_port} "
                     "\n"
                 )
 

--- a/tests/gui/learning/test_cli_construction.py
+++ b/tests/gui/learning/test_cli_construction.py
@@ -17,7 +17,6 @@ from sleap.gui.learning.runners import (
     DatasetItemForInference,
     ItemsForInference,
     InferenceTask,
-    write_pipeline_files,
 )
 
 
@@ -763,9 +762,10 @@ class TestWritePipelineFiles:
         train_script_content = train_script_path.read_text()
 
         # CRITICAL ASSERTION: train script should NOT contain zmq
-        assert (
-            "zmq" not in train_script_content
-        ), f"Train script should not contain zmq overrides. Content:\n{train_script_content}"
+        assert "zmq" not in train_script_content, (
+            f"Train script should not contain zmq overrides. "
+            f"Content:\n{train_script_content}"
+        )
 
         # Verify the script has basic required content
         assert "sleap-nn-train" in train_script_content

--- a/tests/gui/learning/test_cli_construction.py
+++ b/tests/gui/learning/test_cli_construction.py
@@ -17,6 +17,7 @@ from sleap.gui.learning.runners import (
     DatasetItemForInference,
     ItemsForInference,
     InferenceTask,
+    write_pipeline_files,
 )
 
 
@@ -675,6 +676,101 @@ class TestModelPathHandling:
 # =============================================================================
 # Output Path Generation Tests
 # =============================================================================
+
+
+class TestWritePipelineFiles:
+    """Tests for write_pipeline_files function."""
+
+    def test_train_script_does_not_contain_zmq(self, tmp_path, mock_labels):
+        """Train script should not contain zmq overrides.
+
+        Regression test for issue #2562: The export training package feature
+        crashed because the code tried to access zmq config fields that don't
+        exist in the GUI-generated config. The fix removes zmq overrides entirely
+        since they're unnecessary for Colab training.
+        """
+        from sleap.gui.learning.runners import write_pipeline_files
+        from sleap.gui.learning.configs import ConfigFileInfo
+        from omegaconf import OmegaConf
+
+        # Create a minimal config WITHOUT zmq fields (simulating GUI form data)
+        # This is exactly the scenario that caused the bug
+        config_dict = {
+            "trainer_config": {
+                "ckpt_dir": str(tmp_path / "models"),
+                "run_name": "test_run",
+                "save_ckpt": True,
+            },
+            "data_config": {
+                "train_labels_path": ["labels.slp"],
+            },
+            "model_config": {
+                "head_configs": {},
+            },
+        }
+        config = OmegaConf.create(config_dict)
+
+        # Create ConfigFileInfo with the minimal config
+        cfg_info = ConfigFileInfo(
+            config=config,
+            path="test_config.yaml",
+            filename="test_config.yaml",
+            head_name="centroid",
+            dont_retrain=False,
+        )
+
+        # Create output directory
+        output_dir = tmp_path / "export"
+        output_dir.mkdir()
+        labels_path = tmp_path / "labels.slp"
+        labels_path.touch()
+
+        # Create video item for inference
+        video_item = VideoItemForInference(
+            video=mock_labels.videos[0],
+            frames=[0, 1, 2],
+            labels_path=str(labels_path),
+            video_idx=0,
+        )
+
+        items_for_inference = ItemsForInference(
+            items=[video_item],
+            total_frame_count=3,
+        )
+
+        # Mock the sleap_nn functions to avoid requiring the full sleap-nn install
+        # verify_training_cfg is imported inside the function from sleap_nn
+        # filter_cfg is imported at module level from sleap.gui.config_utils
+        with patch(
+            "sleap_nn.config.training_job_config.verify_training_cfg",
+            side_effect=lambda cfg: cfg,
+        ), patch(
+            "sleap.gui.config_utils.filter_cfg",
+            side_effect=lambda cfg: cfg,
+        ):
+            # Call write_pipeline_files
+            write_pipeline_files(
+                output_dir=str(output_dir),
+                labels_filename=str(labels_path),
+                config_info_list=[cfg_info],
+                inference_params={},
+                items_for_inference=items_for_inference,
+            )
+
+        # Read the generated train script
+        train_script_path = output_dir / "train-script.sh"
+        assert train_script_path.exists(), "train-script.sh should be created"
+        train_script_content = train_script_path.read_text()
+
+        # CRITICAL ASSERTION: train script should NOT contain zmq
+        assert (
+            "zmq" not in train_script_content
+        ), f"Train script should not contain zmq overrides. Content:\n{train_script_content}"
+
+        # Verify the script has basic required content
+        assert "sleap-nn-train" in train_script_content
+        assert "--config-name" in train_script_content
+        assert "--config-dir" in train_script_content
 
 
 class TestOutputPathGeneration:


### PR DESCRIPTION
## Summary

- Remove unnecessary ZMQ CLI overrides from the generated training script in `write_pipeline_files()`
- Add regression test to verify train scripts don't contain zmq overrides

## Problem

The "Export Training Job Package" feature crashes with `ConfigAttributeError: Missing key zmq` on SLEAP v1.6.0a0/v1.6.0a1. This occurs because the code in `write_pipeline_files()` tries to access `cfg_info.config.trainer_config.zmq.*` but these fields don't exist in GUI-generated configs.

## Root Cause

In `sleap/gui/learning/runners.py:557-560`, the code tried to access ZMQ ports from the original config (`cfg_info.config`) instead of the verified config (`cfg`) which has schema defaults. The GUI form data never includes ZMQ fields since they're not user-editable.

## Solution

Remove the ZMQ CLI overrides entirely. They were unnecessary because:
1. The saved YAML config already contains ZMQ defaults (`None` values) from schema merge
2. ZMQ with `None` ports disables the ZMQ callbacks (see `sleap_nn/training/model_trainer.py:924-931`)
3. ZMQ is only used for local GUI training monitoring (LossViewer), not for Colab/remote training

## Test plan

- [x] New regression test: `test_train_script_does_not_contain_zmq`
- [x] All existing CLI construction tests pass (34/34)
- [ ] Manual test: Export training package in GUI (no crash)
- [ ] Manual test: Run exported `train-script.sh` (training works)

Fixes #2562

🤖 Generated with [Claude Code](https://claude.com/claude-code)