### PR TITLE
Rename `sleap export` to `sleap export-model`

### DIFF
--- a/docs/guides/migrating-to-sleap-1-5.md
+++ b/docs/guides/migrating-to-sleap-1-5.md
@@ -75,7 +75,7 @@ See [Instance Size Distribution](instance-size-distribution.md) for details.
 Export trained models to ONNX or TensorRT format for 3-6x faster inference:
 
 ```bash
-sleap export --model models/my_model --format onnx
+sleap export-model models/my_model --format onnx
 ```
 
 ### Additional Improvements

--- a/docs/reference/command-line-interfaces.md
+++ b/docs/reference/command-line-interfaces.md
@@ -27,7 +27,7 @@ Run `sleap --help` to see all available commands, or `sleap <command> --help` fo
 | [`sleap train`](#sleap-train) | Train pose estimation models |
 | [`sleap track`](#sleap-track) | Run inference and tracking |
 | [`sleap eval`](#other-neural-network-commands) | Evaluate predictions against ground truth |
-| [`sleap export`](#other-neural-network-commands) | Export model for deployment |
+| [`sleap export-model`](#other-neural-network-commands) | Export model for deployment |
 | [`sleap predict`](#other-neural-network-commands) | Run inference with exported model |
 | [`sleap system`](#other-neural-network-commands) | Show sleap-nn system information |
 
@@ -142,7 +142,7 @@ sleap track -i video.mp4 -m models/centroid/ -m models/instance/ --tracking
 | Command | Description |
 |---------|-------------|
 | `sleap eval` | Evaluate model predictions against ground truth |
-| `sleap export` | Export model to ONNX for deployment |
+| `sleap export-model` | Export model to ONNX for deployment |
 | `sleap predict` | Run inference with exported ONNX model |
 | `sleap system` | Show sleap-nn system information |
 

--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -179,7 +179,7 @@ click.rich_click.COMMAND_GROUPS = {
         {"name": "Application", "commands": ["label", "doctor"]},
         {
             "name": "Neural Network",
-            "commands": ["train", "track", "eval", "export", "predict", "system"],
+            "commands": ["train", "track", "eval", "export-model", "predict", "system"],
         },
         {"name": "Data Inspection", "commands": ["show", "filenames"]},
         {
@@ -1137,12 +1137,12 @@ if _SLEAP_NN_AVAILABLE:
     cli.add_command(wrap_nn_command(nn_train), name="train")
     cli.add_command(wrap_nn_command(nn_track), name="track")
     cli.add_command(wrap_nn_command(nn_eval), name="eval")
-    cli.add_command(wrap_nn_command(nn_export), name="export")
+    cli.add_command(wrap_nn_command(nn_export), name="export-model")
     cli.add_command(wrap_nn_command(nn_predict), name="predict")
     cli.add_command(wrap_nn_command(nn_system), name="system")
 else:
     # Register stub commands that show helpful error messages
-    for cmd_name in ["train", "track", "eval", "export", "predict", "system"]:
+    for cmd_name in ["train", "track", "eval", "export-model", "predict", "system"]:
         cli.add_command(_make_nn_stub(cmd_name), name=cmd_name)
 
 

--- a/sleap/nn_cli.py
+++ b/sleap/nn_cli.py
@@ -642,7 +642,7 @@ def export(
         sleap-nn-export /path/to/model -o exports/my_model --format both
         sleap-nn-export /path/to/centroid /path/to/instance -o exports/topdown
     """
-    _warn_deprecated("sleap-nn-export", "sleap export")
+    _warn_deprecated("sleap-nn-export", "sleap export-model")
 
     try:
         from sleap_nn.export.cli import export as sleap_nn_export


### PR DESCRIPTION
## Summary
- Rename the unified CLI command for model export from `sleap export` to `sleap export-model`
- The generic name "export" could conflict with future export functionality (data, configs, etc.)
- The legacy entry point `sleap-nn-export` remains unchanged for backwards compatibility

## Test plan
- [ ] Verify `sleap export-model --help` works
- [ ] Verify `sleap --help` shows `export-model` in the Neural Network section
- [ ] Verify legacy `sleap-nn-export` still works and shows deprecation warning pointing to `sleap export-model`

🤖 Generated with [Claude Code](https://claude.ai/code)