### PR TITLE
ci: serialize gh-pages pushes across docs and PR-preview workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,9 +8,11 @@ on:
     branches:
       - develop
 
-# Ensure only one docs deployment runs at a time to prevent gh-pages push conflicts
+# Serialize all gh-pages pushes (this workflow and pr-preview.yml's deploy/cleanup
+# jobs share the same group) so simultaneous pushes don't race and trip
+# "rejected (fetch first)". See talmolab/sleap#2689.
 concurrency:
-  group: docs-deployment
+  group: gh-pages-write
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -27,6 +27,11 @@ jobs:
     name: Deploy Preview
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    # Serialize gh-pages pushes against docs.yml and the cleanup job to avoid
+    # racing on the gh-pages branch. See talmolab/sleap#2689.
+    concurrency:
+      group: gh-pages-write
+      cancel-in-progress: false
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -98,6 +103,10 @@ jobs:
     name: Cleanup Preview
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
+    # Same shared gh-pages-write lock as the deploy job and docs.yml.
+    concurrency:
+      group: gh-pages-write
+      cancel-in-progress: false
     steps:
       - name: Checkout gh-pages
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Diagnosed and documented in #2689: the `Deploy MkDocs to GitHub Pages` workflow has been failing on most pushes to `develop` for ~2 months because it races with `Docs - PR Preview` on the `gh-pages` push.
- Root cause is mismatched concurrency groups (`docs-deployment` vs `pr-preview-<N>`), so on PR merge GitHub launches both workflows simultaneously and one push gets `! [rejected] gh-pages -> gh-pages (fetch first)`.
- This change puts all three gh-pages writers (the `docs.yml` job, `pr-preview.yml`'s `deploy` job, `pr-preview.yml`'s `cleanup` job) under a shared `gh-pages-write` concurrency group with `cancel-in-progress: false`. The shared lock is applied at the **job** level on `pr-preview.yml` so its existing workflow-level per-PR cancellation behavior (new commits on a PR still cancel that PR's in-flight preview build) is unchanged.

## Test plan
- [ ] Merge a small PR after this change lands and confirm both `Deploy MkDocs to GitHub Pages` (push on develop) and `Docs - PR Preview` cleanup runs go green — the second one to start should show "Waiting for a previous job" in the Actions UI, not race.
- [ ] Open a fresh PR and confirm the deploy preview still runs (just serialized with anything else holding `gh-pages-write`).
- [ ] Push a follow-up commit to an open PR and confirm the previous PR-preview deploy run is cancelled (workflow-level concurrency still works).

Closes #2689
