### PR TITLE
Revamp installation documentation for uv-based workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --extra nn-cpu --extra docs
+          uv sync --extra nn-cpu
 
       - name: Print environment info
         run: |

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: uv sync --extra nn-cpu --extra docs
+        run: uv sync --extra nn-cpu
 
       - name: Build docs
         env:

--- a/docs/guides/creating-a-custom-training-profile.md
+++ b/docs/guides/creating-a-custom-training-profile.md
@@ -54,4 +54,4 @@ SLEAP supports training on:
 - AMD GPUs and older Macs (pre-M1) may fail during training.
 - Other GPU architectures or unsupported hardware configurations may lead to memory or allocation errors.
 
-For detailed GPU setup instructions, see [Do You Have an NVIDIA GPU?](../installation.md#do-you-have-an-nvidia-gpu).
+GPU detection is automatic when you install SLEAP. Run `sleap doctor` to verify your GPU is detected. If you need to manually specify a backend, see the [Pre-release Versions](../installation.md#pre-release-versions) section.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,552 +1,354 @@
 # Installation
 
-SLEAP is a tool for tracking animal poses in video. This guide will help you install it.
+SLEAP is a tool for tracking animal poses in video. This guide will get you up and running.
 
 **What do you want to do?**
 
-- **Just use SLEAP** → [Install SLEAP](#install-sleap) (most users)
-- **Try it first without installing** → [Quick Run](#quick-run)
-- **Test new features before release** → [Pre-release Versions](#pre-release-versions)
-- **Test a bug fix from a branch** → [Install from Git](#install-from-git)
-- **Develop or contribute to SLEAP** → [Development Setup](#development-setup)
-- **Use SLEAP programmatically** → [Programmatic Usage](#programmatic-usage)
-- **Previously used conda?** → [Migrating from Conda](#migrating-from-conda)
+- [**Use SLEAP**](#install-sleap) (most users)
+- [**Update SLEAP**](#updating)
+- [**Try pre-release features**](#pre-release-versions)
+- [**Develop or contribute**](#development-setup)
+- [**Use SLEAP as a library**](#programmatic-usage)
 
 ---
 
 ## Before You Start
 
-### System Requirements
+??? question "Why do I need `uv`?"
+    **What is Python package management?**
 
-- **Operating System:** Windows 10+, macOS 12+, or Linux
-- **RAM:** 8GB minimum, 16GB+ recommended for training
-- **Disk Space:** 5GB for installation
-- **GPU (optional):** NVIDIA GPU with CUDA support speeds up training significantly
+    Python packages often depend on other packages, which in turn have their own dependencies—each requiring specific versions. Without careful management, you can end up in "dependency hell" where different projects need conflicting versions. Package managers solve this by creating isolated environments where each project gets exactly the versions it needs.
 
-### Do You Have an NVIDIA GPU?
+    **Why did SLEAP use `conda` before?**
 
-Training neural networks is much faster with a GPU. Check if you have one:
+    SLEAP's neural networks required GPU libraries (CUDA) that were notoriously difficult to install correctly. Conda handled this by bundling CUDA inside isolated environments, making GPU-accelerated training "just work." For many years, this was the only reliable way to install SLEAP.
 
-=== "Windows"
-    1. Press the **Windows key**, type `Device Manager`, press **Enter**
-    2. Click the arrow next to **Display adapters**
-    3. If you see **NVIDIA** in the name, you have a compatible GPU → use **CUDA** commands
-    4. If you see Intel, AMD, or something else → use **CPU** commands
+    **What changed?**
 
-=== "Linux"
-    Run in terminal: `lspci | grep -i nvidia`
+    Starting in SLEAP 1.5, we transitioned from TensorFlow to PyTorch. Unlike TensorFlow, PyTorch bundles all GPU dependencies directly in its `pip` package—no separate CUDA installation needed. This eliminated the main reason we needed conda.
 
-    - If output shows NVIDIA → use **CUDA** commands
-    - If empty → use **CPU** commands
+    Conda also had drawbacks: it was slow (environment creation could take 10+ minutes), and you had to remember to "activate" your environment every time you wanted to use SLEAP. If you forgot, you'd get confusing errors.
 
-=== "macOS"
-    Apple Silicon Macs (M1/M2/M3/M4) have GPU acceleration built-in. No special setup needed.
+    **What is `uv` and why use it?**
 
-**Not sure?** Use CPU commands. You can always reinstall with CUDA later.
+    `uv` is a modern Python package manager that's blazingly fast (10-100x faster than pip or conda). Beyond speed, `uv` has a killer feature: it can install packages as **tools** that are available system-wide without needing to activate anything.
+
+    When you run `uv tool install sleap`, it creates an isolated environment behind the scenes, but exposes the `sleap` command globally. You just type `sleap` and it works—no activation, no environment management, no mental overhead.
+
+    Because `uv` is so fast, it's even practical to have multiple versions installed or switch between them. But for most users, the best part is that you can just install SLEAP once and forget about environments entirely.
 
 ### Install uv
 
-`uv` is the package manager used to install SLEAP. Install it first:
+SLEAP uses `uv` to manage installation. It's a fast, modern package manager that handles everything automatically—including GPU detection.
 
 === "Windows"
-    1. Press the **Windows key**, type `cmd`, press **Enter** to open Command Prompt
-    2. Copy and paste this command, then press **Enter**:
+    1. Press the **Windows key**, type `PowerShell`, press **Enter**
+    2. Paste this command and press **Enter**:
+    ```powershell
+    irm https://astral.sh/uv/install.ps1 | iex
     ```
-    powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
-    ```
-    3. **Close Command Prompt and reopen it** (required for the installation to take effect)
-    4. Verify it worked by typing: `uv --version`
-
-    You should see something like `uv 0.5.14`. If you see "command not found", restart your computer and try again.
+    3. **Close and reopen** PowerShell
+    4. Verify: `uv --version`
 
 === "macOS"
     1. Press **Cmd+Space**, type `Terminal`, press **Enter**
-    2. Copy and paste this command, then press **Enter**:
-    ```
+    2. Paste this command and press **Enter**:
+    ```bash
     curl -LsSf https://astral.sh/uv/install.sh | sh
     ```
-    3. Close Terminal and reopen it
+    3. **Close and reopen** Terminal
     4. Verify: `uv --version`
 
 === "Linux"
-    1. Open a terminal (Ctrl+Alt+T on most systems)
-    2. Run:
-    ```
+    1. Open a terminal (usually **Ctrl+Alt+T**)
+    2. Paste this command and press **Enter**:
+    ```bash
     curl -LsSf https://astral.sh/uv/install.sh | sh
     ```
-    3. Close terminal and reopen it
+    3. **Close and reopen** the terminal
     4. Verify: `uv --version`
 
 ---
 
 ## Install SLEAP
 
-This installs SLEAP as a system-wide tool. After installation, you can run `sleap` from any terminal.
+One command works on all platforms. It automatically detects your GPU and installs the right version of PyTorch.
 
-Choose your platform (Windows and Linux commands are the same):
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn]" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn]" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv tool install --python 3.13 "sleap[nn]"
-    ```
-
-**What does `[nn]` mean?** The `[nn]` installs neural network dependencies (PyTorch) for training models. If you only need to view and annotate data (no training), you can omit it: `uv tool install --python 3.13 sleap`
-
-**Expected output:**
-```
-Resolved X packages in Xs
-Installed sleap
- + sleap
- ...
+```bash
+uv tool install --python 3.13 "sleap[nn]==1.6.0a1" --with "sleap-io==0.6.1" --with "sleap-nn==0.1.0a1" --prerelease allow --torch-backend auto
 ```
 
-**Verify it worked:**
-```
+That's it! SLEAP is now available system-wide. Run it from any terminal:
+
+```bash
 sleap
 ```
-A window should open within a few seconds. Close it with the X button.
 
-**Update to latest stable version:**
-```
-uv tool upgrade sleap
-```
+A window should open within a few seconds.
 
-**Check installed version:**
-```
+??? info "What does this command do?"
+    - `--python 3.13` — Uses Python 3.13
+    - `sleap[nn]` — Installs SLEAP with neural network support for training
+    - `--with "sleap-io==..."` — Pins dependency versions for compatibility
+    - `--prerelease allow` — Required for alpha/beta versions
+    - `--torch-backend auto` — Automatically detects your GPU (NVIDIA, AMD, Intel, or CPU)
+
+??? tip "Getting an error about `--torch-backend`?"
+    Update uv to the latest version:
+    ```bash
+    uv self update
+    ```
+
+### Verify installation
+
+```bash
 sleap doctor
 ```
 
-**Uninstall:**
+This shows your system info, package versions, and confirms GPU detection.
+
+### Just viewing or annotating (no training)
+
+If you only need to view and annotate data without training models, you don't even need to install anything:
+
+```bash
+uvx sleap labels.slp
 ```
+
+This runs SLEAP directly without a permanent installation. Replace `labels.slp` with your file, or omit it to open SLEAP with an empty project.
+
+---
+
+## Updating
+
+### Check your current version
+
+```bash
+sleap doctor
+```
+
+### Upgrade everything to latest
+
+```bash
+uv tool upgrade sleap
+```
+
+This upgrades SLEAP and all its dependencies to the latest compatible versions. It remembers your original settings (like `--prerelease allow` and `--torch-backend auto`).
+
+### Upgrade just sleap-io or sleap-nn
+
+If there's a new release of a dependency but not SLEAP itself:
+
+```bash
+uv tool upgrade sleap --upgrade-package sleap-io
+```
+
+```bash
+uv tool upgrade sleap --upgrade-package sleap-nn
+```
+
+```bash
+uv tool upgrade sleap --upgrade-package sleap-io --upgrade-package sleap-nn
+```
+
+### Upgrade to a specific version
+
+If you need specific versions (for reproducibility or to match a collaborator), reinstall:
+
+```bash
+uv tool install --python 3.13 "sleap[nn]==1.6.0a1" --with "sleap-io==0.6.1" --with "sleap-nn==0.1.0a1" --prerelease allow --torch-backend auto
+```
+
+This replaces the existing installation with the exact versions specified.
+
+### Downgrade
+
+Just reinstall with the older version:
+
+```bash
+uv tool install --python 3.13 "sleap[nn]==1.5.2" --torch-backend auto
+```
+
+### Uninstall
+
+```bash
 uv tool uninstall sleap
 ```
+
+??? note "When to use `--reinstall`"
+    Most of the time, you don't need it. Use `--reinstall` when:
+
+    - Something is broken and you want a completely fresh environment
+    - Installing from local source code (to pick up changes)
+
+    ```bash
+    uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.0a1" --with "sleap-io==0.6.1" --with "sleap-nn==0.1.0a1" --prerelease allow --torch-backend auto
+    ```
 
 ---
 
 ## Pre-release Versions
 
-To test new features before official release, you can install pre-release versions (alpha, beta, release candidates). Pre-releases require the `--prerelease allow` flag.
+Pre-releases let you try new features before official release. They may have bugs, so use stable versions for important annotation work.
 
-!!! warning "Pre-release software"
-    Pre-release versions may contain bugs or incomplete features. Use stable releases for production annotation work.
+### Latest pre-release
 
-### Install Latest Pre-release
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]" --prerelease allow --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]" --prerelease allow --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]" --prerelease allow
-    ```
-
-### Install a Specific Version
-
-Pin to an exact version for reproducibility or to test a specific release:
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --prerelease allow --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --prerelease allow --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --prerelease allow
-    ```
-
-### Pin Dependency Versions
-
-For full reproducibility, you can explicitly pin the versions of `sleap-io` and `sleap-nn` using the `--with` flag:
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --with "sleap-io==0.6.0" --with "sleap-nn==0.1.0a0" --prerelease allow --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --with "sleap-io==0.6.0" --with "sleap-nn==0.1.0a0" --prerelease allow --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]==1.6.0a0" --with "sleap-io==0.6.0" --with "sleap-nn==0.1.0a0" --prerelease allow
-    ```
-
-!!! info "Version compatibility"
-    The SLEAP ecosystem has three packages with coordinated releases:
-
-    | SLEAP | sleap-io | sleap-nn |
-    |-------|----------|----------|
-    | 1.6.0aN | 0.6.x | 0.1.0aN |
-    | 1.6.x | 0.6.x | 0.1.x |
-    | 1.5.x | 0.5.x | 0.0.x |
-
-    When pinning versions, ensure you use compatible combinations. Mismatched versions may cause errors.
-
-### Rollback to Stable
-
-If you encounter issues with a pre-release, rollback to the latest stable version:
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]==1.5.2" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]==1.5.2" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv tool install --force --python 3.13 "sleap[nn]==1.5.2"
-    ```
-
-### CUDA 13.0 Support
-
-Starting with v1.6.0, SLEAP supports CUDA 13.0 for the latest NVIDIA GPUs:
-
-```
-uv tool install --force --python 3.13 "sleap[nn]" --prerelease allow --index https://download.pytorch.org/whl/cu130 --index https://pypi.org/simple
+```bash
+uv tool install --python 3.13 "sleap[nn]" --prerelease allow --torch-backend auto
 ```
 
----
+### Version compatibility
 
-## Quick Run
+The SLEAP ecosystem has three packages that work together:
 
-Run SLEAP without installing it permanently. Useful for quickly viewing or annotating data on any computer with `uv`.
+| SLEAP | sleap-io | sleap-nn |
+|-------|----------|----------|
+| 1.6.0a1 | 0.6.1 | 0.1.0a1 |
+| 1.6.0a0 | 0.6.0 | 0.1.0a0 |
+| 1.5.x | <0.6.0 | <0.1.0 |
 
-**View and annotate (no training):**
-```
-uvx sleap
-```
+Always use compatible versions when pinning.
 
-Open a file directly:
-```
-uvx sleap labels.slp
-```
+??? note "Force a specific PyTorch backend"
+    If `--torch-backend auto` doesn't detect your GPU correctly, you can specify it manually:
 
-This works on any platform—no GPU or extra setup needed.
+    | Backend | For |
+    |---------|-----|
+    | `cu128` | NVIDIA GPUs (CUDA 12.8) |
+    | `cu130` | Newest NVIDIA GPUs (CUDA 13.0) |
+    | `cpu` | No GPU / CPU only |
+    | `rocm` | AMD GPUs |
+    | `xpu` | Intel GPUs |
 
-**With training support:**
-
-If you need to train models, include the `[nn]` extra:
-
-=== "Windows/Linux with NVIDIA GPU"
+    ```bash
+    uv tool install --python 3.13 "sleap[nn]==1.6.0a1" --with "sleap-io==0.6.1" --with "sleap-nn==0.1.0a1" --prerelease allow --torch-backend cu128
     ```
-    uvx --python 3.13 --from "sleap[nn]" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple sleap
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uvx --python 3.13 --from "sleap[nn]" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple sleap
-    ```
-
-=== "macOS"
-    ```
-    uvx --python 3.13 --from "sleap[nn]" sleap
-    ```
-
----
-
-## Install from Git
-
-Install SLEAP from source to test bug fixes before they're released. The SLEAP ecosystem has three packages, and you may need to install one or more from git depending on where the fix is.
-
-### Quick Reference
-
-| What needs testing | Command pattern |
-|-------------------|-----------------|
-| Only `sleap` | `uv tool install "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH" ...` |
-| Only `sleap-io` | `uv tool install "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH" ...` |
-| Only `sleap-nn` | `uv tool install "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH" ...` |
-| All from `develop` | See [Testing everything from develop](#testing-everything-from-develop) |
-
-Replace `BRANCH` with the branch name (e.g., `fix/video-loading`) or `develop` for the latest development version.
-
-### Testing a branch in `sleap`
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@BRANCH"
-    ```
-
-### Testing a branch in `sleap-io`
-
-Install SLEAP from PyPI but override `sleap-io` with a git version:
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv tool install --python 3.13 "sleap[nn]" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@BRANCH"
-    ```
-
-### Testing a branch in `sleap-nn`
-
-Install SLEAP from PyPI but override `sleap-nn` with a git version:
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv tool install --python 3.13 "sleap[nn]" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@BRANCH"
-    ```
-
-### Testing everything from develop
-
-Install the latest development version of all three packages:
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@develop" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@develop" --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@develop" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@develop" --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --with "sleap-io @ git+https://github.com/talmolab/sleap-io@develop" --with "sleap-nn @ git+https://github.com/talmolab/sleap-nn@develop"
-    ```
-
-### Pinning to a specific commit
-
-For reproducibility, you can install from a specific commit hash instead of a branch:
-
-```
-uv tool install --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@abc123def"
-```
 
 ---
 
 ## Development Setup
 
-For contributing to SLEAP or modifying the source code.
+For contributors and developers who want to modify SLEAP's source code.
 
-### Prerequisites
+### Full ecosystem setup (all three repos)
 
-**Git must be installed.** Check by running `git --version`. If not installed:
-
-- Windows: Download from [git-scm.com/downloads](https://git-scm.com/downloads)
-- macOS: Run `xcode-select --install`
-- Linux: Run `sudo apt install git` (Ubuntu/Debian) or `sudo dnf install git` (Fedora)
-
-### Setup
-
-These commands download SLEAP's source code to a folder called `sleap` in your current directory:
+**1. Clone the repositories:**
 
 ```bash
-git clone https://github.com/talmolab/sleap.git
+git clone https://github.com/talmolab/sleap
+git clone https://github.com/talmolab/sleap-nn
+git clone https://github.com/talmolab/sleap-io
 cd sleap
 ```
 
-Then install dependencies:
-
-=== "Windows/Linux with NVIDIA GPU"
-    ```
-    uv sync --python 3.13 --extra dev --extra nn-cuda128 --index https://download.pytorch.org/whl/cu128 --index https://pypi.org/simple
-    ```
-
-=== "Windows/Linux without GPU"
-    ```
-    uv sync --python 3.13 --extra dev --extra nn-cpu --index https://download.pytorch.org/whl/cpu --index https://pypi.org/simple
-    ```
-
-=== "macOS"
-    ```
-    uv sync --python 3.13 --extra dev --extra nn-cpu
-    ```
-
-### Running Commands
-
-Use `uv run` to run commands in the development environment:
+**2. Install with editable local packages:**
 
 ```bash
-uv run sleap              # Launch GUI
-uv run sleap doctor       # Check system diagnostics
-uv run pytest tests/      # Run tests
-uv run ruff check sleap   # Check code style
+uv sync --extra nn --reinstall
+uv pip install -e "../sleap-io[all]"
+uv pip install -e "../sleap-nn[torch]" --torch-backend=auto
 ```
 
-!!! tip "Activate the virtual environment"
+??? warning "Note about `uv sync`"
+    Running `uv sync` again will overwrite your local editable installs with PyPI versions. After any `uv sync`, re-run the `uv pip install -e` commands.
 
-    To avoid typing `uv run` before every command, activate the virtual environment:
+**3. Activate the environment:**
 
-    === "Windows (Command Prompt)"
-        ```
-        .venv\Scripts\activate.bat
-        ```
+=== "Linux/macOS"
+    ```bash
+    source .venv/bin/activate
+    ```
 
-    === "Windows (PowerShell)"
-        ```powershell
-        .venv\Scripts\Activate.ps1
-        ```
+=== "Windows (PowerShell)"
+    ```powershell
+    .venv\Scripts\Activate.ps1
+    ```
 
-    === "macOS/Linux"
-        ```bash
-        source .venv/bin/activate
-        ```
+=== "Windows (Command Prompt)"
+    ```cmd
+    .venv\Scripts\activate.bat
+    ```
 
-    Once activated, you can run commands directly (e.g., `sleap`, `pytest tests/`).
-
-### Developing Multiple Packages
-
-If you're working on `sleap-io` or `sleap-nn` alongside `sleap`, you can install them in editable mode after running `uv sync`:
+**4. Run commands:**
 
 ```bash
-# After uv sync, install local packages in editable mode
-uv pip install -e ../sleap-io
-uv pip install -e ../sleap-nn
+sleap
+pytest tests/
 ```
 
-Note: You'll need to re-run these commands after each `uv sync`, as syncing resets the environment to match the lockfile.
+Or without activating the environment:
+
+```bash
+uv run sleap
+uv run pytest tests/
+```
+
+### Use local dev as system tool
+
+Want to run your modified SLEAP from anywhere without activating a venv? Install from local source:
+
+```bash
+uv tool install --reinstall --python 3.13 ".[nn]" --with "../sleap-io[all]" --with "../sleap-nn" --prerelease allow --torch-backend auto
+```
+
+Now you can run `sleap` from anywhere and it uses your local code!
+
+Re-run with `--reinstall` after making changes to pick them up.
 
 ---
 
 ## Programmatic Usage
 
-The main [`sleap`](https://github.com/talmolab/sleap) package is primarily the GUI frontend and is not designed to be used as a library. If you want to use SLEAP programmatically, consider these options:
+The `sleap` package is primarily the GUI application. For scripting and automation, use these libraries:
 
-1. **[Command-line interface](reference/command-line-interfaces.md):** Use SLEAP's CLI (`sleap track`, `sleap convert`, etc.) for batch processing and automation.
+### sleap-io
 
-2. **[`sleap-io`](https://io.sleap.ai):** For working with `.slp` files, labels, skeletons, and videos programmatically. This is the **recommended** library for most scripting needs.
-    ```bash
-    uv add sleap-io
-    ```
-    ```python
-    import sleap_io as sio
-    labels = sio.load_slp("predictions.slp")
-    ```
+For working with `.slp` files, labels, skeletons, and videos programmatically. Use this for loading predictions, extracting coordinates, filtering data, merging projects, and custom analysis pipelines.
 
-3. **[`sleap-nn`](https://nn.sleap.ai):** For working with the deep learning backend, training models programmatically, or running inference.
-    ```bash
-    uv add sleap-nn
-    ```
+Documentation and installation: [io.sleap.ai](https://io.sleap.ai)
 
----
+### sleap-nn
 
-## Migrating from Conda
+For training models, running inference, and evaluating predictions programmatically. Use this for custom training workflows, batch inference, and integration with other ML pipelines.
 
-Prior to SLEAP v1.5, installation used conda and conda environments. Starting with v1.5, we switched to `uv` for faster, more reliable installations.
-
-The [Install SLEAP](#install-sleap) and [Development Setup](#development-setup) sections above cover all use cases. However, if you prefer working within conda environments, you can still do so:
-
-### Using uv inside a conda environment
-
-```bash
-# Create and activate a conda environment
-conda create -n sleap python=3.13
-conda activate sleap
-
-# Install uv inside the conda environment
-pip install uv
-
-# Install SLEAP using uv pip (works inside conda)
-uv pip install "sleap[nn]"
-```
-
-### Disabling conda auto-activation
-
-If you're switching fully to uv and want to prevent conda from activating automatically:
-
-```bash
-conda config --set auto_activate_base false
-conda deactivate
-```
-
-Then install Python via uv:
-
-```bash
-uv python install 3.13
-uv python pin 3.13
-```
-
-Now you can use any of the installation methods above without conda interference.
+Documentation and installation: [nn.sleap.ai](https://nn.sleap.ai)
 
 ---
 
 ## Troubleshooting
 
-### "command not found" after install
-
-1. Close your terminal completely and reopen it
-2. Run `uv tool list` to verify SLEAP is installed
-3. If still not working, restart your computer
-
-### "running scripts is disabled" (Windows)
-
-Open PowerShell as Administrator and run:
-```powershell
-Set-ExecutionPolicy RemoteSigned
-```
-
-### Python version errors
-
-Always include `--python 3.13` in your commands. Python 3.14 is not yet supported.
-
-### Installation seems stuck
-
-Large packages like PyTorch take time to download. Installation can take 5-15 minutes on slower connections. If it takes more than 30 minutes, cancel with Ctrl+C and try again.
-
-### Check your installation
+### Verify your installation
 
 ```bash
 sleap doctor
 ```
 
-This shows your system info and whether GPU is detected.
+This is always the first step. It shows:
+
+- SLEAP version and all package versions
+- Python version
+- GPU detection status
+- System information
+
+### `--torch-backend` not recognized
+
+Update uv:
+
+```bash
+uv self update
+```
+
+### Force a clean reinstall
+
+If something is broken:
+
+```bash
+uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.0a1" --with "sleap-io==0.6.1" --with "sleap-nn==0.1.0a1" --prerelease allow --torch-backend auto
+```
+
+### Installation seems stuck
+
+Large packages like PyTorch take time. Installation can take 5-15 minutes on slower connections. Wait up to 30 minutes before cancelling.
 
 ### Still stuck?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,17 +60,6 @@ version = {attr = "sleap.version.__version__"}
 readme = {file = ["README.md"], content-type="text/markdown"}
 
 [project.optional-dependencies]
-docs = [
-    "mkdocs",
-    "mkdocs-material",
-    "mkdocs-jupyter",
-    "mkdocstrings[python]",
-    "mkdocs-gen-files",
-    "mkdocs-literate-nav",
-    "mkdocs-section-index",
-    "mike",
-]
-
 jupyter = [
     "jupyter",
     "jupyterlab",
@@ -99,11 +88,22 @@ nn-cuda130 = [
 [dependency-groups]
 # PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv`)
 dev = [
+    # Testing
     "pytest",
     "pytest-cov",
     "pytest-qt>=4.4.0",
     "pytest-xvfb",
+    # Linting
     "ruff",
+    # Docs
+    "mkdocs",
+    "mkdocs-material",
+    "mkdocs-jupyter",
+    "mkdocstrings[python]",
+    "mkdocs-gen-files",
+    "mkdocs-literate-nav",
+    "mkdocs-section-index",
+    "mike",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

- **Simplify installation docs** from 555 lines to ~350 lines, reducing 8 install paths down to 2 (tool install + dev setup)
- **Single universal command** with `--torch-backend auto` for all platforms (no more GPU/CPU/macOS tabs)
- **Add "Why do I need uv?" explainer** for users coming from conda, covering the mental model shift
- **Fix broken anchor link** in training profile guide (`#do-you-have-an-nvidia-gpu` → updated for automatic GPU detection)
- **Move docs deps** from `[project.optional-dependencies]` to `[dependency-groups]` dev, update CI workflows accordingly

## Key Changes

| Before | After |
|--------|-------|
| 8 installation paths | 2 paths (tool + dev) |
| GPU/CPU/macOS tabs with different commands | Single universal command |
| Manual CUDA index URL specification | `--torch-backend auto` |
| Conda migration section | Removed (no longer needed) |
| 555 lines | ~350 lines |

## New Documentation Structure

```
# Installation
├── Before You Start
│   ├── Why do I need uv? (collapsed explainer)
│   └── Install uv (Windows/macOS/Linux tabs)
├── Install SLEAP
│   ├── Universal command
│   ├── Verify installation (sleap doctor)
│   └── Just viewing (uvx)
├── Updating
├── Pre-release Versions
├── Development Setup
├── Programmatic Usage
└── Troubleshooting
```

## Test plan

- [ ] Preview docs locally with `uv run mkdocs serve`
- [ ] Test install command on fresh Windows/Linux/macOS
- [ ] Verify all internal anchor links work
- [ ] Check that CI workflows pass (docs build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)