### PR TITLE
Improve inference dialog with real-time progress and UI fixes

### DIFF
--- a/sleap/config/pipeline_form.yaml
+++ b/sleap/config/pipeline_form.yaml
@@ -222,7 +222,7 @@ training:
   type: list
 
 - name: trainer_config.train_data_loader.num_workers
-  label: Data Loader Workers
+  label: Dataloader Workers
   type: int
   default: 0
   range: 0,16
@@ -236,7 +236,7 @@ training:
   help: Number of GPU devices to train on. "Auto" detects available GPUs.
 
 - name: trainer_config.trainer_accelerator
-  label: Device Accelerator
+  label: Accelerator
   type: list
   default: "auto"
   options: auto,cuda,cpu,mps

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3310,6 +3310,19 @@ class DeleteAllPredictions(InstanceDeleteCommand):
             if type(inst) == PredictedInstance
         ]
 
+    @classmethod
+    def do_action(cls, context: CommandContext, params: dict):
+        # Use efficient batch removal instead of per-instance deletion
+        # This is much faster for large datasets (O(n) vs O(n^2))
+        context.labels.remove_predictions()
+
+        # Clear selected instance if it was a prediction
+        if context.state["instance"] is not None:
+            if type(context.state["instance"]) == PredictedInstance:
+                context.state["instance"] = None
+
+        context.changestack_push("delete instances")
+
 
 class DeleteFramePredictions(InstanceDeleteCommand):
     @staticmethod

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1347,22 +1347,8 @@ class LearningDialog(QtWidgets.QDialog):
         )
 
         self._handle_learning_finished.emit(new_counts)
-
-        # count < 0 means there was an error and we didn't get any results.
-        if new_counts is not None and new_counts >= 0:
-            total_count = items_for_inference.total_frame_count
-            no_result_count = max(0, total_count - new_counts)
-
-            message = (
-                f"Inference ran on {total_count} frames."
-                f"\n\nInstances were predicted on {new_counts} frames "
-                f"({no_result_count} frame{'s' if no_result_count != 1 else ''} with "
-                "no instances found)."
-            )
-
-            win = QtWidgets.QMessageBox(text=message)
-            win.setWindowTitle("Inference Results")
-            win.exec_()
+        # Note: The inference progress dialog now shows the completion message
+        # with frame counts, so we don't need a separate popup here.
 
     def copy(self):
         """Copy scripts and configs to clipboard"""

--- a/sleap/gui/learning/main_tab.py
+++ b/sleap/gui/learning/main_tab.py
@@ -786,9 +786,9 @@ class MainTabWidget(QWidget):
         layout.setSpacing(8)
 
         # Fixed-width labels for alignment
-        LABEL_WIDTH_COL1 = 105  # "Device Accelerator:" width
+        LABEL_WIDTH_COL1 = 105  # "Accelerator:" width
         DROPDOWN_WIDTH = 140  # Dropdown width for alignment
-        LABEL_WIDTH_COL2 = 115  # "Data Loader Workers:" is longest
+        LABEL_WIDTH_COL2 = 115  # "Dataloader Workers:" is longest
 
         # Row 1: Data Pipeline + Workers (training only)
         if self._mode == "training":
@@ -810,7 +810,7 @@ class MainTabWidget(QWidget):
 
             row1.addSpacing(20)
 
-            workers_label = QLabel("Data Loader Workers:")
+            workers_label = QLabel("Dataloader Workers:")
             workers_label.setFixedWidth(LABEL_WIDTH_COL2)
             row1.addWidget(workers_label)
 
@@ -858,7 +858,7 @@ class MainTabWidget(QWidget):
         row2 = QHBoxLayout()
         row2.setSpacing(8)
 
-        accel_label = QLabel("Device Accelerator:")
+        accel_label = QLabel("Accelerator:")
         accel_label.setFixedWidth(LABEL_WIDTH_COL1)
         row2.addWidget(accel_label)
 

--- a/sleap/gui/learning/main_tab.py
+++ b/sleap/gui/learning/main_tab.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from qtpy.QtCore import Qt, Signal
-from qtpy.QtGui import QGuiApplication
+from qtpy.QtGui import QGuiApplication, QPalette
 from qtpy.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -279,7 +279,10 @@ class MainTabWidget(QWidget):
         scroll_area.setFrameShape(QScrollArea.NoFrame)
 
         scroll_content = QWidget()
-        # No explicit background - use default Qt palette like the config tabs
+        # Use QPalette.Base for system-aware background:
+        # white in light mode, dark in dark mode
+        scroll_content.setAutoFillBackground(True)
+        scroll_content.setBackgroundRole(QPalette.Base)
         main_layout = QVBoxLayout(scroll_content)
         main_layout.setSpacing(12)
         main_layout.setContentsMargins(12, 12, 12, 12)

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -277,9 +277,7 @@ class InferenceWorker(QtCore.QThread):
                             eta_mins, eta_secs = divmod(eta, 60)
                             if eta_mins > 60:
                                 eta_hours, eta_mins = divmod(eta_mins, 60)
-                                eta_str = (
-                                    f"{int(eta_hours)}h {int(eta_mins):02}m"
-                                )
+                                eta_str = f"{int(eta_hours)}h {int(eta_mins):02}m"
                             elif eta_mins > 0:
                                 eta_str = f"{int(eta_mins)}m {int(eta_secs):02}s"
                             else:

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -52,9 +52,10 @@ class InferenceProgressDialog(QtWidgets.QDialog):
 
         layout = QtWidgets.QVBoxLayout(self)
 
-        # Status label
+        # Status label (centered)
         self._label = QtWidgets.QLabel("Initializing...")
         self._label.setWordWrap(True)
+        self._label.setAlignment(QtCore.Qt.AlignCenter)
         layout.addWidget(self._label)
 
         # Progress bar with minimum height for better visibility
@@ -225,7 +226,7 @@ class InferenceWorker(QtCore.QThread):
             item_for_inference, gui=True
         )
 
-        self.logOutput.emit(f"Running: {' '.join(cli_args[:3])}...")
+        self.logOutput.emit(f"Running: {' '.join(cli_args)}")
 
         # Run inference CLI capturing output
         # Use unbuffered mode for real-time log streaming
@@ -269,22 +270,21 @@ class InferenceWorker(QtCore.QThread):
                     if n_processed is not None and n_total is not None:
                         self.progressUpdate.emit(n_processed, n_total)
 
-                        # Build status message
-                        msg = f"<b>Predicted:</b> {n_processed:,}/{n_total:,}"
+                        # Build status message (all on one line with spacing)
+                        msg = f"Predicted: <b>{n_processed:,}/{n_total:,}</b>"
                         if rate is not None and eta is not None:
                             eta_mins, eta_secs = divmod(eta, 60)
                             if eta_mins > 60:
                                 eta_hours, eta_mins = divmod(eta_mins, 60)
                                 eta_str = (
-                                    f"{int(eta_hours)} hours, {int(eta_mins):02} mins"
+                                    f"{int(eta_hours)}h {int(eta_mins):02}m"
                                 )
                             elif eta_mins > 0:
-                                eta_str = f"{int(eta_mins)} mins, {int(eta_secs):02} secs"
+                                eta_str = f"{int(eta_mins)}m {int(eta_secs):02}s"
                             else:
-                                eta_str = f"{int(eta_secs):02} secs"
-                            msg += f"<br><b>ETA:</b> {eta_str}"
-                            msg += f"<br><b>FPS:</b> {rate:.1f}"
-                        msg = msg.replace(" ", "&nbsp;")
+                                eta_str = f"{int(eta_secs)}s"
+                            msg += f" &nbsp; &nbsp; FPS: <b>{rate:.1f}</b>"
+                            msg += f" &nbsp; &nbsp; ETA: <b>{eta_str}</b>"
                         self.statusUpdate.emit(msg)
                 else:
                     # Non-JSON output goes to log

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -178,10 +178,15 @@ class InferenceWorker(QtCore.QThread):
         self._canceled = False
         self._new_frame_count = 0
         self._total_frame_count = items_for_inference.total_frame_count
+        self._current_process = None  # Track current subprocess for cancellation
 
     def cancel(self):
         """Request cancellation of inference."""
         self._canceled = True
+        # Kill the subprocess immediately if running
+        # This is needed because readline() blocks and won't check _canceled
+        if self._current_process is not None:
+            kill_process(self._current_process.pid)
 
     def run(self):
         """Run inference in background thread."""
@@ -230,17 +235,21 @@ class InferenceWorker(QtCore.QThread):
             cli_args,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,  # Merge stderr into stdout
+            text=True,  # Text mode (required for line buffering)
             bufsize=1,  # Line buffered
             env=env,
         ) as proc:
+            # Track process for cancellation from main thread
+            self._current_process = proc
+
             while proc.poll() is None:
                 if self._canceled:
                     kill_process(proc.pid)
+                    self._current_process = None
                     return "", "canceled"
 
-                # Read line
-                line = proc.stdout.readline()
-                line = line.decode().rstrip()
+                # Read line (already decoded in text mode)
+                line = proc.stdout.readline().rstrip()
 
                 is_json = False
                 if line.startswith("{"):
@@ -284,6 +293,8 @@ class InferenceWorker(QtCore.QThread):
 
                 time.sleep(0.02)
 
+            # Clear process reference now that it's finished
+            self._current_process = None
             success = proc.returncode == 0
 
         if success:
@@ -709,8 +720,12 @@ class InferenceTask:
         ret = "success" if success else proc.returncode
         return output_path, ret
 
-    def merge_results(self):
-        """Merges result frames into labels dataset."""
+    def merge_results(self) -> int:
+        """Merges result frames into labels dataset.
+
+        Returns:
+            Number of frames with predicted instances.
+        """
 
         def remove_empty_instances_and_frames(lf: LabeledFrame):
             """Removes instances without visible points and empty frames."""
@@ -738,6 +753,8 @@ class InferenceTask:
             self.labels.merge(new_labels, frame="replace_predictions")
         else:
             self.labels.merge(new_labels, frame="keep_both")
+
+        return len(self.results)
 
 
 def write_pipeline_files(

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -165,7 +165,8 @@ class InferenceWorker(QtCore.QThread):
     progressUpdate = QtCore.Signal(int, int)  # (current, total)
     statusUpdate = QtCore.Signal(str)  # status message (HTML)
     logOutput = QtCore.Signal(str)  # log line
-    finished = QtCore.Signal(bool, int, int)  # (success, new_frame_count, total_frame_count)
+    # (success, new_frame_count, total_frame_count)
+    finished = QtCore.Signal(bool, int, int)
 
     def __init__(
         self,
@@ -700,7 +701,7 @@ class InferenceTask:
                     line_data = {"log_line": line} if line else {}
 
                 if waiting_callback is not None:
-                    # Pass line data to callback (includes log_line for non-JSON output).
+                    # Pass line data to callback (log_line for non-JSON output).
                     ret = waiting_callback(**line_data)
 
                     if ret == "cancel":

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -530,6 +530,8 @@ class InferenceTask:
         cli_args = [
             "sleap-nn-track",
         ]
+        if gui:
+            cli_args.append("--gui")
         cli_args.extend(
             item_for_inference.cli_args
         )  # sample inference CLI args: ['--data_path', '...', '--video_index', '0',

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Dict, List, Optional, Text, Tuple
 import logging
 from sleap.util import show_sleap_nn_installation_message
 
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from sleap_io import Labels, Video, LabeledFrame
 import sleap_io as sio
@@ -27,6 +27,243 @@ from sleap.gui.learning.configs import ConfigFileInfo
 from sleap.gui.config_utils import filter_cfg
 
 logger = logging.getLogger(__name__)
+
+
+class InferenceProgressDialog(QtWidgets.QDialog):
+    """Custom progress dialog for inference with log display.
+
+    Features:
+    - Taller progress bar for better visibility
+    - Scrollable log area showing subprocess output (dark theme)
+    - OK button (enabled when done) and Cancel button (disabled when done)
+    """
+
+    # Signal emitted when cancel is requested
+    cancelRequested = QtWidgets.QDialog.rejected  # Reuse rejected signal
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Running Inference")
+        self.setMinimumWidth(600)
+        self.setMinimumHeight(500)
+
+        self._canceled = False
+        self._finished = False
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        # Status label
+        self._label = QtWidgets.QLabel("Initializing...")
+        self._label.setWordWrap(True)
+        layout.addWidget(self._label)
+
+        # Progress bar with minimum height for better visibility
+        self._progress_bar = QtWidgets.QProgressBar()
+        self._progress_bar.setMinimumHeight(25)
+        self._progress_bar.setRange(0, 1)
+        layout.addWidget(self._progress_bar)
+
+        # Log area
+        log_label = QtWidgets.QLabel("Log output:")
+        layout.addWidget(log_label)
+
+        self._log_area = QtWidgets.QPlainTextEdit()
+        self._log_area.setReadOnly(True)
+        self._log_area.setMinimumHeight(250)
+        # Dark theme: light grey text on black background
+        self._log_area.setStyleSheet(
+            "QPlainTextEdit { background-color: #1e1e1e; color: #a0a0a0; }"
+        )
+        # Use monospace font, smaller size
+        font = self._log_area.font()
+        font.setFamily("Consolas, Monaco, monospace")
+        font.setPointSize(8)
+        self._log_area.setFont(font)
+        layout.addWidget(self._log_area, stretch=1)
+
+        # OK and Cancel buttons
+        button_layout = QtWidgets.QHBoxLayout()
+        button_layout.addStretch()
+
+        self._ok_button = QtWidgets.QPushButton("OK")
+        self._ok_button.setEnabled(False)  # Disabled until inference completes
+        self._ok_button.clicked.connect(self.accept)
+        button_layout.addWidget(self._ok_button)
+
+        self._cancel_button = QtWidgets.QPushButton("Cancel")
+        self._cancel_button.clicked.connect(self._on_cancel)
+        button_layout.addWidget(self._cancel_button)
+
+        layout.addLayout(button_layout)
+
+    def _on_cancel(self):
+        """Handle cancel button click."""
+        self._canceled = True
+        self._cancel_button.setEnabled(False)
+        self._cancel_button.setText("Canceling...")
+
+    def wasCanceled(self) -> bool:
+        """Return whether the dialog was canceled."""
+        return self._canceled
+
+    def setLabelText(self, text: str):
+        """Set the status label text."""
+        self._label.setText(text)
+
+    def setMaximum(self, maximum: int):
+        """Set the progress bar maximum value."""
+        self._progress_bar.setMaximum(maximum)
+
+    def setValue(self, value: int):
+        """Set the progress bar current value."""
+        self._progress_bar.setValue(value)
+
+    def appendLog(self, text: str):
+        """Append text to the log area and auto-scroll."""
+        if not text:
+            return
+        self._log_area.appendPlainText(text)
+        # Auto-scroll to bottom
+        scrollbar = self._log_area.verticalScrollBar()
+        scrollbar.setValue(scrollbar.maximum())
+
+    def setFinished(self, success: bool = True):
+        """Mark inference as finished and update button states."""
+        self._finished = True
+        self._ok_button.setEnabled(True)
+        self._cancel_button.setEnabled(False)
+        if success:
+            self._label.setText("<b>Inference complete!</b>")
+        else:
+            self._label.setText("<b>Inference failed.</b>")
+
+
+class InferenceWorker(QtCore.QThread):
+    """Background worker thread for running inference without blocking UI."""
+
+    # Signals for communicating with main thread
+    progressUpdate = QtCore.Signal(int, int)  # (current, total)
+    statusUpdate = QtCore.Signal(str)  # status message (HTML)
+    logOutput = QtCore.Signal(str)  # log line
+    finished = QtCore.Signal(bool, int)  # (success, new_frame_count)
+
+    def __init__(
+        self,
+        inference_task: "InferenceTask",
+        items_for_inference: "ItemsForInference",
+        parent=None,
+    ):
+        super().__init__(parent)
+        self._inference_task = inference_task
+        self._items_for_inference = items_for_inference
+        self._canceled = False
+        self._new_frame_count = 0
+
+    def cancel(self):
+        """Request cancellation of inference."""
+        self._canceled = True
+
+    def run(self):
+        """Run inference in background thread."""
+        try:
+            for i, item_for_inference in enumerate(self._items_for_inference.items):
+                if self._canceled:
+                    self.finished.emit(False, -1)
+                    return
+
+                # Run inference for this item
+                predictions_path, ret = self._run_inference_item(
+                    item_for_inference, i, len(self._items_for_inference.items)
+                )
+
+                if ret == "canceled":
+                    self.finished.emit(False, -1)
+                    return
+                elif ret != "success":
+                    self.logOutput.emit(f"Error: Inference failed with code {ret}")
+                    self.finished.emit(False, 0)
+                    return
+
+            # Merge results
+            self._new_frame_count = self._inference_task.merge_results()
+            self.finished.emit(True, self._new_frame_count)
+
+        except Exception as e:
+            self.logOutput.emit(f"Error: {e}")
+            self.finished.emit(False, 0)
+
+    def _run_inference_item(
+        self, item_for_inference: "ItemForInference", item_idx: int, total_items: int
+    ) -> Tuple[str, str]:
+        """Run inference for a single item, emitting progress signals."""
+        cli_args, output_path = self._inference_task.make_predict_cli_call(
+            item_for_inference, gui=True
+        )
+
+        self.logOutput.emit(f"Running: {' '.join(cli_args[:3])}...")
+
+        # Run inference CLI capturing output
+        with subprocess.Popen(cli_args, stdout=subprocess.PIPE) as proc:
+            while proc.poll() is None:
+                if self._canceled:
+                    kill_process(proc.pid)
+                    return "", "canceled"
+
+                # Read line
+                line = proc.stdout.readline()
+                line = line.decode().rstrip()
+
+                is_json = False
+                if line.startswith("{"):
+                    try:
+                        line_data = json.loads(line)
+                        is_json = True
+                    except (json.JSONDecodeError, ValueError):
+                        is_json = False
+
+                if is_json:
+                    # Extract progress info
+                    n_processed = line_data.get("n_processed")
+                    n_total = line_data.get("n_total")
+                    rate = line_data.get("rate")
+                    eta = line_data.get("eta")
+
+                    if n_processed is not None and n_total is not None:
+                        self.progressUpdate.emit(n_processed, n_total)
+
+                        # Build status message
+                        msg = f"<b>Predicted:</b> {n_processed:,}/{n_total:,}"
+                        if rate is not None and eta is not None:
+                            eta_mins, eta_secs = divmod(eta, 60)
+                            if eta_mins > 60:
+                                eta_hours, eta_mins = divmod(eta_mins, 60)
+                                eta_str = (
+                                    f"{int(eta_hours)} hours, {int(eta_mins):02} mins"
+                                )
+                            elif eta_mins > 0:
+                                eta_str = f"{int(eta_mins)} mins, {int(eta_secs):02} secs"
+                            else:
+                                eta_str = f"{int(eta_secs):02} secs"
+                            msg += f"<br><b>ETA:</b> {eta_str}"
+                            msg += f"<br><b>FPS:</b> {rate:.1f}"
+                        msg = msg.replace(" ", "&nbsp;")
+                        self.statusUpdate.emit(msg)
+                else:
+                    # Non-JSON output goes to log
+                    if line:
+                        self.logOutput.emit(line)
+
+                time.sleep(0.02)
+
+            success = proc.returncode == 0
+
+        if success:
+            # Load frames from inference into results list
+            new_inference_labels = sio.load_slp(output_path)
+            self._inference_task.results.extend(new_inference_labels.labeled_frames)
+
+        ret = "success" if success else proc.returncode
+        return output_path, ret
 
 
 def get_timestamp() -> Text:
@@ -418,10 +655,10 @@ class InferenceTask:
                 if not is_json:
                     # Pass through non-json output.
                     print(line)
-                    line_data = {}
+                    line_data = {"log_line": line} if line else {}
 
                 if waiting_callback is not None:
-                    # Pass line data to callback.
+                    # Pass line data to callback (includes log_line for non-JSON output).
                     ret = waiting_callback(**line_data)
 
                     if ret == "cancel":
@@ -874,91 +1111,72 @@ def run_gui_inference(
     Returns:
         Number of new frames added to labels.
     """
+    if not gui:
+        # Non-GUI mode: run synchronously with original callback approach
+        return _run_inference_sync(inference_task, items_for_inference)
 
-    if gui:
-        progress = QtWidgets.QProgressDialog(
-            "Initializing...",
-            "Cancel",
-            0,
-            1,
-        )
-        progress.show()
-        QtWidgets.QApplication.instance().processEvents()
+    # GUI mode: use threaded worker for responsive UI
+    dialog = InferenceProgressDialog()
+    result = {"frame_count": 0, "success": False}
 
-    # Make callback to process events while running inference
-    def waiting(
-        n_processed: Optional[int] = None,
-        n_total: Optional[int] = None,
-        elapsed: Optional[float] = None,
-        rate: Optional[float] = None,
-        eta: Optional[float] = None,
-        current_item: Optional[int] = None,
-        total_items: Optional[int] = None,
-        **kwargs,
-    ) -> str:
-        if gui:
-            QtWidgets.QApplication.instance().processEvents()
-            if n_total is not None:
-                progress.setMaximum(n_total)
-            if n_processed is not None:
-                progress.setValue(n_processed)
+    # Create worker thread
+    worker = InferenceWorker(inference_task, items_for_inference)
 
-            msg = "Predicting..."
+    # Connect signals
+    def on_progress(current, total):
+        dialog.setValue(current)
+        dialog.setMaximum(total)
 
-            if n_processed is not None and n_total is not None:
-                msg = f"<b>Predicted:</b> {n_processed:,}/{n_total:,}"
+    def on_status(msg):
+        dialog.setLabelText(msg)
 
-            # Show time elapsed?
-            if rate is not None and eta is not None:
-                eta_mins, eta_secs = divmod(eta, 60)
-                if eta_mins > 60:
-                    eta_hours, eta_mins = divmod(eta_mins, 60)
-                    eta_str = f"{int(eta_hours)} hours, {int(eta_mins):02} mins"
-                elif eta_mins > 0:
-                    eta_str = f"{int(eta_mins)} mins, {int(eta_secs):02} secs"
-                else:
-                    eta_str = f"{int(eta_secs):02} secs"
-                msg += f"<br><b>ETA:</b> {eta_str}"
-                msg += f"<br><b>FPS:</b> {rate:.1f}"
+    def on_log(line):
+        dialog.appendLog(line)
 
-            msg = msg.replace(" ", "&nbsp;")
+    def on_finished(success, frame_count):
+        result["success"] = success
+        result["frame_count"] = frame_count
+        dialog.setFinished(success)
 
-            progress.setLabelText(msg)
-            QtWidgets.QApplication.instance().processEvents()
+    worker.progressUpdate.connect(on_progress)
+    worker.statusUpdate.connect(on_status)
+    worker.logOutput.connect(on_log)
+    worker.finished.connect(on_finished)
 
-            if progress.wasCanceled():
-                return "cancel"
+    # Connect cancel button to worker
+    dialog._cancel_button.clicked.connect(worker.cancel)
 
-    for i, item_for_inference in enumerate(items_for_inference.items):
+    # Start worker and show dialog
+    worker.start()
+    dialog.exec_()  # Blocks until user clicks OK or Cancel
 
-        def waiting_item(**kwargs):
-            kwargs["current_item"] = i
-            kwargs["total_items"] = len(items_for_inference.items)
-            return waiting(**kwargs)
+    # Wait for worker to finish if still running
+    if worker.isRunning():
+        worker.cancel()
+        worker.wait(5000)  # Wait up to 5 seconds
 
-        # Run inference for desired frames in this video.
+    return result["frame_count"] if result["success"] else -1
+
+
+def _run_inference_sync(
+    inference_task: InferenceTask,
+    items_for_inference: ItemsForInference,
+) -> int:
+    """Run inference synchronously (non-GUI mode)."""
+    for item_for_inference in items_for_inference.items:
         predictions_path, ret = inference_task.predict_subprocess(
             item_for_inference,
             append_results=True,
-            waiting_callback=waiting_item,
-            gui=gui,
+            waiting_callback=None,
+            gui=False,
         )
 
         if ret == "canceled":
             return -1
         elif ret != "success":
-            if gui:
-                QtWidgets.QMessageBox(
-                    text=(
-                        "An error occcured during inference. Your command line "
-                        "terminal may have more information about the error."
-                    )
-                ).exec_()
             return -1
 
     inference_task.merge_results()
-    if gui:
-        progress.close()
     return len(inference_task.results)
 
 

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -127,15 +127,34 @@ class InferenceProgressDialog(QtWidgets.QDialog):
         scrollbar = self._log_area.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
 
-    def setFinished(self, success: bool = True):
-        """Mark inference as finished and update button states."""
+    def setFinished(
+        self,
+        success: bool = True,
+        new_frame_count: int = 0,
+        total_frame_count: int = 0,
+    ):
+        """Mark inference as finished and update button states.
+
+        Args:
+            success: Whether inference completed successfully.
+            new_frame_count: Number of frames with predicted instances.
+            total_frame_count: Total number of frames processed.
+        """
         self._finished = True
         self._ok_button.setEnabled(True)
         self._cancel_button.setEnabled(False)
         if success:
-            self._label.setText("<b>Inference complete!</b>")
+            no_result_count = max(0, total_frame_count - new_frame_count)
+            msg = (
+                f"<b>Inference complete!</b><br><br>"
+                f"Inference ran on {total_frame_count:,} frames.<br>"
+                f"Instances were predicted on {new_frame_count:,} frames "
+                f"({no_result_count:,} frame{'s' if no_result_count != 1 else ''} "
+                f"with no instances found)."
+            )
+            self._label.setText(msg)
         else:
-            self._label.setText("<b>Inference failed.</b>")
+            self._label.setText("<b>Inference failed or was canceled.</b>")
 
 
 class InferenceWorker(QtCore.QThread):
@@ -145,7 +164,7 @@ class InferenceWorker(QtCore.QThread):
     progressUpdate = QtCore.Signal(int, int)  # (current, total)
     statusUpdate = QtCore.Signal(str)  # status message (HTML)
     logOutput = QtCore.Signal(str)  # log line
-    finished = QtCore.Signal(bool, int)  # (success, new_frame_count)
+    finished = QtCore.Signal(bool, int, int)  # (success, new_frame_count, total_frame_count)
 
     def __init__(
         self,
@@ -158,6 +177,7 @@ class InferenceWorker(QtCore.QThread):
         self._items_for_inference = items_for_inference
         self._canceled = False
         self._new_frame_count = 0
+        self._total_frame_count = items_for_inference.total_frame_count
 
     def cancel(self):
         """Request cancellation of inference."""
@@ -168,7 +188,7 @@ class InferenceWorker(QtCore.QThread):
         try:
             for i, item_for_inference in enumerate(self._items_for_inference.items):
                 if self._canceled:
-                    self.finished.emit(False, -1)
+                    self.finished.emit(False, -1, self._total_frame_count)
                     return
 
                 # Run inference for this item
@@ -177,20 +197,20 @@ class InferenceWorker(QtCore.QThread):
                 )
 
                 if ret == "canceled":
-                    self.finished.emit(False, -1)
+                    self.finished.emit(False, -1, self._total_frame_count)
                     return
                 elif ret != "success":
                     self.logOutput.emit(f"Error: Inference failed with code {ret}")
-                    self.finished.emit(False, 0)
+                    self.finished.emit(False, 0, self._total_frame_count)
                     return
 
             # Merge results
             self._new_frame_count = self._inference_task.merge_results()
-            self.finished.emit(True, self._new_frame_count)
+            self.finished.emit(True, self._new_frame_count, self._total_frame_count)
 
         except Exception as e:
             self.logOutput.emit(f"Error: {e}")
-            self.finished.emit(False, 0)
+            self.finished.emit(False, 0, self._total_frame_count)
 
     def _run_inference_item(
         self, item_for_inference: "ItemForInference", item_idx: int, total_items: int
@@ -203,7 +223,16 @@ class InferenceWorker(QtCore.QThread):
         self.logOutput.emit(f"Running: {' '.join(cli_args[:3])}...")
 
         # Run inference CLI capturing output
-        with subprocess.Popen(cli_args, stdout=subprocess.PIPE) as proc:
+        # Use unbuffered mode for real-time log streaming
+        env = os.environ.copy()
+        env["PYTHONUNBUFFERED"] = "1"
+        with subprocess.Popen(
+            cli_args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,  # Merge stderr into stdout
+            bufsize=1,  # Line buffered
+            env=env,
+        ) as proc:
             while proc.poll() is None:
                 if self._canceled:
                     kill_process(proc.pid)
@@ -1128,15 +1157,17 @@ def run_gui_inference(
         dialog.setMaximum(total)
 
     def on_status(msg):
-        dialog.setLabelText(msg)
+        if msg:  # Guard against None
+            dialog.setLabelText(msg)
 
     def on_log(line):
-        dialog.appendLog(line)
+        if line:  # Guard against None
+            dialog.appendLog(line)
 
-    def on_finished(success, frame_count):
+    def on_finished(success, frame_count, total_frame_count):
         result["success"] = success
         result["frame_count"] = frame_count
-        dialog.setFinished(success)
+        dialog.setFinished(success, frame_count, total_frame_count)
 
     worker.progressUpdate.connect(on_progress)
     worker.statusUpdate.connect(on_status)

--- a/sleap/gui/widgets/frame_target_selector.py
+++ b/sleap/gui/widgets/frame_target_selector.py
@@ -69,7 +69,7 @@ class FrameTargetSelection:
     target_key: str = "frame"
     exclude_user_labeled: bool = False
     exclude_predicted: bool = False
-    prediction_mode: str = "add"
+    prediction_mode: str = "replace"
     clear_all_first: bool = False
     sample_count: int = 20
 
@@ -240,12 +240,12 @@ class FrameTargetSelector(QWidget):
 
         self.predictions_replace_radio = QRadioButton("Replace")
         self.predictions_replace_radio.setStyleSheet("font-size: 11px;")
+        self.predictions_replace_radio.setChecked(True)  # Default to Replace
         self.predictions_button_group.addButton(self.predictions_replace_radio, 1)
         options_layout.addWidget(self.predictions_replace_radio)
 
         self.predictions_keep_radio = QRadioButton("Keep")
         self.predictions_keep_radio.setStyleSheet("font-size: 11px;")
-        self.predictions_keep_radio.setChecked(True)  # Default to Keep
         self.predictions_button_group.addButton(self.predictions_keep_radio, 2)
         options_layout.addWidget(self.predictions_keep_radio)
 

--- a/sleap/nn_cli.py
+++ b/sleap/nn_cli.py
@@ -511,6 +511,12 @@ def train(config_name, config_dir, overrides):
         "Typical values: 0.3 (aggressive) to 0.8 (permissive). (default: 0.8)"
     ),
 )
+@click.option(
+    "--gui",
+    is_flag=True,
+    default=False,
+    help="Output JSON progress for GUI integration instead of Rich progress bar.",
+)
 def track(**kwargs):
     """Run Inference and Tracking workflow.
 

--- a/tests/gui/widgets/test_frame_target_selector.py
+++ b/tests/gui/widgets/test_frame_target_selector.py
@@ -179,7 +179,7 @@ class TestSelection:
         assert selection.target_key == "frame"
         assert selection.exclude_user_labeled is False
         assert selection.exclude_predicted is False
-        assert selection.prediction_mode == "add"
+        assert selection.prediction_mode == "replace"
         assert selection.clear_all_first is False
 
     def test_set_selection_target_key(self, training_selector):
@@ -237,11 +237,11 @@ class TestSelection:
 class TestPredictionModeRadios:
     """Tests for prediction mode radio button behavior."""
 
-    def test_default_is_keep(self, training_selector):
-        """Default prediction mode should be 'Keep'."""
-        assert training_selector.predictions_keep_radio.isChecked() is True
+    def test_default_is_replace(self, training_selector):
+        """Default prediction mode should be 'Replace'."""
+        assert training_selector.predictions_replace_radio.isChecked() is True
+        assert training_selector.predictions_keep_radio.isChecked() is False
         assert training_selector.predictions_clear_radio.isChecked() is False
-        assert training_selector.predictions_replace_radio.isChecked() is False
 
     def test_clear_all_selection(self, training_selector):
         """Selecting Clear all should set clear_all_first=True."""
@@ -339,7 +339,7 @@ class TestFormData:
         assert data["_predict_target"] == "frame"
         assert data["_exclude_user_labeled"] is False
         assert data["_exclude_predicted"] is False
-        assert data["_prediction_mode"] == "add"
+        assert data["_prediction_mode"] == "replace"
         assert data["_clear_all_first"] is False
 
     def test_get_form_data_after_changes(self, training_selector):
@@ -614,15 +614,15 @@ class TestEdgeCases:
 
     def test_suggestions_auto_configures_replace_and_skip(self, inference_selector):
         """Selecting 'Suggestions' should auto-select Replace and enable Skip."""
-        # Verify initial state - Keep is selected and skip is unchecked
-        assert inference_selector.predictions_keep_radio.isChecked()
+        # Verify initial state - Replace is selected (new default) and skip is unchecked
+        assert inference_selector.predictions_replace_radio.isChecked()
         assert not inference_selector.skip_user_labeled_cb.isChecked()
 
         # Select Suggestions
         suggestions_index = inference_selector._option_keys.index("suggestions")
         inference_selector.target_dropdown.setCurrentIndex(suggestions_index)
 
-        # Verify auto-configuration
+        # Verify auto-configuration (Replace stays selected, Skip gets enabled)
         assert inference_selector.predictions_replace_radio.isChecked()
         assert inference_selector.skip_user_labeled_cb.isChecked()
         assert not inference_selector.predictions_keep_radio.isChecked()
@@ -686,7 +686,7 @@ class TestFrameTargetSelection:
         assert selection.target_key == "frame"
         assert selection.exclude_user_labeled is False
         assert selection.exclude_predicted is False
-        assert selection.prediction_mode == "add"
+        assert selection.prediction_mode == "replace"
         assert selection.clear_all_first is False
 
     def test_selection_custom_values(self):


### PR DESCRIPTION
## Summary

This PR overhauls the inference progress dialog and fixes several GUI issues:

### Inference Progress Dialog Improvements
- **Threaded inference**: Runs inference in background QThread to keep UI responsive
- **Real-time progress**: Added `--gui` flag to `sleap-nn-track` CLI that outputs JSON progress instead of Rich text, enabling live progress bar updates
- **Log display**: Dark-themed scrollable log area showing subprocess output in real-time
- **Better UX**: 
  - Taller progress bar (25px) for better visibility
  - OK button disabled until done, Cancel button disabled when done
  - Frame count shown in dialog instead of separate popup
  - Full CLI command shown in log
  - Status line: `Predicted: **100/1,410**    FPS: **38.4**    ETA: **34s**` (centered, values bolded)

### Bug Fixes
- **Cancel button**: Now properly kills subprocess (previously blocked on readline)
- **Delete All Predictions**: Fixed GUI freeze on large datasets by using batch `labels.remove_predictions()` instead of O(n²) individual removals
- **Log buffering**: Added `PYTHONUNBUFFERED=1` and text mode for real-time streaming
- **Frame count display**: Fixed `merge_results()` to return count instead of None

### UI Polish
- **Main tab background**: Use `QPalette.Base` for system-aware color (white in light mode)
- **Label renames**: "Data Loader Workers" → "Dataloader Workers", "Device Accelerator" → "Accelerator"
- **Default behavior**: Changed existing predictions default from "Keep" to "Replace"

## Files Changed
- `sleap/gui/learning/runners.py` - New `InferenceProgressDialog` and `InferenceWorker` classes
- `sleap/gui/learning/dialog.py` - Removed redundant frame count popup
- `sleap/gui/commands.py` - Optimized `DeleteAllPredictions` batch removal
- `sleap/nn_cli.py` - Added `--gui` CLI flag

## Test Plan
- [x] Run inference from GUI - progress bar updates in real-time
- [x] Cancel inference - subprocess terminates cleanly
- [x] Delete All Predictions on large dataset - completes in milliseconds
- [x] Main tab background is white in light mode
- [x] Frame count shows in dialog after inference completes

## Related
- Requires sleap-nn with `--gui` support (adds JSON progress output to predictor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)