### PR TITLE
feat(gui): improve loss plot y-axis scaling and add batch subsample dropdown

### DIFF
--- a/sleap/gui/widgets/monitor.py
+++ b/sleap/gui/widgets/monitor.py
@@ -378,35 +378,46 @@ class LossPlot(MplCanvas):
     def _calculate_ylim(self, y: np.ndarray, dy: float = 0.02):
         """Calculates y-axis limits.
 
+        For log scale, padding is computed in log space so the visible loss band
+        is not compressed by a hard ``1e-8`` floor. For linear scale, padding is
+        proportional to the data range.
+
         Args:
             y: Array of y data to fit the limits to.
-            dy: The padding to add to the limits.
+            dy: Unused; padding is recomputed from the data range/spread.
 
         Returns:
             Tuple of the minimum and maximum y-axis limits.
         """
 
-        if self.ignore_outliers:
-            dy = np.ptp(y) * 0.02
-            # Set Y scale to exclude outliers
-            q1, q3 = np.quantile(y, (0.25, 0.75))
-            iqr = q3 - q1  # Interquartile range
-            y_min = q1 - iqr * 1.5
-            y_max = q3 + iqr * 1.5
+        y = np.asarray(y)
 
-            # Keep within range of data
-            y_min = max(y_min, min(y) - dy)
-            y_max = min(y_max, max(y) + dy)
-        else:
-            # Set Y scale to show all points
-            dy = np.ptp(y) * 0.02
-            y_min = min(y) - dy
-            y_max = max(y) + dy
-
-        # For log scale, low cannot be 0
         if self.log_scale:
-            y_min = max(y_min, 1e-8)
+            # Work in log space so padding is symmetric on a log axis.
+            y_pos = y[y > 0]
+            if y_pos.size == 0:
+                return 1e-8, 1.0
+            log_y = np.log10(y_pos)
+            if self.ignore_outliers and log_y.size >= 4:
+                q1, q3 = np.quantile(log_y, (0.25, 0.75))
+                iqr = q3 - q1
+                log_min = max(q1 - 1.5 * iqr, log_y.min())
+                log_max = min(q3 + 1.5 * iqr, log_y.max())
+            else:
+                log_min, log_max = log_y.min(), log_y.max()
+            pad = (log_max - log_min) * 0.02 if log_max > log_min else 0.05
+            return 10 ** (log_min - pad), 10 ** (log_max + pad)
 
+        # Linear scale (unchanged behavior).
+        dy = np.ptp(y) * 0.02
+        if self.ignore_outliers:
+            q1, q3 = np.quantile(y, (0.25, 0.75))
+            iqr = q3 - q1
+            y_min = max(q1 - iqr * 1.5, y.min() - dy)
+            y_max = min(q3 + iqr * 1.5, y.max() + dy)
+        else:
+            y_min = y.min() - dy
+            y_max = y.max() + dy
         return y_min, y_max
 
     def _set_title_space(self):
@@ -611,6 +622,7 @@ class LossViewer(QtWidgets.QMainWindow):
         self.zmq_ports = zmq_ports
 
         self.batches_to_show = -1  # -1 to show all
+        self.batch_subsample = 1  # stride applied to batch markers (1 = show all)
         self._ignore_outliers = False
         self._log_scale = True
         self.message_poll_time_ms = 20  # ms
@@ -728,6 +740,21 @@ class LossViewer(QtWidgets.QMainWindow):
             self.batches_to_show_field = field
             control_layout.addWidget(self.batches_to_show_field)
 
+            control_layout.addWidget(QtWidgets.QLabel("Batch Subsample:"))
+
+            # Dropdown to thin out batch markers (1=all, 10=every 10th, 100=every 100th)
+            field = QtWidgets.QComboBox()
+            self.batch_subsample_options = ["1", "10", "100"]
+            for opt in self.batch_subsample_options:
+                field.addItem(opt)
+            if str(self.batch_subsample) in self.batch_subsample_options:
+                field.setCurrentText(str(self.batch_subsample))
+            field.currentIndexChanged.connect(
+                lambda x: self._set_batch_subsample(self.batch_subsample_options[x])
+            )
+            self.batch_subsample_field = field
+            control_layout.addWidget(self.batch_subsample_field)
+
             control_layout.addStretch(1)
 
             # WandB URL label (hidden until URL is received)
@@ -836,6 +863,22 @@ class LossViewer(QtWidgets.QMainWindow):
             self.batches_to_show = int(batches)
         else:
             self.batches_to_show = -1
+
+    def _set_batch_subsample(self, stride: str):
+        """Set the subsampling stride for batch markers.
+
+        Stored data (``self.X``/``self.Y``) is preserved; only the points sent
+        to the scatter series are thinned. The most recent batch point is
+        always kept so progress remains visible.
+
+        Args:
+            stride: Stride as a string. ``"1"`` shows every batch; ``"10"``
+                shows every 10th; ``"100"`` shows every 100th.
+        """
+        if stride.isdigit() and int(stride) >= 1:
+            self.batch_subsample = int(stride)
+        else:
+            self.batch_subsample = 1
 
     def _set_start_time(self, t0: float):
         """Mark the start flag and time of the run.
@@ -1028,6 +1071,11 @@ class LossViewer(QtWidgets.QMainWindow):
                         self.X[-self.batches_to_show :],
                         self.Y[-self.batches_to_show :],
                     )
+
+                # Subsample batch markers (preserve the most recent point).
+                if self.batch_subsample > 1 and len(xs) > self.batch_subsample:
+                    xs = xs[:: -self.batch_subsample][::-1]
+                    ys = ys[:: -self.batch_subsample][::-1]
 
                 # Set data, resize and redraw the plot
                 self._set_data_on_scatter(xs, ys, which)

--- a/tests/gui/test_monitor.py
+++ b/tests/gui/test_monitor.py
@@ -1,4 +1,6 @@
-from sleap.gui.widgets.monitor import LossViewer
+import numpy as np
+
+from sleap.gui.widgets.monitor import LossPlot, LossViewer
 
 
 def test_monitor_release(qtbot, min_centroid_model_path):
@@ -63,3 +65,97 @@ def test_monitor_release(qtbot, min_centroid_model_path):
     assert win3.zmq_ports["publish_port"] == publish_port
 
     win3.close()
+
+
+def test_ylim_log_scale_tracks_data(qtbot):
+    """Log-scale y-limits should hug the data, not floor at 1e-8."""
+    plot = LossPlot(log_scale=True, ignore_outliers=False)
+    y = np.geomspace(1e-3, 1e-1, 200)
+    y_min, y_max = plot._calculate_ylim(y)
+
+    # Lower bound should be near min(y), not the legacy 1e-8 floor.
+    assert y_min > 1e-4
+    assert y_min < y.min()
+    # Upper bound should be just above max(y).
+    assert y_max > y.max()
+    assert y_max < y.max() * 2
+
+
+def test_ylim_log_scale_ignore_outliers(qtbot):
+    """Outlier rejection should run in log space and bracket the IQR."""
+    plot = LossPlot(log_scale=True, ignore_outliers=True)
+    bulk = np.geomspace(1e-3, 1e-2, 200)
+    # Add a single extreme outlier; IQR rejection in log space should clip it.
+    y = np.concatenate([bulk, [10.0]])
+    y_min, y_max = plot._calculate_ylim(y)
+
+    assert y_min > 1e-4
+    assert y_max < 1.0  # outlier excluded
+
+
+def test_ylim_log_scale_all_nonpositive_fallback(qtbot):
+    """All non-positive values on log scale should fall back to a safe range."""
+    plot = LossPlot(log_scale=True, ignore_outliers=False)
+    y = np.array([0.0, -1.0, 0.0])
+    y_min, y_max = plot._calculate_ylim(y)
+    assert y_min == 1e-8
+    assert y_max == 1.0
+
+
+def test_ylim_linear_scale_unchanged(qtbot):
+    """Linear scale path should pad relative to the data range."""
+    plot = LossPlot(log_scale=False, ignore_outliers=False)
+    y = np.linspace(0.5, 1.5, 100)
+    y_min, y_max = plot._calculate_ylim(y)
+    # 2% of range = 0.02; expect padding within that order of magnitude.
+    assert y.min() - 0.05 < y_min < y.min()
+    assert y.max() < y_max < y.max() + 0.05
+
+
+def test_batch_subsample_field_defaults_and_updates(qtbot):
+    """The new batch-subsample dropdown should default to 1 and update state."""
+    win = LossViewer()
+    win.show()
+    try:
+        assert win.batch_subsample == 1
+        assert win.batch_subsample_field.currentText() == "1"
+
+        win.batch_subsample_field.setCurrentText("10")
+        assert win.batch_subsample == 10
+
+        win.batch_subsample_field.setCurrentText("100")
+        assert win.batch_subsample == 100
+    finally:
+        win.close()
+
+
+def test_batch_subsample_thins_scatter_data(qtbot):
+    """When subsample > 1, scatter should receive a strided subset that ends on last."""
+    win = LossViewer()
+    win.show()
+    try:
+        win.batch_subsample = 10
+        # Force a redraw on the very next batch by clearing throttle state.
+        win.last_redraw_batch = None
+
+        n = 105
+        for i in range(n):
+            win._add_datapoint(x=i, y=1.0 / (i + 1), which="batch")
+            # Reset throttle so every point triggers a redraw — keeps the test
+            # deterministic regardless of wall-clock perf.
+            win.last_redraw_batch = None
+
+        # Stored data is preserved (no subsampling on the underlying buffers).
+        assert len(win.X) == n
+        assert len(win.Y) == n
+
+        # The scatter on the canvas should reflect the strided view.
+        offsets = win.canvas.series["batch"].get_offsets()
+        xs = np.asarray(offsets[:, 0])
+        # Last point should always be visible.
+        assert xs[-1] == n - 1
+        # Roughly n/stride points (with last point pinned).
+        expected = (n + 9) // 10
+        assert len(xs) == expected
+    finally:
+        win.close()


### PR DESCRIPTION
## Summary
- **Log-scale Y-axis fix**: Replace the hard-coded `1e-8` floor in `_calculate_ylim` with log-space-aware padding so the visible loss band fills the plot instead of being compressed into a thin sliver.
- **Batch subsample dropdown**: Add a "Batch Subsample" combobox (1 / 10 / 100) to `LossViewer` that thins out batch-loss scatter markers for faster rendering on long training runs. Stored data is preserved; only the displayed points are strided.

Addresses both items from [Discussion #2583](https://github.com/talmolab/sleap/discussions/2583).

## Changes Made
- `sleap/gui/widgets/monitor.py`:
  - `LossPlot._calculate_ylim` — log-scale branch now works in log₁₀ space for padding and outlier rejection; linear branch unchanged.
  - `LossViewer.reset` — new "Batch Subsample:" `QComboBox` (1/10/100) in the control bar.
  - `LossViewer._set_batch_subsample` — setter for the stride value.
  - `LossViewer._add_datapoint` — applies reverse stride before passing batch data to scatter, keeping the most recent point visible.
- `tests/gui/test_monitor.py` — 6 new tests covering log-scale padding, outlier rejection, fallback, linear path, dropdown defaults, and scatter thinning.

## Visual Verification

| Subsample = 1 (all 4000 pts) | Subsample = 10 (~400 pts) | Subsample = 100 (~40 pts) |
|---|---|---|
| Y-axis hugs 10⁻³–10⁻¹, no dead band | Same curve, fewer markers | Sparse and fast |

## Test plan
- [x] 7/7 tests pass (`tests/gui/test_monitor.py`)
- [x] `ruff check` and `ruff format` clean
- [x] Offscreen Qt screenshots captured for subsample = 1, 10, 100
- [ ] CI (Ubuntu / Windows / macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)