### PR TITLE
Fix #2684: persist skeleton on save when no instances are labeled

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3211,6 +3211,15 @@ class NewNode(EditCommand):
         # Add the node to the skeleton
         context.state["skeleton"].add_node(part_name)
 
+        # The GUI's state["skeleton"] is an orphan until something attaches it to
+        # labels.skeletons. Without this, a skeleton edited only via the side
+        # panel (no labeled instances) is silently dropped on save (#2684).
+        if (
+            context.labels is not None
+            and context.state["skeleton"] not in context.labels.skeletons
+        ):
+            context.labels.skeletons.append(context.state["skeleton"])
+
 
 class DeleteNode(EditCommand):
     topics = [UpdateTopic.skeleton]
@@ -3280,6 +3289,15 @@ class NewEdge(EditCommand):
 
         # Add edge
         context.state["skeleton"].add_edge(src_node, dst_node)
+
+        # Safety net for #2684: ensure the GUI's state["skeleton"] is attached
+        # to labels.skeletons so the edge is persisted on save even if NewNode
+        # didn't run (e.g., nodes added through other paths).
+        if (
+            context.labels is not None
+            and context.state["skeleton"] not in context.labels.skeletons
+        ):
+            context.labels.skeletons.append(context.state["skeleton"])
 
 
 class DeleteEdge(EditCommand):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -26,6 +26,8 @@ from sleap.gui.commands import (
     ExportFullPackage,
     ExportVideoClip,
     ImportDeepLabCutFolder,
+    NewEdge,
+    NewNode,
     RemoveVideo,
     ReplaceVideo,
     OpenSkeleton,
@@ -708,6 +710,89 @@ def test_DeleteNode_without_labels():
     assert skeleton.node_names == ["head", "tail"]
     # Edge from head to neck should be removed
     assert len(skeleton.edges) == 0
+
+
+def test_NewNode_attaches_skeleton_to_labels():
+    """Issue #2684: clicking New Node on a fresh project must attach the
+    GUI's state["skeleton"] to labels.skeletons so it persists on save.
+    """
+    labels = Labels()
+    context = CommandContext.from_labels(labels)
+    # Mirrors MainWindow.__init__: an orphan Skeleton in state, not in labels.
+    context.state["skeleton"] = Skeleton()
+    assert labels.skeletons == []
+
+    NewNode.do_action(context, params={})
+
+    assert len(labels.skeletons) == 1
+    assert labels.skeletons[0] is context.state["skeleton"]
+    assert "new_part" in context.state["skeleton"].node_names
+
+
+def test_NewNode_does_not_duplicate_skeleton():
+    """Repeated NewNode calls must not append the same skeleton multiple times."""
+    labels = Labels()
+    context = CommandContext.from_labels(labels)
+    context.state["skeleton"] = Skeleton()
+
+    NewNode.do_action(context, params={})
+    NewNode.do_action(context, params={})
+    NewNode.do_action(context, params={})
+
+    assert len(labels.skeletons) == 1
+    assert len(context.state["skeleton"].nodes) == 3
+
+
+def test_NewNode_persists_skeleton_across_save_reload(tmpdir):
+    """Issue #2684 end-to-end: NewNode + save + reload must round-trip
+    the skeleton without requiring any labeled instances.
+    """
+    import sleap_io as sio
+
+    labels = Labels()
+    context = CommandContext.from_labels(labels)
+    context.state["skeleton"] = Skeleton()
+    context.state["labels"] = labels
+
+    NewNode.do_action(context, params={})
+
+    fn = str(PurePath(tmpdir, "test_skeleton_only.slp"))
+    sio.save_file(labels, fn)
+    reloaded = sio.load_file(fn)
+
+    assert len(reloaded.skeletons) == 1
+    assert "new_part" in reloaded.skeletons[0].node_names
+
+
+def test_NewNode_without_labels():
+    """NewNode must not crash when there is no labels context (skeleton-only
+    editing). The skeleton itself should still be mutated.
+    """
+    context = CommandContext.from_labels(None)
+    context.state["skeleton"] = Skeleton()
+
+    NewNode.do_action(context, params={})
+
+    assert "new_part" in context.state["skeleton"].node_names
+
+
+def test_NewEdge_attaches_skeleton_to_labels():
+    """Safety net for #2684: NewEdge also ensures the skeleton is attached
+    to labels.skeletons.
+    """
+    labels = Labels()
+    context = CommandContext.from_labels(labels)
+    skeleton = Skeleton()
+    skeleton.add_node("a")
+    skeleton.add_node("b")
+    context.state["skeleton"] = skeleton
+    assert labels.skeletons == []
+
+    NewEdge.do_action(context, params={"src_node": "a", "dst_node": "b"})
+
+    assert len(labels.skeletons) == 1
+    assert labels.skeletons[0] is skeleton
+    assert len(skeleton.edges) == 1
 
 
 def test_SaveProjectAs(centered_pair_predictions: Labels, tmpdir):


### PR DESCRIPTION
## Summary
- A skeleton edited only via the **New Node** / **New Edge** buttons is silently dropped on save when the project has no labeled instances (issue #2684).
- Root cause: the GUI's `state[\"skeleton\"]` is an orphan `Skeleton` that `NewNode` / `NewEdge` mutate in place but never attach to `labels.skeletons` — so `sio.save_file(labels, ...)` writes no skeleton.
- Fix: append `state[\"skeleton\"]` to `labels.skeletons` from inside `NewNode` / `NewEdge` if it isn't already there. Matches the existing `OpenSkeleton` pattern at `commands.py:3111-3113`.

## Changes Made
- `sleap/gui/commands.py` — `NewNode.do_action` and `NewEdge.do_action` now append `context.state[\"skeleton\"]` to `context.labels.skeletons` when missing (guarded on `context.labels is not None` to preserve the skeleton-only editing path).
- `tests/gui/test_commands.py` — added tests:
  - `test_NewNode_attaches_skeleton_to_labels` — fresh project, after `NewNode` the skeleton is in `labels.skeletons`.
  - `test_NewNode_does_not_duplicate_skeleton` — repeated calls don't append duplicates.
  - `test_NewNode_persists_skeleton_across_save_reload` — end-to-end repro of the bug now passes.
  - `test_NewNode_without_labels` — skeleton-only editing path (no labels) still works.
  - `test_NewEdge_attaches_skeleton_to_labels` — safety-net coverage for `NewEdge`.

## Reproduction (before this fix)
1. Launch SLEAP on a fresh project.
2. Click **New Node** on the Skeleton panel.
3. **Save** and close.
4. Reopen the file — node is gone.

After the fix, the node round-trips correctly even with zero labeled instances.

## Design Decisions
- **Append on first edit, not at app init.** Keeps the invariant \"`labels.skeletons == []` means no skeleton has been configured\" for fresh, untouched projects. The list only gains a skeleton once the user makes a real edit. This is the same trigger pattern `OpenSkeleton` uses.
- **Fixed in the commands, not in save.** A save-time safety net would also work, but it would hide the actual state ↔ labels sync issue and leave `labels.skeletons` empty during the session, breaking any in-session code that reads `labels.skeletons` (e.g., `app.py:1320`, `lf_labels_utils.py:1366`).
- **Identity check (`not in`).** Uses Python `in` against the list; relies on object identity / equality the same way `OpenSkeleton` does. The skeleton in `state` is the same instance shown in the panel, so identity is the right notion here.
- **Guard on `context.labels is not None`.** Preserves the skeleton-only editing path (covered by `test_DeleteNode_without_labels` style use cases).

## Testing
- `uv run pytest tests/gui/test_commands.py` → 30 passed, 1 skipped.
- `uv run pytest tests/gui/test_app.py` → 3 passed.
- Ruff format + ruff check clean.

## Related Issues
Closes #2684

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)