### PR TITLE
Fix augmentation settings not loading from baseline configs

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1992,7 +1992,14 @@ class TrainingEditorWidget(QtWidgets.QWidget):
             "data_config.augmentation_config.geometric.rotation_max"
         )
         rot_p = key_val_dict.get("data_config.augmentation_config.geometric.rotation_p")
-        if rot_p is None or rot_p == 0:
+        affine_p = key_val_dict.get(
+            "data_config.augmentation_config.geometric.affine_p"
+        )
+
+        # Check rotation_p first, fall back to affine_p for legacy configs
+        effective_rot_p = rot_p if rot_p is not None else affine_p
+
+        if effective_rot_p is None or effective_rot_p == 0:
             key_val_dict["_rotation_preset"] = "Off"
         elif rot_min is not None and rot_max is not None:
             # Check for symmetric presets
@@ -2008,6 +2015,28 @@ class TrainingEditorWidget(QtWidgets.QWidget):
                 # Asymmetric (rare) - use Custom with max as angle
                 key_val_dict["_rotation_preset"] = "Custom"
                 key_val_dict["_rotation_custom_angle"] = max(abs(rot_min), abs(rot_max))
+
+        # Reverse-map scale settings to _scale_enabled checkbox
+        scale_p = key_val_dict.get("data_config.augmentation_config.geometric.scale_p")
+        scale_min = key_val_dict.get(
+            "data_config.augmentation_config.geometric.scale_min"
+        )
+        scale_max = key_val_dict.get(
+            "data_config.augmentation_config.geometric.scale_max"
+        )
+
+        # Check scale_p first, fall back to affine_p for legacy configs
+        effective_scale_p = scale_p if scale_p is not None else affine_p
+
+        # Scale is enabled if probability > 0 AND min != max (actual scaling occurs)
+        scale_enabled = (
+            effective_scale_p is not None
+            and effective_scale_p > 0
+            and scale_min is not None
+            and scale_max is not None
+            and scale_min != scale_max
+        )
+        key_val_dict["_scale_enabled"] = scale_enabled
 
         self.set_fields_from_key_val_dict(key_val_dict)
 

--- a/tests/gui/learning/test_config_bindings.py
+++ b/tests/gui/learning/test_config_bindings.py
@@ -912,3 +912,211 @@ class TestFullConfigPipeline:
         assert (
             filtered_cfg.model_config.head_configs.single_instance.confmaps.sigma == 4.0
         )
+
+
+# =============================================================================
+# Config Loading Reverse Mapping Tests
+# =============================================================================
+
+
+class TestConfigLoadingReverseMapping:
+    """Tests for reverse mapping when loading configs into the GUI.
+
+    These tests verify that augmentation settings from loaded configs
+    (including legacy configs using affine_p) are correctly mapped to
+    GUI form fields.
+    """
+
+    def test_rotation_preset_from_rotation_p(self):
+        """rotation_p should be used to determine _rotation_preset."""
+        key_val_dict = {
+            "data_config.augmentation_config.geometric.rotation_min": -180,
+            "data_config.augmentation_config.geometric.rotation_max": 180,
+            "data_config.augmentation_config.geometric.rotation_p": 1.0,
+        }
+
+        # Simulate the reverse mapping logic from _load_config
+        rot_min = key_val_dict.get(
+            "data_config.augmentation_config.geometric.rotation_min"
+        )
+        rot_max = key_val_dict.get(
+            "data_config.augmentation_config.geometric.rotation_max"
+        )
+        rot_p = key_val_dict.get("data_config.augmentation_config.geometric.rotation_p")
+        affine_p = key_val_dict.get(
+            "data_config.augmentation_config.geometric.affine_p"
+        )
+
+        effective_rot_p = rot_p if rot_p is not None else affine_p
+
+        assert effective_rot_p == 1.0
+        assert rot_min == -180 and rot_max == 180
+
+    def test_rotation_preset_fallback_to_affine_p(self):
+        """affine_p should be used as fallback when rotation_p is None.
+
+        This is the case for legacy/baseline configs that use affine_p
+        instead of the new rotation_p/scale_p parameters.
+        """
+        # This is how baseline configs look - they have affine_p but no rotation_p
+        key_val_dict = {
+            "data_config.augmentation_config.geometric.rotation_min": -180.0,
+            "data_config.augmentation_config.geometric.rotation_max": 180.0,
+            "data_config.augmentation_config.geometric.affine_p": 1.0,
+            # rotation_p is NOT present (None)
+        }
+
+        rot_min = key_val_dict.get(
+            "data_config.augmentation_config.geometric.rotation_min"
+        )
+        rot_max = key_val_dict.get(
+            "data_config.augmentation_config.geometric.rotation_max"
+        )
+        rot_p = key_val_dict.get("data_config.augmentation_config.geometric.rotation_p")
+        affine_p = key_val_dict.get(
+            "data_config.augmentation_config.geometric.affine_p"
+        )
+
+        # Check rotation_p first, fall back to affine_p for legacy configs
+        effective_rot_p = rot_p if rot_p is not None else affine_p
+
+        # With affine_p=1.0 and rotation_min=-180, rotation_max=180,
+        # should NOT be "Off"
+        assert effective_rot_p == 1.0
+        assert rot_min == -180.0 and rot_max == 180.0
+
+        # Determine preset
+        if effective_rot_p is None or effective_rot_p == 0:
+            preset = "Off"
+        elif rot_min == -180 and rot_max == 180:
+            preset = "±180°"
+        elif rot_min == -15 and rot_max == 15:
+            preset = "±15°"
+        else:
+            preset = "Custom"
+
+        assert preset == "±180°"
+
+    def test_scale_enabled_from_scale_p(self):
+        """scale_p should be used to determine _scale_enabled."""
+        key_val_dict = {
+            "data_config.augmentation_config.geometric.scale_min": 0.9,
+            "data_config.augmentation_config.geometric.scale_max": 1.1,
+            "data_config.augmentation_config.geometric.scale_p": 1.0,
+        }
+
+        scale_p = key_val_dict.get("data_config.augmentation_config.geometric.scale_p")
+        scale_min = key_val_dict.get(
+            "data_config.augmentation_config.geometric.scale_min"
+        )
+        scale_max = key_val_dict.get(
+            "data_config.augmentation_config.geometric.scale_max"
+        )
+        affine_p = key_val_dict.get(
+            "data_config.augmentation_config.geometric.affine_p"
+        )
+
+        effective_scale_p = scale_p if scale_p is not None else affine_p
+
+        scale_enabled = (
+            effective_scale_p is not None
+            and effective_scale_p > 0
+            and scale_min is not None
+            and scale_max is not None
+            and scale_min != scale_max
+        )
+
+        assert scale_enabled is True
+
+    def test_scale_enabled_fallback_to_affine_p(self):
+        """affine_p should be used as fallback when scale_p is None.
+
+        This is the case for legacy/baseline configs that use affine_p
+        instead of the new rotation_p/scale_p parameters.
+        """
+        # This is how baseline configs look - they have affine_p but no scale_p
+        key_val_dict = {
+            "data_config.augmentation_config.geometric.scale_min": 0.9,
+            "data_config.augmentation_config.geometric.scale_max": 1.1,
+            "data_config.augmentation_config.geometric.affine_p": 1.0,
+            # scale_p is NOT present (None)
+        }
+
+        scale_p = key_val_dict.get("data_config.augmentation_config.geometric.scale_p")
+        scale_min = key_val_dict.get(
+            "data_config.augmentation_config.geometric.scale_min"
+        )
+        scale_max = key_val_dict.get(
+            "data_config.augmentation_config.geometric.scale_max"
+        )
+        affine_p = key_val_dict.get(
+            "data_config.augmentation_config.geometric.affine_p"
+        )
+
+        # Check scale_p first, fall back to affine_p for legacy configs
+        effective_scale_p = scale_p if scale_p is not None else affine_p
+
+        # Scale is enabled if probability > 0 AND min != max
+        scale_enabled = (
+            effective_scale_p is not None
+            and effective_scale_p > 0
+            and scale_min is not None
+            and scale_max is not None
+            and scale_min != scale_max
+        )
+
+        assert scale_enabled is True
+
+    def test_scale_disabled_when_min_equals_max(self):
+        """Scale should be disabled when min == max (no actual scaling)."""
+        key_val_dict = {
+            "data_config.augmentation_config.geometric.scale_min": 1.0,
+            "data_config.augmentation_config.geometric.scale_max": 1.0,
+            "data_config.augmentation_config.geometric.affine_p": 1.0,
+        }
+
+        scale_p = key_val_dict.get("data_config.augmentation_config.geometric.scale_p")
+        scale_min = key_val_dict.get(
+            "data_config.augmentation_config.geometric.scale_min"
+        )
+        scale_max = key_val_dict.get(
+            "data_config.augmentation_config.geometric.scale_max"
+        )
+        affine_p = key_val_dict.get(
+            "data_config.augmentation_config.geometric.affine_p"
+        )
+
+        effective_scale_p = scale_p if scale_p is not None else affine_p
+
+        scale_enabled = (
+            effective_scale_p is not None
+            and effective_scale_p > 0
+            and scale_min is not None
+            and scale_max is not None
+            and scale_min != scale_max
+        )
+
+        # scale_min == scale_max means no actual scaling occurs
+        assert scale_enabled is False
+
+    def test_rotation_off_when_affine_p_zero(self):
+        """Rotation should be Off when affine_p is 0."""
+        key_val_dict = {
+            "data_config.augmentation_config.geometric.rotation_min": -180.0,
+            "data_config.augmentation_config.geometric.rotation_max": 180.0,
+            "data_config.augmentation_config.geometric.affine_p": 0.0,
+        }
+
+        rot_p = key_val_dict.get("data_config.augmentation_config.geometric.rotation_p")
+        affine_p = key_val_dict.get(
+            "data_config.augmentation_config.geometric.affine_p"
+        )
+
+        effective_rot_p = rot_p if rot_p is not None else affine_p
+
+        if effective_rot_p is None or effective_rot_p == 0:
+            preset = "Off"
+        else:
+            preset = "±180°"
+
+        assert preset == "Off"


### PR DESCRIPTION
## Summary

- Fix bug where augmentation settings (rotation, scale) were not populated in the training dialog when selecting baseline configs from training profiles
- Baseline configs use `affine_p` (legacy bundled augmentation) while the GUI only checked for `rotation_p`/`scale_p` (new independent parameters)
- Add `affine_p` fallback and reverse mapping for `_scale_enabled` checkbox

## Test plan

- [x] Run `uv run pytest tests/gui/learning/test_config_bindings.py` - all 72 tests pass
- [x] Manual testing: Open training dialog, select a baseline config, verify rotation shows "±180°" instead of "Off"
- [x] Manual testing: Verify scale checkbox is checked when loading configs with scale augmentation


🤖 Generated with [Claude Code](https://claude.ai/code)