### PR TITLE
feat(gui): add optional "Mean Node Score" column to Instances panel

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -701,9 +701,7 @@ class MainWindow(QMainWindow):
         )
         add_menu_check_item(viewMenu, "show labels", "Show Node Names")
         add_menu_check_item(viewMenu, "show edges", "Show Edges")
-        add_menu_check_item(
-            viewMenu, "show mean node score", "Show Mean Node Score"
-        )
+        add_menu_check_item(viewMenu, "show mean node score", "Show Mean Node Score")
 
         add_submenu_choices(
             menu=viewMenu,

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -188,6 +188,7 @@ class MainWindow(QMainWindow):
         self.state["last_interacted_frame"] = None
         self.state["filename"] = None
         self.state["show non-visible nodes"] = prefs["show non-visible nodes"]
+        self.state["show mean node score"] = prefs["show mean node score"]
         self.state["show instances"] = True
         self.state["show labels"] = True
         self.state["show edges"] = True
@@ -275,6 +276,7 @@ class MainWindow(QMainWindow):
         prefs["window state"] = self.saveState()
         prefs["marker size"] = self.state["marker size"]
         prefs["show non-visible nodes"] = self.state["show non-visible nodes"]
+        prefs["show mean node score"] = self.state["show mean node score"]
         prefs["node label size"] = self.state["node label size"]
         prefs["edge style"] = self.state["edge style"]
         prefs["propagate track labels"] = self.state["propagate track labels"]
@@ -699,6 +701,9 @@ class MainWindow(QMainWindow):
         )
         add_menu_check_item(viewMenu, "show labels", "Show Node Names")
         add_menu_check_item(viewMenu, "show edges", "Show Edges")
+        add_menu_check_item(
+            viewMenu, "show mean node score", "Show Mean Node Score"
+        )
 
         add_submenu_choices(
             menu=viewMenu,

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -474,7 +474,7 @@ class LabeledFrameTableModel(GenericTableModel):
         labels: `Labels` datasource
     """
 
-    properties = ("points", "track", "score", "skeleton")
+    properties = ("points", "track", "score", "mean node score", "skeleton")
 
     def object_to_items(self, labeled_frame: LabeledFrame):
         if not labeled_frame:
@@ -492,10 +492,24 @@ class LabeledFrameTableModel(GenericTableModel):
         if hasattr(instance, "score"):
             score = str(round(instance.score, 2))
 
+        mean_node_score = ""
+        pts = getattr(instance, "points", None)
+        if pts is not None and getattr(pts, "dtype", None) is not None:
+            names = pts.dtype.names or ()
+            if "score" in names and "xy" in names:
+                # Visibility = non-NaN xy (matches sleap-nn's filter definition
+                # and the "Points" column above).
+                visible = ~np.isnan(pts["xy"]).any(axis=1)
+                visible_scores = pts["score"][visible]
+                visible_scores = visible_scores[~np.isnan(visible_scores)]
+                if visible_scores.size > 0:
+                    mean_node_score = f"{float(np.mean(visible_scores)):.2f}"
+
         return dict(
             points=points,
             track=track_name,
             score=score,
+            **{"mean node score": mean_node_score},
             skeleton=instance.skeleton.name,
         )
 

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -576,7 +576,27 @@ class InstancesDock(DockWidget):
             name_prefix="",
             model=self.model,
         )
+
+        # Apply initial visibility for the optional "mean node score" column,
+        # and keep it in sync with the View-menu toggle.
+        self._apply_mean_node_score_visibility()
+        self.main_window.state.connect(
+            "show mean node score",
+            lambda _: self._apply_mean_node_score_visibility(),
+        )
+
         return self.table
+
+    def _apply_mean_node_score_visibility(self) -> None:
+        """Hide or show the 'mean node score' column based on the View toggle."""
+        if not hasattr(self, "table") or self.table is None:
+            return
+        try:
+            col_idx = self.model.properties.index("mean node score")
+        except ValueError:
+            return
+        show = bool(self.main_window.state.get("show mean node score", default=False))
+        self.table.setColumnHidden(col_idx, not show)
 
     def lay_everything_out(self) -> None:
         self.wgt_layout.addWidget(self.table)

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -34,6 +34,7 @@ class Preferences(object):
         "window state": b"",
         "node label size": 12,
         "show non-visible nodes": True,
+        "show mean node score": False,
         "share usage data": True,
         "node marker sizes": (1, 2, 3, 4, 6, 8, 12),
         "node label sizes": (6, 9, 12, 18, 24, 36),

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -1,3 +1,6 @@
+import numpy as np
+import sleap_io as sio
+
 from sleap.gui.dataviews import *
 
 
@@ -84,3 +87,52 @@ def test_table_sort_string(qtbot):
     # Make sure we can sort with both numbers and strings (i.e., "")
     table.model().sort(0)
     table.model().sort(1)
+
+
+def test_labeled_frame_mean_node_score(qtbot, centered_pair_predictions):
+    """The 'mean node score' column should reflect mean of point scores over
+    visible (non-NaN) nodes, matching sleap-nn's filter definition."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+
+    assert "mean node score" in model.properties
+
+    for row, instance in enumerate(lf.instances):
+        cell = model._data[row]["mean node score"]
+
+        pts = instance.points
+        visible = ~np.isnan(pts["xy"]).any(axis=1)
+        scores = pts["score"][visible]
+        scores = scores[~np.isnan(scores)]
+        expected = f"{float(np.mean(scores)):.2f}"
+        assert cell == expected
+
+
+def test_labeled_frame_mean_node_score_user_instance(qtbot, centered_pair_predictions):
+    """User instances have no per-point scores; the column should be empty."""
+    skeleton = centered_pair_predictions.skeletons[0]
+    video = centered_pair_predictions.videos[0]
+    user_inst = sio.Instance.from_numpy(
+        np.zeros((len(skeleton.nodes), 2)), skeleton=skeleton
+    )
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[user_inst])
+
+    model = LabeledFrameTableModel(items=lf)
+    assert model._data[0]["mean node score"] == ""
+
+
+def test_labeled_frame_mean_node_score_all_nan(qtbot, centered_pair_predictions):
+    """If all keypoints are NaN, the column should be empty rather than NaN."""
+    skeleton = centered_pair_predictions.skeletons[0]
+    video = centered_pair_predictions.videos[0]
+    n_nodes = len(skeleton.nodes)
+    pred_inst = sio.PredictedInstance.from_numpy(
+        points_data=np.full((n_nodes, 2), np.nan),
+        skeleton=skeleton,
+        point_scores=np.full(n_nodes, 0.9),
+        score=0.0,
+    )
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=[pred_inst])
+
+    model = LabeledFrameTableModel(items=lf)
+    assert model._data[0]["mean node score"] == ""


### PR DESCRIPTION
## Summary

- Adds a 5th column **Mean Node Score** to the Instances dock, showing each predicted instance's mean point-confidence over visible (non-NaN) nodes — mirroring sleap-nn 0.1.2's `filter_min_mean_node_score`.
- Column is **hidden by default**; togglable via **View → Show Mean Node Score** (persisted across sessions via preferences).
- Empty cell for user instances, all-NaN poses, and any case where point scores are missing.

Closes #2651.

## Why

`sleap-nn 0.1.2` shipped four filters: `filter_min_visible_nodes`, `filter_min_visible_node_fraction`, `filter_min_instance_score`, and `filter_min_mean_node_score`. The first three are already reflected in existing GUI columns (Points, Score), but mean-node-score had no GUI counterpart — users could filter on it via the CLI but couldn't see the per-instance value when inspecting frames.

## Implementation

- `sleap/prefs.py` — `"show mean node score": False` default.
- `sleap/gui/dataviews.py` (`LabeledFrameTableModel`) — adds the column; visibility = `~np.isnan(xy).any(axis=1)` to match sleap-nn's canonical `_mean_node_score` definition (`sleap-nn/sleap_nn/inference/ops/filters.py:187`).
- `sleap/gui/widgets/docks.py` (`InstancesDock`) — `setColumnHidden()` on init; reconnects on state change.
- `sleap/gui/app.py` — load/save pref + `add_menu_check_item` for the View toggle (placed next to "Show Edges").

## Test plan

- [x] `pytest tests/gui/test_dataviews.py` — 6/6 pass (3 new tests covering predicted, user-instance, and all-NaN cases).
- [x] `pytest tests/gui/test_state.py tests/test_prefs.py tests/gui/test_app.py` — all pass.
- [x] `ruff check` clean on touched files.
- [ ] Manual: open a `.slp` with predicted instances, confirm column hidden by default, toggle via View menu, confirm values match `np.nanmean` of `points["score"]` over visible nodes, confirm preference persists across restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)