### PR TITLE
docs: align uv install commands with astral's official guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ You can find the latest version of SLEAP in the [Releases](https://github.com/ta
 
 **`uv tool install` (any OS):**
 
-First, install [`uv`](https://github.com/astral-sh/uv) if you haven't already:
+First, install [`uv`](https://docs.astral.sh/uv/getting-started/installation/) if you haven't already:
 
 ```bash
 # macOS/Linux
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Windows
-powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 Then install SLEAP:

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,14 +88,14 @@
 
 ### Quick start
 
-Install [`uv`](https://github.com/astral-sh/uv) first:
+Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/) first:
 
 ```bash
 # macOS/Linux
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Windows
-powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 Then install SLEAP:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,13 +43,13 @@ SLEAP is a tool for tracking animal poses in video. This guide will get you up a
 
 ### Install uv
 
-SLEAP uses `uv` to manage installation. It's a fast, modern package manager that handles everything automatically—including GPU detection.
+SLEAP uses `uv` to manage installation. It's a fast, modern package manager that handles everything automatically—including GPU detection. The commands below come from the [official `uv` installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 
 === "Windows"
     1. Press the **Windows key**, type `PowerShell`, press **Enter**
     2. Paste this command and press **Enter**:
     ```powershell
-    irm https://astral.sh/uv/install.ps1 | iex
+    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
     ```
     3. **Close and reopen** PowerShell
     4. Verify: `uv --version`


### PR DESCRIPTION
## Summary

- Replace the Windows `uv` install snippet with astral's official `powershell -ExecutionPolicy ByPass -c "..."` form so PowerShell does not flash-close on hosts where the default execution policy blocks the install script (reported in #2683).
- Hyperlink `uv` to the [official install guide](https://docs.astral.sh/uv/getting-started/installation/) instead of the GitHub repo.
- Applied consistently to `README.md`, `docs/index.md`, and `docs/installation.md`. macOS/Linux commands already match astral's official form.

Closes the doc gap surfaced in discussion #2683.

## Test plan

- [ ] `mkdocs serve` locally and confirm the **Windows** tab on `/installation/#install-uv` shows the new command and the `uv` link in the intro paragraph points at `docs.astral.sh/uv/getting-started/installation/`.
- [ ] Confirm the **Quick start** section on the home page (`/`) shows the new Windows command.
- [ ] Confirm `README.md` renders correctly on GitHub.
- [ ] (Optional, Windows host) verify the new command runs end-to-end without flash-closing PowerShell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)