### PR TITLE
Bump version to 1.6.3 and update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
     "seaborn",
     "requests",
     "matplotlib",
-    "sleap-io[all]>=0.6.5,<0.7.0",
+    "sleap-io[all]>=0.7.0,<0.8.0",
 ]
 
 [tool.setuptools.dynamic]
@@ -66,38 +66,38 @@ jupyter = [
 ]
 
 nn = [
-    "sleap-nn[torch]>=0.1.2"
+    "sleap-nn[torch]>=0.2.0,<0.3.0"
 ]
 
 nn-cpu = [
-    "sleap-nn[torch]>=0.1.2"
+    "sleap-nn[torch]>=0.2.0,<0.3.0"
 ]
 
 nn-cuda128 = [
-    "sleap-nn[torch]>=0.1.2"
+    "sleap-nn[torch]>=0.2.0,<0.3.0"
 ]
 
 nn-cuda118 = [
-    "sleap-nn[torch]>=0.1.2"
+    "sleap-nn[torch]>=0.2.0,<0.3.0"
 ]
 
 nn-cuda130 = [
-    "sleap-nn[torch]>=0.1.2"
+    "sleap-nn[torch]>=0.2.0,<0.3.0"
 ]
 
 # Export extras - self-contained with torch
 # Can be used alone (defaults to cu128) or combined with nn-cuda* for specific CUDA version
 nn-export = [
-    "sleap-nn[torch,export]>=0.1.2"
+    "sleap-nn[torch,export]>=0.2.0,<0.3.0"
 ]
 
 nn-export-gpu = [
-    "sleap-nn[torch,export-gpu]>=0.1.2"
+    "sleap-nn[torch,export-gpu]>=0.2.0,<0.3.0"
 ]
 
 # TensorRT - Linux/Windows only (not supported on macOS)
 nn-tensorrt = [
-    "sleap-nn[torch,tensorrt]>=0.1.2; sys_platform != 'darwin'"
+    "sleap-nn[torch,tensorrt]>=0.2.0,<0.3.0; sys_platform != 'darwin'"
 ]
 
 [dependency-groups]

--- a/sleap/version.py
+++ b/sleap/version.py
@@ -11,7 +11,7 @@ For example, if you set the version to X.Y.Z, then the tag should be "vX.Y.Z".
 Must be a semver string, "aN" should be appended for alpha releases.
 """
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"
 
 
 def versions():


### PR DESCRIPTION
## Summary
- Bump SLEAP version from 1.6.2 to 1.6.3
- Update sleap-io constraint from `>=0.6.5,<0.7.0` to `>=0.7.0,<0.8.0`
- Update sleap-nn constraint from `>=0.1.2` to `>=0.2.0,<0.3.0` (added upper bound to mirror sleap-io style)

## Changes Made
- `sleap/version.py`: Updated `__version__` to `"1.6.3"`
- `pyproject.toml`: Updated dependency version constraints:
  - `sleap-io[all]>=0.7.0,<0.8.0`
  - `sleap-nn[torch]>=0.2.0,<0.3.0` (across `nn`, `nn-cpu`, `nn-cuda118`, `nn-cuda128`, `nn-cuda130`, `nn-export`, `nn-export-gpu`, `nn-tensorrt` extras)

## Dependency Updates

### sleap-io 0.6.5 → 0.7.0
See [sleap-io v0.7.0 release notes](https://github.com/talmolab/sleap-io/releases/tag/v0.7.0)

### sleap-nn 0.1.2 → 0.2.0
See [sleap-nn v0.1.3](https://github.com/talmolab/sleap-nn/releases/tag/v0.1.3) and [v0.2.0](https://github.com/talmolab/sleap-nn/releases/tag/v0.2.0) release notes.

`sleap-nn==0.2.0` requires `sleap-io>=0.7.0,<0.8.0`, consistent with the new constraint.

## Testing
- Version bump is a minimal change
- `uv lock` succeeds locally with the new constraints (resolution clean)
- CI will verify cross-platform dependency resolution and tests

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)