### PR TITLE
fix(gui): pass parent widget to LearningDialog to fix window stacking on Windows

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1735,6 +1735,7 @@ class MainWindow(QMainWindow):
                 mode,
                 self.state["filename"],
                 self.labels,
+                parent=self,
             )
             self._child_windows[mode]._handle_learning_finished.connect(
                 self._handle_learning_finished

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -82,10 +82,11 @@ class LearningDialog(QtWidgets.QDialog):
         labels_filename: Text,
         labels: Optional[Labels] = None,
         skeleton: Optional["Skeleton"] = None,
+        parent=None,
         *args,
         **kwargs,
     ):
-        super(LearningDialog, self).__init__()
+        super(LearningDialog, self).__init__(parent)
 
         # Set window title based on mode
         mode_title = "Training" if mode == "training" else "Inference"


### PR DESCRIPTION
## Summary
- Fix training/inference dialogs appearing **behind** the main SLEAP window on Windows
- Pass `MainWindow` as parent widget to `LearningDialog` so Qt manages window stacking correctly

## Changes Made
- **`sleap/gui/learning/dialog.py`**: Added `parent=None` parameter to `LearningDialog.__init__()` and forwarded it to `super().__init__(parent)`
- **`sleap/gui/app.py`**: Pass `parent=self` when creating `LearningDialog` instances

## Root Cause
`LearningDialog` was calling `super().__init__()` without a parent widget. On Windows, parentless dialogs have no guaranteed Z-order relationship with the main window, so they frequently appear behind it — users had to Alt-Tab or minimize the main window to find the dialog.

## Testing
- All 55 existing `LearningDialog` tests pass
- Backwards compatible: `parent` defaults to `None`, so any external callers are unaffected

## Design Decisions
- Minimal two-line fix rather than broader refactor — this is the standard Qt pattern for modal/child dialogs
- Default `parent=None` preserves backward compatibility for any code that instantiates `LearningDialog` directly

## Related Issues
Closes #995

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)