### PR TITLE
feat(gui): add keyboard shortcut for Propagate Track Labels toggle

### DIFF
--- a/docs/guides/tracking-and-proofreading.md
+++ b/docs/guides/tracking-and-proofreading.md
@@ -307,7 +307,7 @@ When the tracker assigns instances to the wrong tracks (swapping identities betw
 
 **Propagating Fixes:**
 
-Enable **Propagate Track Labels** to apply track changes to all subsequent frames automatically.
+Enable **Propagate Track Labels** (toggle with the **P** shortcut) to apply track changes to all subsequent frames automatically.
 
 ---
 

--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -34,6 +34,7 @@ show edges: Ctrl+Shift+Tab
 show labels: Ctrl+Tab
 show trails: 
 transpose: Ctrl+T
+propagate track labels: P
 frame next: Right
 frame prev: Left
 frame next medium step: Ctrl+Right

--- a/sleap/gui/shortcuts.py
+++ b/sleap/gui/shortcuts.py
@@ -38,6 +38,7 @@ class Shortcuts(object):
         "delete instance",
         "delete track",
         "transpose",
+        "propagate track labels",
         "select next",
         "clear selection",
         "goto next labeled",

--- a/tests/gui/test_shortcuts.py
+++ b/tests/gui/test_shortcuts.py
@@ -11,3 +11,6 @@ def test_shortcuts():
     shortcuts["new"] = QKeySequence.fromString("Ctrl+Shift+N")
     assert shortcuts["new"] == QKeySequence.fromString("Ctrl+Shift+N")
     assert list(shortcuts[0:2].keys()) == ["new", "open"]
+
+    # "propagate track labels" toggle shortcut (discussion #1638)
+    assert shortcuts["propagate track labels"] == QKeySequence.fromString("P")


### PR DESCRIPTION
## Description

Adds a keyboard shortcut for toggling **Tracks > Propagate Track Labels**, as requested in discussion #1638. During proofreading, users frequently flip this toggle depending on whether a track correction should apply to one frame or all subsequent frames; reaching it through the menu every time is slow. The shortcut makes the toggle reachable without leaving the keyboard.

**Default key: `P`** (for "propagate"). It is unused elsewhere and consistent with existing single-key shortcuts like `H` (show instances). Users can rebind it in the Keyboard Shortcuts dialog.

## How it works

The `Propagate Track Labels` menu item is created via `add_menu_check_item(...)` → `add_menu_item(...)`, which already passes `self.shortcuts["propagate track labels"]` to `menu.addAction`. The shortcut lookup was already wired — it just resolved to `""` because the name wasn't in the `Shortcuts` whitelist. So no `app.py` change was needed.

## Changes

- `sleap/gui/shortcuts.py` — register `"propagate track labels"` in `Shortcuts._names` (also exposes it in the Keyboard Shortcuts dialog).
- `sleap/config/shortcuts.yaml` — add `propagate track labels: P` default.
- `tests/gui/test_shortcuts.py` — assert the new shortcut loads as `QKeySequence("P")`.
- `docs/guides/tracking-and-proofreading.md` — mention the `P` shortcut.

## Testing

- `uv run pytest tests/gui/test_shortcuts.py` — passes.
- `uv run pytest tests/gui/test_app.py` — passes (menu creation unaffected).
- `uv run ruff check` — clean.
- Verified end-to-end by instantiating `MainWindow`: the `Propagate Track Labels` action is checkable and reports shortcut `P`.

Resolves #1638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)