### PR TITLE
feat(gui): add Replace Videos button to Videos dock

### DIFF
--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -198,6 +198,7 @@ class VideosDock(DockWidget):
         self.add_button(hb, "Toggle Grayscale", main_window.commands.toggleGrayscale)
         self.add_button(hb, "Show Video", self.table.activateSelected)
         self.add_button(hb, "Add Videos", main_window.commands.addVideo)
+        self.add_button(hb, "Replace Videos", main_window.commands.replaceVideo)
         self.add_button(hb, "Remove Video", main_window.commands.removeVideo)
         hbw = QWidget()
         hbw.setLayout(hb)

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -48,6 +48,11 @@ def test_videos_dock(
     assert dock.main_window is main_window
     assert dock.wgt_layout is dock.widget().layout()
 
+    # Test that the video edit buttons are wired up
+    assert "add videos" in dock.main_window._buttons
+    assert "replace videos" in dock.main_window._buttons
+    assert "remove video" in dock.main_window._buttons
+
     # Test that videos can be removed
 
     # No videos selected, won't remove anything


### PR DESCRIPTION
## Summary
- Adds a **Replace Videos** button to the Videos tab of the right-side dock, placed between **Add Videos** and **Remove Video**.
- Groups all three video-file operations (add / replace / remove) in one place, so replacing videos no longer requires a trip to the File menu.

## Changes Made
- `sleap/gui/widgets/docks.py`: added one `add_button` call in `VideosDock.create_video_edit_and_nav_buttons()`, wired to the existing `commands.replaceVideo` handler.
- `tests/gui/widgets/test_docks.py`: added assertions confirming the three video-edit buttons (`add videos`, `replace videos`, `remove video`) are registered in `main_window._buttons`.

## API Changes
- None. Reuses the existing `Commands.replaceVideo` / `ReplaceVideo` command — no new command logic.

## Testing
- `uv run pytest tests/gui/widgets/test_docks.py` → 4 passed.
- `uv run ruff check` / `ruff format` → clean.
- Manual: the new button opens the same replace-videos dialog flow as **File → Replace Videos...**.

## Design Decisions
- The button is labeled `Replace Videos` (no ellipsis) to match its sibling dock buttons `Add Videos` and `Remove Video`, even though it opens a dialog. The File menu item keeps its `Replace Videos...` label; both invoke the same command.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)