### PR TITLE
Fix training config save dialog bugs (#2602)

### DIFF
--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -595,7 +595,7 @@ class TrainingConfigFilesWidget(FieldComboWidget):
 
     def doFileSelection(self):
         """Shows file browser to add training profile for given model type."""
-        filters = ["JSON (*.json)", "YAML (*.yaml;*.yml)"]
+        filters = ["JSON (*.json)", "YAML (*.yaml *.yml)"]
         filename, _ = FileDialog.open(
             None,
             dir=None,

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1427,6 +1427,7 @@ class LearningDialog(QtWidgets.QDialog):
             config_info_list=config_info_list,
             inference_params=pipeline_form_data,
             items_for_inference=items_for_inference,
+            num_user_labeled_frames=len(self.labels.user_labeled_frames),
         )
 
     def export_package(self, output_path: Optional[str] = None, gui: bool = True):

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -773,8 +773,18 @@ def write_pipeline_files(
     config_info_list: List[ConfigFileInfo],
     inference_params: Dict[str, Any],
     items_for_inference: ItemsForInference,
+    num_user_labeled_frames: Optional[int] = None,
 ):
-    """Writes the config files and scripts for manually running pipeline."""
+    """Writes the config files and scripts for manually running pipeline.
+
+    Args:
+        output_dir: Directory to write the files to.
+        labels_filename: Path to the labels file.
+        config_info_list: List of ConfigFileInfo objects for each model.
+        inference_params: Dictionary of inference parameters.
+        items_for_inference: ItemsForInference object with inference targets.
+        num_user_labeled_frames: Number of user-labeled frames (for default run name).
+    """
 
     # Use absolute path for all files that aren't contained in the output dir.
     labels_filename = os.path.abspath(labels_filename)
@@ -794,13 +804,11 @@ def write_pipeline_files(
             cfg_run_name = OmegaConf.select(
                 cfg_info.config, "trainer_config.run_name", default=""
             )
-            # Append head_name to run_name if it exists and is valid
-            if cfg_run_name and cfg_run_name != "None":
-                cfg_info.config.trainer_config.run_name = (
-                    cfg_run_name + cfg_info.head_name
-                )
-            else:
-                cfg_info.config.trainer_config.run_name = cfg_info.head_name
+            # If user provided a custom run_name, preserve it as-is.
+            # If not, clear it so setup_new_run_folder will generate default
+            # with format: timestamp.head_name
+            if not cfg_run_name or cfg_run_name == "None":
+                cfg_info.config.trainer_config.run_name = None
 
     training_jobs = []
     for cfg_info in config_info_list:
@@ -819,7 +827,13 @@ def write_pipeline_files(
             # is the main reason we're setting it to the output directory rather
             # than just using normpath.
             # cfg_info.config.outputs.runs_folder = ""
-            ckpt_path = setup_new_run_folder(cfg_info.config)
+            # Build base_run_name: head_name.n=X (matches training behavior)
+            base_run_name = cfg_info.head_name
+            if num_user_labeled_frames is not None:
+                base_run_name = f"{cfg_info.head_name}.n={num_user_labeled_frames}"
+            ckpt_path = setup_new_run_folder(
+                cfg_info.config, base_run_name=base_run_name
+            )
             cfg_info.config.trainer_config.run_name = Path(ckpt_path).name
             cfg_info.config.trainer_config.ckpt_dir = Path(ckpt_path).parent.as_posix()
             # training.setup_new_run_folder(

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -324,10 +324,18 @@ def setup_new_run_folder(
     """
     run_path = None
     if config.trainer_config.save_ckpt:
-        # Generate fresh run name: YYMMDD_HHMMSS.{base_run_name}
-        run_name = get_timestamp()
-        if isinstance(base_run_name, str):
-            run_name = run_name + "." + base_run_name
+        # Check if user specified a custom run_name in the config
+        user_run_name = OmegaConf.select(
+            config, "trainer_config.run_name", default=None
+        )
+        if user_run_name and user_run_name not in ("", "None"):
+            # Use user-specified run_name
+            run_name = user_run_name
+        else:
+            # Generate fresh run name: YYMMDD_HHMMSS.{base_run_name}
+            run_name = get_timestamp()
+            if isinstance(base_run_name, str):
+                run_name = run_name + "." + base_run_name
 
         # Build run path (always use fresh name, don't prepend old run_name)
         run_path = (Path(config.trainer_config.ckpt_dir) / run_name).as_posix()


### PR DESCRIPTION
## Summary

- **Fix Run Name being ignored**: User-entered run names in the Training Configuration dialog were being overwritten with auto-generated timestamps. Modified `setup_new_run_folder()` to check for and preserve user-specified `run_name` values.

- **Fix YAML file picker not showing files**: The file filter used semicolon separator (`*.yaml;*.yml`) but Qt's QFileDialog expects space separator (`*.yaml *.yml`). This caused YAML files to not appear in the file browser when selecting a training config file.

Fixes #2602

## Test plan

- [ ] Open Training Configuration dialog
- [ ] Enter a custom run name in the "Run Name" field
- [ ] Click "Save configuration files..." and verify the saved YAML contains the custom run name
- [ ] Click the config dropdown and select "Select training config file..."
- [ ] Verify that `.yaml` and `.yml` files are now visible in the file picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)