### PR TITLE
fix: Add model type suffix to custom run_name for top-down training

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -332,10 +332,13 @@ def setup_new_run_folder(
             # Use user-specified run_name
             run_name = user_run_name
         else:
-            # Generate fresh run name: YYMMDD_HHMMSS.{base_run_name}
+            # Generate fresh run name: YYMMDD_HHMMSS
             run_name = get_timestamp()
-            if isinstance(base_run_name, str):
-                run_name = run_name + "." + base_run_name
+
+        # Always append base_run_name suffix (contains model type like "centroid.n=10")
+        # This ensures unique names for multi-model pipelines like top-down
+        if isinstance(base_run_name, str):
+            run_name = run_name + "." + base_run_name
 
         # Build run path (always use fresh name, don't prepend old run_name)
         run_path = (Path(config.trainer_config.ckpt_dir) / run_name).as_posix()


### PR DESCRIPTION
## Summary
- Fixes a bug where top-down training with a custom run_name would save both centroid and centered_instance models to the same folder, causing inference errors
- The model type suffix (e.g., `.centroid.n=42`) is now always appended to the run folder name

## Problem
When training a top-down model from the GUI with a custom `run_name`:
- **Before**: Both models saved to `models/my_model/` (collision!)
- **After**: Models saved to `models/my_model.centroid.n=42/` and `models/my_model.centered_instance.n=42/`

This caused inference to fail because it expected two separate model folders but found only one (the second model overwrote the first).

## Changes Made
- Modified `setup_new_run_folder()` in `sleap/gui/learning/runners.py` to always append the `base_run_name` suffix, even when a user provides a custom run_name
- The suffix was previously only added for auto-generated (timestamp-based) names

## Code Change
```python
# Before (buggy): suffix only added for auto-generated names
if user_run_name:
    run_name = user_run_name  # base_run_name ignored!
else:
    run_name = get_timestamp()
    if isinstance(base_run_name, str):
        run_name = run_name + "." + base_run_name

# After (fixed): suffix always added
if user_run_name:
    run_name = user_run_name
else:
    run_name = get_timestamp()

if isinstance(base_run_name, str):  # Always append
    run_name = run_name + "." + base_run_name
```

## Impact Analysis
Verified this change does NOT break other workflows:
- **Timestamp parsing**: Regex uses non-greedy `.*?`, works with any prefix
- **Resume training**: Uses full path from config, doesn't parse folder names
- **Config discovery**: Extracts metadata from config content, not folder names
- **Inference**: Passes model paths directly, no folder name parsing
- **CLI training**: Uses separate code path, unaffected

## Testing
- Syntax verified with `python -m py_compile`
- Logic tested with 5 test cases covering:
  - User run_name + centroid suffix
  - User run_name + centered_instance suffix  
  - Auto-generated name (no user run_name)
  - Single model pipelines (bottomup)
  - No base_run_name (edge case)

## Applies To
- Top-down pipeline (centroid + centered_instance)
- Top-down-id pipeline (centroid + multi_class_topdown)
- Bottom-up-id pipeline (single model, but suffix still added for consistency)
- Single/Bottom-up pipelines (single model, suffix added for consistency)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)