### PR TITLE
docs: use official uv Windows install, bump version pins, fix broken nn.sleap.ai links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ You can find the latest version of SLEAP in the [Releases](https://github.com/ta
 
 **`uv tool install` (any OS):**
 
-First, install [`uv`](https://github.com/astral-sh/uv) if you haven't already:
+First, install [`uv`](https://docs.astral.sh/uv/getting-started/installation/) if you haven't already:
 
 ```bash
 # macOS/Linux
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Windows
-powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 Then install SLEAP:

--- a/docs/guides/creating-a-custom-training-profile.md
+++ b/docs/guides/creating-a-custom-training-profile.md
@@ -40,7 +40,7 @@ sleap-nn train --config /path/to/profile.yaml "data_config.train_labels_path=[pa
 for each model you want to train (where `path/to/custom/profile.yaml` should be replaced with the path to your custom training profile and `path/to/dataset.pkg.slp` replaced with the path to your training job package). See our guide to [remote training](running-sleap-remotely.md) for more details.
 
 !!! note
-    If you exported the training package as a ZIP file, it contains both the `.pkg.slp` and `.yaml` files necessary to train with the configuration you selected in the GUI. Before running the [`sleap-nn train`](https://nn.sleap.ai/latest/training/#using-cli) command, make sure to unzip this file:
+    If you exported the training package as a ZIP file, it contains both the `.pkg.slp` and `.yaml` files necessary to train with the configuration you selected in the GUI. Before running the [`sleap-nn train`](https://nn.sleap.ai/latest/guides/training/#using-cli) command, make sure to unzip this file:
 
     === "macOS/Linux"
 

--- a/docs/guides/migrating-to-sleap-1-5.md
+++ b/docs/guides/migrating-to-sleap-1-5.md
@@ -27,7 +27,7 @@ PyTorch-based neural network backend for training and inference. Perfect for cus
 ## Torch Backend Changes
 
 ### New Backbones
-SLEAP 1.5 introduces three powerful new backbone architectures (check [here](https://nn.sleap.ai/latest/models/#backbone-architectures) for more details):
+SLEAP 1.5 introduces three powerful new backbone architectures (check [here](https://nn.sleap.ai/latest/reference/models/#backbones) for more details):
 
 - **UNet** - Classic encoder-decoder architecture for precise pose estimation
 - **SwinT** - Swin Transformer for state-of-the-art performance
@@ -36,8 +36,8 @@ SLEAP 1.5 introduces three powerful new backbone architectures (check [here](htt
 ### Legacy Support
 We've maintained full backward compatibility:
 
-- **GUI Support**: SLEAP now uses a new <u>YAML-based</u> config file structure, but you can still upload and work with old SLEAP JSON files in the GUI. For details on converting legacy SLEAP 1.4 config/JSON files to the new YAML format, see our [conversion guide](https://nn.sleap.ai/latest/config/#converting-legacy-sleap-14-configjson-to-sleap-nn-yaml).
-- **Using TensorFlow Model Weights**: Continue to support running inference on SLEAP <1.4 TensorFlow model weights (UNet backbone only). Check [using legacy models](https://nn.sleap.ai/latest/inference/#legacy-sleap-model-support) for more details.
+- **GUI Support**: SLEAP now uses a new <u>YAML-based</u> config file structure, but you can still upload and work with old SLEAP JSON files in the GUI. For details on converting legacy SLEAP 1.4 config/JSON files to the new YAML format, see our [conversion guide](https://nn.sleap.ai/latest/configuration/#converting-from-legacy-sleap).
+- **Using TensorFlow Model Weights**: Continue to support running inference on SLEAP <1.4 TensorFlow model weights (UNet backbone only). Check [using legacy models](https://nn.sleap.ai/latest/guides/inference/#legacy-sleap-model-support) for more details.
 
 
 ## What's New in v1.6

--- a/docs/guides/running-sleap-remotely.md
+++ b/docs/guides/running-sleap-remotely.md
@@ -29,7 +29,7 @@ Our guide to [creating a custom training profile](creating-a-custom-training-pro
 
 **Command-line training**:
 
-Once you have your training job package (or labels package and training profile), you can run training using the [`sleap-nn train`](https://nn.sleap.ai/latest/training/#using-cli) command like so:
+Once you have your training job package (or labels package and training profile), you can run training using the [`sleap-nn train`](https://nn.sleap.ai/latest/guides/training/#using-cli) command like so:
 
 ```sh
 sleap-nn train --config <path/to/config.yaml> "data_config.train_labels_path=[<path/to/slp/file>]" trainer_config.ckpt_dir="models" trainer_config.run_name=<run_name>
@@ -38,7 +38,7 @@ sleap-nn train --config <path/to/config.yaml> "data_config.train_labels_path=[<p
 The model will be saved in the `models/` directory within the same directory as the **training job package** (in this case, `models/run_name/`).
 
 !!! note
-    If you exported the training package as a ZIP file, it contains both the `.pkg.slp` and `.yaml` files necessary to train with the configuration you selected in the GUI. Before running the [`sleap-nn train`](https://nn.sleap.ai/latest/training/#using-cli) command, make sure to unzip this file:
+    If you exported the training package as a ZIP file, it contains both the `.pkg.slp` and `.yaml` files necessary to train with the configuration you selected in the GUI. Before running the [`sleap-nn train`](https://nn.sleap.ai/latest/guides/training/#using-cli) command, make sure to unzip this file:
 
     === "macOS/Linux"
 
@@ -85,7 +85,7 @@ You'll need both of these files for each model you're going to use for inference
 
 !!! note "Legacy SLEAP Model Support"
     SLEAP-NN supports running inference on models trained with legacy SLEAP (version 1.4.1 or earlier).  
-    You can use the `sleap-nn track` command with legacy model files (`.h5` and `.json`) as described in the [Legacy SLEAP Model Support documentation](https://nn.sleap.ai/latest/inference/#legacy-sleap-model-support).  
+    You can use the `sleap-nn track` command with legacy model files (`.h5` and `.json`) as described in the [Legacy SLEAP Model Support documentation](https://nn.sleap.ai/latest/guides/inference/#legacy-sleap-model-support).  
     This allows you to run inference on older models without needing to retrain them with the new backend.
 
 
@@ -101,7 +101,7 @@ For this example, let's suppose you're working with an HDF5 video at `path/to/vi
 
 **Command-line inference**:
 
-To run inference, you'll call [`sleap-nn track`](https://nn.sleap.ai/latest/inference/#run-inference-with-cli) with the paths to each trained model and your video file, like so:
+To run inference, you'll call [`sleap-nn track`](https://nn.sleap.ai/latest/guides/inference/#running-inference) with the paths to each trained model and your video file, like so:
 
 ```sh
 sleap-nn track -i path/to/video.mp4 --video_dataset video --video_input_format channels_last -m path/to/models/centroid -m path/to/models/centered-instance
@@ -111,6 +111,6 @@ This will run inference on the entire video. If you only want to run inference o
 
 This will give you predictions frame-by-frame, but will not connect those predictions across frames into `tracks`. If you want cross-frame identity tracking, set `--tracking` argument. For optical flow, use `--use_flow`. For matching identities without optical flow and using each instance centroid (rather than all the predicted nodes), use `--features centroids --scoring_method euclidean_dist`.
 
-It's also be possible to run tracking separately after you've generated a predictions file (see [`Track-only workflow`](https://nn.sleap.ai/latest/inference/#track-only-workflow)). This makes it easy to try different tracking methods and parameters without needing to re-run the full inference process.
+It's also be possible to run tracking separately after you've generated a predictions file (see [`Track-only workflow`](https://nn.sleap.ai/latest/guides/tracking/#track-only-mode)). This makes it easy to try different tracking methods and parameters without needing to re-run the full inference process.
 
 When inference is finished, it will save the predictions in a new slp file. This file has the same format as a standard SLEAP project file, and you can use the GUI to proofread this file or merge the predictions into an existing SLEAP project. The file will be in the same directory as the video and the filename will be `{video filename}.predictions.slp`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,14 +88,14 @@
 
 ### Quick start
 
-Install [`uv`](https://github.com/astral-sh/uv) first:
+Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/) first:
 
 ```bash
 # macOS/Linux
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Windows
-powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
 Then install SLEAP:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,13 +43,13 @@ SLEAP is a tool for tracking animal poses in video. This guide will get you up a
 
 ### Install uv
 
-SLEAP uses `uv` to manage installation. It's a fast, modern package manager that handles everything automatically—including GPU detection.
+SLEAP uses [`uv`](https://docs.astral.sh/uv/getting-started/installation/) to manage installation. It's a fast, modern package manager that handles everything automatically—including GPU detection.
 
 === "Windows"
     1. Press the **Windows key**, type `PowerShell`, press **Enter**
     2. Paste this command and press **Enter**:
     ```powershell
-    irm https://astral.sh/uv/install.ps1 | iex
+    powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
     ```
     3. **Close and reopen** PowerShell
     4. Verify: `uv --version`
@@ -80,7 +80,7 @@ One command works on all platforms. It automatically detects your GPU and instal
 
 !!! success "Quick Install"
     ```bash
-    uv tool install --python 3.13 "sleap[nn]==1.6.1" --with "sleap-io==0.6.4" --with "sleap-nn==0.1.0" --torch-backend auto
+    uv tool install --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
     ```
 
     Check the [version compatibility table](#version-compatibility) for the latest versions.
@@ -170,7 +170,7 @@ uv tool upgrade sleap --upgrade-package sleap-io --upgrade-package sleap-nn
 If you need specific versions (for reproducibility or to match a collaborator), reinstall:
 
 ```bash
-uv tool install --python 3.13 "sleap[nn]==1.6.1" --with "sleap-io==0.6.4" --with "sleap-nn==0.1.0" --torch-backend auto
+uv tool install --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
 ```
 
 This replaces the existing installation with the exact versions specified.
@@ -180,7 +180,7 @@ This replaces the existing installation with the exact versions specified.
 Just reinstall with the older version:
 
 ```bash
-uv tool install --python 3.13 "sleap[nn]==1.5.2" --torch-backend auto
+uv tool install --python 3.13 "sleap[nn]==1.6.1" --torch-backend auto
 ```
 
 ### Uninstall
@@ -196,7 +196,7 @@ uv tool uninstall sleap
     - Installing from local source code (to pick up changes)
 
     ```bash
-    uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.1" --with "sleap-io==0.6.4" --with "sleap-nn==0.1.0" --torch-backend auto
+    uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
     ```
 
 ---
@@ -217,6 +217,7 @@ The SLEAP ecosystem has three packages that work together:
 
 | SLEAP | sleap-io | sleap-nn |
 |-------|----------|----------|
+| 1.6.3 | 0.7.0 | 0.2.0 |
 | 1.6.1 | 0.6.4 | 0.1.0 |
 | 1.6.0 | 0.6.4 | 0.1.0 |
 | 1.6.0a3 | 0.6.3 | 0.1.0a4 |
@@ -239,7 +240,7 @@ Always use compatible versions when pinning.
     | `xpu` | Intel GPUs |
 
     ```bash
-    uv tool install --python 3.13 "sleap[nn]==1.6.1" --with "sleap-io==0.6.4" --with "sleap-nn==0.1.0" --torch-backend cu128
+    uv tool install --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend cu128
     ```
 
 ---
@@ -361,10 +362,10 @@ If you installed SLEAP as a tool:
 
 ```bash
 # Add ONNX export support (CPU runtime)
-uv tool install --python 3.13 "sleap[nn,nn-export]==1.6.1" --with "sleap-io==0.6.4" --with "sleap-nn==0.1.0" --torch-backend auto
+uv tool install --python 3.13 "sleap[nn,nn-export]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
 
 # Add ONNX export support (GPU runtime - faster inference)
-uv tool install --python 3.13 "sleap[nn,nn-export-gpu]==1.6.1" --with "sleap-io==0.6.4" --with "sleap-nn==0.1.0" --torch-backend auto
+uv tool install --python 3.13 "sleap[nn,nn-export-gpu]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
 ```
 
 If you're using a development setup:
@@ -386,7 +387,7 @@ For NVIDIA TensorRT support on Linux or Windows:
 uv sync --extra nn-cuda128 --extra nn-tensorrt
 
 # Tool install
-uv tool install --python 3.13 "sleap[nn,nn-tensorrt]==1.6.1" --with "sleap-io==0.6.4" --with "sleap-nn==0.1.0" --torch-backend cu128
+uv tool install --python 3.13 "sleap[nn,nn-tensorrt]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend cu128
 ```
 
 !!! note
@@ -408,7 +409,7 @@ uv tool install --python 3.13 "sleap[nn,nn-tensorrt]==1.6.1" --with "sleap-io==0
 ??? note "Force a clean reinstall"
     If something is broken:
     ```bash
-    uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.1" --with "sleap-io==0.6.4" --with "sleap-nn==0.1.0" --torch-backend auto
+    uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
     ```
 
 ??? note "Installation seems stuck"

--- a/docs/notebooks/Post_inference_tracking.ipynb
+++ b/docs/notebooks/Post_inference_tracking.ipynb
@@ -219,7 +219,7 @@
         "id": "hwFC2WYWBQXe"
       },
       "source": [
-        "Here we create a tracker with the options we want to experiment with. You can [read more about tracking in the documentation](../../guides/tracking-and-proofreading/#tracking-methods) or the parameters in the [`sleap-track` CLI help](../../reference/command-line-interfaces/#inference-and-tracking) or [`sleap-nn track CLI`](https://nn.sleap.ai/latest/inference/#tracking)."
+        "Here we create a tracker with the options we want to experiment with. You can [read more about tracking in the documentation](../../guides/tracking-and-proofreading/#tracking-methods) or the parameters in the [`sleap-track` CLI help](../../reference/command-line-interfaces/#inference-and-tracking) or [`sleap-nn track CLI`](https://nn.sleap.ai/latest/guides/tracking/#tracking)."
       ]
     },
     {

--- a/docs/reference/command-line-interfaces.md
+++ b/docs/reference/command-line-interfaces.md
@@ -124,7 +124,7 @@ sleap train config.yaml                    # Train with config file
 sleap train --config configs/baseline.yaml
 ```
 
-[:octicons-arrow-right-24: Full training documentation](https://nn.sleap.ai/latest/training/)
+[:octicons-arrow-right-24: Full training documentation](https://nn.sleap.ai/latest/guides/training/)
 
 ### `sleap track`
 
@@ -138,7 +138,7 @@ sleap track -i video.mp4 -m models/centroid/
 sleap track -i video.mp4 -m models/centroid/ -m models/instance/ --tracking
 ```
 
-[:octicons-arrow-right-24: Full inference documentation](https://nn.sleap.ai/latest/inference/)
+[:octicons-arrow-right-24: Full inference documentation](https://nn.sleap.ai/latest/guides/inference/)
 
 ### Other Neural Network Commands
 


### PR DESCRIPTION
## Summary

- Switch the Windows `uv` install command to the official form documented at [docs.astral.sh/uv/getting-started/installation/](https://docs.astral.sh/uv/getting-started/installation/). The previous form silently closed PowerShell on machines with a restricted execution policy ([#2683](https://github.com/talmolab/sleap/discussions/2683)).
- Bump installation version pins to the current releases: SLEAP **1.6.1 → 1.6.3**, sleap-io **0.6.4 → 0.7.0**, sleap-nn **0.1.0 → 0.2.0**.
- Repair 11 broken `nn.sleap.ai` links across 5 files after the sleap-nn docs reorganization.

## Changes

### Windows uv install command (closes [#2683](https://github.com/talmolab/sleap/discussions/2683))

Replaced the bare `irm https://astral.sh/uv/install.ps1 | iex` with the official wrapper that explicitly bypasses execution policy:

```powershell
powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
```

Without `-ExecutionPolicy ByPass`, PowerShell can close instantly on systems where the default execution policy disallows running scripts from the internet — which is exactly what the user in #2683 hit. Updated in: `README.md`, `docs/index.md`, `docs/installation.md`. Also retargeted the `uv` link from the GitHub repo to the official install docs.

### Version pin bumps

In `docs/installation.md`, updated every pinned install command (quick install, reinstall, ONNX export CPU/GPU, TensorRT, troubleshooting reinstall) to the current ecosystem versions:

```
"sleap[nn]==1.6.3"  --with "sleap-io==0.7.0"  --with "sleap-nn==0.2.0"
```

Also added a 1.6.3 row to the compatibility table and bumped the downgrade example from 1.5.2 → 1.6.1 (a more relevant "older version" for users today).

### Broken nn.sleap.ai links

The sleap-nn docs site reorganized several top-level pages. Fixed page-level 404s:

| Old (404) | New |
|---|---|
| `/latest/inference/` | `/latest/guides/inference/` |
| `/latest/training/` | `/latest/guides/training/` |
| `/latest/models/` | `/latest/reference/models/` |
| `/latest/config/` | `/latest/configuration/` |

Renamed anchors:
- `#backbone-architectures` → `#backbones`
- `#converting-legacy-sleap-14-configjson-to-sleap-nn-yaml` → `#converting-from-legacy-sleap`

Removed-anchor remaps to the closest current section:
- `inference/#run-inference-with-cli` → `guides/inference/#running-inference`
- `inference/#track-only-workflow` → `guides/tracking/#track-only-mode`
- `inference/#tracking` → `guides/tracking/#tracking`

Files touched: `docs/guides/migrating-to-sleap-1-5.md`, `docs/guides/running-sleap-remotely.md`, `docs/guides/creating-a-custom-training-profile.md`, `docs/reference/command-line-interfaces.md`, `docs/notebooks/Post_inference_tracking.ipynb`.

## Test plan

- [ ] Open the deployed docs preview and visit the Windows install instructions on the Installation page; copy the new command and paste into a clean PowerShell on a Windows machine with default execution policy to confirm it runs without closing.
- [ ] Verify the compatibility table on the Installation page shows the new 1.6.3 row.
- [ ] Click through every previously-broken `nn.sleap.ai` link on the deployed preview and confirm each lands on the intended section (no 404, anchor scrolls to the right heading):
  - migrating-to-sleap-1-5.md: backbones, configuration converting, legacy model support
  - running-sleap-remotely.md: training using-cli (×2), inference legacy model support, running-inference, track-only-mode
  - creating-a-custom-training-profile.md: training using-cli
  - reference/command-line-interfaces.md: training page, inference page
  - notebooks/Post_inference_tracking.ipynb: tracking section
- [ ] Confirm no other `nn.sleap.ai/latest/{inference,training,models,config}/` paths leaked through (`grep -rnE "nn\.sleap\.ai/latest/(inference|training|models|config)(/|#|$)" docs/` should be empty).

## Related

- Discussion: [#2683](https://github.com/talmolab/sleap/discussions/2683)

🤖 Generated with [Claude Code](https://claude.com/claude-code)