### PR TITLE
Fix training dialog main tab background to match config tabs

### DIFF
--- a/sleap/gui/learning/main_tab.py
+++ b/sleap/gui/learning/main_tab.py
@@ -279,10 +279,7 @@ class MainTabWidget(QWidget):
         scroll_area.setFrameShape(QScrollArea.NoFrame)
 
         scroll_content = QWidget()
-        scroll_content.setObjectName("mainTabScrollContent")
-        scroll_content.setStyleSheet(
-            "#mainTabScrollContent { background-color: white; }"
-        )
+        # No explicit background - use default Qt palette like the config tabs
         main_layout = QVBoxLayout(scroll_content)
         main_layout.setSpacing(12)
         main_layout.setContentsMargins(12, 12, 12, 12)


### PR DESCRIPTION
## Summary
- Remove hardcoded white background from the main tab scroll content
- Use default Qt palette instead, matching the config tabs (Centroid, Bottom-up, etc.)
- Ensures consistent appearance and proper dark mode support

## Test plan
- [x] All 93 main_tab tests pass
- [ ] Verify main tab background matches config tabs visually
- [ ] Test in dark mode (should now adapt properly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)