### PR TITLE
fix: Handle ImageVideo list filenames in export and replace video dialogs

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -2775,15 +2775,16 @@ class ReplaceVideo(EditCommand):
                 if last_lf_frame > last_vid_frame:
                     # ImageVideo backends return a list[str] for filename; use the
                     # first path as the representative name for display.
-                    current_video_filename = (
+                    cur_fn = (
                         video.filename[0]
                         if isinstance(video.filename, list)
                         else video.filename
                     )
+                    cur_name = Path(cur_fn).name
                     message = (
                         "<p><strong>Warning:</strong> Replacing this video will "
                         f"remove {len(lfs)} labeled frames.</p>"
-                        f"<p><em>Current video</em>: <b>{Path(current_video_filename).name}</b>"
+                        f"<p><em>Current video</em>: <b>{cur_name}</b>"
                         f" (last label at frame {last_lf_frame})<br>"
                         f"<em>Replacement video</em>: <b>{Path(path).name}"
                         f"</b> ({last_vid_frame} frames)</p>"

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1227,7 +1227,14 @@ class ExportAnalysisFile(AppCommand):
         for video in videos:
             # Create the filename
             video_idx = labels.videos.index(video)
-            vn = Path(video.filename)
+            # ImageVideo backends return a list[str] for filename; use the first
+            # path as the representative name for output file naming.
+            video_filename = (
+                video.filename[0]
+                if isinstance(video.filename, list)
+                else video.filename
+            )
+            vn = Path(video_filename)
             default_name = str(
                 Path(
                     dirname,
@@ -2727,7 +2734,14 @@ class ReplaceVideo(EditCommand):
             import_params = import_item["params"]
 
             # TODO: Will need to create a new backend if import has different extension.
-            if Path(video.filename).suffix != Path(import_params["filename"]).suffix:
+            # ImageVideo backends return a list[str] for filename; use the first path
+            # as the representative name for the extension check.
+            video_filename = (
+                video.filename[0]
+                if isinstance(video.filename, list)
+                else video.filename
+            )
+            if Path(video_filename).suffix != Path(import_params["filename"]).suffix:
                 raise TypeError(
                     "Importing videos with different extensions is not supported."
                 )
@@ -2759,10 +2773,17 @@ class ReplaceVideo(EditCommand):
 
                 # Message to warn users that labels will be removed if proceed
                 if last_lf_frame > last_vid_frame:
+                    # ImageVideo backends return a list[str] for filename; use the
+                    # first path as the representative name for display.
+                    current_video_filename = (
+                        video.filename[0]
+                        if isinstance(video.filename, list)
+                        else video.filename
+                    )
                     message = (
                         "<p><strong>Warning:</strong> Replacing this video will "
                         f"remove {len(lfs)} labeled frames.</p>"
-                        f"<p><em>Current video</em>: <b>{Path(video.filename).name}</b>"
+                        f"<p><em>Current video</em>: <b>{Path(current_video_filename).name}</b>"
                         f" (last label at frame {last_lf_frame})<br>"
                         f"<em>Replacement video</em>: <b>{Path(path).name}"
                         f"</b> ({last_vid_frame} frames)</p>"
@@ -2779,8 +2800,13 @@ class ReplaceVideo(EditCommand):
             ).exec_()
             return False
 
-        # Select the videos we want to swap
-        old_paths = [video.filename for video in context.labels.videos]
+        # Select the videos we want to swap.
+        # ImageVideo backends return a list[str] for filename; use the first path
+        # so MissingFilesDialog can treat each entry as a single file path.
+        old_paths = [
+            video.filename[0] if isinstance(video.filename, list) else video.filename
+            for video in context.labels.videos
+        ]
         paths = list(old_paths)
         okay = MissingFilesDialog(filenames=paths, replace=True).exec_()
         if not okay:


### PR DESCRIPTION
## Summary

Fixes `TypeError` crashes in four GUI command paths that broke when a project contained `ImageVideo` (image-directory) backends. `ImageVideo.filename` returns a `list[str]` of per-frame image paths rather than a single string, and these paths passed the list directly to `Path()` or used it where a scalar string was expected.

Discovered while running an end-to-end sanity test of SLEAP against sleap-io 0.7.0's `main` branch on a multi-video project with TIFF image-directory backends. The bugs are pre-existing on `develop` and reproduce with sleap-io `0.6.x` too — they're not a regression from the 0.7.0 upgrade.

## Crashes reproduced and fixed

### 1. File > Export Analysis HDF5... / Export Analysis CSV...

```python
File "sleap/gui/commands.py", line 1230, in ask
    vn = Path(video.filename)
...
TypeError: argument should be a str or an os.PathLike object where __fspath__ returns a str, not 'list'
```

`ExportAnalysisFile.ask()` constructs default output filenames by stemming `video.filename`. Both HDF5 and CSV export share this `ask()` method, so a single fix covers both menu items.

### 2. File > Replace Videos...

```python
File "sleap/gui/commands.py", line 2792, in ask
    okay = MissingFilesDialog(filenames=paths, replace=True).exec_()
...
File "sleap/io/pathutils.py", line 13, in list_file_missing
    return [not os.path.exists(filename) for filename in filenames]
TypeError: stat: path should be string, bytes, os.PathLike or integer, not list
```

Three sites in `ReplaceVideo` needed the same normalization:
- `do_action` — extension-compatibility check via `Path(video.filename).suffix`
- `ask._get_truncation_message` — display filename in the truncation warning dialog via `Path(video.filename).name`
- `ask` — `old_paths` list passed to `MissingFilesDialog` → `pathutils.list_file_missing` → `os.path.exists`

## Fix

Each site now normalizes `video.filename` to a representative single path before use:

```python
video_filename = (
    video.filename[0]
    if isinstance(video.filename, list)
    else video.filename
)
```

This follows the existing convention in `sleap/sleap_io_adaptors/lf_labels_utils.py:57` and `:713`, which inline the same `isinstance(filename, list)` check to handle image-sequence backends.

Using `filename[0]` is appropriate for these sites because the list is only consumed for display strings or output-filename construction — no site needs to iterate over every image in the sequence.

## Test plan

- [ ] Load a project with at least one `ImageVideo` backend (e.g., a TIFF directory)
- [ ] File > Export Analysis HDF5... → picks a default output name derived from the first image, file writes successfully
- [ ] File > Export Analysis CSV... → same
- [ ] File > Replace Videos... → dialog opens instead of crashing (replacement semantics for ImageVideo → ImageVideo are still not meaningful and may fail the extension check, but the crash before the dialog appears is resolved)
- [ ] Regression: existing projects with only `MediaVideo` backends still work for the same commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)