### PR TITLE
feat(gui): add Previous User Labeled Frame navigation (Ctrl+Shift+U)

### DIFF
--- a/docs/learnings/gui.md
+++ b/docs/learnings/gui.md
@@ -27,6 +27,7 @@ The SLEAP labeling interface is launched via the `sleap label` command (or legac
 |---------|-------------|
 | **Next Labeled Frame** | Jump to next frame with any labels (user or predicted) |
 | **Next User Labeled Frame** | Jump to next frame with user labels only |
+| **Previous User Labeled Frame** | Jump to previous frame with user labels only |
 | **Next Suggestion** | Jump to the next suggested frame |
 | **Next Track Spawn Frame** | Jump to where a new track starts (useful for proofreading) |
 | **Next Video** | Switch to the next video in the project |

--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -15,6 +15,7 @@ goto last interacted: Ctrl+A
 goto next suggestion: Space
 goto next track spawn: Ctrl+E
 goto next user: Ctrl+U
+goto prev user: Ctrl+Shift+U
 goto next labeled: Alt+Right
 goto prev suggestion: Shift+Space
 goto prev labeled: Alt+Left

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -598,6 +598,12 @@ class MainWindow(QMainWindow):
         )
         add_menu_item(
             goMenu,
+            "goto prev user",
+            "Previous User Labeled Frame",
+            self.commands.prevUserLabeledFrame,
+        )
+        add_menu_item(
+            goMenu,
             "goto next suggestion",
             "Next Suggestion",
             self._goto_next_suggestion_or_flag,

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -421,6 +421,10 @@ class CommandContext:
         """Goes to next labeled frame with user instances."""
         self.execute(GoNextUserLabeledFrame)
 
+    def prevUserLabeledFrame(self):
+        """Goes to previous labeled frame with user instances."""
+        self.execute(GoPrevUserLabeledFrame)
+
     def lastInteractedFrame(self):
         """Goes to last frame that user interacted with."""
         self.execute(GoLastInteractedFrame)
@@ -2575,6 +2579,23 @@ class GoNextUserLabeledFrame(GoIteratorCommand):
             from_frame_idx=context.state["frame_idx"],
         )
         # Filter to frames with user instances
+        iterate_labeled_frames = filter(
+            lambda lf: lf.has_user_instances, iterate_labeled_frames
+        )
+        return iterate_labeled_frames
+
+
+class GoPrevUserLabeledFrame(GoIteratorCommand):
+    @staticmethod
+    def _get_frame_iterator(context: CommandContext):
+        from sleap.sleap_io_adaptors.lf_labels_utils import iterate_labeled_frames
+
+        iterate_labeled_frames = iterate_labeled_frames(
+            context.labels,
+            context.state["video"],
+            from_frame_idx=context.state["frame_idx"],
+            reverse=True,
+        )
         iterate_labeled_frames = filter(
             lambda lf: lf.has_user_instances, iterate_labeled_frames
         )

--- a/sleap/gui/shortcuts.py
+++ b/sleap/gui/shortcuts.py
@@ -44,6 +44,7 @@ class Shortcuts(object):
         "goto prev labeled",
         "goto last interacted",
         "goto next user",
+        "goto prev user",
         "goto next suggestion",
         "goto prev suggestion",
         "goto next track spawn",


### PR DESCRIPTION
## Summary
- Add **Previous User Labeled Frame** command (`Ctrl+Shift+U`) to complement the existing **Next User Labeled Frame** (`Ctrl+U`)
- Allows navigating backwards through frames that have user (non-predicted) instances

## Changes Made
- **`sleap/gui/commands.py`**: Added `GoPrevUserLabeledFrame` command class (mirrors `GoNextUserLabeledFrame` with `reverse=True`) and `prevUserLabeledFrame()` method on `CommandContext`
- **`sleap/gui/app.py`**: Added "Previous User Labeled Frame" menu item in the Go menu
- **`sleap/gui/shortcuts.py`**: Registered `"goto prev user"` shortcut name
- **`sleap/config/shortcuts.yaml`**: Default keybinding `Ctrl+Shift+U`
- **`docs/learnings/gui.md`**: Added to the Go menu command table

## Testing
- All 35 passing command tests still pass (1 pre-existing failure in `test_LoadProjectFile[new_directory]` due to `PermissionError`, unrelated)
- Verified imports and shortcut keybinding resolution

## Design Decisions
- `Ctrl+Shift+U` follows the standard forward/backward convention (matching `Next/Previous Suggestion` with `Space`/`Shift+Space`)
- Mirrors the `GoPreviousLabeledFrame` / `GoNextLabeledFrame` pattern but filters to `has_user_instances`

## Related Issues
Closes #1417

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)