### PR TITLE
docs: align license section with README (closes #2402)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -216,6 +216,8 @@ SLEAP is currently being developed and maintained in the [Talmo Lab](https://tal
 
 ## License
 
-SLEAP is released under a [Clear BSD License](https://raw.githubusercontent.com/talmolab/sleap/main/LICENSE) and is intended for research/academic use only.
+<!-- SLEAP is released under a [Clear BSD License](https://raw.githubusercontent.com/talmolab/sleap/main/LICENSE) and is intended for research/academic use only.
 
-For commercial use, please contact: **Laurie Tzodikov** (Assistant Director, Office of Technology Licensing), Princeton University, 609-258-7256.
+For commercial use, please contact: **Laurie Tzodikov** (Assistant Director, Office of Technology Licensing), Princeton University, 609-258-7256. -->
+
+SLEAP is released under a [BSD 3-Clause Clear License](https://github.com/talmolab/sleap/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

- The docs.sleap.ai landing page (`docs/index.md`) still rendered the old "research/academic use only" + Princeton-OTL commercial-contact prose that was already removed from `README.md` in #2661.
- The actual `LICENSE` file is — and has been since #2248 — the standard Clear BSD with no commercial-use restriction. The remaining surface text was simply out of sync.
- This brings `docs/index.md` to the same pattern as the README: HTML-comment the old block (for easy revert), add a one-line "SLEAP is released under a [BSD 3-Clause Clear License](https://github.com/talmolab/sleap/blob/main/LICENSE)." line.

Closes #2402 — reported by @mprib.

## Test plan
- [ ] CI passes
- [ ] Confirm the rendered docs.sleap.ai landing page picks up the change on the next deploy