### PR TITLE
Fix blank progress dialog during Generate Suggestions

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3949,9 +3949,7 @@ class GenerateSuggestions(EditCommand):
 
         result = {"status": None, "suggestions": None, "error": None}
 
-        worker = GenerateSuggestionsThread(
-            labels=context.labels, params=params
-        )
+        worker = GenerateSuggestionsThread(labels=context.labels, params=params)
 
         def on_finished(suggestions):
             result["status"] = "finished"

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3894,6 +3894,27 @@ class SetTrackName(EditCommand):
         track.name = name
 
 
+class GenerateSuggestionsThread(QtCore.QThread):
+    """Background thread for generating frame suggestions without freezing GUI."""
+
+    finished = QtCore.Signal(list)
+    error = QtCore.Signal(str)
+
+    def __init__(self, labels, params, parent=None):
+        super().__init__(parent)
+        self.labels = labels
+        self.params = params
+
+    def run(self):
+        try:
+            suggestions = VideoFrameSuggestions.suggest(
+                labels=self.labels, params=self.params
+            )
+            self.finished.emit(suggestions)
+        except Exception as e:
+            self.error.emit(str(e))
+
+
 class GenerateSuggestions(EditCommand):
     topics = [UpdateTopic.suggestions]
 
@@ -3902,12 +3923,6 @@ class GenerateSuggestions(EditCommand):
         if len(context.labels.videos) == 0:
             print("Error: no videos to generate suggestions for")
             return
-
-        # TODO: Progress bar
-        win = MessageDialog(
-            "Generating list of suggested frames... This may take a few minutes.",
-            context.app,
-        )
 
         if (
             params["target"]
@@ -3921,22 +3936,59 @@ class GenerateSuggestions(EditCommand):
         else:
             params["videos"] = context.labels.videos
 
-        try:
-            new_suggestions = VideoFrameSuggestions.suggest(
-                labels=context.labels, params=params
-            )
+        win = QtWidgets.QProgressDialog(
+            "Generating suggested frames...", "Cancel", 0, 0, context.app
+        )
+        win.setWindowTitle("Generating Suggestions")
+        win.setWindowModality(QtCore.Qt.WindowModal)
+        win.setMinimumDuration(0)
+        win.setCancelButton(None)
+        win.setMinimumWidth(300)
+        win.show()
+        QtWidgets.QApplication.instance().processEvents()
 
-            context.labels.suggestions.extend(new_suggestions)
-        except Exception as e:
-            win.hide()
+        result = {"status": None, "suggestions": None, "error": None}
+
+        worker = GenerateSuggestionsThread(
+            labels=context.labels, params=params
+        )
+
+        def on_finished(suggestions):
+            result["status"] = "finished"
+            result["suggestions"] = suggestions
+
+        def on_error(msg):
+            result["status"] = "error"
+            result["error"] = msg
+
+        worker.finished.connect(on_finished)
+        worker.error.connect(on_error)
+
+        worker.start()
+
+        while worker.isRunning():
+            QtWidgets.QApplication.instance().processEvents()
+            worker.wait(10)
+
+        worker.wait()
+        QtWidgets.QApplication.instance().processEvents()
+
+        worker.finished.disconnect()
+        worker.error.disconnect()
+        worker.deleteLater()
+
+        win.close()
+
+        if result["status"] == "error":
             QtWidgets.QMessageBox(
                 text="An error occurred while generating suggestions. "
                 "Your command line terminal may have more information about "
                 "the error."
             ).exec_()
-            raise e
+            raise RuntimeError(result["error"])
 
-        win.hide()
+        if result["suggestions"]:
+            context.labels.suggestions.extend(result["suggestions"])
 
 
 class AddSuggestion(EditCommand):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1597,7 +1597,7 @@ def test_remove_video_uses_identity_not_content_matching(centered_pair_predictio
 
 
 class TestGenerateSuggestionsThread:
-    """Tests for GenerateSuggestionsThread (runs suggestion generation off main thread)."""
+    """Tests for GenerateSuggestionsThread."""
 
     def test_thread_emits_finished_with_suggestions(self, qtbot, centered_pair_labels):
         """Thread should emit finished signal with suggestion list on success."""

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -25,6 +25,7 @@ from sleap.gui.commands import (
     ExportDatasetWithImages,
     ExportFullPackage,
     ExportVideoClip,
+    GenerateSuggestionsThread,
     ImportDeepLabCutFolder,
     NewEdge,
     NewNode,
@@ -1593,3 +1594,74 @@ def test_remove_video_uses_identity_not_content_matching(centered_pair_predictio
     assert len(remaining_suggestions_video3) == 1, (
         "Suggestions for video3 should NOT have been deleted!"
     )
+
+
+class TestGenerateSuggestionsThread:
+    """Tests for GenerateSuggestionsThread (runs suggestion generation off main thread)."""
+
+    def test_thread_emits_finished_with_suggestions(self, qtbot, centered_pair_labels):
+        """Thread should emit finished signal with suggestion list on success."""
+        labels = centered_pair_labels
+        params = {
+            "method": "sample",
+            "target": "all videos",
+            "videos": labels.videos,
+            "per_video": 5,
+            "sampling_method": "random",
+        }
+
+        worker = GenerateSuggestionsThread(labels=labels, params=params)
+        with qtbot.waitSignal(worker.finished, timeout=10000) as blocker:
+            worker.start()
+
+        suggestions = blocker.args[0]
+        assert isinstance(suggestions, list)
+        assert len(suggestions) > 0
+
+    def test_thread_emits_error_on_invalid_method(self, qtbot, centered_pair_labels):
+        """Thread should emit error signal when suggest() raises."""
+        labels = centered_pair_labels
+        params = {
+            "method": "nonexistent_method",
+            "target": "all videos",
+            "videos": labels.videos,
+        }
+
+        worker = GenerateSuggestionsThread(labels=labels, params=params)
+        with qtbot.waitSignal(worker.error, timeout=10000) as blocker:
+            worker.start()
+
+        error_msg = blocker.args[0]
+        assert isinstance(error_msg, str)
+        assert len(error_msg) > 0
+
+    def test_thread_does_not_block_event_loop(self, qtbot, centered_pair_labels):
+        """Main event loop should remain responsive while thread is running."""
+        labels = centered_pair_labels
+        params = {
+            "method": "sample",
+            "target": "all videos",
+            "videos": labels.videos,
+            "per_video": 5,
+            "sampling_method": "random",
+        }
+
+        worker = GenerateSuggestionsThread(labels=labels, params=params)
+        events_processed = []
+
+        def on_finished(suggestions):
+            events_processed.append("finished")
+
+        worker.finished.connect(on_finished)
+
+        with qtbot.waitSignal(worker.finished, timeout=10000):
+            worker.start()
+            # Process events while waiting — this would hang if suggest() was
+            # still on the main thread.
+            from qtpy import QtWidgets
+
+            for _ in range(10):
+                QtWidgets.QApplication.instance().processEvents()
+                worker.wait(5)
+
+        assert "finished" in events_processed


### PR DESCRIPTION
## Summary
- Addresses #2685: "Generate Suggestions" blocked the main GUI thread, causing the progress dialog to render as a black rectangle (Linux/Wayland) or trigger the spinning beach ball (macOS)
- Moves `VideoFrameSuggestions.suggest()` onto a `QThread` worker, mirroring the existing pattern used by `RenderVideoThread` and `ExportPackageThread`
- Replaces the old `MessageDialog` with a `QProgressDialog` that stays responsive while suggestions are computed

## Test plan
- [x] Verified on macOS: no beach ball, progress dialog renders correctly, suggestion frames generated successfully
- [x] 3 new unit tests for `GenerateSuggestionsThread`: success path, error path, event loop responsiveness
- [ ] Test on Linux with Wayland (original reporter's environment)
- [ ] Test with "image features" method on a large video to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>