### PR TITLE
Fix `sleap label` parsing "label" as filename

### DIFF
--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -360,7 +360,7 @@ def label(
     # Import and call the existing GUI launcher
     from sleap.gui.app import main as gui_main
 
-    gui_main(args=args if args else None)
+    gui_main(args=args)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Fixes bug where running `sleap label` without arguments caused the error "Could not infer format from filename: 'label'"
- The issue was that an empty args list `[]` was converted to `None` due to falsy check, causing argparse to fall back to `sys.argv[1:]`
- Changed `gui_main(args=args if args else None)` to `gui_main(args=args)` so empty list is passed correctly

## Test plan
- [ ] Run `sleap label` without arguments - should launch GUI without error
- [ ] Run `sleap label myfile.slp` - should still open the file correctly
- [ ] Run `sleap` without arguments - should launch GUI without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)