### PR TITLE
fix: Correct multi-video clip rendering (dedup, order, source, fps)

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1576,6 +1576,10 @@ class ExportLabeledClip(AppCommand):
         # Collect parameters from dialog
         params["video_filename"] = dialog.get_output_path()
         params["frame_indices"] = dialog.get_frame_indices()
+        # Capture the dialog's selected video — it may differ from the main
+        # window's selection when the user picks a different source in the
+        # multi-video selector.
+        params["video"] = dialog.video
         export_params = dialog.get_export_params()
 
         # Map dialog params to render params
@@ -1604,7 +1608,7 @@ class ExportLabeledClip(AppCommand):
             params: Export parameters from ask().
         """
         labels = context.state["labels"]
-        video = context.state["video"]
+        video = params.get("video", context.state["video"])
 
         # Build render parameters
         render_params = {
@@ -1885,6 +1889,31 @@ class RenderVideoThread(QtCore.QThread):
                 self.error.emit(str(e))
 
 
+def _labels_with_visible_instances(labels, video):
+    """Return a shallow copy of ``labels`` with used predictions hidden.
+
+    ``sio.render_video`` faithfully draws every instance in each
+    ``LabeledFrame``. When a user corrects a ``PredictedInstance``, SLEAP
+    leaves the prediction in place and links a new user ``Instance`` to it via
+    ``from_predicted``. Without filtering, both get drawn and the rendered
+    clip shows two overlapping skeletons for the same animal. ``Labels``
+    objects are otherwise preserved so tracks, centroids, masks, rois etc.
+    still flow through.
+
+    Only frames whose ``video`` matches are filtered; other frames are passed
+    through unchanged so the result can still be used for unrelated purposes.
+    """
+    import attr
+
+    new_lfs = []
+    for lf in labels.labeled_frames:
+        if video is None or lf.video is video:
+            new_lfs.append(attr.evolve(lf, instances=get_instances_to_show(lf)))
+        else:
+            new_lfs.append(lf)
+    return attr.evolve(labels, labeled_frames=new_lfs)
+
+
 def render_video_gui(
     labels,
     filename: str,
@@ -1906,6 +1935,10 @@ def render_video_gui(
     Returns:
         The filename if successful, "canceled" if canceled by user.
     """
+    # Hide predictions that were already converted into user instances so they
+    # aren't rendered as ghost skeletons alongside their user counterparts.
+    labels = _labels_with_visible_instances(labels, video)
+
     # Calculate total frames for progress
     if frame_inds is not None:
         total_frames = len(frame_inds)

--- a/sleap/gui/dialogs/render_clip.py
+++ b/sleap/gui/dialogs/render_clip.py
@@ -473,9 +473,7 @@ class RenderClipDialog(QtWidgets.QDialog):
         """
         src = self._source_fps()
         if src is None:
-            self.match_source_fps.setText(
-                "Match source video FPS (unavailable)"
-            )
+            self.match_source_fps.setText("Match source video FPS (unavailable)")
             # Avoid emitting toggled() while we flip state.
             self.match_source_fps.blockSignals(True)
             self.match_source_fps.setChecked(False)

--- a/sleap/gui/dialogs/render_clip.py
+++ b/sleap/gui/dialogs/render_clip.py
@@ -206,6 +206,10 @@ class RenderClipDialog(QtWidgets.QDialog):
         self.preview._do_render()
         # Update frame range limits
         self._update_frame_range_limits()
+        # Re-read source fps — may differ between videos in a multi-video
+        # project, and the match-source-fps label/value tracks the active one.
+        if hasattr(self, "match_source_fps"):
+            self._refresh_match_source_fps()
 
     def _update_frame_range_limits(self):
         """Update frame range spinboxes based on current video."""
@@ -418,10 +422,25 @@ class RenderClipDialog(QtWidgets.QDialog):
 
         # FPS
         self.fps = QtWidgets.QSpinBox()
-        self.fps.setRange(1, 120)
+        self.fps.setRange(1, 240)
         self.fps.setValue(30)
         self.fps.setToolTip("Output video frame rate")
         layout.addRow("FPS:", self.fps)
+
+        # "Match source FPS" — keeps the output real-time relative to the
+        # source. Defaults on when the source fps is readable; otherwise the
+        # checkbox is disabled and the spinbox holds whatever default the user
+        # picks.
+        self.match_source_fps = QtWidgets.QCheckBox("Match source video FPS")
+        self.match_source_fps.setToolTip(
+            "When checked, the output FPS matches the source video so the "
+            "rendered clip plays at the same real-time speed as the original. "
+            "Uncheck to set the output FPS manually."
+        )
+        self.match_source_fps.setChecked(True)
+        self.match_source_fps.toggled.connect(self._on_match_source_fps_toggled)
+        layout.addRow("", self.match_source_fps)
+        self._refresh_match_source_fps()
 
         # Open when done
         self.open_when_done = QtWidgets.QCheckBox("Open video when done")
@@ -429,6 +448,65 @@ class RenderClipDialog(QtWidgets.QDialog):
         layout.addRow("", self.open_when_done)
 
         return group
+
+    def _source_fps(self) -> float | None:
+        """Return the source video's fps, or ``None`` if unavailable.
+
+        Older / malformed video backends may not expose ``fps`` or may raise
+        when queried; callers must treat ``None`` as "unknown".
+        """
+        video = self.video
+        if video is None:
+            return None
+        try:
+            backend = getattr(video, "backend", None)
+            if backend is None:
+                return None
+            fps = getattr(backend, "fps", None)
+            return float(fps) if fps else None
+        except Exception:
+            return None
+
+    def _refresh_match_source_fps(self):
+        """Update the match-source-fps checkbox label / enabled state / value
+        based on the currently selected video.
+        """
+        src = self._source_fps()
+        if src is None:
+            self.match_source_fps.setText(
+                "Match source video FPS (unavailable)"
+            )
+            # Avoid emitting toggled() while we flip state.
+            self.match_source_fps.blockSignals(True)
+            self.match_source_fps.setChecked(False)
+            self.match_source_fps.blockSignals(False)
+            self.match_source_fps.setEnabled(False)
+            self.fps.setEnabled(True)
+            return
+
+        self.match_source_fps.setEnabled(True)
+        # ``%g`` avoids a trailing ".0" for integer rates like 120.
+        self.match_source_fps.setText(f"Match source video FPS ({src:g})")
+        if self.match_source_fps.isChecked():
+            self.fps.setValue(int(round(src)))
+            self.fps.setEnabled(False)
+        else:
+            self.fps.setEnabled(True)
+
+    def _on_match_source_fps_toggled(self, checked: bool):
+        if checked:
+            src = self._source_fps()
+            if src is None:
+                # Nothing to match — bail by unchecking.
+                self.match_source_fps.blockSignals(True)
+                self.match_source_fps.setChecked(False)
+                self.match_source_fps.blockSignals(False)
+                self.fps.setEnabled(True)
+                return
+            self.fps.setValue(int(round(src)))
+            self.fps.setEnabled(False)
+        else:
+            self.fps.setEnabled(True)
 
     def _create_buttons(self) -> QtWidgets.QWidget:
         """Create dialog buttons (fixed at bottom, outside scroll area)."""
@@ -572,22 +650,25 @@ class RenderClipDialog(QtWidgets.QDialog):
         """Get list of frame indices to render.
 
         Returns:
-            List of frame indices to include in the rendered video.
+            Sorted list of frame indices to include in the rendered video.
+            Sorting is required because ``Labels.labeled_frames`` is not
+            guaranteed to be in frame order, and ``sio.render_video()`` writes
+            frames in the order given by ``frame_inds``.
         """
         if self.range_all.isChecked():
             # All labeled frames for current video
-            return [
+            return sorted(
                 lf.frame_idx
                 for lf in self.labels.labeled_frames
                 if self.video is None or lf.video == self.video
-            ]
+            )
         else:
             # Custom range - all labeled frames within range
             start = self.start_frame.value()
             end = self.end_frame.value()
-            return [
+            return sorted(
                 lf.frame_idx
                 for lf in self.labels.labeled_frames
                 if (self.video is None or lf.video == self.video)
                 and start <= lf.frame_idx <= end
-            ]
+            )

--- a/tests/gui/test_render_clip.py
+++ b/tests/gui/test_render_clip.py
@@ -1,0 +1,231 @@
+"""Tests for render-clip GUI plumbing.
+
+Covers the bugs surfaced by rendering a multi-video predictions file:
+  - Duplicated skeletons when a user-corrected ``Instance`` coexists with the
+    ``PredictedInstance`` it was derived from.
+  - Out-of-order output when ``Labels.labeled_frames`` is not stored in frame
+    order (``sio.render_video`` writes frames in the order of ``frame_inds``).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap.gui.commands import _labels_with_visible_instances
+
+
+def _skeleton() -> sio.Skeleton:
+    return sio.Skeleton([sio.Node("a"), sio.Node("b")])
+
+
+def _pred(skel: sio.Skeleton, xy: tuple[float, float]) -> sio.PredictedInstance:
+    points = np.array([[xy[0], xy[1]], [xy[0] + 1.0, xy[1] + 1.0]])
+    return sio.PredictedInstance.from_numpy(points, skeleton=skel, score=0.9)
+
+
+def _user(
+    skel: sio.Skeleton,
+    xy: tuple[float, float],
+    from_predicted: sio.PredictedInstance | None = None,
+) -> sio.Instance:
+    points = np.array([[xy[0], xy[1]], [xy[0] + 1.0, xy[1] + 1.0]])
+    inst = sio.Instance.from_numpy(points, skeleton=skel)
+    if from_predicted is not None:
+        inst.from_predicted = from_predicted
+    return inst
+
+
+def test_labels_with_visible_instances_hides_used_predictions():
+    skel = _skeleton()
+    video_a = sio.Video(filename="a.mp4")
+    video_b = sio.Video(filename="b.mp4")
+
+    # Frame 0: prediction corrected by a user instance -> prediction hidden.
+    pred_used = _pred(skel, (10.0, 20.0))
+    user_corrected = _user(skel, (11.0, 21.0), from_predicted=pred_used)
+    lf_corrected = sio.LabeledFrame(
+        video=video_a, frame_idx=0, instances=[pred_used, user_corrected]
+    )
+
+    # Frame 1: only a raw prediction -> kept.
+    pred_orphan = _pred(skel, (30.0, 40.0))
+    lf_orphan = sio.LabeledFrame(
+        video=video_a, frame_idx=1, instances=[pred_orphan]
+    )
+
+    # Frame 2 (different video): prediction + user pair, must also be filtered
+    # because we pass video=None (means "filter all videos").
+    pred_used_b = _pred(skel, (50.0, 60.0))
+    user_corrected_b = _user(skel, (51.0, 61.0), from_predicted=pred_used_b)
+    lf_other_video = sio.LabeledFrame(
+        video=video_b,
+        frame_idx=5,
+        instances=[pred_used_b, user_corrected_b],
+    )
+
+    labels = sio.Labels(
+        labeled_frames=[lf_corrected, lf_orphan, lf_other_video],
+        videos=[video_a, video_b],
+        skeletons=[skel],
+    )
+
+    # Filter only video_a: video_b frame should pass through unchanged.
+    filtered = _labels_with_visible_instances(labels, video_a)
+
+    assert filtered is not labels
+    assert filtered.labeled_frames is not labels.labeled_frames
+    # Original must not be mutated.
+    assert [type(i).__name__ for i in lf_corrected.instances] == [
+        "PredictedInstance",
+        "Instance",
+    ]
+
+    # video_a/frame 0: prediction hidden, only user instance visible.
+    out_corrected = next(
+        lf for lf in filtered.labeled_frames if lf.video is video_a and lf.frame_idx == 0
+    )
+    assert len(out_corrected.instances) == 1
+    assert isinstance(out_corrected.instances[0], sio.Instance)
+    assert not isinstance(out_corrected.instances[0], sio.PredictedInstance)
+
+    # video_a/frame 1: orphan prediction kept.
+    out_orphan = next(
+        lf for lf in filtered.labeled_frames if lf.video is video_a and lf.frame_idx == 1
+    )
+    assert len(out_orphan.instances) == 1
+    assert isinstance(out_orphan.instances[0], sio.PredictedInstance)
+
+    # video_b frame: passthrough (same LabeledFrame object).
+    out_other = next(lf for lf in filtered.labeled_frames if lf.video is video_b)
+    assert out_other is lf_other_video
+
+
+def test_labels_with_visible_instances_uses_track_when_present():
+    """With tracks, the "used" check goes through tracks, not ``from_predicted``."""
+    skel = _skeleton()
+    video = sio.Video(filename="a.mp4")
+    track = sio.Track(name="t0")
+
+    pred = _pred(skel, (10.0, 20.0))
+    pred.track = track
+    user = _user(skel, (11.0, 21.0))
+    user.track = track
+
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred, user])
+    labels = sio.Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        skeletons=[skel],
+        tracks=[track],
+    )
+
+    filtered = _labels_with_visible_instances(labels, video)
+
+    out = filtered.labeled_frames[0]
+    assert len(out.instances) == 1
+    assert isinstance(out.instances[0], sio.Instance)
+    assert not isinstance(out.instances[0], sio.PredictedInstance)
+
+
+def test_labels_with_visible_instances_preserves_top_level_state():
+    skel = _skeleton()
+    video = sio.Video(filename="a.mp4")
+    track = sio.Track(name="t0")
+    pred = _pred(skel, (0.0, 0.0))
+    user = _user(skel, (0.1, 0.1), from_predicted=pred)
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred, user])
+    labels = sio.Labels(
+        labeled_frames=[lf],
+        videos=[video],
+        skeletons=[skel],
+        tracks=[track],
+        provenance={"source": "test"},
+    )
+
+    filtered = _labels_with_visible_instances(labels, video)
+
+    # Shared references preserved; only labeled_frames is new.
+    assert filtered.videos is labels.videos
+    assert filtered.skeletons is labels.skeletons
+    assert filtered.tracks is labels.tracks
+    assert filtered.provenance == labels.provenance
+
+
+def test_get_frame_indices_sorts_output(centered_pair_predictions):
+    """``RenderClipDialog.get_frame_indices()`` must return frame indices in
+    ascending order — ``Labels.labeled_frames`` storage is not guaranteed to
+    be in frame order, and ``sio.render_video`` writes frames in the order it
+    receives them.
+    """
+    pytest.importorskip("qtpy.QtWidgets")
+
+    from qtpy import QtWidgets
+
+    from sleap.gui.dialogs.render_clip import RenderClipDialog
+
+    _ = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    labels: sio.Labels = centered_pair_predictions
+
+    # Shuffle labeled_frames to mimic the wild — sleap-io load order is not
+    # guaranteed to be frame-sorted on all files (confirmed with multi-video
+    # prediction files exported via the GUI).
+    lfs = list(labels.labeled_frames)
+    shuffled = [lfs[i] for i in (len(lfs) // 2, 0, *range(1, len(lfs) // 2))]
+    shuffled += [lf for lf in lfs if lf not in shuffled]
+    labels.labeled_frames = shuffled
+
+    video = labels.videos[0]
+    dialog = RenderClipDialog(labels=labels, video=video)
+    try:
+        # Only the "all labeled frames" radio is exercised here — custom range
+        # uses the same comprehension and sort.
+        dialog.range_all.setChecked(True)
+        indices = dialog.get_frame_indices()
+    finally:
+        dialog.deleteLater()
+
+    assert indices == sorted(indices)
+    assert len(indices) == sum(1 for lf in labels.labeled_frames if lf.video == video)
+
+
+def test_match_source_fps_checkbox(centered_pair_predictions):
+    """Dialog's match-source-fps checkbox should pin the FPS spinbox to the
+    source video's reported FPS when checked, disable the spinbox, and restore
+    manual editing when unchecked. Pre-corrections shipped a hardcoded
+    ``fps=30`` default that silently slowed high-fps source footage (120+ fps
+    in this project).
+    """
+    pytest.importorskip("qtpy.QtWidgets")
+
+    from qtpy import QtWidgets
+
+    from sleap.gui.dialogs.render_clip import RenderClipDialog
+
+    _ = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    labels: sio.Labels = centered_pair_predictions
+    video = labels.videos[0]
+    src_fps = video.backend.fps
+
+    dialog = RenderClipDialog(labels=labels, video=video)
+    try:
+        assert dialog.match_source_fps.isChecked()
+        assert dialog.fps.value() == int(round(src_fps))
+        assert not dialog.fps.isEnabled()
+
+        # Unchecking re-enables the spinbox without changing its value.
+        dialog.match_source_fps.setChecked(False)
+        assert dialog.fps.isEnabled()
+        dialog.fps.setValue(15)
+        assert dialog.get_export_params()["fps"] == 15
+
+        # Re-checking pins back to source fps.
+        dialog.match_source_fps.setChecked(True)
+        assert dialog.fps.value() == int(round(src_fps))
+        assert not dialog.fps.isEnabled()
+        assert dialog.get_export_params()["fps"] == int(round(src_fps))
+    finally:
+        dialog.deleteLater()

--- a/tests/gui/test_render_clip.py
+++ b/tests/gui/test_render_clip.py
@@ -84,7 +84,9 @@ def test_labels_with_visible_instances_hides_used_predictions():
 
     # video_a/frame 0: prediction hidden, only user instance visible.
     out_corrected = next(
-        lf for lf in filtered.labeled_frames if lf.video is video_a and lf.frame_idx == 0
+        lf
+        for lf in filtered.labeled_frames
+        if lf.video is video_a and lf.frame_idx == 0
     )
     assert len(out_corrected.instances) == 1
     assert isinstance(out_corrected.instances[0], sio.Instance)
@@ -92,7 +94,9 @@ def test_labels_with_visible_instances_hides_used_predictions():
 
     # video_a/frame 1: orphan prediction kept.
     out_orphan = next(
-        lf for lf in filtered.labeled_frames if lf.video is video_a and lf.frame_idx == 1
+        lf
+        for lf in filtered.labeled_frames
+        if lf.video is video_a and lf.frame_idx == 1
     )
     assert len(out_orphan.instances) == 1
     assert isinstance(out_orphan.instances[0], sio.PredictedInstance)

--- a/tests/gui/test_render_clip.py
+++ b/tests/gui/test_render_clip.py
@@ -51,9 +51,7 @@ def test_labels_with_visible_instances_hides_used_predictions():
 
     # Frame 1: only a raw prediction -> kept.
     pred_orphan = _pred(skel, (30.0, 40.0))
-    lf_orphan = sio.LabeledFrame(
-        video=video_a, frame_idx=1, instances=[pred_orphan]
-    )
+    lf_orphan = sio.LabeledFrame(video=video_a, frame_idx=1, instances=[pred_orphan])
 
     # Frame 2 (different video): prediction + user pair, must also be filtered
     # because we pass video=None (means "filter all videos").


### PR DESCRIPTION
## Summary

Fixes four independent bugs in the render-clip (Video → Render Video Clip) path. On a multi-video predictions file with corrected user labels, the rendered output showed **double skeletons**, **out-of-order frames**, **the wrong source video**, and **played at 1/4 real time** — all at once. Each is a small, independent fix.

1. **Deduplicate used predictions.** `sio.render_video` draws every instance in a `LabeledFrame`. When a user corrects a `PredictedInstance`, SLEAP leaves the prediction in place and links a user `Instance` via `from_predicted`, so both got rendered as overlapping skeletons. `render_video_gui` now applies `get_instances_to_show` through a shallow-cloned `Labels` (via `attr.evolve`), preserving all Labels state (tracks, centroids, masks, rois, …).
2. **Sort frame indices.** `RenderClipDialog.get_frame_indices()` returned indices in `Labels.labeled_frames` storage order (not frame-sorted). `sio.render_video` writes frames in the order of `frame_inds`, so the clip played in roughly random order. Sorted now.
3. **Honour the dialog's video pick.** `ExportLabeledClip.do_action` pulled `video` from `context.state` (main-window selection) instead of `dialog.video` (the dialog's source dropdown). Multi-video projects silently rendered the main window's video instead of the dialog's pick.
4. **"Match source video FPS" checkbox.** The dialog hardcoded output FPS to 30, silently slowing 120/240 fps behavioural footage to 1/4–1/8 real time. New checkbox (on by default when source fps is readable; disabled otherwise) pins the FPS spinbox to the source video's fps and re-evaluates when the source dropdown changes. Users can uncheck to override manually.

## Test plan
- [x] `pytest tests/gui/test_render_clip.py` — 5 new tests (filter helper, track path, top-level state preserved, sort order, match-source-fps checkbox)
- [x] `pytest tests/gui/test_commands.py` — 25 existing command tests still pass
- [ ] Manual: open a multi-video predictions SLP, render each video from the dialog, verify:
  - Single skeleton on corrected frames (previously double)
  - Smooth playback (previously chaotic / out-of-order)
  - Picking a video in the dialog renders *that* video (previously always first)
  - FPS spinbox starts at source fps; unchecking restores manual control

🤖 Generated with [Claude Code](https://claude.com/claude-code)