### PR TITLE
feat(gui): add frame range filter for labeling suggestions

### DIFF
--- a/sleap/config/suggestions.yaml
+++ b/sleap/config/suggestions.yaml
@@ -193,6 +193,20 @@ main:
 
     "all videos":
     "current video":
+      - name: frame_range_enabled
+        label: Restrict to frame range
+        type: bool
+        default: false
+      - name: frame_from
+        label: From frame
+        type: int
+        default: 1
+        range: 1, 1000000
+      - name: frame_to
+        label: To frame
+        type: int
+        default: 1000
+        range: 1, 1000000
 
   - name: generate_button
     label: Generate Suggestions

--- a/sleap/gui/suggestions.py
+++ b/sleap/gui/suggestions.py
@@ -57,12 +57,24 @@ class VideoFrameSuggestions(object):
 
         method = str.replace(params["method"], " ", "_")
         if method_functions.get(method, None) is not None:
-            return method_functions[method](labels=labels, **params)
+            suggestions = method_functions[method](labels=labels, **params)
         else:
             raise ValueError(
                 f"No {'' if method == '_' else method + ' '}method found for "
                 "generating suggestions."
             )
+
+        if params.get("frame_range_enabled", False) and method not in (
+            "frame_chunk",
+            "sample",
+        ):
+            frame_from = max(int(params.get("frame_from", 1)) - 1, 0)
+            frame_to = int(params.get("frame_to", float("inf")))
+            suggestions = [
+                s for s in suggestions if frame_from <= s.frame_idx < frame_to
+            ]
+
+        return suggestions
 
     # Functions corresponding to "method" param
 
@@ -84,7 +96,7 @@ class VideoFrameSuggestions(object):
 
         for video in videos:
             # Get unique sample space
-            vid_idx = list(range(len(video)))
+            vid_idx = cls._get_frame_range(video, **kwargs)
             vid_sugg_idx = sugg_idx_dict[video]
             unique_idx = list(set(vid_idx) - set(vid_sugg_idx))
             n_frames = len(unique_idx)
@@ -368,6 +380,21 @@ class VideoFrameSuggestions(object):
         return suggestions
 
     # Utility functions
+
+    @staticmethod
+    def _get_frame_range(video: "Video", **kwargs) -> list:
+        """Get frame indices for a video, optionally restricted to a range.
+
+        Args:
+            video: The video to get frame indices for.
+            **kwargs: May contain frame_range_enabled, frame_from, frame_to.
+        """
+        frame_from = 0
+        frame_to = len(video)
+        if kwargs.get("frame_range_enabled", False):
+            frame_from = max(int(kwargs.get("frame_from", 1)) - 1, 0)
+            frame_to = min(int(kwargs.get("frame_to", len(video))), len(video))
+        return list(range(frame_from, frame_to))
 
     @staticmethod
     def idx_list_to_frame_list(


### PR DESCRIPTION
## Summary
- Add optional **frame range restriction** when generating labeling suggestions
- Appears under the "Current Video" target as a "Restrict to frame range" checkbox with From/To fields
- Works with all suggestion methods except "frame chunk" (which already has its own range)

## Changes Made
- **`sleap/config/suggestions.yaml`**: Added `frame_range_enabled` (bool), `frame_from` (int), `frame_to` (int) fields under the "current video" target stack
- **`sleap/gui/suggestions.py`**:
  - Added `_get_frame_range()` helper that returns frame indices respecting the optional range
  - `basic_sample_suggestion_method`: Filters the frame pool *before* sampling so the requested sample count comes from the restricted range
  - `suggest()`: Post-filters results for all other methods (image features, prediction score, velocity, max point displacement)

## Example Usage
1. In the **Labeling Suggestions** panel, set Target to **"Current Video"**
2. Check **"Restrict to frame range"**
3. Set **From** and **To** frame numbers
4. Choose any method (sample, image features, velocity, etc.) and click **Generate**

Suggestions will only come from the specified frame range.

## Testing
- All 6 existing suggestion tests pass
- Verified form fields load correctly under the "current video" stack

## Design Decisions
- Frame range fields only appear when "Current Video" is selected (hidden for "All Videos") since the range is video-specific
- For the **sample** method, the input pool is filtered *before* sampling so you get the full `per_video` count from within the range
- For other methods (velocity, prediction score, etc.), results are **post-filtered** since they operate on labeled frame data rather than raw frame indices
- "frame chunk" method is excluded from filtering since it already has its own From/To fields
- Frame numbers are 1-indexed in the UI (matching the seekbar) but 0-indexed internally

## Related Issues
Closes #1434

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)