### PR TITLE
Bump version to v1.6.0a3, sleap-nn to 0.1.0a4

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,7 +75,7 @@ SLEAP uses `uv` to manage installation. It's a fast, modern package manager that
 One command works on all platforms. It automatically detects your GPU and installs the right version of PyTorch.
 
 ```bash
-uv tool install --python 3.13 "sleap[nn]==1.6.0a2" --with "sleap-io==0.6.2" --with "sleap-nn==0.1.0a2" --prerelease allow --torch-backend auto
+uv tool install --python 3.13 "sleap[nn]==1.6.0a3" --with "sleap-io==0.6.3" --with "sleap-nn==0.1.0a4" --prerelease allow --torch-backend auto
 ```
 
 That's it! SLEAP is now available system-wide. Run it from any terminal:
@@ -156,7 +156,7 @@ uv tool upgrade sleap --upgrade-package sleap-io --upgrade-package sleap-nn
 If you need specific versions (for reproducibility or to match a collaborator), reinstall:
 
 ```bash
-uv tool install --python 3.13 "sleap[nn]==1.6.0a2" --with "sleap-io==0.6.2" --with "sleap-nn==0.1.0a2" --prerelease allow --torch-backend auto
+uv tool install --python 3.13 "sleap[nn]==1.6.0a3" --with "sleap-io==0.6.3" --with "sleap-nn==0.1.0a4" --prerelease allow --torch-backend auto
 ```
 
 This replaces the existing installation with the exact versions specified.
@@ -182,7 +182,7 @@ uv tool uninstall sleap
     - Installing from local source code (to pick up changes)
 
     ```bash
-    uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.0a2" --with "sleap-io==0.6.2" --with "sleap-nn==0.1.0a2" --prerelease allow --torch-backend auto
+    uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.0a3" --with "sleap-io==0.6.3" --with "sleap-nn==0.1.0a4" --prerelease allow --torch-backend auto
     ```
 
 ---
@@ -203,6 +203,7 @@ The SLEAP ecosystem has three packages that work together:
 
 | SLEAP | sleap-io | sleap-nn |
 |-------|----------|----------|
+| 1.6.0a3 | 0.6.3 | 0.1.0a4 |
 | 1.6.0a2 | 0.6.2 | 0.1.0a2 |
 | 1.6.0a1 | 0.6.1 | 0.1.0a1 |
 | 1.6.0a0 | 0.6.0 | 0.1.0a0 |
@@ -222,7 +223,7 @@ Always use compatible versions when pinning.
     | `xpu` | Intel GPUs |
 
     ```bash
-    uv tool install --python 3.13 "sleap[nn]==1.6.0a2" --with "sleap-io==0.6.2" --with "sleap-nn==0.1.0a2" --prerelease allow --torch-backend cu128
+    uv tool install --python 3.13 "sleap[nn]==1.6.0a3" --with "sleap-io==0.6.3" --with "sleap-nn==0.1.0a4" --prerelease allow --torch-backend cu128
     ```
 
 ---
@@ -344,7 +345,7 @@ uv self update
 If something is broken:
 
 ```bash
-uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.0a2" --with "sleap-io==0.6.2" --with "sleap-nn==0.1.0a2" --prerelease allow --torch-backend auto
+uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.0a3" --with "sleap-io==0.6.3" --with "sleap-nn==0.1.0a4" --prerelease allow --torch-backend auto
 ```
 
 ### Installation seems stuck

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,23 +66,23 @@ jupyter = [
 ]
 
 nn = [
-    "sleap-nn[torch]>=0.1.0a3"
+    "sleap-nn[torch]>=0.1.0a4"
 ]
 
 nn-cpu = [
-    "sleap-nn[torch]>=0.1.0a3"
+    "sleap-nn[torch]>=0.1.0a4"
 ]
 
 nn-cuda128 = [
-    "sleap-nn[torch]>=0.1.0a3"
+    "sleap-nn[torch]>=0.1.0a4"
 ]
 
 nn-cuda118 = [
-    "sleap-nn[torch]>=0.1.0a3"
+    "sleap-nn[torch]>=0.1.0a4"
 ]
 
 nn-cuda130 = [
-    "sleap-nn[torch]>=0.1.0a3"
+    "sleap-nn[torch]>=0.1.0a4"
 ]
 
 [dependency-groups]

--- a/sleap/version.py
+++ b/sleap/version.py
@@ -11,7 +11,7 @@ For example, if you set the version to X.Y.Z, then the tag should be "vX.Y.Z".
 Must be a semver string, "aN" should be appended for alpha releases.
 """
 
-__version__ = "1.6.0a2"
+__version__ = "1.6.0a3"
 
 
 def versions():


### PR DESCRIPTION
## Summary
- Update SLEAP version from 1.6.0a2 to 1.6.0a3
- Bump sleap-nn minimum from 0.1.0a3 to 0.1.0a4
- sleap-io minimum remains at 0.6.3 (already updated in #2573)
- Update all version references in installation docs

## Test plan
- [ ] CI passes
- [ ] Verify version numbers are correct in all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)