### PR TITLE
Fix NaN-predicted nodes converting to visible=True user labels

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -4259,6 +4259,13 @@ class AddInstance(EditCommand):
                 new_instance[node]["name"] = node
             else:
                 has_missing_nodes = True
+                # Initialize the skipped point with NaN xy and visible=False so
+                # downstream `add_*_nodes` gates fire and the buffer is not
+                # left holding uninitialized memory from `Instance.empty()`.
+                new_instance[node]["xy"] = np.array([np.nan, np.nan])
+                new_instance[node]["visible"] = False
+                new_instance[node]["complete"] = False
+                new_instance[node]["name"] = node
 
         return has_missing_nodes
 
@@ -4582,11 +4589,16 @@ class AddUserInstancesFromPredictions(EditCommand):
             from_predicted=copy_instance,
         )
 
-        # Copy point data from prediction
+        # Copy point data from prediction. Predicted nodes that were not
+        # detected have NaN coordinates; mark those as not visible so the
+        # user instance starts in a well-defined state.
         for i, node in enumerate(copy_instance.skeleton.node_names):
             pred_point = copy_instance.points[i]
+            xy_is_nan = bool(np.any(np.isnan(pred_point["xy"])))
             new_instance.points[i]["xy"] = pred_point["xy"]
-            new_instance.points[i]["visible"] = pred_point["visible"]
+            new_instance.points[i]["visible"] = (
+                bool(pred_point["visible"]) and not xy_is_nan
+            )
             new_instance.points[i]["complete"] = False
 
         return new_instance

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -4465,10 +4465,15 @@ class AddMissingInstanceNodes(EditCommand):
                 input_arrays[node_idx] = input_array
             else:
                 x, y = instance.points[node_idx]["xy"]
-                visible = instance.points[node_idx]["visible"]
-                complete = instance.points[node_idx]["complete"]
+                # Use distinct names so we don't shadow the `visible` function
+                # parameter -- otherwise a per-node visibility from this branch
+                # bleeds into the if-branch on later iterations and overrides
+                # the caller-requested default (which is how NaN-coord
+                # predicted nodes were ending up with visible=True).
+                point_visible = instance.points[node_idx]["visible"]
+                point_complete = instance.points[node_idx]["complete"]
                 input_arrays[node_idx] = np.array(
-                    (np.array([x, y]), visible, complete, node_name),
+                    (np.array([x, y]), point_visible, point_complete, node_name),
                     dtype=[
                         ("xy", "<f8", (2,)),
                         ("visible", "bool"),

--- a/tests/test_predictions_to_instances.py
+++ b/tests/test_predictions_to_instances.py
@@ -26,7 +26,11 @@ from sleap.sleap_io_adaptors.lf_labels_utils import (
     get_unused_predictions,
     get_instances_to_show,
 )
-from sleap.gui.commands import AddInstance, AddUserInstancesFromPredictions
+from sleap.gui.commands import (
+    AddInstance,
+    AddMissingInstanceNodes,
+    AddUserInstancesFromPredictions,
+)
 
 
 @pytest.fixture
@@ -511,6 +515,76 @@ class TestNaNPredictedNodeVisibilityBug:
             new_instance.points[head_idx]["xy"], np.array([10.0, 20.0])
         )
         assert bool(new_instance.points[head_idx]["visible"]) is True
+
+    def test_add_random_nodes_does_not_leak_visible_across_iterations(
+        self, simple_skeleton, prediction_with_nan_node
+    ):
+        """`add_random_nodes` must not let one node's visibility bleed into the next.
+
+        Regression for the variable-shadowing bug: the function parameter
+        `visible` was reassigned inside the loop's else branch, so a valid
+        node (visible=True) processed before a NaN node would clobber the
+        local `visible` and the NaN node's if-branch would write
+        visible=True instead of the requested False. End result: NaN
+        predicted nodes appeared as visible user labels in the GUI.
+        """
+        from PySide6 import QtCore
+
+        # Run set_visible_nodes first to set up the new instance the same
+        # way `AddInstance.create_new_instance` would after my upstream fix:
+        # valid nodes copied with visible=True, NaN nodes initialized with
+        # xy=NaN/visible=False.
+        new_instance = Instance.empty(
+            skeleton=simple_skeleton,
+            from_predicted=prediction_with_nan_node,
+        )
+
+        class _StubVideo:
+            shape = (1, 480, 640, 3)
+
+        class _StubPlayer:
+            @staticmethod
+            def getVisibleRect():
+                return QtCore.QRectF(0.0, 0.0, 640.0, 480.0)
+
+        class _StubApp:
+            player = _StubPlayer()
+
+        class _StubLabels:
+            videos = [_StubVideo()]
+
+        class _StubContext:
+            labels = _StubLabels()
+            app = _StubApp()
+            state = {"video": _StubVideo(), "skeleton": simple_skeleton}
+
+        AddInstance.set_visible_nodes(
+            context=_StubContext(),
+            copy_instance=prediction_with_nan_node,
+            new_instance=new_instance,
+            mark_complete=False,
+            init_method="best",
+        )
+
+        # Now run add_random_nodes with visible=False (the value that the
+        # double-click-from-prediction flow passes in via fill_missing_nodes).
+        AddMissingInstanceNodes.add_random_nodes(
+            _StubContext(), new_instance, visible=False
+        )
+
+        names = list(new_instance.points["name"])
+        thorax_idx = names.index("thorax")
+        head_idx = names.index("head")
+        abdomen_idx = names.index("abdomen")
+
+        # NaN-pred node must be invisible regardless of where it falls in
+        # iteration order relative to the valid nodes.
+        assert bool(new_instance.points[thorax_idx]["visible"]) is False, (
+            "NaN-pred node must remain invisible after add_random_nodes"
+        )
+        # Valid nodes must remain visible (their predicted xy is preserved).
+        assert bool(new_instance.points[head_idx]["visible"]) is True
+        assert bool(new_instance.points[abdomen_idx]["visible"]) is True
 
 
 class TestOriginalPredictionNotRemovedBug:

--- a/tests/test_predictions_to_instances.py
+++ b/tests/test_predictions_to_instances.py
@@ -26,7 +26,7 @@ from sleap.sleap_io_adaptors.lf_labels_utils import (
     get_unused_predictions,
     get_instances_to_show,
 )
-from sleap.gui.commands import AddUserInstancesFromPredictions
+from sleap.gui.commands import AddInstance, AddUserInstancesFromPredictions
 
 
 @pytest.fixture
@@ -372,6 +372,145 @@ class TestMakeInstanceFromPredictedInstanceBug:
         assert new_instance.from_predicted is prediction_with_track, (
             "Instance.from_predicted should reference the original PredictedInstance"
         )
+
+
+class TestNaNPredictedNodeVisibilityBug:
+    """Tests for the NaN-predicted-node visibility bug.
+
+    When a predicted instance has NaN-coordinate nodes (i.e. nodes that were
+    not detected by the model), converting it to a user Instance via the
+    GUI should result in those nodes having `visible=False`. The previous
+    behavior left those nodes with `visible=True` and uninitialized xy
+    values, because `Instance.empty()` allocates points via `np.empty()`
+    (uninitialized memory) and the conversion code did not explicitly set
+    visibility for NaN-coord nodes.
+
+    See: scratch/2026-04-27-nan-predicted-to-user-visibility-bug/README.md
+    """
+
+    @pytest.fixture
+    def prediction_with_nan_node(self, simple_skeleton):
+        """PredictedInstance with one valid and one NaN-coord node."""
+        pred = PredictedInstance.empty(skeleton=simple_skeleton, score=0.8)
+        pred["head"] = (10.0, 20.0, 0.9)
+        pred["thorax"] = (np.nan, np.nan, 0.0)
+        pred["abdomen"] = (40.0, 50.0, 0.7)
+        # Predictions typically come back with visible=True even when the
+        # coordinates are NaN -- that is the upstream condition that
+        # exposes this bug.
+        pred.points["visible"] = True
+        return pred
+
+    def test_make_instance_nan_node_is_invisible(self, prediction_with_nan_node):
+        """make_instance_from_predicted_instance: NaN-coord -> visible=False."""
+        new_instance = (
+            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
+                prediction_with_nan_node
+            )
+        )
+
+        names = list(new_instance.points["name"])
+        thorax_idx = names.index("thorax")
+        head_idx = names.index("head")
+        abdomen_idx = names.index("abdomen")
+
+        assert bool(new_instance.points[thorax_idx]["visible"]) is False, (
+            "NaN-coord predicted node should be invisible after conversion"
+        )
+        assert bool(new_instance.points[head_idx]["visible"]) is True, (
+            "Valid predicted node should remain visible after conversion"
+        )
+        assert bool(new_instance.points[abdomen_idx]["visible"]) is True
+
+    def test_set_visible_nodes_initializes_nan_node_with_dirty_heap(
+        self, simple_skeleton, prediction_with_nan_node
+    ):
+        """set_visible_nodes should set NaN-coord nodes to visible=False, xy=NaN.
+
+        We poison the freshly-allocated `Instance.empty()` buffer with non-NaN,
+        non-zero, visible=True garbage to simulate dirty heap memory in a
+        long-running GUI session. Without the fix, the missing-node branch
+        leaves the buffer untouched and downstream gating fails to recognize
+        it as missing, propagating the garbage values through.
+        """
+        new_instance = Instance.empty(
+            skeleton=simple_skeleton,
+            from_predicted=prediction_with_nan_node,
+        )
+        # Pollute the buffer to simulate dirty heap.
+        for i in range(len(new_instance.points)):
+            new_instance.points[i]["xy"] = np.array([1234.5, 6789.0])
+            new_instance.points[i]["visible"] = True
+            new_instance.points[i]["complete"] = True
+
+        # Minimal stub context: set_visible_nodes only reads
+        # context.state["video"], context.state["skeleton"], and
+        # context.labels.videos[0] (as a fallback for video shape).
+        class _StubVideo:
+            shape = (1, 480, 640, 3)  # (n_frames, height, width, channels)
+
+        class _StubLabels:
+            videos = [_StubVideo()]
+
+        class _StubContext:
+            labels = _StubLabels()
+            state = {"video": _StubVideo(), "skeleton": simple_skeleton}
+
+        has_missing = AddInstance.set_visible_nodes(
+            context=_StubContext(),
+            copy_instance=prediction_with_nan_node,
+            new_instance=new_instance,
+            mark_complete=False,
+            init_method="best",
+        )
+
+        assert has_missing is True, "Expected has_missing_nodes=True for NaN node"
+
+        names = list(new_instance.points["name"])
+        thorax_idx = names.index("thorax")
+
+        thorax_xy = new_instance.points[thorax_idx]["xy"]
+        assert np.all(np.isnan(thorax_xy)), (
+            f"NaN-coord node should have xy=NaN after set_visible_nodes; "
+            f"got {thorax_xy!r}"
+        )
+        assert bool(new_instance.points[thorax_idx]["visible"]) is False, (
+            "NaN-coord node should have visible=False after set_visible_nodes"
+        )
+
+    def test_set_visible_nodes_preserves_valid_node_visibility(
+        self, simple_skeleton, prediction_with_nan_node
+    ):
+        """Valid (non-NaN) predicted nodes should remain visible after copy."""
+        new_instance = Instance.empty(
+            skeleton=simple_skeleton,
+            from_predicted=prediction_with_nan_node,
+        )
+
+        class _StubVideo:
+            shape = (1, 480, 640, 3)
+
+        class _StubLabels:
+            videos = [_StubVideo()]
+
+        class _StubContext:
+            labels = _StubLabels()
+            state = {"video": _StubVideo(), "skeleton": simple_skeleton}
+
+        AddInstance.set_visible_nodes(
+            context=_StubContext(),
+            copy_instance=prediction_with_nan_node,
+            new_instance=new_instance,
+            mark_complete=False,
+            init_method="best",
+        )
+
+        names = list(new_instance.points["name"])
+        head_idx = names.index("head")
+        np.testing.assert_array_equal(
+            new_instance.points[head_idx]["xy"], np.array([10.0, 20.0])
+        )
+        assert bool(new_instance.points[head_idx]["visible"]) is True
 
 
 class TestOriginalPredictionNotRemovedBug:


### PR DESCRIPTION
## Summary

When the user double-clicks a `PredictedInstance` (or runs "Add instances from all predictions"), nodes whose predicted coordinates were NaN now correctly become `visible=False` user labels — matching the legacy behavior. Previously these nodes ended up with `visible=True` at random heap-garbage locations.

This turned out to be **two stacked bugs** along the same conversion path. Each one alone was enough to put NaN-coord nodes into a visible-but-wrong state.

## Bugs and fixes

### Bug 1 — `Instance.empty()` returns uninitialized memory; conversion didn't write to skipped nodes

`Instance.empty()` (in `sleap-io`) allocates points via `np.empty()` — `xy`/`visible`/`complete` are uninitialized memory until written.

In the double-click flow (`_handle_instance_double_click` → `commands.newInstance` → `AddInstance`), `AddInstance.set_visible_nodes` skipped NaN-coord nodes entirely (just set `has_missing_nodes = True` without writing anything). The downstream `add_nodes_from_template` / `add_random_nodes` helpers then tried to recognize "missing" nodes via `np.all(np.isnan(xy))`, `np.allclose(xy, 0.0)`, or `np.any(np.isnan(numpy()[i]))` — but with dirty heap memory those gates miss (the garbage isn't all NaN and isn't zero), so the uninitialized `visible` flag (often True) propagated through.

The "Add instances from all predictions" menu command (`AddUserInstancesFromPredictions.make_instance_from_predicted_instance`) had a parallel bug: it copied `pred_point["visible"]` blindly, including for NaN-coord predictions where visibility was logically meaningless.

**Fix (commit 1):**
- `AddInstance.set_visible_nodes`: in the missing-node `else` branch, explicitly write `xy=[NaN, NaN]`, `visible=False`, `complete=False`, `name=node`. Downstream `add_nodes_from_template` then correctly recognizes the slot as missing and places a sensible fallback at template/random coords with `visible=False`.
- `AddUserInstancesFromPredictions.make_instance_from_predicted_instance`: gate copied visibility on a NaN check of the predicted `xy` (`visible = bool(pred.visible) and not any(isnan(xy))`).

### Bug 2 — `add_random_nodes` shadowed its `visible` parameter inside the loop

`AddMissingInstanceNodes.add_random_nodes` reassigned the function parameter `visible` inside the else branch (`visible = instance.points[node_idx]["visible"]`), shadowing the caller-requested default. When a valid predicted node (visible=True) was processed before a NaN-coord node:

1. Valid node hits the else branch → local `visible` becomes `True` (overriding the `visible=False` arg).
2. NaN node hits the if branch → uses the now-clobbered `True` → places with `visible=True`.

This was the actual surface manifestation in the running GUI: even after Fix 1, this final pass overrode the correct `visible=False` with the leaked `True`.

**Fix (commit 2):** rename the per-node locals in `add_random_nodes` to `point_visible` / `point_complete` so the function parameter `visible` is preserved across iterations.

## Behavior matrix (verified)

| Scenario | `copy_instance` | After fix |
|---|---|---|
| Fresh blank instance ("Add Instance" button) | `None` | All nodes placed with `visible=True` — **unchanged** (early-return guard in `set_visible_nodes` is preserved) |
| Copy from another user instance | `Instance` | Visible flag copied from source — **unchanged** |
| Double-click predicted, valid node | `PredictedInstance` | xy + `visible=True` from prediction — **unchanged** |
| **Double-click predicted, NaN node** | `PredictedInstance` | `visible=False` at template/random fallback — **fixed** |
| **"Add instances from all predictions", NaN node** | `PredictedInstance` | xy preserved as NaN, `visible=False` — **fixed** |

## Testing

`tests/test_predictions_to_instances.py::TestNaNPredictedNodeVisibilityBug` — 4 new tests:

- `test_make_instance_nan_node_is_invisible` — direct check on the menu command path.
- `test_set_visible_nodes_initializes_nan_node_with_dirty_heap` — poisons the freshly-allocated `Instance.empty()` buffer with non-NaN, non-zero, `visible=True` values to simulate a long-running GUI session's dirty heap, then asserts `xy=NaN, visible=False`. (Without poisoning, a naive test would pass even with the bug present, because fresh process pools often start zeroed.)
- `test_set_visible_nodes_preserves_valid_node_visibility` — regression guard on the unchanged path.
- `test_add_random_nodes_does_not_leak_visible_across_iterations` — exercises the full `set_visible_nodes` → `add_random_nodes` pipeline and verifies a NaN-coord predicted node ends up with `visible=False` even when processed after a valid (visible=True) node. Confirmed to fail prior to the Fix 2 patch.

Local results:
- Full `tests/test_predictions_to_instances.py`: 19 passed.
- Full `tests/gui/test_commands.py`: 25 passed, 1 skipped.
- `tests/info/test_h5.py`: 4 passed.
- `ruff format` / `ruff check` clean.

GUI smoke test pending — load a project with NaN-coord predictions, double-click a prediction, confirm thorax (NaN) shows up as invisible/hollow node rather than at a random location with a filled marker.

## Design notes

- The `set_visible_nodes` fix is **path-specific**: only modifies the missing-node else branch, which is only reachable when there is a `copy_instance`. The fresh-blank-instance path (`copy_instance is None`) returns at the early `if copy_instance is None` guard, so it keeps `visible=True` defaults — this preserves the user-expected behavior of "creating a new instance from scratch puts visible markers down for the user to drag."
- The `add_random_nodes` shadowing fix is an isolated rename — does not change semantics for any caller.
- Considered but rejected: changing `PointsArray.empty()` upstream in `sleap-io` to use `np.zeros` instead of `np.empty`. That would close this whole class of uninitialized-memory bugs at the root, but it's invasive (touches a foundational data structure shared across consumers), requires a sleap-io release + dep bump, and we have no other known bug in this class.

## Investigation notes

Full trace and call-chain documentation in `scratch/2026-04-27-nan-predicted-to-user-visibility-bug/` (not committed; scratch is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)