### PR TITLE
feat(gui): add Actual Size (1:1) view option

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -195,6 +195,7 @@ class MainWindow(QMainWindow):
         self.state["edge style"] = prefs["edge style"]
         self.state["fit"] = False
         self.state["fit_selection"] = False
+        self.state["actual_size"] = False
         self.state["color predicted"] = prefs["color predicted"]
         self.state["trail_length"] = prefs["trail length"]
         self.state["trail_shade"] = prefs["trail shade"]
@@ -664,18 +665,28 @@ class MainWindow(QMainWindow):
         viewMenu.addSeparator()
         add_menu_check_item(viewMenu, "fit", "Fit View to Instances")
         add_menu_check_item(viewMenu, "fit_selection", "Fit View to Selection")
+        add_menu_check_item(viewMenu, "actual_size", "Actual Size (1:1)")
 
-        # Make fit and fit_selection mutually exclusive
+        # Make fit, fit_selection, and actual_size mutually exclusive
         def _on_fit_changed(value):
             if value:
                 self.state["fit_selection"] = False
+                self.state["actual_size"] = False
 
         def _on_fit_selection_changed(value):
             if value:
                 self.state["fit"] = False
+                self.state["actual_size"] = False
+
+        def _on_actual_size_changed(value):
+            if value:
+                self.state["fit"] = False
+                self.state["fit_selection"] = False
+                self.player.zoomToActualSize()
 
         self.state.connect("fit", _on_fit_changed)
         self.state.connect("fit_selection", _on_fit_selection_changed)
+        self.state.connect("actual_size", _on_actual_size_changed)
 
         viewMenu.addSeparator()
         add_menu_check_item(viewMenu, "color predicted", "Color Predicted Instances")
@@ -1408,6 +1419,8 @@ class MainWindow(QMainWindow):
             player.zoomToFit()
         elif self.state["fit_selection"]:
             player.zoomToSelection()
+        elif self.state["actual_size"]:
+            player.zoomToActualSize()
 
         # Update related displays
         self.updateStatusMessage()

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -683,6 +683,9 @@ class MainWindow(QMainWindow):
                 self.state["fit"] = False
                 self.state["fit_selection"] = False
                 self.player.zoomToActualSize()
+            else:
+                self.player.view.clearZoom()
+                self.player.view.updateViewer()
 
         self.state.connect("fit", _on_fit_changed)
         self.state.connect("fit_selection", _on_fit_selection_changed)

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -620,6 +620,10 @@ class QtVideoPlayer(QWidget):
             return True
         return False
 
+    def zoomToActualSize(self):
+        """Zoom view to 1:1 pixel mapping (actual size)."""
+        self.view.zoomToActualSize()
+
     def setFitZoom(self, value):
         """Zooms or unzooms current view to fit all instances."""
         if self.video:
@@ -1189,6 +1193,17 @@ class GraphicsView(QGraphicsView):
         self.zoomFactor = scale
         self.updateViewer()
         self.centerOn(zoom_rect.center())
+
+    def zoomToActualSize(self):
+        """Zoom to 1:1 pixel mapping so the image displays at native resolution."""
+        if not self.hasImage():
+            return
+        base_w_scale = self.width() / self.sceneRect().width()
+        base_h_scale = self.height() / self.sceneRect().height()
+        base_scale = min(base_w_scale, base_h_scale)
+        if base_scale > 0:
+            self.zoomFactor = 1.0 / base_scale
+            self.updateViewer()
 
     def clearZoom(self):
         """Clear zoom stack. Doesn't update display."""


### PR DESCRIPTION
## Summary
- Add **View > Actual Size (1:1)** toggle that displays the video at native resolution
- Solves the complaint that low-resolution videos look overly pixelated when SLEAP upsamples them to fit the window

## Changes Made
- **`sleap/gui/app.py`**: Added `actual_size` state, menu item in View menu, mutually exclusive with "Fit View to Instances" and "Fit View to Selection", applied on frame updates
- **`sleap/gui/widgets/video.py`**: Added `zoomToActualSize()` on both `GraphicsView` and `QtVideoPlayer` — computes `zoomFactor = 1.0 / base_scale` so the final transform scale is exactly 1.0 (1:1 pixel mapping)

## Example Usage
1. Open a project with a low-resolution video
2. Go to **View > Actual Size (1:1)**
3. The video displays at its native resolution — pan with click-drag to navigate

Toggle it off to return to the default zoom-to-fit behavior.

## Testing
- All 8 existing video player tests pass
- Verified programmatically that actual size produces exactly 1.0 transform scale

## Design Decisions
- Default is OFF (current zoom-to-fit behavior preserved)
- Mutually exclusive with "Fit View to Instances" and "Fit View to Selection"
- Persists across frame changes (re-applied on each frame update)

## Related Issues
Closes #1471

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)