### PR TITLE
feat(gui): expose peak threshold in inference dialog

### DIFF
--- a/sleap/gui/learning/main_tab.py
+++ b/sleap/gui/learning/main_tab.py
@@ -854,6 +854,33 @@ class MainTabWidget(QWidget):
             )
             batch_size.setEnabled(False)  # Start disabled since "Default" is checked
 
+            row1.addSpacing(20)
+
+            peak_label = QLabel("Peak Threshold:")
+            row1.addWidget(peak_label)
+
+            peak_threshold = QDoubleSpinBox()
+            peak_threshold.setRange(0.0, 1.0)
+            peak_threshold.setSingleStep(0.05)
+            peak_threshold.setValue(0.2)
+            peak_threshold.setMinimumWidth(60)
+            peak_threshold.setToolTip(
+                "Minimum confidence map value to consider a peak as valid. "
+                "Lower values keep more detections, higher values are stricter."
+            )
+            self._fields["_peak_threshold"] = peak_threshold
+            row1.addWidget(peak_threshold)
+
+            default_peak_cb = QCheckBox("Default")
+            default_peak_cb.setChecked(True)
+            self._fields["_peak_threshold_default"] = default_peak_cb
+            row1.addWidget(default_peak_cb)
+
+            default_peak_cb.stateChanged.connect(
+                lambda state, sb=peak_threshold: sb.setEnabled(not state)
+            )
+            peak_threshold.setEnabled(False)
+
             row1.addStretch()
             layout.addLayout(row1)
 
@@ -1254,6 +1281,10 @@ class MainTabWidget(QWidget):
         # Handle batch_size: if "Default" is checked, omit so CLI uses model default
         if data.get("_batch_size_default", True):
             data.pop("_batch_size", None)
+
+        # Handle peak_threshold: if "Default" is checked, omit so CLI uses its default
+        if data.get("_peak_threshold_default", True):
+            data.pop("_peak_threshold", None)
 
         # Strip placeholder from API key if user didn't change it
         api_key = data.get("trainer_config.wandb.api_key")

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -598,6 +598,11 @@ class InferenceTask:
         if "_batch_size" in self.inference_params:
             cli_args.extend(["--batch_size", str(self.inference_params["_batch_size"])])
 
+        if "_peak_threshold" in self.inference_params:
+            cli_args.extend(
+                ["--peak_threshold", str(self.inference_params["_peak_threshold"])]
+            )
+
         if (
             "_max_instances" in self.inference_params
             and self.inference_params["_max_instances"] is not None


### PR DESCRIPTION
## Summary
- Add a **Peak Threshold** field to the GUI inference dialog so users can control the minimum confidence for node detections without using the CLI
- Follows the same pattern as the existing Batch Size field (spinbox + "Default" checkbox)

## Changes Made
- **`sleap/gui/learning/main_tab.py`**: Added `QDoubleSpinBox` for peak threshold (range 0.0–1.0, step 0.05, default 0.2) with a "Default" checkbox that disables the spinbox when checked
- **`sleap/gui/learning/runners.py`**: Pass `--peak_threshold` to the CLI when the user has set a custom value

## Example Usage
In the inference dialog, uncheck "Default" next to "Peak Threshold" and set a value:
- **Lower values** (e.g., 0.1) keep more node detections (more permissive)
- **Higher values** (e.g., 0.5) keep only high-confidence detections (stricter)

When "Default" is checked, the CLI default (0.2) is used.

## API Changes
- None — this is a GUI-only change that passes an existing CLI parameter

## Testing
- All 55 existing `LearningDialog` tests pass
- Manually verified form field behavior: default checkbox hides value from form data, unchecking exposes the custom value correctly

## Design Decisions
- Placed on the same row as Batch Size to keep the inference dialog compact
- Used "Default" checkbox pattern (same as Batch Size) for consistency — when checked, the CLI uses its built-in default (0.2) rather than forcing a value
- Tooltip explains the effect of lower vs higher values

## Related Issues
Closes #1113

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)