### PR TITLE
Fix Hydra override parsing error in exported train-script.sh

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -864,11 +864,12 @@ def write_pipeline_files(
                 )
 
                 # Add a line to the script for training this model
+                # Quote values to handle special characters in Hydra overrides
                 train_script += (
                     f"sleap train --config-name {new_cfg_filename} "
                     f"--config-dir . "
-                    f"trainer_config.ckpt_dir={Path(ckpt_path).parent.as_posix()} "
-                    f"trainer_config.run_name={Path(ckpt_path).name} "
+                    f"trainer_config.ckpt_dir='{Path(ckpt_path).parent.as_posix()}' "
+                    f"trainer_config.run_name='{Path(ckpt_path).name}' "
                     "\n"
                 )
 


### PR DESCRIPTION
## Summary
- Quote `trainer_config.ckpt_dir` and `trainer_config.run_name` values in the generated `train-script.sh` to handle special characters properly
- This fixes `OverrideParseException` errors when running exported training packages on SLURM clusters

Fixes #2611

## Test plan
- [ ] Export a training package from the GUI
- [ ] Verify the generated `train-script.sh` has quoted values for Hydra overrides
- [ ] Run the exported script on a SLURM cluster to confirm it no longer throws `OverrideParseException`

🤖 Generated with [Claude Code](https://claude.ai/code)