### PR TITLE
Fix macOS crash caused by Homebrew libpng conflict

### DIFF
--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -17,8 +17,23 @@ compatibility but the unified `sleap` command is preferred.
 from __future__ import annotations
 
 import os
-import platform
 import sys
+
+# Fix macOS Homebrew libpng conflict with ImageIO.
+# Homebrew's libpng can cause bus errors when Qt renders text via CoreText/ImageIO.
+# DYLD_* vars are read at process startup, so we must re-exec with a clean environment.
+# See: https://github.com/talmolab/sleap/issues/TBD
+if (
+    sys.platform == "darwin"
+    and os.environ.get("DYLD_LIBRARY_PATH")
+    and not os.environ.get("_SLEAP_DYLD_FIXED")
+):
+    env = os.environ.copy()
+    del env["DYLD_LIBRARY_PATH"]  # Must delete, not set to ""
+    env["_SLEAP_DYLD_FIXED"] = "1"
+    os.execve(sys.executable, [sys.executable] + sys.argv, env)
+
+import platform
 from typing import Any, Optional
 
 import rich_click as click

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -45,11 +45,26 @@ frame and instances listed in data view table.
 """
 
 import os
+import sys
+
+# Fix macOS Homebrew libpng conflict with ImageIO.
+# Homebrew's libpng can cause bus errors when Qt renders text via CoreText/ImageIO.
+# DYLD_* vars are read at process startup, so we must re-exec with a clean environment.
+# See: https://github.com/talmolab/sleap/issues/TBD
+if (
+    sys.platform == "darwin"
+    and os.environ.get("DYLD_LIBRARY_PATH")
+    and not os.environ.get("_SLEAP_DYLD_FIXED")
+):
+    env = os.environ.copy()
+    del env["DYLD_LIBRARY_PATH"]  # Must delete, not set to ""
+    env["_SLEAP_DYLD_FIXED"] = "1"
+    os.execve(sys.executable, [sys.executable] + sys.argv, env)
+
 import re
 from logging import getLogger
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
-import sys
 import subprocess
 
 from qtpy import QtCore, QtGui


### PR DESCRIPTION
## Summary
- Fix bus error crash on macOS when opening training config dialog
- Root cause: Homebrew's libpng conflicts with macOS ImageIO framework during Qt font rendering
- Solution: Re-exec process with `DYLD_LIBRARY_PATH` removed before Qt initializes

## Details

On macOS with Homebrew installed, `DYLD_LIBRARY_PATH` may include `/opt/homebrew/lib`, causing Homebrew's libpng to be loaded instead of the system libpng. When Qt renders text via CoreText → ImageIO → libpng, an ABI mismatch causes a bus error crash (SIGBUS at `0xbad4007`).

The fix detects this condition at startup and re-execs the process with `DYLD_LIBRARY_PATH` removed from the environment. A sentinel variable `_SLEAP_DYLD_FIXED` prevents infinite loops.

**Why re-exec?** Setting `os.environ["DYLD_LIBRARY_PATH"] = ""` doesn't work because `DYLD_*` variables are read by the dynamic linker at process startup, before Python code runs.

**Key insight:** Must `del env["DYLD_LIBRARY_PATH"]` (delete entirely), not set to empty string.

## Test plan
- [x] Verified fix works on macOS with `DYLD_LIBRARY_PATH` set to `/opt/homebrew/lib`
- [x] Verified `sleap` and `sleap-label` entry points both work
- [x] Linting passes (`ruff check`)
- [ ] Test on clean macOS environment with Homebrew

## Related
- Similar issue in dotnet/sdk: https://github.com/dotnet/sdk/issues/44425
- Investigation notes: `scratch/2026-01-16-mac-training-config-crash/README.md`

🤖 Generated with [Claude Code](https://claude.ai/code)