### PR TITLE
Fix Linux Qt library conflicts with system/OpenCV-bundled Qt

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -41,6 +41,75 @@ SLEAP 1.5+ uses PyTorch, which bundles its own CUDA libraries. Your system CUDA 
 </details>
 
 
+## Display / GUI Issues
+
+<details class="plain" open markdown>
+<summary>SLEAP crashes on Linux with <code>ImportError: undefined symbol: _ZN14QObjectPrivateC2Ei, version Qt_6_PRIVATE_API</code></summary>
+
+This error occurs when the system has Qt 6 libraries (e.g., Debian 12 ships Qt 6.4) that conflict with the Qt libraries bundled inside PySide6. The dynamic linker loads the system's older `libQt6DBus.so.6` or `libQt6Core.so.6` instead of PySide6's bundled version, causing a symbol version mismatch.
+
+Common error messages:
+
+```
+ImportError: /usr/lib/x86_64-linux-gnu/libQt6DBus.so.6: undefined symbol: _ZN14QObjectPrivateC2Ei, version Qt_6_PRIVATE_API
+```
+
+**This is fixed automatically in SLEAP v1.6.1+.** On Linux, SLEAP now ensures PySide6's bundled Qt libraries and plugins are loaded before any system or conda-provided Qt libraries.
+
+If you're on an older version, you can work around it by prepending PySide6's Qt library path when launching SLEAP:
+
+```bash
+PYSIDE_QT=$("$(uv tool dir)/sleap/bin/python" -c "import os,PySide6;print(os.path.join(os.path.dirname(PySide6.__file__),'Qt'))") && \
+  LD_LIBRARY_PATH="$PYSIDE_QT/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+  QT_PLUGIN_PATH="$PYSIDE_QT/plugins" \
+  sleap
+```
+
+If you suspect the automatic fix is causing issues on your system (e.g., a native Linux desktop that was working before), you can disable it:
+
+```bash
+export SLEAP_SKIP_QT_FIX=1
+sleap
+```
+
+</details>
+
+<details class="plain" open markdown>
+<summary>SLEAP crashes with <code>Could not load the Qt platform plugin "xcb"</code></summary>
+
+This typically has two causes:
+
+**1. Missing `libxcb-cursor0`** (required since Qt 6.5):
+
+```bash
+sudo apt install libxcb-cursor0  # Debian/Ubuntu
+```
+
+**2. OpenCV's Qt plugins conflicting with PySide6's.** The error may mention a path like `.../cv2/qt/plugins`. This happens because `opencv-python` bundles its own Qt and its plugin path takes priority over PySide6's.
+
+SLEAP v1.6.1+ handles this automatically by setting `QT_PLUGIN_PATH` to PySide6's plugins on Linux. If you're on an older version, use the workaround in the entry above.
+
+</details>
+
+<details class="plain" open markdown>
+<summary>SLEAP GUI doesn't work over SSH / X11 forwarding</summary>
+
+When connecting to a remote Linux machine via SSH with X forwarding (`ssh -X` or `ssh -Y`), make sure:
+
+1. **X forwarding is enabled** on both client and server (`X11Forwarding yes` in `/etc/ssh/sshd_config`)
+2. **`DISPLAY` is set** — run `echo $DISPLAY` (should show something like `localhost:10.0`)
+3. **`libxcb-cursor0` is installed** on the remote machine (`sudo apt install libxcb-cursor0`)
+4. **Conda base is deactivated** if active — conda can inject conflicting Qt libraries:
+   ```bash
+   conda deactivate
+   conda config --set auto_activate_base false  # prevent future interference
+   ```
+
+If you still see Qt library errors, see the entries above. Running `sleap doctor` will report your environment details for further debugging.
+
+</details>
+
+
 ## Usage
 
 <details class="plain" open markdown>

--- a/docs/help.md
+++ b/docs/help.md
@@ -109,6 +109,43 @@ If you still see Qt library errors, see the entries above. Running `sleap doctor
 
 </details>
 
+<details class="plain" open markdown>
+<summary>Videos fail to load with <code>Could not open codec h264</code> or <code>Failed initializing scaling graph</code></summary>
+
+This can happen on Linux when OpenCV's video decoder picks up incompatible ffmpeg libraries. Common error messages:
+
+```
+[ERROR:0@70.376] global cap_ffmpeg_impl.hpp:1448 open Could not open codec h264, error: -11
+[ERROR:0@70.376] global cap_ffmpeg_impl.hpp:1456 open VIDEOIO/FFMPEG: Failed to initialize VideoCapture
+```
+
+Often preceded by many lines of:
+
+```
+[swscaler @ ...] Failed initializing scaling graph (Resource temporarily unavailable):
+  fmt:yuv420p csp:unknown prim:unknown trc:unknown -> fmt:bgr24 ...
+```
+
+And ultimately:
+
+```
+IndexError: Failed to read frame index 0.
+```
+
+**Fix:** Switch the video backend from OpenCV to imageio-ffmpeg:
+
+```bash
+sleap --video-backend ffmpeg
+```
+
+This persists to your preferences — all future launches will use the FFMPEG backend automatically. You can also use `pyav` as an alternative. To switch back:
+
+```bash
+sleap --video-backend opencv
+```
+
+</details>
+
 
 ## Usage
 

--- a/docs/reference/command-line-interfaces.md
+++ b/docs/reference/command-line-interfaces.md
@@ -66,6 +66,7 @@ sleap                        # Launch empty GUI
 sleap label                  # Same as above
 sleap my_project.slp         # Open existing project
 sleap label --reset          # Reset GUI preferences
+sleap --video-backend ffmpeg # Use imageio-ffmpeg for video
 ```
 
 **Options:**
@@ -76,6 +77,7 @@ sleap label --reset          # Reset GUI preferences
 | `--reset` | Reset GUI preferences to defaults |
 | `--no-usage-data` | Disable anonymous usage data collection |
 | `--nonnative` | Use non-native file dialogs |
+| `--video-backend` | Video backend plugin: `opencv`, `FFMPEG`, or `pyav`. Persists to preferences on use. |
 
 ---
 

--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -112,6 +112,16 @@ class DefaultGroup(click.RichGroup):
         # If no args and we have a default, insert it
         if not args and self.default_if_no_args and self.default_cmd_name:
             args.insert(0, self.default_cmd_name)
+        # If first arg is a flag (not a subcommand), route to default
+        # so e.g. `sleap --video-backend ffmpeg` works like
+        # `sleap label --video-backend ffmpeg`
+        if (
+            args
+            and args[0].startswith("--")
+            and self.default_cmd_name
+            and args[0] not in ("--help", "-h", "--version")
+        ):
+            args.insert(0, self.default_cmd_name)
         return super().parse_args(ctx, args)
 
     def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[click.Command]:

--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -333,6 +333,12 @@ def cli(ctx: click.Context) -> None:
     is_flag=True,
     help="Enable performance profiling.",
 )
+@click.option(
+    "--video-backend",
+    type=click.Choice(["opencv", "FFMPEG", "pyav"], case_sensitive=False),
+    default=None,
+    help="Video backend plugin. Overrides saved preference.",
+)
 def label(
     labels_path: Optional[str],
     verbose: bool,
@@ -340,6 +346,7 @@ def label(
     no_usage_data: bool,
     nonnative: bool,
     profiling: bool,
+    video_backend: Optional[str],
 ) -> None:
     """Launch the SLEAP labeling GUI.
 
@@ -365,6 +372,8 @@ def label(
         args.append("--nonnative")
     if profiling:
         args.append("--profiling")
+    if video_backend:
+        args.extend(["--video-backend", video_backend])
 
     # Import and call the existing GUI launcher
     from sleap.gui.app import main as gui_main

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1966,6 +1966,9 @@ def main(args: Optional[list] = None, labels: Optional[Labels] = None):
     # Apply video backend: CLI flag overrides saved preference
     import sleap_io as sio
 
+    if args.video_backend:
+        prefs["default video backend"] = args.video_backend
+        prefs.save()
     video_backend = args.video_backend or prefs["default video backend"]
     if video_backend:
         sio.set_default_video_plugin(video_backend)

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1928,6 +1928,12 @@ def create_sleap_label_parser():
         const=True,
         default=False,
     )
+    parser.add_argument(
+        "--video-backend",
+        help="Video backend plugin: opencv, FFMPEG, or pyav.",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -1956,6 +1962,13 @@ def main(args: Optional[list] = None, labels: Optional[Labels] = None):
 
     if args.nonnative:
         os.environ["USE_NON_NATIVE_FILE"] = "1"
+
+    # Apply video backend: CLI flag overrides saved preference
+    import sleap_io as sio
+
+    video_backend = args.video_backend or prefs["default video backend"]
+    if video_backend:
+        sio.set_default_video_plugin(video_backend)
 
     app = create_app()
 

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -62,10 +62,11 @@ if (
     os.execve(sys.executable, [sys.executable] + sys.argv, env)
 
 # Fix Linux Qt library conflicts with system/conda/OpenCV-bundled Qt.
-# PySide6 (pip) bundles Qt 6.x but the system (e.g. Debian 12 ships Qt 6.4) or OpenCV may
-# have incompatible Qt libraries that get loaded first. We prepend PySide6's bundled Qt lib
-# and plugin paths so the dynamic linker resolves all Qt symbols from the same version.
-# LD_LIBRARY_PATH is read at process startup, so we must re-exec like the macOS fix above.
+# PySide6 (pip) bundles Qt 6.x but the system (e.g. Debian 12 ships
+# Qt 6.4) or OpenCV may have incompatible Qt libraries that get loaded
+# first. We prepend PySide6's bundled Qt lib and plugin paths so the
+# dynamic linker resolves all Qt symbols from the same version.
+# LD_LIBRARY_PATH is read at process startup, so we must re-exec.
 # Set SLEAP_SKIP_QT_FIX=1 to disable this fix if it causes issues on your system.
 if (
     sys.platform.startswith("linux")

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -61,6 +61,31 @@ if (
     env["_SLEAP_DYLD_FIXED"] = "1"
     os.execve(sys.executable, [sys.executable] + sys.argv, env)
 
+# Fix Linux Qt library conflicts with system/conda/OpenCV-bundled Qt.
+# PySide6 (pip) bundles Qt 6.x but the system (e.g. Debian 12 ships Qt 6.4) or OpenCV may
+# have incompatible Qt libraries that get loaded first. We prepend PySide6's bundled Qt lib
+# and plugin paths so the dynamic linker resolves all Qt symbols from the same version.
+# LD_LIBRARY_PATH is read at process startup, so we must re-exec like the macOS fix above.
+# Set SLEAP_SKIP_QT_FIX=1 to disable this fix if it causes issues on your system.
+if (
+    sys.platform.startswith("linux")
+    and not os.environ.get("_SLEAP_LD_FIXED")
+    and not os.environ.get("SLEAP_SKIP_QT_FIX")
+):
+    import PySide6
+
+    pyside_qt = os.path.join(os.path.dirname(PySide6.__file__), "Qt")
+    pyside_qt_lib = os.path.join(pyside_qt, "lib")
+    pyside_qt_plugins = os.path.join(pyside_qt, "plugins")
+    ld_path = os.environ.get("LD_LIBRARY_PATH", "")
+    qt_plugin_path = os.environ.get("QT_PLUGIN_PATH", "")
+    if pyside_qt_lib not in ld_path or pyside_qt_plugins not in qt_plugin_path:
+        env = os.environ.copy()
+        env["LD_LIBRARY_PATH"] = pyside_qt_lib + ((":" + ld_path) if ld_path else "")
+        env["QT_PLUGIN_PATH"] = pyside_qt_plugins
+        env["_SLEAP_LD_FIXED"] = "1"
+        os.execve(sys.executable, [sys.executable] + sys.argv, env)
+
 import re
 from logging import getLogger
 from pathlib import Path

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -42,6 +42,8 @@ class Preferences(object):
         "training num workers": 0,
         "training num devices": None,  # None = auto-detect
         "training accelerator": "auto",
+        # Video backend: None = auto-detect (opencv → FFMPEG → pyav)
+        "default video backend": None,
     }
     _filename = "preferences.yaml"
 


### PR DESCRIPTION
## Summary

- Fix Linux Qt library conflicts: prepend PySide6's bundled Qt lib/plugin paths to `LD_LIBRARY_PATH` and `QT_PLUGIN_PATH` at GUI startup, then re-exec the process
- Add `--video-backend` CLI option to switch video backends (`opencv`, `FFMPEG`, `pyav`), with persistent preference support
- Add Display/GUI troubleshooting section to help docs
- Fix `DefaultGroup` flag routing so `sleap --video-backend ffmpeg` works

## Problem

**Qt library mismatch:** On Linux systems with system Qt 6 packages (e.g., Debian 12 ships Qt 6.4.2), launching the SLEAP GUI fails with:

```
ImportError: /usr/lib/x86_64-linux-gnu/libQt6DBus.so.6: undefined symbol: _ZN14QObjectPrivateC2Ei, version Qt_6_PRIVATE_API
```

PySide6 6.10 bundles Qt 6.10, but the dynamic linker finds the system's older Qt libraries first. Additionally, `opencv-python` bundles its own Qt plugins which hijack `QT_PLUGIN_PATH`. Common on HPC clusters with SSH/X11 forwarding.

**h264 codec failure:** After the Qt library path fix, OpenCV's ffmpeg backend can fail to decode h264 video due to picking up wrong ffmpeg libraries from the modified `LD_LIBRARY_PATH`.

## Changes

### Qt library fix (`sleap/gui/app.py`)
- On Linux, detect and prepend PySide6's bundled `Qt/lib/` to `LD_LIBRARY_PATH` and override `QT_PLUGIN_PATH` with PySide6's `Qt/plugins/`
- Uses `os.execve` to restart with corrected paths (same pattern as existing macOS `DYLD_LIBRARY_PATH` fix)
- Always applies on Linux, opt-out with `SLEAP_SKIP_QT_FIX=1`

### Video backend option (`sleap/cli.py`, `sleap/gui/app.py`, `sleap/prefs.py`)
- `sleap label --video-backend ffmpeg` switches to imageio-ffmpeg backend
- Persists to `preferences.yaml` on use — subsequent launches remember the setting
- Priority: CLI flag > saved preference > auto-detect (opencv → FFMPEG → pyav)

### CLI routing fix (`sleap/cli.py`)
- `DefaultGroup.parse_args` now detects flags as the first argument and inserts the default subcommand, so `sleap --video-backend ffmpeg` works the same as `sleap label --video-backend ffmpeg`

### Docs (`docs/help.md`, `docs/reference/command-line-interfaces.md`)
- New "Display / GUI Issues" troubleshooting section with entries for Qt library mismatch, xcb plugin failures, and SSH/X11 forwarding
- Updated CLI reference with `--video-backend` option

## Test plan

- [x] Tested Qt fix on Debian 12 (system Qt 6.4.2, PySide6 6.10.2) over SSH/X forwarding
- [x] Tested `--video-backend ffmpeg` resolves h264 codec failure
- [x] Verified `sleap --video-backend ffmpeg` routes correctly via DefaultGroup
- [x] Verified `sleap --help`, `sleap --version`, `sleap doctor` unaffected
- [x] Verify no regression on native Linux desktop
- [ ] Verify `SLEAP_SKIP_QT_FIX=1` disables the Qt fix
- [ ] Verify macOS and Windows are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)