### PR TITLE
Add prerelease alias for docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            uv run mike deploy --allow-empty --push "${{ github.event.release.tag_name }}"
+            uv run mike deploy --update-aliases --allow-empty --push "${{ github.event.release.tag_name }}" prerelease
 
       - name: Build and upload docs (dev)
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
## Summary
- Adds a `prerelease` alias to the docs deployment workflow for prerelease versions
- Users can now access latest prerelease docs at `docs.sleap.ai/prerelease/`

This mirrors how `latest` works for stable releases.

## Test plan
- [ ] Verify workflow syntax is valid (CI will check this)
- [ ] On next prerelease, confirm `prerelease` alias is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)