### PR TITLE
ci(docs): add workflow_dispatch to manually redeploy versioned docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,26 @@ on:
   push:
     branches:
       - develop
+  # Manual redeploy, e.g. to refresh a release's docs after a post-release fix
+  # lands on develop. Always builds from the dispatched branch (normally
+  # develop); the inputs only control the mike version label and alias. See
+  # talmolab/sleap#2693 (install-doc fix that shipped after the v1.6.3 tag).
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "mike version label to deploy (e.g. v1.6.3)"
+        required: true
+        type: string
+      alias:
+        description: "Alias to point at this version"
+        required: true
+        default: latest
+        type: choice
+        options:
+          - latest
+          - prerelease
+          - dev
+          - none
 
 # Serialize all gh-pages pushes (this workflow and pr-preview.yml's deploy/cleanup
 # jobs share the same group) so simultaneous pushes don't race and trip
@@ -67,3 +87,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
             uv run mike deploy --update-aliases --allow-empty --push dev
+
+      - name: Build and upload docs (manual dispatch)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            ALIAS="${{ inputs.alias }}"
+            if [ "$ALIAS" = "none" ]; then ALIAS=""; fi
+            uv run mike deploy --update-aliases --allow-empty --push "${{ inputs.version }}" $ALIAS


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` trigger to `.github/workflows/docs.yml` so a release's published docs can be manually redeployed.
- Until now the docs pipeline only ran on `release: published` and `push: develop` — there was no way to refresh `latest`/a version folder after a release.

## Motivation

`docs/installation.md` on `develop` has correct install commands for 1.6.3 (`sleap[nn]==1.6.3`, `sleap-io==0.7.0`, `sleap-nn==0.2.0`), but the live site does not:

| URL | install command |
|---|---|
| `docs.sleap.ai/latest/installation/` | ❌ `sleap[nn]==1.6.1 ... sleap-io==0.6.4 ... sleap-nn==0.1.0` |
| `docs.sleap.ai/dev/installation/` | ✅ `sleap[nn]==1.6.3 ... sleap-io==0.7.0 ... sleap-nn==0.2.0` |

Root cause: the v1.6.3 docs job ran successfully when the release was published (2026-05-04), building `latest` from the **`v1.6.3` git tag**. The install-doc fix — #2693 — landed on `develop` *after* the tag. `mike` froze `latest` to the tag's (stale) content, and re-running the original release job only rebuilds that same stale tag.

## Changes Made

- New `workflow_dispatch` trigger with two inputs:
  - `version` — the `mike` version label / folder to deploy (e.g. `v1.6.3`)
  - `alias` — `choice` of `latest` / `prerelease` / `dev` / `none`
- New step `Build and upload docs (manual dispatch)`, gated on `github.event_name == 'workflow_dispatch'`, running `mike deploy --update-aliases --allow-empty --push <version> <alias>`.
- Existing `release`/`push` steps are gated on their own event names, so the dispatch event does not retrigger them. The shared `gh-pages-write` concurrency lock still applies.

## How versioning works

`mike` version labels are **decoupled from git tags** — the label is just a folder name in `gh-pages`; the content is whatever ref is checked out. A `workflow_dispatch` run executes the workflow file from the dispatched ref, so in practice it always runs from a branch carrying this trigger (normally `develop`). The `version`/`alias` inputs only control *labeling*. Dispatching `version=v1.6.3 alias=latest` from `develop` therefore overwrites the `v1.6.3` folder with develop's corrected docs and keeps `latest` pointed at it.

## Example Usage

\`\`\`bash
# Refresh the v1.6.3 docs + latest alias from current develop
gh workflow run docs.yml -f version=v1.6.3 -f alias=latest
\`\`\`

Or via the Actions tab → "Deploy MkDocs to GitHub Pages" → "Run workflow".

## Testing

- Workflow-file-only change; YAML structure verified locally.
- The new step's `if` condition matches only `workflow_dispatch`, so existing release/dev deploys are unaffected.
- Full verification happens once merged to `develop` (the default branch) — `workflow_dispatch` only appears in the Actions UI / `gh workflow run` after the trigger is on the default branch.

## Design Decisions

- **Inputs label, branch supplies content.** Since a dispatch must run from a branch with the updated workflow, content is always "the dispatched branch as of now." Making `version`/`alias` explicit inputs keeps the labeling intentional rather than guessed.
- **`alias` is a `choice`** restricted to the aliases the pipeline already uses (`latest`/`prerelease`/`dev`), plus `none` for a version with no alias.
- **`none` handled in shell**, not by passing an empty arg, to avoid `mike` receiving a stray empty argument.

## Follow-up

After this merges, run `gh workflow run docs.yml -f version=v1.6.3 -f alias=latest` to fix the stale `latest` install docs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)