### PR TITLE
Bump version to 1.6.2 and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "seaborn",
     "requests",
     "matplotlib",
-    "sleap-io[all]>=0.6.4,<0.7.0",
+    "sleap-io[all]>=0.6.5,<0.7.0",
 ]
 
 [tool.setuptools.dynamic]
@@ -66,38 +66,38 @@ jupyter = [
 ]
 
 nn = [
-    "sleap-nn[torch]>=0.1.0"
+    "sleap-nn[torch]>=0.1.2"
 ]
 
 nn-cpu = [
-    "sleap-nn[torch]>=0.1.0"
+    "sleap-nn[torch]>=0.1.2"
 ]
 
 nn-cuda128 = [
-    "sleap-nn[torch]>=0.1.0"
+    "sleap-nn[torch]>=0.1.2"
 ]
 
 nn-cuda118 = [
-    "sleap-nn[torch]>=0.1.0"
+    "sleap-nn[torch]>=0.1.2"
 ]
 
 nn-cuda130 = [
-    "sleap-nn[torch]>=0.1.0"
+    "sleap-nn[torch]>=0.1.2"
 ]
 
 # Export extras - self-contained with torch
 # Can be used alone (defaults to cu128) or combined with nn-cuda* for specific CUDA version
 nn-export = [
-    "sleap-nn[torch,export]>=0.1.0"
+    "sleap-nn[torch,export]>=0.1.2"
 ]
 
 nn-export-gpu = [
-    "sleap-nn[torch,export-gpu]>=0.1.0"
+    "sleap-nn[torch,export-gpu]>=0.1.2"
 ]
 
 # TensorRT - Linux/Windows only (not supported on macOS)
 nn-tensorrt = [
-    "sleap-nn[torch,tensorrt]>=0.1.0; sys_platform != 'darwin'"
+    "sleap-nn[torch,tensorrt]>=0.1.2; sys_platform != 'darwin'"
 ]
 
 [dependency-groups]

--- a/sleap/version.py
+++ b/sleap/version.py
@@ -11,7 +11,7 @@ For example, if you set the version to X.Y.Z, then the tag should be "vX.Y.Z".
 Must be a semver string, "aN" should be appended for alpha releases.
 """
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 
 
 def versions():


### PR DESCRIPTION
## Summary
- Bump SLEAP version from 1.6.1 to 1.6.2
- Update sleap-io minimum version from 0.6.4 to 0.6.5
- Update sleap-nn minimum version from 0.1.0 to 0.1.2

## Changes Made
- `sleap/version.py`: Updated `__version__` to "1.6.2"
- `pyproject.toml`: Updated dependency version constraints:
  - `sleap-io[all]>=0.6.5,<0.7.0`
  - `sleap-nn[torch]>=0.1.2` (all nn-* extras)

## Dependency Updates

### sleap-io 0.6.4 → 0.6.5
See [sleap-io v0.6.5 release notes](https://github.com/talmolab/sleap-io/releases/tag/v0.6.5)

### sleap-nn 0.1.0 → 0.1.2
See [sleap-nn v0.1.2 release notes](https://github.com/talmolab/sleap-nn/releases/tag/v0.1.2)

## Testing
- Version bump is a minimal change
- CI will verify dependencies resolve correctly

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)