### PR TITLE
fix(gui): clarify Delete Predictions beyond Frame Limit dialog text

### DIFF
--- a/sleap/config/frame_range_form.yaml
+++ b/sleap/config/frame_range_form.yaml
@@ -1,13 +1,13 @@
 main:
 
   - name: min_frame_idx
-    label: Minimum frame index
+    label: Keep from frame
     type: int
     range: 1,1000000
     default: 1
 
   - name: max_frame_idx
-    label: Maximum frame index
+    label: Keep to frame
     type: int
     range: 1,1000000
     default: 1000

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3620,7 +3620,8 @@ class DeleteFrameLimitPredictions(InstanceDeleteCommand):
     def ask(cls, context: CommandContext, params: Dict) -> bool:
         current_video = context.state["video"]
         dialog = FrameRangeDialog(
-            title="Delete Instances in Frame Range...", max_frame_idx=len(current_video)
+            title="Delete Predictions Outside Frame Range",
+            max_frame_idx=len(current_video),
         )
         results = dialog.get_results()
         if results:


### PR DESCRIPTION
## Summary
- The "Delete Predictions beyond Frame Limit" dialog title said "Delete Instances in Frame Range" which implied instances **inside** the range would be deleted — the opposite of what actually happens
- Updated dialog title to "Delete Predictions Outside Frame Range" and field labels from "Minimum/Maximum frame index" to "Keep from frame" / "Keep to frame"

## Changes Made
- `sleap/gui/commands.py`: Updated `FrameRangeDialog` title in `DeleteFrameLimitPredictions.ask()`
- `sleap/config/frame_range_form.yaml`: Updated field labels to clarify keep-range semantics

## Testing
- Existing `test_commands.py` delete tests pass
- No logic changes, text-only fix

## Related Issues
Closes https://github.com/talmolab/sleap/discussions/2077

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)