### PR TITLE
fix(gui): add "Include unlabeled frames" option to Render Video Clip dialog (#2245)

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1596,6 +1596,9 @@ class ExportLabeledClip(AppCommand):
         params["show_edges"] = export_params.get("show_edges", True)
         params["background"] = export_params.get("background")
         params["open_when_done"] = export_params.get("open_when_done", True)
+        params["include_unlabeled"] = export_params.get("include_unlabeled", False)
+        params["start"] = export_params.get("start")
+        params["end"] = export_params.get("end")
 
         return True
 
@@ -1629,12 +1632,26 @@ class ExportLabeledClip(AppCommand):
         if params.get("background"):
             render_params["background"] = params["background"]
 
+        # When the user opts in to include unlabeled frames, hand sleap-io the
+        # full range instead of a labeled-only frame_inds list — otherwise the
+        # explicit frame_inds would restrict output back to labeled frames.
+        include_unlabeled = params.get("include_unlabeled", False)
+        if include_unlabeled:
+            render_params["include_unlabeled"] = True
+            if params.get("start") is not None:
+                render_params["start"] = params["start"]
+            if params.get("end") is not None:
+                render_params["end"] = params["end"]
+            frame_inds = None
+        else:
+            frame_inds = params.get("frame_indices")
+
         # Render with progress dialog (non-blocking)
         render_video_gui(
             labels=labels,
             filename=params["video_filename"],
             video=video,
-            frame_inds=params.get("frame_indices"),
+            frame_inds=frame_inds,
             render_params=render_params,
             open_when_done=params.get("open_when_done", True),
         )
@@ -1939,9 +1956,20 @@ def render_video_gui(
     # aren't rendered as ghost skeletons alongside their user counterparts.
     labels = _labels_with_visible_instances(labels, video)
 
-    # Calculate total frames for progress
+    # Calculate total frames for progress. When the caller asked for unlabeled
+    # frames to be included we can't infer the count from labeled frames; try
+    # the video shape, then fall back to the labeled-frame count as a starting
+    # estimate (the progress callback corrects ``total`` on its first tick).
     if frame_inds is not None:
         total_frames = len(frame_inds)
+    elif render_params.get("include_unlabeled"):
+        start = render_params.get("start")
+        end = render_params.get("end")
+        if start is not None and end is not None:
+            total_frames = max(end - start, 0)
+        else:
+            video_shape = getattr(video, "shape", None)
+            total_frames = int(video_shape[0]) if video_shape is not None else 0
     else:
         total_frames = len(
             [lf for lf in labels.labeled_frames if video is None or lf.video == video]

--- a/sleap/gui/dialogs/render_clip.py
+++ b/sleap/gui/dialogs/render_clip.py
@@ -258,6 +258,20 @@ class RenderClipDialog(QtWidgets.QDialog):
         range_layout.addStretch()
         layout.addLayout(range_layout)
 
+        # Include-unlabeled toggle. Without this, the render only writes frames
+        # that have a LabeledFrame, so a sparse predictions file collapses to a
+        # short highlight reel instead of an overlay over the original video.
+        self.include_unlabeled = QtWidgets.QCheckBox(
+            "Include unlabeled frames in range"
+        )
+        self.include_unlabeled.setToolTip(
+            "When unchecked, only frames with labeled or predicted instances "
+            "are written to the output video.\n"
+            "When checked, every frame in the selected range is written, with "
+            "skeleton overlays drawn on the frames that have instances."
+        )
+        layout.addWidget(self.include_unlabeled)
+
         # Connect range mode changes
         self.range_custom.toggled.connect(self.start_frame.setEnabled)
         self.range_custom.toggled.connect(self.end_frame.setEnabled)
@@ -637,22 +651,36 @@ class RenderClipDialog(QtWidgets.QDialog):
         params["crf"] = self.crf.value()
         params["open_when_done"] = self.open_when_done.isChecked()
 
-        # Frame range
+        include_unlabeled = self.include_unlabeled.isChecked()
+        if include_unlabeled:
+            params["include_unlabeled"] = True
+
+        # Frame range. sleap-io's `end` is exclusive while the dialog spinbox
+        # is inclusive, so add 1 when forwarding. start/end are only consumed
+        # downstream when frame_inds is None (i.e. include_unlabeled is on).
         if self.range_custom.isChecked():
             params["start"] = self.start_frame.value()
-            params["end"] = self.end_frame.value()
+            params["end"] = self.end_frame.value() + 1
 
         return params
 
-    def get_frame_indices(self) -> list[int]:
+    def get_frame_indices(self) -> list[int] | None:
         """Get list of frame indices to render.
 
         Returns:
-            Sorted list of frame indices to include in the rendered video.
+            Sorted list of frame indices to include in the rendered video, or
+            ``None`` when "Include unlabeled frames" is checked — in that case
+            ``sio.render_video()`` enumerates frames itself from the video and
+            the start/end range, which is required for the unlabeled frames
+            to actually appear in the output.
+
             Sorting is required because ``Labels.labeled_frames`` is not
             guaranteed to be in frame order, and ``sio.render_video()`` writes
             frames in the order given by ``frame_inds``.
         """
+        if self.include_unlabeled.isChecked():
+            return None
+
         if self.range_all.isChecked():
             # All labeled frames for current video
             return sorted(

--- a/tests/gui/test_render_clip.py
+++ b/tests/gui/test_render_clip.py
@@ -231,3 +231,79 @@ def test_match_source_fps_checkbox(centered_pair_predictions):
         assert dialog.get_export_params()["fps"] == int(round(src_fps))
     finally:
         dialog.deleteLater()
+
+
+def test_include_unlabeled_returns_none_frame_indices(centered_pair_predictions):
+    """When "Include unlabeled frames" is checked, ``get_frame_indices()``
+    must return ``None`` so that ``sio.render_video()`` enumerates frames
+    from the video instead of restricting output to the labeled-only list.
+    """
+    pytest.importorskip("qtpy.QtWidgets")
+
+    from qtpy import QtWidgets
+
+    from sleap.gui.dialogs.render_clip import RenderClipDialog
+
+    _ = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    labels: sio.Labels = centered_pair_predictions
+    video = labels.videos[0]
+
+    dialog = RenderClipDialog(labels=labels, video=video)
+    try:
+        # Default is unchecked -> falls back to labeled-only behavior.
+        assert not dialog.include_unlabeled.isChecked()
+        assert isinstance(dialog.get_frame_indices(), list)
+
+        # Once checked, the dialog hands over driver responsibility to sleap-io.
+        dialog.include_unlabeled.setChecked(True)
+        assert dialog.get_frame_indices() is None
+    finally:
+        dialog.deleteLater()
+
+
+def test_include_unlabeled_export_params_forward_range(centered_pair_predictions):
+    """Checking "Include unlabeled frames" should add ``include_unlabeled=True``
+    to the export params, and a custom range should be forwarded with an
+    exclusive ``end`` (sleap-io's convention) so the user's inclusive UI value
+    maps correctly.
+    """
+    pytest.importorskip("qtpy.QtWidgets")
+
+    from qtpy import QtWidgets
+
+    from sleap.gui.dialogs.render_clip import RenderClipDialog
+
+    _ = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    labels: sio.Labels = centered_pair_predictions
+    video = labels.videos[0]
+
+    dialog = RenderClipDialog(labels=labels, video=video)
+    try:
+        # Unchecked path: no include_unlabeled key, no start/end.
+        params = dialog.get_export_params()
+        assert "include_unlabeled" not in params
+        assert "start" not in params
+        assert "end" not in params
+
+        # Checked + all-frames radio: include_unlabeled=True, no start/end so
+        # sleap-io renders the whole target video.
+        dialog.include_unlabeled.setChecked(True)
+        dialog.range_all.setChecked(True)
+        params = dialog.get_export_params()
+        assert params["include_unlabeled"] is True
+        assert "start" not in params
+        assert "end" not in params
+
+        # Checked + custom range: include_unlabeled=True with start/end+1 so
+        # the inclusive UI bound maps to sleap-io's exclusive end.
+        dialog.range_custom.setChecked(True)
+        dialog.start_frame.setValue(5)
+        dialog.end_frame.setValue(17)
+        params = dialog.get_export_params()
+        assert params["include_unlabeled"] is True
+        assert params["start"] == 5
+        assert params["end"] == 18
+    finally:
+        dialog.deleteLater()


### PR DESCRIPTION
## Summary

- Adds an **Include unlabeled frames in range** checkbox to the **View → Render Video Clip with Instances...** dialog. When checked, the output video covers every frame in the selected range (with skeleton overlays drawn on the frames that have instances) instead of only the labeled frames.
- Wires the new option through `RenderClipDialog` → `ExportLabeledClip` → `render_video_gui()` so that `sio.render_video()` receives `frame_inds=None` plus `include_unlabeled=True`, the existing sleap-io semantics that the GUI never exposed.
- Maps the inclusive UI end-frame value to sleap-io's exclusive `end` (i.e. `end + 1`) so a "Custom range" of `[s, e]` renders exactly the frames the user picks.

## Why

Reported in #2245: rendering a sparse predictions file via `sleap-render` or the GUI's Render Video Clip command produced a short highlight reel instead of a full video, because both paths default to writing only frames that have a `LabeledFrame`. `sio render` already exposes `--all-frames` and auto-enables it for single-video prediction files, but the GUI dialog had no equivalent toggle.

## Test plan

- [x] `uv run pytest tests/gui/test_render_clip.py` — 7/7 pass (5 existing + 2 new):
  - `test_include_unlabeled_returns_none_frame_indices` — checked checkbox → `get_frame_indices()` returns `None`.
  - `test_include_unlabeled_export_params_forward_range` — checked + all-frames → `include_unlabeled=True` with no start/end; checked + custom range `[5, 17]` → `include_unlabeled=True, start=5, end=18`.
- [x] `uv run ruff check` + `uv run ruff format --check` clean on changed files.
- [x] Visual check via the qt-testing skill: dialog still renders the existing Frame Range / Appearance / Quality / Output groups; new checkbox appears below the Start/End spinboxes, unchecked by default.
- [ ] Manual end-to-end on a real sparse predictions file (e.g. one of the project's `.slp` predictions): verify the rendered `.mp4` length matches `(end − start) / fps` instead of collapsing to the labeled-frame count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)