### PR TITLE
Bump version to v1.6.1

### DIFF
--- a/sleap/version.py
+++ b/sleap/version.py
@@ -11,7 +11,7 @@ For example, if you set the version to X.Y.Z, then the tag should be "vX.Y.Z".
 Must be a semver string, "aN" should be appended for alpha releases.
 """
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"
 
 
 def versions():


### PR DESCRIPTION
## Summary
- Bumps `sleap.__version__` from `1.6.0` to `1.6.1` in preparation for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)