### PR TITLE
Fix Copy Prior Frame copying stale prediction instead of user correction (#1065)

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -4336,9 +4336,13 @@ class AddInstance(EditCommand):
             prev_idx = AddInstance.get_previous_frame_index(context)
 
             if prev_idx is not None:
-                prev_instances = context.labels.find(
+                prev_lf = context.labels.find(
                     context.state["video"], prev_idx, return_new=True
-                )[0].instances
+                )[0]
+                # Prefer user-corrected instances over their predicted
+                # counterparts so "Copy Prior Frame" picks up edits the user
+                # made in the previous frame (#1065).
+                prev_instances = AddInstance._effective_prior_instances(prev_lf)
                 if len(prev_instances) > len(context.state["labeled_frame"].instances):
                     # If more instances in previous frame than current, then use the
                     # first unmatched instance.
@@ -4380,6 +4384,17 @@ class AddInstance(EditCommand):
             return
 
         return next_idx
+
+    @staticmethod
+    def _effective_prior_instances(
+        prev_lf: LabeledFrame,
+    ) -> List[Union[Instance, PredictedInstance]]:
+        # When a user corrects a prediction the original PredictedInstance
+        # stays on the frame alongside the new user Instance. Returning raw
+        # `lf.instances` would let "Copy Prior Frame" land on the stale
+        # prediction; prefer the user version of each animal and drop
+        # predictions whose user counterpart is already present.
+        return list(prev_lf.user_instances) + list(prev_lf.unused_predictions)
 
 
 class SetInstancePointLocations(EditCommand):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1336,6 +1336,99 @@ def test_newInstance(qtbot, centered_pair_predictions: Labels):
     assert np.all(diff == offset)
 
 
+def _build_prior_frame_labels(
+    centered_pair_predictions: Labels,
+) -> tuple[Labels, LabeledFrame, LabeledFrame, PredictedInstance, Instance]:
+    """Build a two-frame Labels where frame 0 has a user correction of a prediction.
+
+    Returns (labels, prev_lf, curr_lf, pred_inst, user_inst).
+    """
+    labels = deepcopy(centered_pair_predictions)
+    skeleton = labels.skeleton
+    video = labels.videos[0]
+
+    # Frame 0: one prediction + a user instance derived from it (simulating the
+    # user having corrected the prediction).
+    prev_lf = LabeledFrame(video=video, frame_idx=0)
+    pred_inst = PredictedInstance.from_numpy(
+        np.array([[10.0, 10.0]] * len(skeleton.nodes)),
+        point_scores=np.ones(len(skeleton.nodes)),
+        score=0.9,
+        skeleton=skeleton,
+    )
+    user_inst = Instance.from_numpy(
+        np.array([[100.0, 200.0]] * len(skeleton.nodes)),
+        skeleton=skeleton,
+        from_predicted=pred_inst,
+    )
+    prev_lf.instances = [pred_inst, user_inst]
+
+    # Frame 1: empty.
+    curr_lf = LabeledFrame(video=video, frame_idx=1)
+
+    labels.labeled_frames = [prev_lf, curr_lf]
+    return labels, prev_lf, curr_lf, pred_inst, user_inst
+
+
+def test_copy_prior_frame_prefers_user_instance(qtbot, centered_pair_predictions):
+    """Copy Prior Frame must pick the user-corrected instance, not the original
+    prediction it was derived from (#1065)."""
+    labels, prev_lf, curr_lf, pred_inst, user_inst = _build_prior_frame_labels(
+        centered_pair_predictions
+    )
+
+    main_window = MainWindow(labels=labels)
+    context = main_window.commands
+    context.state["labeled_frame"] = curr_lf
+    context.state["frame_idx"] = curr_lf.frame_idx
+    context.state["skeleton"] = labels.skeleton
+    context.state["video"] = labels.videos[0]
+
+    copy_instance, from_predicted, from_prev_frame = (
+        AddInstance.find_instance_to_copy_from(
+            context, copy_instance=None, init_method="prior_frame"
+        )
+    )
+
+    assert copy_instance is user_inst
+    assert from_predicted is None
+    assert from_prev_frame is True
+
+
+def test_effective_prior_instances_drops_used_predictions(centered_pair_predictions):
+    """The helper should hide each prediction whose user counterpart is in frame."""
+    _, prev_lf, _, pred_inst, user_inst = _build_prior_frame_labels(
+        centered_pair_predictions
+    )
+    effective = AddInstance._effective_prior_instances(prev_lf)
+    assert effective == [user_inst]
+    assert pred_inst not in effective
+
+
+def test_effective_prior_instances_keeps_unmatched_predictions(
+    centered_pair_predictions,
+):
+    """A prediction with no user counterpart must remain so a second animal can
+    still be copied across."""
+    labels, prev_lf, _, pred_inst, user_inst = _build_prior_frame_labels(
+        centered_pair_predictions
+    )
+    skeleton = labels.skeleton
+
+    extra_pred = PredictedInstance.from_numpy(
+        np.array([[50.0, 50.0]] * len(skeleton.nodes)),
+        point_scores=np.ones(len(skeleton.nodes)),
+        score=0.8,
+        skeleton=skeleton,
+    )
+    prev_lf.instances = [pred_inst, user_inst, extra_pred]
+
+    effective = AddInstance._effective_prior_instances(prev_lf)
+    assert user_inst in effective
+    assert extra_pred in effective
+    assert pred_inst not in effective
+
+
 def test_ExportLabelsSubset(
     tmp_path, centered_pair_predictions: Labels, small_robot_mp4_vid: Video
 ):


### PR DESCRIPTION
## Summary
Closes #1065.

When a user corrects a `PredictedInstance` in a frame, sleap-io keeps the
original prediction on `LabeledFrame.instances` alongside the new user
`Instance`. The "Copy Prior Frame" path in
`AddInstance.find_instance_to_copy_from` iterates the raw
`prev_lf.instances` and picks one by index, so it can land on the stale
prediction instead of the user's correction. The reporter saw this as
"my new instance had the same shape as the original prediction, not the
corrected one."

The "Copy Predictions" / unused-prediction path was already correct — it
goes through `LabeledFrame.unused_predictions`, which hides any
prediction whose user counterpart exists in the same frame (matched via
`from_predicted` or shared track).

## Fix
Introduce `AddInstance._effective_prior_instances(prev_lf)` returning
`prev_lf.user_instances + prev_lf.unused_predictions`. This yields one
instance per animal in the prior frame, preferring the user version,
which is then fed to the existing index-based selection logic unchanged.

Only the `prior_frame` branch is touched; the `prediction` and
right-clicked-instance branches keep their current behavior.

## Test plan
- [x] `test_copy_prior_frame_prefers_user_instance` — repro from #1065
- [x] `test_effective_prior_instances_drops_used_predictions`
- [x] `test_effective_prior_instances_keeps_unmatched_predictions` — multi-animal
- [x] Full `tests/gui/test_commands.py` suite (31 passed, 3 skipped)
- [x] `ruff check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)