### PR TITLE
Fix Previous Labeled Frame navigation skipping one frame

### DIFF
--- a/sleap/sleap_io_adaptors/lf_labels_utils.py
+++ b/sleap/sleap_io_adaptors/lf_labels_utils.py
@@ -585,9 +585,12 @@ def iterate_labeled_frames(
 
         # Reorder the list to start from the specified position
         if reverse:
-            # For reverse, we need to handle the reordering differently
-            reordered = frame_idxs[cut_list_idx:] + frame_idxs[:cut_list_idx]
-            frame_idxs = reordered[::-1]  # Reverse the reordered list
+            # For reverse: start from cut_list_idx and go backwards, then wrap
+            # Result: [cut_list_idx, cut_list_idx-1, ..., 0, last, ..., cut_list_idx+1]
+            frame_idxs = (
+                frame_idxs[: cut_list_idx + 1][::-1]
+                + frame_idxs[cut_list_idx + 1 :][::-1]
+            )
         else:
             # For forward, just reorder normally
             frame_idxs = frame_idxs[cut_list_idx:] + frame_idxs[:cut_list_idx]

--- a/tests/sleap_io_adaptors/test_lf_labels_utils.py
+++ b/tests/sleap_io_adaptors/test_lf_labels_utils.py
@@ -77,8 +77,8 @@ class TestIterateLabeledFrames:
         result_indices = [lf.frame_idx for lf in frames]
 
         assert result_indices[0] == 20, (
-            f"First frame should be 20 (immediate previous to 30), got {result_indices[0]}. "
-            "This is the bug from issue #2578 - Previous Labeled Frame was skipping one frame."
+            f"First frame should be 20 (immediate previous to 30), "
+            f"got {result_indices[0]}. Bug #2578."
         )
         assert result_indices == [20, 10, 50, 40, 30]
 
@@ -96,8 +96,8 @@ class TestIterateLabeledFrames:
         result_indices = [lf.frame_idx for lf in frames]
 
         assert result_indices[0] == 30, (
-            f"First frame should be 30 (immediate previous to 35), got {result_indices[0]}. "
-            "This is the bug from issue #2578."
+            f"First frame should be 30 (immediate previous to 35), "
+            f"got {result_indices[0]}. Bug #2578."
         )
 
     def test_reverse_iteration_wraps_at_beginning(self, labels_with_frames):

--- a/tests/sleap_io_adaptors/test_lf_labels_utils.py
+++ b/tests/sleap_io_adaptors/test_lf_labels_utils.py
@@ -1,0 +1,148 @@
+"""Tests for sleap.sleap_io_adaptors.lf_labels_utils module."""
+
+import pytest
+from sleap_io import Labels, LabeledFrame, Video
+
+from sleap.sleap_io_adaptors.lf_labels_utils import iterate_labeled_frames
+
+
+@pytest.fixture
+def labels_with_frames():
+    """Create a Labels object with labeled frames at indices 10, 20, 30, 40, 50."""
+    video = Video(filename="test_video.mp4")
+    labels = Labels(videos=[video])
+
+    # Create labeled frames at specific indices
+    frame_indices = [10, 20, 30, 40, 50]
+    for idx in frame_indices:
+        lf = LabeledFrame(video=video, frame_idx=idx)
+        labels.append(lf)
+
+    return labels, video, frame_indices
+
+
+class TestIterateLabeledFrames:
+    """Tests for iterate_labeled_frames function."""
+
+    def test_forward_iteration_basic(self, labels_with_frames):
+        """Test basic forward iteration from beginning."""
+        labels, video, frame_indices = labels_with_frames
+
+        frames = list(iterate_labeled_frames(labels, video))
+        result_indices = [lf.frame_idx for lf in frames]
+
+        assert result_indices == [10, 20, 30, 40, 50]
+
+    def test_forward_iteration_from_frame(self, labels_with_frames):
+        """Test forward iteration starting from a specific frame."""
+        labels, video, frame_indices = labels_with_frames
+
+        # From frame 30, next should be 40
+        frames = list(iterate_labeled_frames(labels, video, from_frame_idx=30))
+        result_indices = [lf.frame_idx for lf in frames]
+
+        assert result_indices[0] == 40, "First frame should be 40 (next after 30)"
+        assert result_indices == [40, 50, 10, 20, 30]
+
+    def test_forward_iteration_from_unlabeled_frame(self, labels_with_frames):
+        """Test forward iteration from a frame that isn't labeled."""
+        labels, video, frame_indices = labels_with_frames
+
+        # From frame 35, next should be 40
+        frames = list(iterate_labeled_frames(labels, video, from_frame_idx=35))
+        result_indices = [lf.frame_idx for lf in frames]
+
+        assert result_indices[0] == 40, "First frame should be 40 (next after 35)"
+
+    def test_reverse_iteration_basic(self, labels_with_frames):
+        """Test basic reverse iteration from end."""
+        labels, video, frame_indices = labels_with_frames
+
+        frames = list(iterate_labeled_frames(labels, video, reverse=True))
+        result_indices = [lf.frame_idx for lf in frames]
+
+        assert result_indices == [50, 40, 30, 20, 10]
+
+    def test_reverse_iteration_from_frame(self, labels_with_frames):
+        """Test reverse iteration starting from a specific frame.
+
+        This is the main regression test for issue #2578.
+        """
+        labels, video, frame_indices = labels_with_frames
+
+        # From frame 30, previous should be 20 (NOT 10!)
+        frames = list(
+            iterate_labeled_frames(labels, video, from_frame_idx=30, reverse=True)
+        )
+        result_indices = [lf.frame_idx for lf in frames]
+
+        assert result_indices[0] == 20, (
+            f"First frame should be 20 (immediate previous to 30), got {result_indices[0]}. "
+            "This is the bug from issue #2578 - Previous Labeled Frame was skipping one frame."
+        )
+        assert result_indices == [20, 10, 50, 40, 30]
+
+    def test_reverse_iteration_from_unlabeled_frame(self, labels_with_frames):
+        """Test reverse iteration from a frame that isn't labeled.
+
+        Additional regression test for issue #2578.
+        """
+        labels, video, frame_indices = labels_with_frames
+
+        # From frame 35, previous should be 30 (NOT 20!)
+        frames = list(
+            iterate_labeled_frames(labels, video, from_frame_idx=35, reverse=True)
+        )
+        result_indices = [lf.frame_idx for lf in frames]
+
+        assert result_indices[0] == 30, (
+            f"First frame should be 30 (immediate previous to 35), got {result_indices[0]}. "
+            "This is the bug from issue #2578."
+        )
+
+    def test_reverse_iteration_wraps_at_beginning(self, labels_with_frames):
+        """Test that reverse iteration wraps to end when at first frame."""
+        labels, video, frame_indices = labels_with_frames
+
+        # From frame 10 (first labeled), previous should wrap to 50
+        frames = list(
+            iterate_labeled_frames(labels, video, from_frame_idx=10, reverse=True)
+        )
+        result_indices = [lf.frame_idx for lf in frames]
+
+        assert result_indices[0] == 50, "Should wrap to last frame (50) when at first"
+
+    def test_forward_iteration_wraps_at_end(self, labels_with_frames):
+        """Test that forward iteration wraps to beginning when at last frame."""
+        labels, video, frame_indices = labels_with_frames
+
+        # From frame 50 (last labeled), next should wrap to 10
+        frames = list(iterate_labeled_frames(labels, video, from_frame_idx=50))
+        result_indices = [lf.frame_idx for lf in frames]
+
+        assert result_indices[0] == 10, "Should wrap to first frame (10) when at last"
+
+    def test_empty_labels(self):
+        """Test iteration with no labeled frames."""
+        video = Video(filename="test_video.mp4")
+        labels = Labels(videos=[video])
+
+        frames = list(iterate_labeled_frames(labels, video))
+        assert frames == []
+
+    def test_single_frame(self):
+        """Test iteration with only one labeled frame."""
+        video = Video(filename="test_video.mp4")
+        labels = Labels(videos=[video])
+        lf = LabeledFrame(video=video, frame_idx=25)
+        labels.append(lf)
+
+        # Forward
+        frames = list(iterate_labeled_frames(labels, video, from_frame_idx=20))
+        assert [f.frame_idx for f in frames] == [25]
+
+        # Reverse
+        frames = list(
+            iterate_labeled_frames(labels, video, from_frame_idx=30, reverse=True)
+        )
+        assert [f.frame_idx for f in frames] == [25]


### PR DESCRIPTION
## Summary
- Fixes the "Previous Labeled Frame" navigation which was incorrectly going to the second previous frame instead of the immediate previous frame
- Also fixes "Copy Previous Frame" functionality which had the same underlying bug

Closes #2578

## Root Cause
The bug was in `iterate_labeled_frames()` in `sleap/sleap_io_adaptors/lf_labels_utils.py`. The reverse iteration logic incorrectly reordered the frame list:

```python
# Before (buggy):
reordered = frame_idxs[cut_list_idx:] + frame_idxs[:cut_list_idx]
frame_idxs = reordered[::-1]
```

This caused the target frame (immediate previous) to end up at the **end** of the list instead of the **beginning**.

**Example with frames [10, 20, 30, 40, 50], current=30:**
- Expected first result: 20 (immediate previous)
- Actual first result: 10 (skipped one frame!)

## Changes
1. Fixed the reordering logic for reverse iteration to properly build the list starting from the target frame
2. Added comprehensive test suite for `iterate_labeled_frames()` with 10 test cases

## Test plan
- [x] All new tests pass (`uv run pytest tests/sleap_io_adaptors/test_lf_labels_utils.py -v`)
- [x] Manual testing: Open SLEAP GUI, label multiple frames, verify "Previous Labeled Frame" goes to immediate previous (VERIFIED)
- [x] Manual testing: Verify "Copy Previous Frame" copies from the correct frame (VERIFIED)

🤖 Generated with [Claude Code](https://claude.ai/code)