### PR TITLE
fix: Multi-GPU training from GUI on Windows/macOS

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -3,6 +3,7 @@
 import abc
 import attr
 import os
+import sys
 from omegaconf import OmegaConf
 from copy import deepcopy
 import psutil
@@ -1298,8 +1299,14 @@ def train_subprocess(
             OmegaConf.save(cfg, (Path(temp_dir) / f"{cfg_file_name}.yaml").as_posix())
 
             # Build CLI arguments for training
+            # Use `python -m` invocation instead of entry point script to ensure
+            # __main__.__spec__ is set. This is required for PyTorch Lightning's
+            # DDP multi-GPU training on Windows/macOS where multiprocessing uses
+            # "spawn" and needs to know what module to re-import in child processes.
             cli_args = [
-                "sleap",
+                sys.executable,
+                "-m",
+                "sleap.cli",
                 "train",
                 "--config-name",
                 f"{cfg_file_name}",


### PR DESCRIPTION
## Summary

- Fixes multi-GPU training failing when launched from the GUI on Windows and macOS
- Changes subprocess invocation from entry point script (`sleap train`) to module invocation (`python -m sleap.cli train`)

## Problem

When training with 2+ GPUs from the GUI, PyTorch Lightning's DDP strategy spawns child processes. On Windows and macOS (Python 3.8+), multiprocessing uses "spawn" instead of "fork", which requires `__main__.__spec__` to know what module to re-import in child processes.

Entry point scripts (like `sleap.exe`) don't set `__main__.__spec__`, causing:
```
ValueError: __main__.__spec__ is None
```

## Solution

Change the subprocess invocation from:
```python
["sleap", "train", ...]
```
to:
```python
[sys.executable, "-m", "sleap.cli", "train", ...]
```

This ensures `__main__.__spec__` is properly set, allowing DDP to spawn worker processes correctly.

## Test plan

- [ ] Test multi-GPU training from GUI on Windows
- [ ] Test multi-GPU training from GUI on macOS  
- [ ] Test single-GPU training still works on all platforms
- [ ] Test training from CLI still works

Fixes #2656

🤖 Generated with [Claude Code](https://claude.com/claude-code)