### PR TITLE
Fix ckpt_dir override bug in training dialog

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -1063,9 +1063,19 @@ def run_gui_training(
             # so we have access to them here (rather than letting
             # train_subprocess update them).
             # training.Trainer.set_run_name(job, labels_filename)
-            job.trainer_config.ckpt_dir = os.path.join(
-                os.path.dirname(labels_filename), "models"
+            # Use user-specified ckpt_dir if provided, otherwise default to "models"
+            user_ckpt_dir = OmegaConf.select(
+                job, "trainer_config.ckpt_dir", default=None
             )
+            if not user_ckpt_dir:
+                user_ckpt_dir = "models"
+            # Resolve relative paths against the labels file directory
+            if not os.path.isabs(user_ckpt_dir):
+                job.trainer_config.ckpt_dir = os.path.join(
+                    os.path.dirname(labels_filename), user_ckpt_dir
+                )
+            else:
+                job.trainer_config.ckpt_dir = user_ckpt_dir
             base_run_name = f"{model_type}.n={len(labels.user_labeled_frames)}"
             run_path = setup_new_run_folder(
                 job,


### PR DESCRIPTION
## Summary

- Fixes bug where custom `ckpt_dir` values from the training dialog GUI were ignored
- Previously, `runners.py:1066-1067` unconditionally overwrote the user's value with `{labels_dir}/models`
- Now respects user-specified checkpoint directories:
  - Empty/None → defaults to `"models"`
  - Relative path → resolved against labels file directory
  - Absolute path → used as-is

## Test plan

- [x] Run existing GUI learning tests (`tests/gui/learning/`) - all 308 tests pass
- [ ] Manual test: Set custom `ckpt_dir` in training dialog, verify models save to that location
- [ ] Manual test: Leave `ckpt_dir` as default "models", verify models save to `{labels_dir}/models/`
- [ ] Manual test: Set absolute path like `/tmp/my_models`, verify models save there

🤖 Generated with [Claude Code](https://claude.com/claude-code)