### PR TITLE
Add ConvNeXt and SwinT backbone options to training dialog

### DIFF
--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -107,13 +107,6 @@ model:
     label: Use Pretrained Weights
     name: _convnext_use_pretrained
     type: bool
-  - default: 32
-    help: "Fixed at 32 for ConvNeXt architecture. Image dimensions must be divisible by this value.
-      Unlike UNet, this cannot be changed."
-    label: Max Stride
-    name: model_config.backbone_config.convnext.max_stride
-    type: int
-    readonly: true
   - default: 3
     help: Kernel size for the decoder upsampling convolutions.
     label: Decoder Kernel Size
@@ -148,13 +141,6 @@ model:
     label: Use Pretrained Weights
     name: _swint_use_pretrained
     type: bool
-  - default: 32
-    help: "Fixed at 32 for Swin Transformer architecture. Image dimensions must be divisible by this value.
-      Unlike UNet, this cannot be changed."
-    label: Max Stride
-    name: model_config.backbone_config.swint.max_stride
-    type: int
-    readonly: true
   - default: 7
     help: Window size for the Swin Transformer attention mechanism.
       Larger windows capture more context but use more memory.

--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -36,7 +36,7 @@ model:
 - default: unet
   label: Backbone
   name: _backbone_name
-  options: unet
+  options: unet,convnext,swint
   type: stacked
 
 
@@ -90,6 +90,94 @@ model:
   #   label: Stacks
   #   name: model.backbone.unet.stacks
   #   type: int
+#####
+
+#####
+  convnext:
+  - default: tiny
+    help: ConvNeXt model variant. Larger models have more parameters and capacity
+      but require more memory and compute. tiny (28M params), small (50M), base (89M), large (198M).
+    label: Model Type
+    name: model_config.backbone_config.convnext.model_type
+    options: tiny,small,base,large
+    type: list
+  - default: false
+    help: Use ImageNet pretrained weights for faster convergence and better performance.
+      Requires RGB input (3 channels). Enable "Ensure RGB" in preprocessing if using grayscale images.
+    label: Use Pretrained Weights
+    name: _convnext_use_pretrained
+    type: bool
+  - default: 32
+    help: "Fixed at 32 for ConvNeXt architecture. Image dimensions must be divisible by this value.
+      Unlike UNet, this cannot be changed."
+    label: Max Stride
+    name: model_config.backbone_config.convnext.max_stride
+    type: int
+    readonly: true
+  - default: 3
+    help: Kernel size for the decoder upsampling convolutions.
+    label: Decoder Kernel Size
+    name: model_config.backbone_config.convnext.kernel_size
+    options: 3,5
+    type: list
+  - default: 2.0
+    help: Factor to scale the number of filters in the decoder relative to the encoder.
+    label: Decoder Filters Rate
+    name: model_config.backbone_config.convnext.filters_rate
+    type: double
+  - default: true
+    help: If True, use bilinear interpolation for upsampling in the decoder.
+      If False, use transposed convolutions.
+    label: Up Interpolate
+    name: model_config.backbone_config.convnext.up_interpolate
+    type: bool
+#####
+
+#####
+  swint:
+  - default: tiny
+    help: Swin Transformer model variant. Larger models have more parameters and capacity
+      but require more memory and compute. tiny (28M params), small (50M), base (88M).
+    label: Model Type
+    name: model_config.backbone_config.swint.model_type
+    options: tiny,small,base
+    type: list
+  - default: false
+    help: Use ImageNet pretrained weights for faster convergence and better performance.
+      Requires RGB input (3 channels). Enable "Ensure RGB" in preprocessing if using grayscale images.
+    label: Use Pretrained Weights
+    name: _swint_use_pretrained
+    type: bool
+  - default: 32
+    help: "Fixed at 32 for Swin Transformer architecture. Image dimensions must be divisible by this value.
+      Unlike UNet, this cannot be changed."
+    label: Max Stride
+    name: model_config.backbone_config.swint.max_stride
+    type: int
+    readonly: true
+  - default: 7
+    help: Window size for the Swin Transformer attention mechanism.
+      Larger windows capture more context but use more memory.
+    label: Window Size
+    name: model_config.backbone_config.swint.window_size
+    type: int
+  - default: 3
+    help: Kernel size for the decoder upsampling convolutions.
+    label: Decoder Kernel Size
+    name: model_config.backbone_config.swint.kernel_size
+    options: 3,5
+    type: list
+  - default: 2.0
+    help: Factor to scale the number of filters in the decoder relative to the encoder.
+    label: Decoder Filters Rate
+    name: model_config.backbone_config.swint.filters_rate
+    type: double
+  - default: true
+    help: If True, use bilinear interpolation for upsampling in the decoder.
+      If False, use transposed convolutions.
+    label: Up Interpolate
+    name: model_config.backbone_config.swint.up_interpolate
+    type: bool
 #####
 
 - centered_instance:

--- a/sleap/gui/config_utils.py
+++ b/sleap/gui/config_utils.py
@@ -215,6 +215,41 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict):
             1.0 if brightness_enabled else 0.0
         )
 
+    # Handle ConvNeXt pretrained weights checkbox
+    if "_convnext_use_pretrained" in key_val_dict:
+        convnext_weights_key = (
+            "model_config.backbone_config.convnext.pre_trained_weights"
+        )
+        if key_val_dict["_convnext_use_pretrained"]:
+            model_type = key_val_dict.get(
+                "model_config.backbone_config.convnext.model_type", "tiny"
+            )
+            weights_map = {
+                "tiny": "ConvNeXt_Tiny_Weights",
+                "small": "ConvNeXt_Small_Weights",
+                "base": "ConvNeXt_Base_Weights",
+                "large": "ConvNeXt_Large_Weights",
+            }
+            key_val_dict[convnext_weights_key] = weights_map.get(model_type)
+        else:
+            key_val_dict[convnext_weights_key] = None
+
+    # Handle SwinT pretrained weights checkbox
+    if "_swint_use_pretrained" in key_val_dict:
+        swint_weights_key = "model_config.backbone_config.swint.pre_trained_weights"
+        if key_val_dict["_swint_use_pretrained"]:
+            model_type = key_val_dict.get(
+                "model_config.backbone_config.swint.model_type", "tiny"
+            )
+            weights_map = {
+                "tiny": "Swin_T_Weights",
+                "small": "Swin_S_Weights",
+                "base": "Swin_B_Weights",
+            }
+            key_val_dict[swint_weights_key] = weights_map.get(model_type)
+        else:
+            key_val_dict[swint_weights_key] = None
+
 
 def get_skeleton_from_config(skeleton_config: OmegaConf):
     """Create Sleap-io Skeleton objects from config.

--- a/sleap/gui/config_utils.py
+++ b/sleap/gui/config_utils.py
@@ -32,7 +32,10 @@ def get_omegaconf_from_gui_form(flat_dict):
         parts = key.split(".")
         d = result
         for p in parts[:-1]:
-            d = d.setdefault(p, {})
+            # Use setdefault but handle case where key exists with None value
+            if p not in d or d[p] is None:
+                d[p] = {}
+            d = d[p]
         d[parts[-1]] = value
     return OmegaConf.create(result)
 

--- a/sleap/gui/config_utils.py
+++ b/sleap/gui/config_utils.py
@@ -58,6 +58,11 @@ def get_head_from_omegaconf(cfg: OmegaConf):
 
 def find_backbone_name_from_key_val_dict(key_val_dict: dict):
     """Find the backbone model name from the config dictionary."""
+    # Prefer explicit selection from form if available
+    if "_backbone_name" in key_val_dict:
+        return key_val_dict["_backbone_name"]
+
+    # Fall back to inferring from keys
     backbone_name = None
     for key in key_val_dict:
         if key.startswith("model_config.backbone_config."):
@@ -113,6 +118,30 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict):
     Returns:
         None, modifies dict in place.
     """
+    # Filter backbone configs to only include the selected backbone
+    # sleap-nn's BackboneConfig uses @oneof pattern - exactly one must be set
+    all_backbones = ["unet", "convnext", "swint"]
+    selected_backbone = key_val_dict.get("_backbone_name")
+    if selected_backbone in all_backbones:
+        # Remove keys for non-selected backbones
+        keys_to_remove = []
+        for key in key_val_dict:
+            if key.startswith("model_config.backbone_config."):
+                backbone_in_key = key.split(".")[2]
+                is_other_backbone = (
+                    backbone_in_key in all_backbones
+                    and backbone_in_key != selected_backbone
+                )
+                if is_other_backbone:
+                    keys_to_remove.append(key)
+        for key in keys_to_remove:
+            del key_val_dict[key]
+
+        # Explicitly set non-selected backbones to None
+        for backbone in all_backbones:
+            if backbone != selected_backbone:
+                key_val_dict[f"model_config.backbone_config.{backbone}"] = None
+
     if "_ensure_channels" in key_val_dict:
         ensure_channels = key_val_dict["_ensure_channels"].lower()
         ensure_rgb = False

--- a/sleap/gui/config_utils.py
+++ b/sleap/gui/config_utils.py
@@ -142,6 +142,12 @@ def apply_cfg_transforms_to_key_val_dict(key_val_dict):
             if backbone != selected_backbone:
                 key_val_dict[f"model_config.backbone_config.{backbone}"] = None
 
+        # Set fixed max_stride for ConvNeXt and SwinT (not configurable like UNet)
+        if selected_backbone in ("convnext", "swint"):
+            key_val_dict[
+                f"model_config.backbone_config.{selected_backbone}.max_stride"
+            ] = 32
+
     if "_ensure_channels" in key_val_dict:
         ensure_channels = key_val_dict["_ensure_channels"].lower()
         ensure_rgb = False

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1002,9 +1002,18 @@ class LearningDialog(QtWidgets.QDialog):
         print(tab_idx)
 
     def merge_pipeline_and_head_config_data(self, head_name, head_data, pipeline_data):
+        # Inference-only fields that should not be merged into training config
+        inference_only_fields = {
+            "filter_overlapping",
+            "filter_overlapping_method",
+            "filter_overlapping_threshold",
+        }
         for key, val in pipeline_data.items():
             # Skip GUI-only fields (not part of sleap-nn config schema)
             if key.startswith("gui."):
+                continue
+            # Skip inference-only fields
+            if key in inference_only_fields:
                 continue
             if key.startswith("model_config.head_configs."):
                 key_scope = key.split(".")

--- a/sleap/gui/learning/main_tab.py
+++ b/sleap/gui/learning/main_tab.py
@@ -313,7 +313,10 @@ class MainTabWidget(QWidget):
         if self._mode == "training":
             main_layout.addWidget(self._create_wandb_section())
 
-            # Section 7: Output (training only)
+            # Section 7: Evaluation (training only)
+            main_layout.addWidget(self._create_evaluation_section())
+
+            # Section 8: Output (training only)
             main_layout.addWidget(self._create_output_section())
 
         main_layout.addStretch()
@@ -1022,6 +1025,46 @@ class MainTabWidget(QWidget):
 
         row4.addStretch()
         layout.addLayout(row4)
+
+        return group
+
+    def _create_evaluation_section(self) -> QGroupBox:
+        """Create the Evaluation section (training only)."""
+        group = QGroupBox("Evaluation")
+        group.setMinimumWidth(self.BOX_MIN_WIDTH)
+
+        layout = QVBoxLayout(group)
+        layout.setSpacing(8)
+
+        # Single row: Enable checkbox + Frequency spinner
+        row = QHBoxLayout()
+        row.setSpacing(8)
+
+        eval_enabled = QCheckBox("Run evaluation during training")
+        eval_enabled.setChecked(True)
+        self._fields["trainer_config.eval.enabled"] = eval_enabled
+        row.addWidget(eval_enabled)
+
+        row.addSpacing(20)
+
+        freq_label = QLabel("Frequency (epochs):")
+        row.addWidget(freq_label)
+
+        eval_freq = QSpinBox()
+        eval_freq.setRange(1, 200)
+        eval_freq.setValue(1)
+        eval_freq.setMinimumWidth(60)
+        eval_freq.setEnabled(True)  # Enabled by default since eval is enabled
+        self._fields["trainer_config.eval.frequency"] = eval_freq
+        row.addWidget(eval_freq)
+
+        # Connect checkbox to enable/disable frequency spinner
+        eval_enabled.stateChanged.connect(
+            lambda state, sb=eval_freq: sb.setEnabled(state)
+        )
+
+        row.addStretch()
+        layout.addLayout(row)
 
         return group
 

--- a/sleap/gui/learning/receptivefield.py
+++ b/sleap/gui/learning/receptivefield.py
@@ -55,11 +55,11 @@ def receptive_field_info_from_model_cfg(cfg: OmegaConf) -> dict:
         - params: Total backbone parameter count
         - params_formatted: Human-readable param count (e.g., "1.30M")
         - head_features: List of (head_name, output_stride, channels) for each head
+        - backbone_type: Type of backbone (unet, convnext, swint)
+        - model_type: For convnext/swint, the model variant (tiny, small, base, large)
     """
     model_cfg = cfg.model_config
-    model_cfg.backbone_config.unet.max_stride = int(
-        model_cfg.backbone_config.unet.max_stride
-    )
+    backbone_config = model_cfg.backbone_config
 
     rf_info = dict(
         size=None,
@@ -71,17 +71,39 @@ def receptive_field_info_from_model_cfg(cfg: OmegaConf) -> dict:
         params=None,
         params_formatted=None,
         head_features=[],  # List of (head_name, output_stride, channels)
-        backbone_type=None,  # e.g., "unet"
+        backbone_type=None,  # e.g., "unet", "convnext", "swint"
+        model_type=None,  # For convnext/swint: "tiny", "small", "base", "large"
     )
+
+    # Detect backbone type
+    backbone_type = None
+    for bt in ["unet", "convnext", "swint"]:
+        if hasattr(backbone_config, bt) and getattr(backbone_config, bt) is not None:
+            backbone_type = bt
+            break
+
+    rf_info["backbone_type"] = backbone_type
+
+    if backbone_type is None:
+        return rf_info
+
+    # Get max_stride based on backbone type
+    if backbone_type == "unet":
+        backbone_config.unet.max_stride = int(backbone_config.unet.max_stride)
+        max_stride = backbone_config.unet.max_stride
+    else:
+        # ConvNeXt and SwinT have fixed max_stride of 32
+        max_stride = 32
+
+    rf_info["max_stride"] = max_stride
+
     head_type = get_head_from_omegaconf(cfg)
 
     # Collect output strides for each sub-head
     head_output_strides = []  # List of (sub_head_name, output_stride)
     for k, head_cfg in model_cfg.head_configs[head_type].items():
         if k == "class_vectors":
-            head_output_strides.append(
-                (k, int(model_cfg.backbone_config.unet.max_stride))
-            )
+            head_output_strides.append((k, int(max_stride)))
         else:
             head_output_strides.append((k, int(head_cfg.output_stride)))
 
@@ -89,89 +111,111 @@ def receptive_field_info_from_model_cfg(cfg: OmegaConf) -> dict:
     output_stride = min(output_strides)
     rf_info["output_stride"] = output_stride
 
-    # Check backbone type - currently only UNet is supported
-    # TODO: Add support for other backbones (ConvNext, SwinT, etc.)
-    if not hasattr(model_cfg.backbone_config, "unet"):
-        return rf_info
+    # Handle backbone-specific RF calculations
+    if backbone_type == "unet":
+        try:
+            _ = np.log2(max_stride / output_stride)
+        except ZeroDivisionError:
+            return rf_info
 
-    rf_info["backbone_type"] = "unet"
+        rf_info["convs_per_block"] = 2
+        rf_info["kernel_size"] = 3
 
-    try:
-        _ = np.log2(model_cfg.backbone_config.unet.max_stride / output_stride)
-    except ZeroDivisionError:
-        # Unable to create model from these config parameters
-        return rf_info
+        stem_stride = None
+        stem_blocks = 0
+        if hasattr(backbone_config.unet, "stem_stride"):
+            cfg_stem_stride = backbone_config.unet.stem_stride
+            if cfg_stem_stride is not None:
+                stem_stride = int(cfg_stem_stride)
+                stem_blocks = np.log2(cfg_stem_stride).astype(int)
 
-    if hasattr(model_cfg.backbone_config.unet, "max_stride"):
-        rf_info["max_stride"] = model_cfg.backbone_config.unet.max_stride
+        down_blocks = np.log2(max_stride).astype(int) - stem_blocks
+        rf_info["down_blocks"] = down_blocks
 
-    rf_info["convs_per_block"] = 2
-
-    rf_info["kernel_size"] = 3
-
-    stem_stride = None
-    stem_blocks = 0
-    if hasattr(model_cfg.backbone_config.unet, "stem_stride"):
-        cfg_stem_stride = model_cfg.backbone_config.unet.stem_stride
-        if cfg_stem_stride is not None:
-            stem_stride = int(cfg_stem_stride)
-            stem_blocks = np.log2(cfg_stem_stride).astype(int)
-
-    down_blocks = (
-        np.log2(model_cfg.backbone_config.unet.max_stride).astype(int) - stem_blocks
-    )
-
-    rf_info["down_blocks"] = down_blocks
-
-    if rf_info["down_blocks"] and rf_info["convs_per_block"] and rf_info["kernel_size"]:
-        rf_info["size"] = compute_rf(
-            down_blocks=rf_info["down_blocks"],
-            convs_per_block=rf_info["convs_per_block"],
-            kernel_size=rf_info["kernel_size"],
+        has_rf_params = (
+            rf_info["down_blocks"]
+            and rf_info["convs_per_block"]
+            and rf_info["kernel_size"]
         )
+        if has_rf_params:
+            rf_info["size"] = compute_rf(
+                down_blocks=rf_info["down_blocks"],
+                convs_per_block=rf_info["convs_per_block"],
+                kernel_size=rf_info["kernel_size"],
+            )
 
-    # Extract UNet config for architecture calculations
-    unet_cfg = model_cfg.backbone_config.unet
-    filters = int(getattr(unet_cfg, "filters", 32))
-    filters_rate = float(getattr(unet_cfg, "filters_rate", 1.5))
-    max_stride = int(unet_cfg.max_stride)
-    middle_block = bool(getattr(unet_cfg, "middle_block", True))
-    up_interpolate = bool(getattr(unet_cfg, "up_interpolate", False))
+        # Extract UNet config for architecture calculations
+        unet_cfg = backbone_config.unet
+        filters = int(getattr(unet_cfg, "filters", 32))
+        filters_rate = float(getattr(unet_cfg, "filters_rate", 1.5))
+        middle_block = bool(getattr(unet_cfg, "middle_block", True))
+        up_interpolate = bool(getattr(unet_cfg, "up_interpolate", False))
 
-    # Compute channel counts at each stride
-    try:
-        # Use min output_stride to get all decoder levels we need
-        min_output_stride = min(s for _, s in head_output_strides)
-        stride_to_channels = unet_utils.compute_unet_channels(
-            filters=filters,
-            filters_rate=filters_rate,
-            max_stride=max_stride,
-            output_stride=min_output_stride,
-            stem_stride=stem_stride,
-        )
-        # Populate head_features for each sub-head
-        for head_name, head_stride in head_output_strides:
-            channels = stride_to_channels.get(head_stride)
-            if channels is not None:
-                rf_info["head_features"].append((head_name, head_stride, channels))
-    except Exception:
-        pass  # Leave as empty list if computation fails
+        # Compute channel counts at each stride
+        try:
+            min_output_stride = min(s for _, s in head_output_strides)
+            stride_to_channels = unet_utils.compute_unet_channels(
+                filters=filters,
+                filters_rate=filters_rate,
+                max_stride=max_stride,
+                output_stride=min_output_stride,
+                stem_stride=stem_stride,
+            )
+            for head_name, head_stride in head_output_strides:
+                channels = stride_to_channels.get(head_stride)
+                if channels is not None:
+                    rf_info["head_features"].append((head_name, head_stride, channels))
+        except Exception:
+            pass
 
-    # Compute total parameter count
-    try:
-        params = unet_utils.compute_unet_params(
-            filters=filters,
-            filters_rate=filters_rate,
-            max_stride=max_stride,
-            output_stride=output_stride,
-            stem_stride=stem_stride,
-            middle_block=middle_block,
-            up_interpolate=up_interpolate,
-        )
-        rf_info["params"] = params
-        rf_info["params_formatted"] = unet_utils.format_params(params)
-    except Exception:
-        pass  # Leave as None if computation fails
+        # Compute total parameter count
+        try:
+            params = unet_utils.compute_unet_params(
+                filters=filters,
+                filters_rate=filters_rate,
+                max_stride=max_stride,
+                output_stride=output_stride,
+                stem_stride=stem_stride,
+                middle_block=middle_block,
+                up_interpolate=up_interpolate,
+            )
+            rf_info["params"] = params
+            rf_info["params_formatted"] = unet_utils.format_params(params)
+        except Exception:
+            pass
+
+    elif backbone_type in ("convnext", "swint"):
+        # ConvNeXt and SwinT have fixed max_stride=32
+        rf_info["down_blocks"] = 5  # log2(32) = 5
+
+        # Get model type (tiny, small, base, large)
+        backbone_cfg = getattr(backbone_config, backbone_type)
+        model_type = getattr(backbone_cfg, "model_type", "tiny")
+        rf_info["model_type"] = model_type
+
+        # Approximate parameter counts for pretrained models
+        # These are rough estimates based on torchvision model sizes
+        if backbone_type == "convnext":
+            param_counts = {
+                "tiny": 28_600_000,
+                "small": 50_200_000,
+                "base": 88_600_000,
+                "large": 197_800_000,
+            }
+        else:  # swint
+            param_counts = {
+                "tiny": 28_300_000,
+                "small": 49_600_000,
+                "base": 87_800_000,
+            }
+
+        params = param_counts.get(model_type)
+        if params:
+            rf_info["params"] = params
+            rf_info["params_formatted"] = unet_utils.format_params(params)
+
+        # RF size is architecture-dependent and complex for transformer-based models
+        # For now, leave as None since exact RF calculation is non-trivial
 
     return rf_info
 
@@ -499,53 +543,77 @@ class ReceptiveFieldWidget(QtWidgets.QWidget):
         params_formatted: Optional[str],
         head_features: list,
         backbone_type: Optional[str] = "unet",
+        model_type: Optional[str] = None,
     ) -> Text:
         """Returns text showing backbone architecture info (params and channels).
 
         Args:
             params_formatted: Human-readable param count (e.g., "1.30M")
             head_features: List of (head_name, output_stride, channels) tuples
-            backbone_type: Type of backbone (e.g., "unet"). Only renders for
-                supported types.
+            backbone_type: Type of backbone (e.g., "unet", "convnext", "swint").
+            model_type: For convnext/swint, the model variant (e.g., "tiny").
         """
-        # Only render for supported backbone types
-        if backbone_type != "unet" or params_formatted is None:
+        if backbone_type is None:
             return ""
 
-        result = "<p><b>UNet:</b><br/>"
-        result += f"<b>Parameters:</b> ~{params_formatted}<br/>"
+        if backbone_type == "unet":
+            if params_formatted is None:
+                return ""
 
-        # Show features for each head with validation
-        for i, (head_name, stride, backbone_channels) in enumerate(head_features):
-            head_output = self._get_head_output_channels(head_name)
+            result = "<p><b>UNet:</b><br/>"
+            result += f"<b>Parameters:</b> ~{params_formatted}<br/>"
 
-            if head_output is not None:
-                if backbone_channels >= head_output:
-                    # Good: backbone has enough channels
-                    result += (
-                        f"<b>Features ({head_name} @ stride {stride}):</b> "
-                        f'<span style="color: green;">'
-                        f"{backbone_channels}\u2192{head_output} \u2713</span>"
-                    )
+            # Show features for each head with validation
+            for i, (head_name, stride, backbone_channels) in enumerate(head_features):
+                head_output = self._get_head_output_channels(head_name)
+
+                if head_output is not None:
+                    if backbone_channels >= head_output:
+                        # Good: backbone has enough channels
+                        result += (
+                            f"<b>Features ({head_name} @ stride {stride}):</b> "
+                            f'<span style="color: green;">'
+                            f"{backbone_channels}\u2192{head_output} \u2713</span>"
+                        )
+                    else:
+                        # Warning: backbone channels less than head output
+                        result += (
+                            f"<b>Features ({head_name} @ stride {stride}):</b> "
+                            f'<span style="color: red;">'
+                            f"{backbone_channels}\u2192{head_output} \u26a0</span>"
+                        )
                 else:
-                    # Warning: backbone channels less than head output
+                    # Can't determine head output, just show backbone channels
                     result += (
                         f"<b>Features ({head_name} @ stride {stride}):</b> "
-                        f'<span style="color: red;">'
-                        f"{backbone_channels}\u2192{head_output} \u26a0</span>"
+                        f"{backbone_channels} ch"
                     )
-            else:
-                # Can't determine head output, just show backbone channels
-                result += (
-                    f"<b>Features ({head_name} @ stride {stride}):</b> "
-                    f"{backbone_channels} ch"
-                )
 
-            if i < len(head_features) - 1:
-                result += "<br/>"
+                if i < len(head_features) - 1:
+                    result += "<br/>"
 
-        result += "</p>"
-        return result
+            result += "</p>"
+            return result
+
+        elif backbone_type == "convnext":
+            model_display = model_type.capitalize() if model_type else "Tiny"
+            result = f"<p><b>ConvNeXt ({model_display}):</b><br/>"
+            result += "<b>Max Stride:</b> 32 (fixed)<br/>"
+            if params_formatted:
+                result += f"<b>Parameters:</b> ~{params_formatted}<br/>"
+            result += "<b>Pretrained:</b> ImageNet weights available</p>"
+            return result
+
+        elif backbone_type == "swint":
+            model_display = model_type.capitalize() if model_type else "Tiny"
+            result = f"<p><b>Swin Transformer ({model_display}):</b><br/>"
+            result += "<b>Max Stride:</b> 32 (fixed)<br/>"
+            if params_formatted:
+                result += f"<b>Parameters:</b> ~{params_formatted}<br/>"
+            result += "<b>Pretrained:</b> ImageNet weights available</p>"
+            return result
+
+        return ""
 
     def setModelConfig(self, model_cfg: OmegaConf, scale: float):
         """Updates receptive field preview from model config."""
@@ -560,6 +628,7 @@ class ReceptiveFieldWidget(QtWidgets.QWidget):
                 params_formatted=rf_info["params_formatted"],
                 head_features=rf_info["head_features"],
                 backbone_type=rf_info["backbone_type"],
+                model_type=rf_info.get("model_type"),
             )
         )
 

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -922,18 +922,27 @@ class LossViewer(QtWidgets.QMainWindow):
                     self.epoch = msg["epoch"]
                 elif msg["event"] == "epoch_end":
                     self.epoch_size = max(self.epoch_size, self.last_batch_number + 1)
-                    self._add_datapoint(
-                        x=(self.epoch + 1) * self.epoch_size,
-                        y=msg["logs"]["train_loss"],
-                        which="train_loss",
+                    # Support both sleap-nn naming (train/loss) and legacy (train_loss)
+                    train_loss = msg["logs"].get(
+                        "train/loss", msg["logs"].get("train_loss")
                     )
-                    if "val_loss" in msg["logs"].keys():
+                    if train_loss is not None:
+                        self._add_datapoint(
+                            x=(self.epoch + 1) * self.epoch_size,
+                            y=train_loss,
+                            which="train_loss",
+                        )
+                    # Support both sleap-nn naming (val/loss) and legacy (val_loss)
+                    val_loss = msg["logs"].get(
+                        "val/loss", msg["logs"].get("val_loss")
+                    )
+                    if val_loss is not None:
                         # update variables and add points to plot
                         self.penultimate_epoch_val_loss = self.last_epoch_val_loss
-                        self.last_epoch_val_loss = msg["logs"]["val_loss"]
+                        self.last_epoch_val_loss = val_loss
                         self._add_datapoint(
                             (self.epoch + 1) * self.epoch_size,
-                            msg["logs"]["val_loss"],
+                            val_loss,
                             "val_loss",
                         )
                         # calculate timing and flags at new epoch
@@ -971,11 +980,16 @@ class LossViewer(QtWidgets.QMainWindow):
                     self.on_epoch.emit()
                 elif msg["event"] == "batch_end":
                     self.last_batch_number = msg["batch"]
-                    self._add_datapoint(
-                        x=(self.epoch * self.epoch_size) + msg["batch"],
-                        y=msg["logs"]["train_loss"],
-                        which="batch",
+                    # Support both sleap-nn naming (loss) and legacy (train_loss)
+                    batch_loss = msg["logs"].get(
+                        "loss", msg["logs"].get("train_loss")
                     )
+                    if batch_loss is not None:
+                        self._add_datapoint(
+                            x=(self.epoch * self.epoch_size) + msg["batch"],
+                            y=batch_loss,
+                            which="batch",
+                        )
 
             # Check for messages again (up to times_to_check times).
             if times_to_check > 0:

--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -933,9 +933,7 @@ class LossViewer(QtWidgets.QMainWindow):
                             which="train_loss",
                         )
                     # Support both sleap-nn naming (val/loss) and legacy (val_loss)
-                    val_loss = msg["logs"].get(
-                        "val/loss", msg["logs"].get("val_loss")
-                    )
+                    val_loss = msg["logs"].get("val/loss", msg["logs"].get("val_loss"))
                     if val_loss is not None:
                         # update variables and add points to plot
                         self.penultimate_epoch_val_loss = self.last_epoch_val_loss
@@ -981,9 +979,7 @@ class LossViewer(QtWidgets.QMainWindow):
                 elif msg["event"] == "batch_end":
                     self.last_batch_number = msg["batch"]
                     # Support both sleap-nn naming (loss) and legacy (train_loss)
-                    batch_loss = msg["logs"].get(
-                        "loss", msg["logs"].get("train_loss")
-                    )
+                    batch_loss = msg["logs"].get("loss", msg["logs"].get("train_loss"))
                     if batch_loss is not None:
                         self._add_datapoint(
                             x=(self.epoch * self.epoch_size) + msg["batch"],


### PR DESCRIPTION
## Summary

- Add ConvNeXt and Swin Transformer backbone options to the training dialog UI
- The sleap-nn backend already supports these architectures; this PR exposes them in the frontend
- Includes several bug fixes discovered during integration testing

## Changes

### New Features
- **Backbone selection**: Users can now choose between UNet, ConvNeXt, and SwinT backbones
- **ConvNeXt options**: Model type (tiny/small/base/large), pretrained weights, decoder settings
- **SwinT options**: Model type (tiny/small/base), pretrained weights, window size, decoder settings
- **Evaluation section**: Added trainer eval enabled/frequency controls to main tab

### Bug Fixes
- Fix form conversion when backbone config has null values
- Exclude inference-only fields (`filter_overlapping*`) from training config merge
- Fix loss monitor to handle sleap-nn metric naming (`loss`, `train/loss`, `val/loss`)
- Filter backbone configs to only include selected backbone (sleap-nn `@oneof` pattern)
- Set fixed `max_stride=32` programmatically for ConvNeXt/SwinT

## Files Changed

| File | Description |
|------|-------------|
| `sleap/config/training_editor_form.yaml` | Add ConvNeXt/SwinT backbone form fields |
| `sleap/gui/config_utils.py` | Pretrained weights transform, backbone filtering, null handling |
| `sleap/gui/learning/receptivefield.py` | Multi-backbone support in RF widget |
| `sleap/gui/learning/dialog.py` | Exclude inference-only fields |
| `sleap/gui/widgets/monitor.py` | Support sleap-nn metric naming |
| `sleap/gui/learning/main_tab.py` | Add Evaluation section |

## Test plan

- [ ] Open training dialog, verify backbone dropdown shows UNet/ConvNeXt/SwinT
- [ ] Switch between backbones, verify form fields update correctly
- [ ] Train with ConvNeXt backbone, verify config is correct
- [ ] Train with SwinT backbone, verify config is correct
- [ ] Verify pretrained weights checkbox maps to correct weight strings
- [ ] Verify loss monitor displays metrics during training

🤖 Generated with [Claude Code](https://claude.ai/code)