### PR TITLE
Fix incorrect intensity augmentation defaults in training profiles

### DIFF
--- a/sleap/training_profiles/baseline.centroid.yaml
+++ b/sleap/training_profiles/baseline.centroid.yaml
@@ -21,16 +21,16 @@ data_config:
   augmentation_config:
     intensity:
       uniform_noise_min: 0.0
-      uniform_noise_max: 1.0
+      uniform_noise_max: 0.04
       uniform_noise_p: 0.0
-      gaussian_noise_mean: 5.0
-      gaussian_noise_std: 1.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
       gaussian_noise_p: 0.0
-      contrast_min: 0.5
-      contrast_max: 2.0
+      contrast_min: 0.9
+      contrast_max: 1.1
       contrast_p: 0.0
-      brightness_min: 0.0
-      brightness_max: 2.0
+      brightness_min: 0.9
+      brightness_max: 1.1
       brightness_p: 0.0
     geometric:
       rotation_min: -180.0

--- a/sleap/training_profiles/baseline.multi_class_bottomup.yaml
+++ b/sleap/training_profiles/baseline.multi_class_bottomup.yaml
@@ -21,10 +21,10 @@ data_config:
   augmentation_config:
     intensity:
       uniform_noise_min: 0.0
-      uniform_noise_max: 1.0
+      uniform_noise_max: 0.04
       uniform_noise_p: 0.0
-      gaussian_noise_mean: 5.0
-      gaussian_noise_std: 1.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
       gaussian_noise_p: 0.0
       contrast_min: 0.9
       contrast_max: 1.1

--- a/sleap/training_profiles/baseline.multi_class_topdown.yaml
+++ b/sleap/training_profiles/baseline.multi_class_topdown.yaml
@@ -21,10 +21,10 @@ data_config:
   augmentation_config:
     intensity:
       uniform_noise_min: 0.0
-      uniform_noise_max: 1.0
+      uniform_noise_max: 0.04
       uniform_noise_p: 0.0
-      gaussian_noise_mean: 5.0
-      gaussian_noise_std: 1.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
       gaussian_noise_p: 0.0
       contrast_min: 0.9
       contrast_max: 1.1

--- a/sleap/training_profiles/baseline_large_rf.bottomup.yaml
+++ b/sleap/training_profiles/baseline_large_rf.bottomup.yaml
@@ -21,16 +21,16 @@ data_config:
   augmentation_config:
     intensity:
       uniform_noise_min: 0.0
-      uniform_noise_max: 1.0
+      uniform_noise_max: 0.04
       uniform_noise_p: 0.0
-      gaussian_noise_mean: 5.0
-      gaussian_noise_std: 1.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
       gaussian_noise_p: 0.0
-      contrast_min: 0.5
-      contrast_max: 2.0
+      contrast_min: 0.9
+      contrast_max: 1.1
       contrast_p: 0.0
-      brightness_min: 0.0
-      brightness_max: 2.0
+      brightness_min: 0.9
+      brightness_max: 1.1
       brightness_p: 0.0
     geometric:
       rotation_min: -180.0

--- a/sleap/training_profiles/baseline_large_rf.single.yaml
+++ b/sleap/training_profiles/baseline_large_rf.single.yaml
@@ -21,16 +21,16 @@ data_config:
   augmentation_config:
     intensity:
       uniform_noise_min: 0.0
-      uniform_noise_max: 1.0
+      uniform_noise_max: 0.04
       uniform_noise_p: 0.0
-      gaussian_noise_mean: 5.0
-      gaussian_noise_std: 1.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
       gaussian_noise_p: 0.0
-      contrast_min: 0.5
-      contrast_max: 2.0
+      contrast_min: 0.9
+      contrast_max: 1.1
       contrast_p: 0.0
-      brightness_min: 0.0
-      brightness_max: 2.0
+      brightness_min: 0.9
+      brightness_max: 1.1
       brightness_p: 0.0
     geometric:
       rotation_min: -180.0

--- a/sleap/training_profiles/baseline_large_rf.topdown.yaml
+++ b/sleap/training_profiles/baseline_large_rf.topdown.yaml
@@ -21,16 +21,16 @@ data_config:
   augmentation_config:
     intensity:
       uniform_noise_min: 0.0
-      uniform_noise_max: 1.0
+      uniform_noise_max: 0.04
       uniform_noise_p: 0.0
-      gaussian_noise_mean: 5.0
-      gaussian_noise_std: 1.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
       gaussian_noise_p: 0.0
-      contrast_min: 0.5
-      contrast_max: 2.0
+      contrast_min: 0.9
+      contrast_max: 1.1
       contrast_p: 0.0
-      brightness_min: 0.0
-      brightness_max: 2.0
+      brightness_min: 0.9
+      brightness_max: 1.1
       brightness_p: 0.0
     geometric:
       rotation_min: -180.0

--- a/sleap/training_profiles/baseline_medium_rf.bottomup.yaml
+++ b/sleap/training_profiles/baseline_medium_rf.bottomup.yaml
@@ -21,16 +21,16 @@ data_config:
   augmentation_config:
     intensity:
       uniform_noise_min: 0.0
-      uniform_noise_max: 1.0
+      uniform_noise_max: 0.04
       uniform_noise_p: 0.0
-      gaussian_noise_mean: 5.0
-      gaussian_noise_std: 1.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
       gaussian_noise_p: 0.0
-      contrast_min: 0.5
-      contrast_max: 2.0
+      contrast_min: 0.9
+      contrast_max: 1.1
       contrast_p: 0.0
-      brightness_min: 0.0
-      brightness_max: 2.0
+      brightness_min: 0.9
+      brightness_max: 1.1
       brightness_p: 0.0
     geometric:
       rotation_min: -180.0

--- a/sleap/training_profiles/baseline_medium_rf.single.yaml
+++ b/sleap/training_profiles/baseline_medium_rf.single.yaml
@@ -21,16 +21,16 @@ data_config:
   augmentation_config:
     intensity:
       uniform_noise_min: 0.0
-      uniform_noise_max: 1.0
+      uniform_noise_max: 0.04
       uniform_noise_p: 0.0
-      gaussian_noise_mean: 5.0
-      gaussian_noise_std: 1.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
       gaussian_noise_p: 0.0
-      contrast_min: 0.5
-      contrast_max: 2.0
+      contrast_min: 0.9
+      contrast_max: 1.1
       contrast_p: 0.0
-      brightness_min: 0.0
-      brightness_max: 2.0
+      brightness_min: 0.9
+      brightness_max: 1.1
       brightness_p: 0.0
     geometric:
       rotation_min: -180.0

--- a/sleap/training_profiles/baseline_medium_rf.topdown.yaml
+++ b/sleap/training_profiles/baseline_medium_rf.topdown.yaml
@@ -21,16 +21,16 @@ data_config:
   augmentation_config:
     intensity:
       uniform_noise_min: 0.0
-      uniform_noise_max: 1.0
+      uniform_noise_max: 0.04
       uniform_noise_p: 0.0
-      gaussian_noise_mean: 5.0
-      gaussian_noise_std: 1.0
+      gaussian_noise_mean: 0.0
+      gaussian_noise_std: 0.02
       gaussian_noise_p: 0.0
-      contrast_min: 0.5
-      contrast_max: 2.0
+      contrast_min: 0.9
+      contrast_max: 1.1
       contrast_p: 0.0
-      brightness_min: 0.0
-      brightness_max: 2.0
+      brightness_min: 0.9
+      brightness_max: 1.1
       brightness_p: 0.0
     geometric:
       rotation_min: -180.0


### PR DESCRIPTION
## Summary
- Fixed legacy/inconsistent intensity augmentation default values in all 9 training profile YAML files
- Standardized to match sleap-nn PR [#485](https://github.com/talmolab/sleap-nn/pull/485)

## Changes Made
Updated all training profiles in `sleap/training_profiles/`:

| Parameter | Old | New | Reason |
|-----------|-----|-----|--------|
| `gaussian_noise_mean` | 5.0 | 0.0 | Zero-mean noise is standard; 5.0 × 255 = 1275 was outside uint8 range |
| `gaussian_noise_std` | 1.0 | 0.02 | 1.0 × 255 = 255 was full pixel range; 0.02 × 255 ≈ 5 is subtle |
| `uniform_noise_max` | 1.0 | 0.04 | 1.0 × 255 = 255 was full range; 0.04 × 255 ≈ 10 is subtle |
| `contrast_min` | 0.5 | 0.9 | Standardized to conservative range |
| `contrast_max` | 2.0 | 1.1 | Standardized to conservative range |
| `brightness_min` | 0.0 | 0.9 | 0.0 would make images black; standardized |
| `brightness_max` | 2.0 | 1.1 | Standardized to conservative range |

Files changed:
- `baseline.centroid.yaml`
- `baseline.multi_class_bottomup.yaml`
- `baseline.multi_class_topdown.yaml`
- `baseline_large_rf.bottomup.yaml`
- `baseline_large_rf.single.yaml`
- `baseline_large_rf.topdown.yaml`
- `baseline_medium_rf.bottomup.yaml`
- `baseline_medium_rf.single.yaml`
- `baseline_medium_rf.topdown.yaml`

## Technical Details
The sleap-nn augmentation code multiplies these values by 255 internally. The old values would produce unusable results if augmentations were enabled:
- `gaussian_noise_mean=5.0` → 5.0 × 255 = 1275 (completely washed out)
- `brightness_min=0.0` → completely black images
- `uniform_noise_max=1.0` → 255 pixel noise (full range)

## Impact
Low - all `*_p` probability parameters default to `0.0`, so these augmentations are disabled by default. This bug only affects users who manually enable intensity augmentations.

## Testing
- No tests required - config-only change
- Matches sleap-nn PR talmolab/sleap-nn#485

## Related Issues
Fixes #2643

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)