### PR TITLE
Fix anchor part sync for top-down-id pipeline

### DIFF
--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -288,6 +288,16 @@ model:
     name: model_config.head_configs.bottomup.pafs.loss_weight
     type: double
   multi_class_topdown:
+  - default: null
+    help: Text name of a body part (node) to use as the anchor point. If None, the
+      midpoint of the bounding box of all visible instance points will be used as
+      the anchor. The bounding box midpoint will also be used if the anchor part is
+      specified but not visible in the instance. Setting a reliable anchor point can
+      significantly improve topdown model accuracy as they benefit from a consistent
+      geometry of the body parts relative to the center of the image.
+    label: Anchor Part
+    name: model_config.head_configs.multi_class_topdown.confmaps.anchor_part
+    type: optional_list
   - default: 1.5
     help: Spread of the Gaussian distribution of the confidence maps as a scalar float.
       Smaller values are more precise but may be difficult to learn as they have a

--- a/sleap/gui/dialogs/formbuilder.py
+++ b/sleap/gui/dialogs/formbuilder.py
@@ -302,13 +302,8 @@ class FormBuilderLayout(QtWidgets.QFormLayout):
         """
         widgets = self.fields
         for name, val in data.items():
-            # print(f"Attempting to set {name} to {val}")
             if name in widgets:
-                # print(f"set {name} to {val} ({type(val)})")
                 self.set_widget_value(widgets[name], val)
-            else:
-                # print(f"cannot set {name} for {widgets}")
-                pass
 
         for stacked_widget in self.stacked:
             stacked_widget.set_form_data(data)

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -680,11 +680,14 @@ class LearningDialog(QtWidgets.QDialog):
         set_anchor = False
 
         # Map pipeline names to their anchor_part config keys
+        _ci = "model_config.head_configs.centered_instance.confmaps.anchor_part"
+        _mct = "model_config.head_configs.multi_class_topdown.confmaps.anchor_part"
+        _cen = "model_config.head_configs.centroid.confmaps.anchor_part"
         pipeline_anchor_keys = {
-            "top-down": "model_config.head_configs.centered_instance.confmaps.anchor_part",
-            "top-down-id": "model_config.head_configs.multi_class_topdown.confmaps.anchor_part",
-            "bottom-up": "model_config.head_configs.centroid.confmaps.anchor_part",
-            "bottom-up-id": "model_config.head_configs.centroid.confmaps.anchor_part",
+            "top-down": _ci,
+            "top-down-id": _mct,
+            "bottom-up": _cen,
+            "bottom-up-id": _cen,
         }
 
         # Determine the current pipeline's anchor key

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -679,27 +679,34 @@ class LearningDialog(QtWidgets.QDialog):
         anchor_part = None
         set_anchor = False
 
-        if "model_config.head_configs.centroid.confmaps.anchor_part" in source_data:
-            anchor_part = source_data[
-                "model_config.head_configs.centroid.confmaps.anchor_part"
-            ]
+        # Map pipeline names to their anchor_part config keys
+        pipeline_anchor_keys = {
+            "top-down": "model_config.head_configs.centered_instance.confmaps.anchor_part",
+            "top-down-id": "model_config.head_configs.multi_class_topdown.confmaps.anchor_part",
+            "bottom-up": "model_config.head_configs.centroid.confmaps.anchor_part",
+            "bottom-up-id": "model_config.head_configs.centroid.confmaps.anchor_part",
+        }
+
+        # Determine the current pipeline's anchor key
+        current_pipeline = source_data.get("_pipeline", "")
+        current_anchor_key = pipeline_anchor_keys.get(current_pipeline)
+
+        # First, try to get the anchor_part from the current pipeline's key
+        if current_anchor_key and current_anchor_key in source_data:
+            anchor_part = source_data[current_anchor_key]
             set_anchor = True
-        elif (
-            "model_config.head_configs.centered_instance.confmaps.anchor_part"
-            in source_data
-        ):
-            anchor_part = source_data[
-                "model_config.head_configs.centered_instance.confmaps.anchor_part"
+        else:
+            # Fallback: check all anchor keys (for head tab changes, etc.)
+            anchor_keys = [
+                "model_config.head_configs.centroid.confmaps.anchor_part",
+                "model_config.head_configs.centered_instance.confmaps.anchor_part",
+                "model_config.head_configs.multi_class_topdown.confmaps.anchor_part",
             ]
-            set_anchor = True
-        elif (
-            "model_config.head_configs.multi_class_topdown.confmaps.anchor_part"
-            in source_data
-        ):
-            anchor_part = source_data[
-                "model_config.head_configs.multi_class_topdown.confmaps.anchor_part"
-            ]
-            set_anchor = True
+            for key in anchor_keys:
+                if key in source_data:
+                    anchor_part = source_data[key]
+                    set_anchor = True
+                    break
 
         # Use None instead of empty string/list
         anchor_part = anchor_part or None


### PR DESCRIPTION
## Summary

Fixes the anchor_part selection bug for the `top-down-id` pipeline reported in #2602.

**Root cause:** Two issues were causing the anchor_part to not sync correctly:

1. The `multi_class_topdown` head type was missing the `anchor_part` field in `training_editor_form.yaml`, so the value was silently ignored when syncing to head tabs.

2. `adjust_data_to_update_other_tabs()` checked anchor keys in a fixed order and used the first one found, even if it was from a different pipeline with a stale value.

**Changes:**
- Added `anchor_part` field to `multi_class_topdown` in `training_editor_form.yaml`
- Fixed `adjust_data_to_update_other_tabs()` to use the current pipeline's anchor key based on `_pipeline` in the source data
- Cleaned up old commented debug code in `formbuilder.py`

## Test plan

- [x] Manual testing: Set anchor part on top-down pipeline, switch to top-down-id, verify value syncs
- [x] Manual testing: Set anchor part on top-down-id pipeline, verify it syncs to head tabs
- [x] Manual testing: Switch between pipelines and verify correct anchor values are used
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)