### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/sleap/version.py
+++ b/sleap/version.py
@@ -11,7 +11,7 @@ For example, if you set the version to X.Y.Z, then the tag should be "vX.Y.Z".
 Must be a semver string, "aN" should be appended for alpha releases.
 """
 
-__version__ = "1.6.0a3"
+__version__ = "1.6.0"
 
 
 def versions():


### PR DESCRIPTION
## Summary
- Bumps `sleap.__version__` from `1.6.0a3` to `1.6.0` for release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)