### PR TITLE
Add ONNX export optional dependencies and documentation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -346,6 +346,52 @@ pip install "sleap[nn]" --extra-index-url https://download.pytorch.org/whl/cu128
 
 ---
 
+## Model Export (ONNX)
+
+To export trained models to ONNX format for deployment, you need additional dependencies.
+
+[:octicons-arrow-right-24: Learn more about exporting models](https://nn.sleap.ai/latest/guides/export/)
+
+### Install export dependencies
+
+If you installed SLEAP as a tool:
+
+```bash
+# Add ONNX export support (CPU runtime)
+uv tool install --python 3.13 "sleap[nn,nn-export]==1.6.0a3" --with "sleap-io==0.6.3" --with "sleap-nn==0.1.0a4" --prerelease allow --torch-backend auto
+
+# Add ONNX export support (GPU runtime - faster inference)
+uv tool install --python 3.13 "sleap[nn,nn-export-gpu]==1.6.0a3" --with "sleap-io==0.6.3" --with "sleap-nn==0.1.0a4" --prerelease allow --torch-backend auto
+```
+
+If you're using a development setup:
+
+```bash
+# CPU ONNX runtime
+uv sync --extra nn --extra nn-export
+
+# GPU ONNX runtime (for faster inference)
+uv sync --extra nn --extra nn-export-gpu
+```
+
+### TensorRT (Linux/Windows only)
+
+For NVIDIA TensorRT support on Linux or Windows:
+
+```bash
+# Development setup
+uv sync --extra nn-cuda128 --extra nn-tensorrt
+
+# Tool install
+uv tool install --python 3.13 "sleap[nn,nn-tensorrt]==1.6.0a3" --with "sleap-io==0.6.3" --with "sleap-nn==0.1.0a4" --prerelease allow --torch-backend cu128
+```
+
+!!! note
+    TensorRT is not supported on macOS.
+
+
+---
+
 ## Troubleshooting
 
 **First step:** Run `sleap doctor` and check the output for errors.

--- a/docs/reference/command-line-interfaces.md
+++ b/docs/reference/command-line-interfaces.md
@@ -142,9 +142,11 @@ sleap track -i video.mp4 -m models/centroid/ -m models/instance/ --tracking
 | Command | Description |
 |---------|-------------|
 | `sleap eval` | Evaluate model predictions against ground truth |
-| `sleap export` | Export model for deployment |
-| `sleap predict` | Run inference with exported model |
+| `sleap export` | Export model to ONNX for deployment |
+| `sleap predict` | Run inference with exported ONNX model |
 | `sleap system` | Show sleap-nn system information |
+
+[:octicons-arrow-right-24: Exporting models to ONNX](https://nn.sleap.ai/latest/guides/export/)
 
 [:octicons-arrow-right-24: Full sleap-nn CLI documentation](https://nn.sleap.ai/latest/reference/cli/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,51 @@ name = "pypi"
 url = "https://pypi.org/simple"
 explicit = true
 
+# Static metadata for TensorRT packages to avoid running their stub setup.py
+# during cross-platform lockfile generation (stubs fail on macOS).
+# See: https://github.com/astral-sh/uv/issues/13942
+#
+# We provide metadata for both cu12 and cu13 variants since:
+#   - Older torch-tensorrt versions depend directly on tensorrt-cu12
+#   - Newer torch-tensorrt versions use the tensorrt metapackage which depends on cu13
+#
+# The tensorrt metapackage metadata assumes cu13 (for tensorrt >=10.13).
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt"
+requires-dist = ["tensorrt-cu13"]
+
+# CUDA 12 variant packages (for older torch-tensorrt direct dependencies)
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu12"
+requires-dist = ["tensorrt-cu12-bindings", "tensorrt-cu12-libs"]
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu12-bindings"
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu12-libs"
+requires-dist = ["nvidia-cuda-runtime-cu12"]
+
+# CUDA 13 variant packages (for tensorrt >=10.13)
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu13"
+requires-dist = ["tensorrt-cu13-bindings", "tensorrt-cu13-libs"]
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu13-bindings"
+
+[[tool.uv.dependency-metadata]]
+name = "tensorrt-cu13-libs"
+requires-dist = ["nvidia-cuda-runtime-cu12"]
+
+# Common CUDA runtime dependency
+[[tool.uv.dependency-metadata]]
+name = "nvidia-cuda-runtime-cu12"
+
+[[tool.uv.dependency-metadata]]
+name = "nvidia-cuda-runtime"
+
 [tool.setuptools.packages.find]
 exclude = ["tests", "tests.*", "docs"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,21 @@ nn-cuda130 = [
     "sleap-nn[torch]>=0.1.0a4"
 ]
 
+# Export extras - self-contained with torch
+# Can be used alone (defaults to cu128) or combined with nn-cuda* for specific CUDA version
+nn-export = [
+    "sleap-nn[torch,export]>=0.1.0a4"
+]
+
+nn-export-gpu = [
+    "sleap-nn[torch,export-gpu]>=0.1.0a4"
+]
+
+# TensorRT - Linux/Windows only (not supported on macOS)
+nn-tensorrt = [
+    "sleap-nn[torch,tensorrt]>=0.1.0a4; sys_platform != 'darwin'"
+]
+
 [dependency-groups]
 # PEP 735: Dev-only dependencies (`dev` is installed automatically by `uv`)
 dev = [
@@ -136,6 +151,10 @@ conflicts = [
         { extra = "nn-cuda118" },
         { extra = "nn-cuda128" },
         { extra = "nn-cuda130" }
+    ],
+    [
+        { extra = "nn-export" },
+        { extra = "nn-export-gpu" }
     ]
 ]
 


### PR DESCRIPTION
## Summary
- Add `nn-export`, `nn-export-gpu`, and `nn-tensorrt` optional extras to `pyproject.toml` for ONNX model export functionality
- Add installation instructions for export dependencies to `docs/installation.md`
- Update CLI reference descriptions in `docs/reference/command-line-interfaces.md` to clarify ONNX export commands

## Test plan
- [ ] Verify `uv sync --extra nn --extra nn-export` installs correctly
- [ ] Verify `uv sync --extra nn --extra nn-export-gpu` installs correctly
- [ ] Verify docs build without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)