### PR TITLE
feat(gui): Negative frames — mark empty frames as background training examples (#640)

### DIFF
--- a/docs/guides/guides-overview.md
+++ b/docs/guides/guides-overview.md
@@ -17,6 +17,8 @@
 
 [Label Quality Control](label-quality-control.md) for detecting and fixing labeling errors using automated quality checks.
 
+[Negative Frames](negative-frames.md) for marking empty frames as background training examples to reduce false positives.
+
 [Instance Size Distribution](instance-size-distribution.md) for determining the optimal crop size for top-down models.
 
 [Run training and inference on Colab](run-training-and-inference-on-colab.md) when you have a project with labeled training data and you’d like to run training or inference in a Colab notebook.

--- a/docs/guides/negative-frames.md
+++ b/docs/guides/negative-frames.md
@@ -1,0 +1,79 @@
+# Negative Frames
+
+*Case: Your model predicts animals on frames that are actually empty, and you
+want to teach it that some frames contain no animals.*
+
+A **negative frame** (also called a *background frame*) is a video frame that you
+explicitly mark as containing **no animals**. When negative frames are included
+in training, the model learns to predict *nothing* on empty frames, which
+reduces false positives — spurious detections on background.
+
+This is different from a frame that is simply *empty* (a labeled frame whose
+instances were all deleted). An empty frame carries no information and is
+discarded during training. A negative frame is a deliberate assertion that the
+frame is background, and it *is* used as a training example.
+
+!!! info "Why a deliberate action"
+    Marking a frame negative is intentional by design. An accidental negative
+    frame introduces a false negative into your training data, so SLEAP asks you
+    to confirm before removing any existing instances, and gives you several ways
+    to review which frames are marked (see [Reviewing negative
+    frames](#reviewing-negative-frames)).
+
+## Marking a frame as negative
+
+Navigate to a frame that contains no animals, then mark it using any of:
+
+- **Menu:** **Labels** → **Mark Frame as Negative**
+- **Keyboard shortcut:** ++ctrl+m++
+- **Right-click** in the video → **Mark Frame as Negative**
+
+The menu item and context-menu entry are **checkable** — the checkmark shows
+whether the current frame is currently marked as negative.
+
+When the current frame already has instances on it, SLEAP shows a confirmation
+dialog reporting how many instances will be removed. Marking the frame negative
+removes those instances, because a frame with a labeled animal is not a
+background frame. Adding a new instance to a negative frame automatically clears
+the negative flag for the same reason.
+
+To unmark a frame, use the same action again. If the frame is empty when you
+unmark it, it is removed from the project entirely (an empty, non-negative frame
+would otherwise be silently dropped during training).
+
+## Reviewing negative frames
+
+Negative frames are surfaced in a few places so accidental ones can be caught:
+
+- **Seekbar marker:** every negative frame gets an amber tick on the seekbar.
+  Hover over it to confirm ("negative (background) frame").
+- **Status bar:** when the current frame is negative, the status bar shows a
+  `[NEGATIVE FRAME]` tag.
+- **Label Quality Control:** the [Label Quality
+  Control](label-quality-control.md) checks flag any negative frame that still
+  has instances — an inconsistency that usually means a mislabel.
+
+## Training with negative frames
+
+Negative frames are stored in your `.slp` project but are only used for training
+when you opt in. In the **Training Pipeline** dialog, on the **Data** tab of a
+model:
+
+- **Use Negative Frames** — when enabled, every frame you marked as negative is
+  added to the training set as a background example.
+- **Negative Loss Weight** — the relative weight of the loss on negative frames.
+  `1.0` weights them the same as labeled frames. Increase it above `1.0` if
+  false positives persist, or decrease it to reduce their influence. It must be
+  greater than `0`, and it is only used when *Use Negative Frames* is enabled.
+
+!!! note "Supported model types"
+    Negative frames are used by **single-instance**, **centroid**,
+    **bottom-up**, and **multi-class bottom-up** models. They are ignored by the
+    **centered-instance** and **multi-class top-down** heads, so the two options
+    are hidden on those tabs. For a top-down pipeline, negative frames still help
+    the **centroid** stage — which is the stage that produces the
+    false-positive detections — so the options remain available there.
+
+If you enable *Use Negative Frames* but have not marked any frames as negative,
+SLEAP warns you in the training dialog, since the option would otherwise have no
+effect.

--- a/docs/guides/negative-frames.md
+++ b/docs/guides/negative-frames.md
@@ -25,7 +25,7 @@ frame is background, and it *is* used as a training example.
 Navigate to a frame that contains no animals, then mark it using any of:
 
 - **Menu:** **Labels** → **Mark Frame as Negative**
-- **Keyboard shortcut:** ++ctrl+m++
+- **Keyboard shortcut:** ++n++
 - **Right-click** in the video → **Mark Frame as Negative**
 
 The menu item and context-menu entry are **checkable** — the checkmark shows

--- a/docs/guides/negative-frames.md
+++ b/docs/guides/negative-frames.md
@@ -48,7 +48,7 @@ Negative frames are surfaced in several places so accidental ones can be caught:
 - **On-canvas overlay:** while you are viewing a negative frame, a thick blue
   border is drawn around the periphery of the frame with a **"Negative Frame"**
   caption in the top-left corner.
-- **Seekbar marker:** every negative frame gets an amber tick on the seekbar.
+- **Seekbar marker:** every negative frame gets a blue tick on the seekbar.
   Hover over it to confirm ("negative (background) frame").
 - **Status bar:** when the current frame is negative, the status bar shows a
   `[NEGATIVE FRAME]` tag.

--- a/docs/guides/negative-frames.md
+++ b/docs/guides/negative-frames.md
@@ -43,8 +43,11 @@ would otherwise be silently dropped during training).
 
 ## Reviewing negative frames
 
-Negative frames are surfaced in a few places so accidental ones can be caught:
+Negative frames are surfaced in several places so accidental ones can be caught:
 
+- **On-canvas overlay:** while you are viewing a negative frame, a thick blue
+  border is drawn around the periphery of the frame with a **"Negative Frame"**
+  caption in the top-left corner.
 - **Seekbar marker:** every negative frame gets an amber tick on the seekbar.
   Hover over it to confirm ("negative (background) frame").
 - **Status bar:** when the current frame is negative, the status bar shows a

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,6 +148,7 @@ nav:
       - Importing predictions for labeling: guides/importing-predictions-for-labeling.md
       - Tracking and proofreading: guides/tracking-and-proofreading.md
       - Label Quality Control: guides/label-quality-control.md
+      - Negative Frames: guides/negative-frames.md
       - Instance Size Distribution: guides/instance-size-distribution.md
       - Run training and inference on Colab: guides/run-training-and-inference-on-colab.md
       - Creating a custom training profile: guides/creating-a-custom-training-profile.md

--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -20,7 +20,7 @@ goto next labeled: Alt+Right
 goto prev suggestion: Shift+Space
 goto prev labeled: Alt+Left
 learning: Ctrl+L
-mark frame: Ctrl+M
+mark negative: Ctrl+M
 new: Ctrl+N
 next video: Alt+Shift+Right
 open: Ctrl+O

--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -20,7 +20,7 @@ goto next labeled: Alt+Right
 goto prev suggestion: Shift+Space
 goto prev labeled: Alt+Left
 learning: Ctrl+L
-mark negative: Ctrl+M
+mark negative: 'N'
 new: Ctrl+N
 next video: Alt+Shift+Right
 open: Ctrl+O

--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -31,6 +31,24 @@ data:
   none_label: Auto
   range: 32,1024
   step: 32
+- default: false
+  help: 'If enabled, frames you explicitly marked as negative (background frames with
+    no instances) are added to the training set. The model learns to predict nothing
+    on them, reducing false positives on empty frames. Mark frames in the labeling
+    window with Labels > Mark Frame as Negative (Ctrl+M). Has no effect for
+    centered-instance and top-down-ID models.'
+  label: Use Negative Frames
+  name: data_config.use_negative_frames
+  type: bool
+- default: 1.0
+  help: 'Relative weight of the loss on negative (background) frames. 1.0 weights them
+    the same as labeled frames; increase above 1.0 if false positives persist, or
+    decrease below 1.0 to reduce their influence. Must be greater than 0. Only used
+    when Use Negative Frames is enabled.'
+  label: Negative Loss Weight
+  name: data_config.negative_loss_weight
+  type: double
+  range: 0.01,100
 
 model:
 - default: unet

--- a/sleap/config/training_editor_form.yaml
+++ b/sleap/config/training_editor_form.yaml
@@ -35,7 +35,7 @@ data:
   help: 'If enabled, frames you explicitly marked as negative (background frames with
     no instances) are added to the training set. The model learns to predict nothing
     on them, reducing false positives on empty frames. Mark frames in the labeling
-    window with Labels > Mark Frame as Negative (Ctrl+M). Has no effect for
+    window with Labels > Mark Frame as Negative (N). Has no effect for
     centered-instance and top-down-ID models.'
   label: Use Negative Frames
   name: data_config.use_negative_frames

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -103,6 +103,7 @@ from sleap.gui.commands import CommandContext, UpdateTopic
 from sleap.gui.dialogs.metrics import MetricsTableDialog
 from sleap.gui.dialogs.shortcuts import ShortcutDialog
 from sleap.gui.overlays.instance import InstanceOverlay
+from sleap.gui.overlays.negative_frame import NegativeFrameOverlay
 from sleap.gui.overlays.tracks import TrackListOverlay, TrackTrailOverlay
 from sleap.gui.shortcuts import Shortcuts
 from sleap.gui.state import GuiState
@@ -1200,6 +1201,9 @@ class MainWindow(QMainWindow):
         )
         self.overlays["instance"] = InstanceOverlay(
             labels=self.labels, player=self.player, state=self.state
+        )
+        self.overlays["negative_frame"] = NegativeFrameOverlay(
+            labels=self.labels, player=self.player
         )
 
         # When gui state changes, we also want to set corresponding attribute

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -821,6 +821,19 @@ class MainWindow(QMainWindow):
 
         labelMenu.addSeparator()
 
+        self.negative_frame_action = labelMenu.addAction(
+            "Mark Frame as Negative",
+            self.commands.toggleCurrentFrameNegative,
+            self.shortcuts["mark negative"],
+        )
+        self.negative_frame_action.setCheckable(True)
+        self.negative_frame_action.setToolTip(
+            "Mark this frame as a negative (background) frame with no animals, "
+            "used as a training example to reduce false positives."
+        )
+
+        labelMenu.addSeparator()
+
         add_menu_item(
             labelMenu,
             "extract clip and labels",
@@ -1328,6 +1341,9 @@ class MainWindow(QMainWindow):
             ]
         ):
             self._update_seekbar_marks()
+            # Toggling the negative-frame flag does not change the plotted
+            # frame, so refresh the status bar (and menu check) explicitly.
+            self.updateStatusMessage()
 
         if _has_topic(
             [UpdateTopic.frame, UpdateTopic.project_instances, UpdateTopic.tracks]
@@ -1500,6 +1516,16 @@ class MainWindow(QMainWindow):
                 self.statusBar().setStyleSheet("color: red")
             else:
                 self.statusBar().setStyleSheet("")
+
+            if lf is not None and lf.is_negative:
+                message += f"{spacer}[NEGATIVE FRAME]"
+
+        # Keep the Labels-menu negative-frame checkmark in sync with the frame.
+        if hasattr(self, "negative_frame_action"):
+            current_lf = self.state["labeled_frame"]
+            self.negative_frame_action.setChecked(
+                bool(current_lf is not None and current_lf.is_negative)
+            )
 
         self.statusBar().showMessage(message)
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -657,6 +657,10 @@ class CommandContext:
         """Create user instances from all predicted instances across all frames."""
         self.execute(AddUserInstancesFromAllPredictions)
 
+    def toggleCurrentFrameNegative(self):
+        """Mark or unmark the current frame as a negative (background) frame."""
+        self.execute(ToggleNegativeFrame)
+
     def copyInstance(self):
         """Copy the selected instance to the instance clipboard."""
         self.execute(CopyInstance)
@@ -4178,6 +4182,9 @@ class AddInstance(EditCommand):
         ):
             context.labels.tracks.append(new_instance.track)
 
+        # A frame with a real instance is not a background frame.
+        context.state["labeled_frame"].is_negative = False
+
         if context.state["labeled_frame"] not in context.labels:
             context.labels.append(context.state["labeled_frame"])
 
@@ -4499,6 +4506,71 @@ class AddInstance(EditCommand):
         # prediction; prefer the user version of each animal and drop
         # predictions whose user counterpart is already present.
         return list(prev_lf.user_instances) + list(prev_lf.unused_predictions)
+
+
+class ToggleNegativeFrame(EditCommand):
+    """Mark or unmark the current frame as a negative (background) frame.
+
+    A negative frame is explicitly marked as containing no animals. It is used
+    as a background training example so the model learns to predict nothing on
+    empty frames, which reduces false positives.
+    """
+
+    topics = [UpdateTopic.frame]
+
+    @staticmethod
+    def ask(context: CommandContext, params: dict) -> bool:
+        lf = context.state["labeled_frame"]
+        if lf is None:
+            return False
+
+        params["was_negative"] = bool(lf.is_negative)
+
+        # Unmarking never needs confirmation.
+        if lf.is_negative:
+            return True
+
+        # Marking a frame that has instances destroys them, so confirm first.
+        n = len(lf.instances)
+        if n > 0:
+            frame_number = (context.state["frame_idx"] or 0) + 1
+            response = QtWidgets.QMessageBox.warning(
+                context.app,
+                "Mark frame as negative",
+                f"Frame {frame_number} has {n} instance(s). Marking it as a "
+                f"negative (background) frame will remove them.\n\nContinue?",
+                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+                QtWidgets.QMessageBox.No,
+            )
+            if response != QtWidgets.QMessageBox.Yes:
+                return False
+
+        return True
+
+    @classmethod
+    def do_action(cls, context: CommandContext, params: dict):
+        lf = context.state["labeled_frame"]
+        if lf is None:
+            return
+
+        if params["was_negative"]:
+            # Unmark the frame.
+            lf.is_negative = False
+            # Drop the now-empty frame so it does not linger as an orphan that
+            # `clean()` / training splits would silently discard.
+            if len(lf.instances) == 0 and lf in context.labels:
+                context.labels.labeled_frames.remove(lf)
+        else:
+            # Mark the frame: clear any instances and flag it.
+            lf.instances = []
+            lf.is_negative = True
+            # The current frame is often a detached `LabeledFrame` (created by
+            # `Labels.find(..., return_new=True)`); attach it or the flag is
+            # lost on the next replot/save.
+            if lf not in context.labels:
+                context.labels.append(lf)
+
+        context.labels.update()
 
 
 class SetInstancePointLocations(EditCommand):

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1340,8 +1340,34 @@ class LearningDialog(QtWidgets.QDialog):
 
                 can_run = False
 
+        # Non-blocking warning: negative frames enabled but none are marked.
+        warning = ""
+        if (
+            self.mode == "training"
+            and self.labels is not None
+            and not self.labels.negative_frames
+        ):
+            uses_negatives = any(
+                self.tabs[tab_name]
+                .get_all_form_data()
+                .get("data_config.use_negative_frames", False)
+                for tab_name in self.shown_tab_names
+                if tab_name in self.tabs
+            )
+            if uses_negatives:
+                warning = (
+                    'The "Use Negative Frames" option is enabled, but no frames '
+                    "are marked as negative, so it will have no effect. Mark "
+                    "frames in the labeling window with Labels &gt; Mark Frame as "
+                    "Negative (Ctrl+M)."
+                )
+
         if not can_run and message:
             message = f"<b>Unable to run:</b><br />{message}"
+        if warning:
+            if message:
+                message += "<br />"
+            message += f"<b>Warning:</b><br />{warning}"
 
         self.message_widget.setText(message)
         self.run_button.setEnabled(can_run)
@@ -1610,6 +1636,12 @@ class TrainingEditorWidget(QtWidgets.QWidget):
 
         # Hide OHKM fields for centroid models (single-point prediction)
         self._setup_ohkm_visibility()
+
+        # Hide negative-frame fields for model types that ignore them
+        self._setup_negative_frames_visibility()
+
+        # Enable the negative loss weight field only when negative frames are on
+        self._setup_negative_frames_toggle()
 
         if hasattr(skeleton, "node_names"):
             for field_name in NODE_LIST_FIELDS:
@@ -1987,6 +2019,56 @@ class TrainingEditorWidget(QtWidgets.QWidget):
                 field.setVisible(False)
                 if label is not None:
                     label.setVisible(False)
+
+    def _setup_negative_frames_visibility(self):
+        """Hide negative-frame fields for model types that ignore them.
+
+        Negative (background) frames are only used by single_instance, centroid,
+        bottomup, and multi_class_bottomup models. The centered_instance and
+        multi_class_topdown heads ignore them, so the fields are hidden on those
+        tabs to avoid implying an effect that will not happen.
+        """
+        if self.head not in ("centered_instance", "multi_class_topdown"):
+            return  # Keep visible for model types that use negative frames.
+
+        data_form = self.form_widgets["data"]
+        form_layout = data_form.form_layout
+
+        for field_name in (
+            "data_config.use_negative_frames",
+            "data_config.negative_loss_weight",
+        ):
+            field = data_form.fields.get(field_name)
+            if field is not None:
+                label = form_layout.labelForField(field)
+                field.setVisible(False)
+                if label is not None:
+                    label.setVisible(False)
+
+    def _setup_negative_frames_toggle(self):
+        """Enable the negative loss weight field only when negatives are enabled.
+
+        Follows the same pattern as `_setup_overfit_mode_toggle`.
+        """
+        data_form = self.form_widgets["data"]
+        form_layout = data_form.form_layout
+        use_field_name = "data_config.use_negative_frames"
+        weight_field_name = "data_config.negative_loss_weight"
+
+        use_checkbox = data_form.fields.get(use_field_name)
+        weight_widget = data_form.fields.get(weight_field_name)
+
+        if use_checkbox is not None and weight_widget is not None:
+            weight_label = form_layout.labelForField(weight_widget)
+
+            def update_state():
+                enabled = use_checkbox.isChecked()
+                weight_widget.setEnabled(enabled)
+                if weight_label is not None:
+                    weight_label.setEnabled(enabled)
+
+            use_checkbox.stateChanged.connect(update_state)
+            update_state()
 
     def acceptSelectedConfigInfo(self, cfg_info: configs.ConfigFileInfo):
         self._load_config(cfg_info)

--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -1359,7 +1359,7 @@ class LearningDialog(QtWidgets.QDialog):
                     'The "Use Negative Frames" option is enabled, but no frames '
                     "are marked as negative, so it will have no effect. Mark "
                     "frames in the labeling window with Labels &gt; Mark Frame as "
-                    "Negative (Ctrl+M)."
+                    "Negative (N)."
                 )
 
         if not can_run and message:

--- a/sleap/gui/overlays/negative_frame.py
+++ b/sleap/gui/overlays/negative_frame.py
@@ -1,0 +1,77 @@
+"""Overlay highlighting frames marked as negative (background) frames."""
+
+from __future__ import annotations
+
+import attr
+from qtpy.QtCore import QRectF
+from qtpy.QtGui import QColor, QPen
+from qtpy.QtWidgets import QGraphicsRectItem
+
+from sleap.gui.overlays.base import BaseOverlay
+from sleap.gui.widgets.video import QtTextWithBackground
+
+# Dodger blue — distinct from the light blue used for predicted instances.
+NEGATIVE_FRAME_COLOR = (30, 144, 255)
+
+
+@attr.s(auto_attribs=True)
+class NegativeFrameOverlay(BaseOverlay):
+    """Draws a blue border and caption when the current frame is negative.
+
+    A negative frame is explicitly marked as containing no animals. This overlay
+    gives an unmissable on-canvas cue so the state is obvious while labeling,
+    mirroring how unconverted predictions are highlighted.
+
+    Attributes:
+        labels: The :class:`Labels` dataset from which to get overlay data.
+        player: The video player in which to show the overlay.
+    """
+
+    def add_to_scene(self, video, frame_idx):
+        """Adds the negative-frame border and caption to the player scene."""
+        self.items = []
+
+        if self.labels is None or video is None or frame_idx is None:
+            return
+
+        lf = self.labels.find(video, frame_idx, return_new=True)[0]
+        if not lf.is_negative:
+            return
+
+        frame_rect = self.player.scene.sceneRect()
+        if frame_rect.isEmpty():
+            return
+
+        color = QColor(*NEGATIVE_FRAME_COLOR)
+
+        # Thick border just inside the periphery of the whole frame. The rect is
+        # inset slightly so the stroke stays fully visible when the view is fit
+        # exactly to the frame; the pen is cosmetic so its width is constant
+        # regardless of zoom.
+        inset_x = frame_rect.width() * 0.012
+        inset_y = frame_rect.height() * 0.012
+        border_rect = QRectF(
+            frame_rect.left() + inset_x,
+            frame_rect.top() + inset_y,
+            frame_rect.width() - 2 * inset_x,
+            frame_rect.height() - 2 * inset_y,
+        )
+        border = QGraphicsRectItem(border_rect)
+        border_pen = QPen(color, 6)
+        border_pen.setCosmetic(True)
+        border.setPen(border_pen)
+        self.player.scene.addItem(border)
+        self.items.append(border)
+
+        # "Negative Frame" caption pinned to the top-left corner. The text item
+        # ignores view transformations, so it stays a constant on-screen size.
+        caption = QtTextWithBackground()
+        caption.setDefaultTextColor(color)
+        font = caption.font()
+        font.setPointSize(14)
+        font.setBold(True)
+        caption.setFont(font)
+        caption.setPlainText("Negative Frame")
+        caption.setPos(border_rect.topLeft())
+        self.player.scene.addItem(caption)
+        self.items.append(caption)

--- a/sleap/gui/shortcuts.py
+++ b/sleap/gui/shortcuts.py
@@ -35,6 +35,7 @@ class Shortcuts(object):
         "goto frame",
         "select to frame",
         "add instance",
+        "mark negative",
         "delete instance",
         "delete track",
         "transpose",

--- a/sleap/gui/widgets/slider.py
+++ b/sleap/gui/widgets/slider.py
@@ -62,6 +62,7 @@ class SliderMark:
             filled="blue",
             open="blue",
             predicted=(1, 170, 247),  # light blue
+            negative=(230, 150, 0),  # amber
             tick="lightGray",
             tick_column="gray",
         )
@@ -111,7 +112,7 @@ class SliderMark:
 
     @property
     def visual_width(self):
-        if self.type in ("open", "filled", "tick"):
+        if self.type in ("open", "filled", "tick", "negative"):
             return 2
         if self.type in ("tick_column", "simple", "predicted"):
             return 1
@@ -1231,6 +1232,7 @@ class SemanticMarkType(Enum):
     suggested_with_user = "filled"
     suggested_with_nothing = "open"
     suggested_with_predicted = "predicted"
+    negative = "negative"
 
 
 def set_slider_marks_from_labels(
@@ -1261,7 +1263,9 @@ def set_slider_marks_from_labels(
 
         frame_mark_types = {mark.type for mark in slider.getMarksAtVal(idx)}
 
-        if SemanticMarkType.user.value in frame_mark_types:
+        if SemanticMarkType.negative.value in frame_mark_types:
+            tooltip += "\nnegative (background) frame"
+        elif SemanticMarkType.user.value in frame_mark_types:
             tooltip += "\nuser labeled"
         elif SemanticMarkType.predicted_no_track.value in frame_mark_types:
             tooltip += "\nprediction without track identity"
@@ -1338,15 +1342,21 @@ def set_slider_marks_from_labels(
 
     labeled_marks = {lf.frame_idx for lf in lfs}
     user_labeled = {lf.frame_idx for lf in lfs if len(lf.user_instances)}
+    negative_frames = {lf.frame_idx for lf in lfs if lf.is_negative}
     suggested_frames = set(get_video_suggestions(labels, video))
 
     all_simple_frames = set()
     all_simple_frames.update(untracked_frames)
     all_simple_frames.update(suggested_frames)
     all_simple_frames.update(user_labeled)
+    all_simple_frames.update(negative_frames)
 
     for frame_idx in all_simple_frames:
-        if frame_idx in suggested_frames:
+        if frame_idx in negative_frames:
+            # Negative frames take priority: they have no instances, so the
+            # only realistic overlap is "suggested + negative".
+            mark_type = SemanticMarkType.negative
+        elif frame_idx in suggested_frames:
             if frame_idx in user_labeled:
                 # suggested frame with user labeled instances
                 mark_type = SemanticMarkType.suggested_with_user

--- a/sleap/gui/widgets/slider.py
+++ b/sleap/gui/widgets/slider.py
@@ -62,7 +62,7 @@ class SliderMark:
             filled="blue",
             open="blue",
             predicted=(1, 170, 247),  # light blue
-            negative=(230, 150, 0),  # amber
+            negative=(30, 144, 255),  # dodger blue (matches NegativeFrameOverlay)
             tick="lightGray",
             tick_column="gray",
         )

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -402,6 +402,19 @@ class QtVideoPlayer(QWidget):
                 action_name, lambda params=params: self.context.newInstance(**params)
             )
 
+        if self.context is not None:
+            self.context_menu.addSeparator()
+            negative_action = self.context_menu.addAction(
+                "Mark Frame as Negative",
+                self.context.toggleCurrentFrameNegative,
+            )
+            negative_action.setCheckable(True)
+            current_lf = self.context.state["labeled_frame"]
+            negative_action.setChecked(
+                bool(current_lf is not None and current_lf.is_negative)
+            )
+            self._menu_actions["Mark Frame as Negative"] = negative_action
+
         return self.context_menu
 
     def show_contextual_menu(self, where: QtCore.QPoint):

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -14,6 +14,7 @@ from sleap.qc.features.visibility import VisibilityModel
 from sleap.qc.features.reference import NearestNeighborScorer, normalize_pose
 from sleap.qc.frame_level import (
     InstanceCountChecker,
+    check_negative_frame,
     detect_duplicates,
 )
 from sleap.qc.gmm import GMMDetector, ZScoreDetector
@@ -251,7 +252,9 @@ class LabelQCDetector:
 
                 # Frame-level checks
                 frame_key = FrameKey(video_idx, frame_idx)
-                frame_qc = self._check_frame(frame_instances, video_id)
+                frame_qc = self._check_frame(
+                    frame_instances, video_id, is_negative=lf.is_negative
+                )
                 results.frame_results[frame_key] = frame_qc
 
         _report("Complete", 1.0, f"{instance_count} instances scored")
@@ -477,7 +480,12 @@ class LabelQCDetector:
 
         return float(score) if np.isfinite(score) else 0.0, contributions
 
-    def _check_frame(self, instances: list[np.ndarray], video_id: str) -> FrameQC:
+    def _check_frame(
+        self,
+        instances: list[np.ndarray],
+        video_id: str,
+        is_negative: bool = False,
+    ) -> FrameQC:
         """Check frame-level quality."""
         frame_qc = FrameQC()
 
@@ -486,6 +494,11 @@ class LabelQCDetector:
         frame_qc.is_incomplete = count_result["is_incomplete"]
         frame_qc.expected_instance_count = int(count_result["expected_count"])
         frame_qc.actual_instance_count = len(instances)
+
+        # Negative (background) frames should have no instances.
+        frame_qc.is_negative_with_instances = check_negative_frame(
+            is_negative, len(instances)
+        )
 
         # Duplicate detection
         if len(instances) >= 2:

--- a/sleap/qc/frame_level.py
+++ b/sleap/qc/frame_level.py
@@ -88,6 +88,23 @@ class InstanceCountChecker:
         }
 
 
+def check_negative_frame(is_negative: bool, instance_count: int) -> bool:
+    """Check whether a negative frame inconsistently still has instances.
+
+    A negative (background) frame is explicitly marked as containing no animals.
+    If it still has instances, it is either a mislabel or instances were added
+    through a path that did not clear the negative flag.
+
+    Args:
+        is_negative: Whether the frame is marked as a negative frame.
+        instance_count: Number of instances on the frame.
+
+    Returns:
+        True if the frame is marked negative but still has instances.
+    """
+    return bool(is_negative) and instance_count > 0
+
+
 def compute_instance_iou(
     points_a: np.ndarray,
     points_b: np.ndarray,

--- a/sleap/qc/results.py
+++ b/sleap/qc/results.py
@@ -34,6 +34,7 @@ class FrameQC:
     actual_instance_count: int = 0
     duplicate_pairs: list[tuple[int, int]] = field(default_factory=list)
     duplicate_reasons: list[str] = field(default_factory=list)
+    is_negative_with_instances: bool = False
 
 
 @dataclass
@@ -117,10 +118,14 @@ class QCResults:
         return flagged
 
     def get_frame_issues(self) -> list[tuple[FrameKey, FrameQC]]:
-        """Get frames with issues (incomplete or duplicates)."""
+        """Get frames with issues (incomplete, duplicates, or bad negatives)."""
         issues = []
         for key, frame_qc in self.frame_results.items():
-            if frame_qc.is_incomplete or frame_qc.duplicate_pairs:
+            if (
+                frame_qc.is_incomplete
+                or frame_qc.duplicate_pairs
+                or frame_qc.is_negative_with_instances
+            ):
                 issues.append((key, frame_qc))
         return issues
 

--- a/tests/gui/learning/test_learning_dialog.py
+++ b/tests/gui/learning/test_learning_dialog.py
@@ -710,3 +710,76 @@ class TestDialogSize:
         size = inference_dialog.size()
         assert size.width() > 0
         assert size.height() > 0
+
+
+class TestNegativeFrames:
+    """Tests for the negative-frame training options."""
+
+    def _data_form(self, training_dialog, head):
+        """Add a tab for `head` and return its data form widget."""
+        training_dialog.remove_tabs()
+        training_dialog.tabs.clear()
+        training_dialog.add_tab(head)
+        return training_dialog.tabs[head].form_widgets["data"]
+
+    def test_fields_present_on_supported_head(self, training_dialog):
+        """Both negative-frame fields exist on a supported head."""
+        data_form = self._data_form(training_dialog, "single_instance")
+        assert data_form.fields.get("data_config.use_negative_frames") is not None
+        assert data_form.fields.get("data_config.negative_loss_weight") is not None
+
+    def test_fields_visible_on_supported_head(self, training_dialog):
+        """Negative-frame fields are visible on heads that use them."""
+        data_form = self._data_form(training_dialog, "bottomup")
+        use_field = data_form.fields.get("data_config.use_negative_frames")
+        weight_field = data_form.fields.get("data_config.negative_loss_weight")
+        assert not use_field.isHidden()
+        assert not weight_field.isHidden()
+
+    def test_fields_hidden_on_centered_instance(self, training_dialog):
+        """Negative-frame fields are hidden for centered-instance models."""
+        data_form = self._data_form(training_dialog, "centered_instance")
+        use_field = data_form.fields.get("data_config.use_negative_frames")
+        weight_field = data_form.fields.get("data_config.negative_loss_weight")
+        assert use_field.isHidden()
+        assert weight_field.isHidden()
+
+    def test_fields_hidden_on_multi_class_topdown(self, training_dialog):
+        """Negative-frame fields are hidden for top-down-ID models."""
+        data_form = self._data_form(training_dialog, "multi_class_topdown")
+        use_field = data_form.fields.get("data_config.use_negative_frames")
+        assert use_field.isHidden()
+
+    def test_weight_field_gated_by_checkbox(self, training_dialog):
+        """The negative loss weight field is enabled only when negatives are on."""
+        data_form = self._data_form(training_dialog, "single_instance")
+        use_field = data_form.fields.get("data_config.use_negative_frames")
+        weight_field = data_form.fields.get("data_config.negative_loss_weight")
+
+        # Disabled by default (checkbox off).
+        assert not weight_field.isEnabled()
+
+        use_field.setChecked(True)
+        assert weight_field.isEnabled()
+
+        use_field.setChecked(False)
+        assert not weight_field.isEnabled()
+
+    def test_form_data_uses_config_paths(self, training_dialog):
+        """The fields round-trip to their sleap-nn config paths."""
+        self._data_form(training_dialog, "single_instance")
+        data = training_dialog.tabs["single_instance"].get_all_form_data()
+        assert "data_config.use_negative_frames" in data
+        assert "data_config.negative_loss_weight" in data
+
+    def test_launch_warning_when_no_negative_frames(self, training_dialog):
+        """Enabling negatives with none marked surfaces a warning banner."""
+        training_dialog.set_pipeline("single")
+        tab_name = training_dialog.shown_tab_names[0]
+        data_form = training_dialog.tabs[tab_name].form_widgets["data"]
+        use_field = data_form.fields.get("data_config.use_negative_frames")
+
+        use_field.setChecked(True)
+        training_dialog._validate_pipeline()
+
+        assert "negative" in training_dialog.message_widget.text().lower()

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -4,8 +4,9 @@ import sys
 import time
 
 import numpy as np
+import sleap_io as sio
 from pathlib import PurePath, Path
-from qtpy import QtCore
+from qtpy import QtCore, QtWidgets
 from typing import List
 
 from sleap_io import (
@@ -1758,3 +1759,111 @@ class TestGenerateSuggestionsThread:
                 worker.wait(5)
 
         assert "finished" in events_processed
+
+
+def _negative_frame_labels():
+    """Build a minimal Labels with one video and a one-node skeleton."""
+    video = Video.from_filename("test.mp4")
+    skeleton = Skeleton(["A"])
+    labels = Labels(videos=[video], skeletons=[skeleton])
+    return labels, video, skeleton
+
+
+def test_ToggleNegativeFrame_mark_unmark_empty():
+    """Marking a detached empty frame attaches it; unmarking removes it."""
+    labels, video, _ = _negative_frame_labels()
+    context = CommandContext.from_labels(labels)
+
+    # A detached frame, as produced by `Labels.find(..., return_new=True)`.
+    lf = LabeledFrame(video=video, frame_idx=5)
+    context.state["labeled_frame"] = lf
+    context.state["frame_idx"] = 5
+
+    # Mark: the flag is set and the frame is attached to the project.
+    context.toggleCurrentFrameNegative()
+    assert lf.is_negative
+    assert lf in labels
+
+    # Unmark: the now-empty frame is pruned from the project.
+    context.toggleCurrentFrameNegative()
+    assert not lf.is_negative
+    assert lf not in labels
+
+
+def test_ToggleNegativeFrame_confirm_clears_instances(monkeypatch):
+    """Marking a frame with instances clears them after the user confirms."""
+    labels, video, skeleton = _negative_frame_labels()
+    inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skeleton)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst])
+    labels.append(lf)
+
+    context = CommandContext.from_labels(labels)
+    context.state["labeled_frame"] = lf
+    context.state["frame_idx"] = 0
+
+    # User confirms the destructive action.
+    monkeypatch.setattr(
+        "sleap.gui.commands.QtWidgets.QMessageBox.warning",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.Yes,
+    )
+    context.toggleCurrentFrameNegative()
+
+    assert lf.is_negative
+    assert len(lf.instances) == 0
+
+
+def test_ToggleNegativeFrame_declined_no_change(monkeypatch):
+    """Declining the confirm dialog leaves the frame untouched."""
+    labels, video, skeleton = _negative_frame_labels()
+    inst = Instance.from_numpy(np.array([[1.0, 2.0]]), skeleton=skeleton)
+    lf = LabeledFrame(video=video, frame_idx=0, instances=[inst])
+    labels.append(lf)
+
+    context = CommandContext.from_labels(labels)
+    context.state["labeled_frame"] = lf
+    context.state["frame_idx"] = 0
+
+    monkeypatch.setattr(
+        "sleap.gui.commands.QtWidgets.QMessageBox.warning",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.No,
+    )
+    context.toggleCurrentFrameNegative()
+
+    assert not lf.is_negative
+    assert len(lf.instances) == 1
+
+
+def test_ToggleNegativeFrame_roundtrip(tmp_path):
+    """The negative flag persists through a save/load round-trip."""
+    labels, video, _ = _negative_frame_labels()
+    context = CommandContext.from_labels(labels)
+
+    lf = LabeledFrame(video=video, frame_idx=7)
+    context.state["labeled_frame"] = lf
+    context.state["frame_idx"] = 7
+    context.toggleCurrentFrameNegative()
+
+    path = str(tmp_path / "negative.slp")
+    sio.save_file(labels, path)
+    reloaded = sio.load_file(path)
+
+    assert len(reloaded.negative_frames) == 1
+    assert reloaded.negative_frames[0].frame_idx == 7
+
+
+def test_AddInstance_clears_negative(qtbot, centered_pair_predictions: Labels):
+    """Adding an instance to a negative frame clears the negative flag."""
+    labels = centered_pair_predictions
+    lf = labels[0]
+    lf.is_negative = True
+
+    main_window = MainWindow(labels=labels)
+    context = main_window.commands
+    context.state["labeled_frame"] = lf
+    context.state["frame_idx"] = lf.frame_idx
+    context.state["skeleton"] = labels.skeleton
+    context.state["video"] = labels.videos[0]
+
+    context.newInstance()
+
+    assert not lf.is_negative

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -4,7 +4,6 @@ import sys
 import time
 
 import numpy as np
-import sleap_io as sio
 from pathlib import PurePath, Path
 from qtpy import QtCore, QtWidgets
 from typing import List
@@ -1834,18 +1833,30 @@ def test_ToggleNegativeFrame_declined_no_change(monkeypatch):
 
 
 def test_ToggleNegativeFrame_roundtrip(tmp_path):
-    """The negative flag persists through a save/load round-trip."""
+    """The negative flag persists when saved/loaded via the GUI command path.
+
+    Marks a frame via `ToggleNegativeFrame`, saves through the `SaveProjectAs`
+    command, and reloads through the GUI's `labels_load_file` helper — i.e. the
+    same code paths the Save As / Open menu actions use.
+    """
     labels, video, _ = _negative_frame_labels()
     context = CommandContext.from_labels(labels)
+    context.state["labels"] = labels
+    # `SaveProjectAs.do_action` redraws the frame at the end.
+    context.app.plotFrame = lambda: None
 
     lf = LabeledFrame(video=video, frame_idx=7)
     context.state["labeled_frame"] = lf
     context.state["frame_idx"] = 7
     context.toggleCurrentFrameNegative()
 
+    # Save through the GUI save command.
     path = str(tmp_path / "negative.slp")
-    sio.save_file(labels, path)
-    reloaded = sio.load_file(path)
+    SaveProjectAs.do_action(context, params={"filename": path})
+    assert Path(path).exists()
+
+    # Reload through the GUI's load helper.
+    reloaded = labels_load_file(path)
 
     assert len(reloaded.negative_frames) == 1
     assert reloaded.negative_frames[0].frame_idx == 7

--- a/tests/gui/test_slider.py
+++ b/tests/gui/test_slider.py
@@ -41,6 +41,24 @@ def test_slider(qtbot, centered_pair_predictions):
     assert slider.enabled()
 
 
+def test_slider_negative_frame_mark(qtbot, centered_pair_predictions):
+    """A negative frame produces a `negative`-type seekbar mark."""
+    labels = centered_pair_predictions
+    video = labels.videos[0]
+
+    # Mark an existing labeled frame as negative.
+    lf = labels.find(video)[0]
+    lf.instances = []
+    lf.is_negative = True
+
+    slider = VideoSlider(min=0, max=1200, val=0)
+    set_slider_marks_from_labels(slider, labels, video)
+
+    negative_marks = slider.getMarks("negative")
+    assert len(negative_marks) == 1
+    assert negative_marks[0].val == lf.frame_idx
+
+
 @pytest.mark.parametrize(
     "slider_width, x_value, handle_width, min_value, max_value",
     [

--- a/tests/gui/test_video_player.py
+++ b/tests/gui/test_video_player.py
@@ -285,3 +285,32 @@ def test_navigate_highlight(qtbot, small_robot_mp4_vid, centered_pair_labels):
     assert not vp.instances[0].navigate_highlight
 
     assert vp.close()
+
+
+def test_negative_frame_overlay(qtbot, small_robot_mp4_vid):
+    """The negative-frame overlay draws a border + caption only on negatives."""
+    from sleap_io import Labels, LabeledFrame, Skeleton
+
+    from sleap.gui.overlays.negative_frame import NegativeFrameOverlay
+
+    labels = Labels(videos=[small_robot_mp4_vid], skeletons=[Skeleton(["A"])])
+    labels.append(
+        LabeledFrame(video=small_robot_mp4_vid, frame_idx=1, is_negative=True)
+    )
+
+    vp = QtVideoPlayer(small_robot_mp4_vid)
+    qtbot.addWidget(vp)
+    overlay = NegativeFrameOverlay(labels=labels, player=vp)
+
+    # Negative frame: border + caption are added.
+    overlay.add_to_scene(small_robot_mp4_vid, 1)
+    assert len(overlay.items) == 2
+    captions = [
+        item for item in overlay.items if isinstance(item, QtTextWithBackground)
+    ]
+    assert len(captions) == 1
+    assert captions[0].toPlainText() == "Negative Frame"
+
+    # Non-negative frame: nothing is drawn.
+    overlay.redraw(small_robot_mp4_vid, 0)
+    assert overlay.items == []

--- a/tests/qc/test_detector.py
+++ b/tests/qc/test_detector.py
@@ -252,6 +252,49 @@ class TestLabelQCDetector:
         incomplete_frames = [(k, v) for k, v in frame_issues if v.is_incomplete]
         assert len(incomplete_frames) >= 1
 
+    def test_negative_frame_with_instances_flagged(self, skeleton):
+        """A negative frame that still has instances is flagged; a clean one is not."""
+        video = sio.Video.from_filename("test_video.mp4")
+        labels = sio.Labels()
+
+        # Normal frames so the detector has a baseline to fit on.
+        for i in range(20):
+            points = np.array(
+                [[100, 100], [100, 120], [100, 150], [80, 115], [120, 115]],
+                dtype=float,
+            )
+            instance = Instance.from_numpy(points, skeleton=skeleton)
+            labels.append(LabeledFrame(video=video, frame_idx=i, instances=[instance]))
+
+        # Inconsistent: marked negative but still has an instance.
+        bad_inst = Instance.from_numpy(
+            np.array(
+                [[100, 100], [100, 120], [100, 150], [80, 115], [120, 115]],
+                dtype=float,
+            ),
+            skeleton=skeleton,
+        )
+        bad_lf = LabeledFrame(video=video, frame_idx=20, instances=[bad_inst])
+        bad_lf.is_negative = True
+        labels.append(bad_lf)
+
+        # Clean: marked negative and empty.
+        clean_lf = LabeledFrame(video=video, frame_idx=21)
+        clean_lf.is_negative = True
+        labels.append(clean_lf)
+
+        detector = LabelQCDetector()
+        detector.fit(labels)
+        results = detector.score(labels)
+
+        flagged_frame_idxs = {
+            k.frame_idx
+            for k, v in results.get_frame_issues()
+            if v.is_negative_with_instances
+        }
+        assert 20 in flagged_frame_idxs
+        assert 21 not in flagged_frame_idxs
+
     def test_duplicate_detection(self, skeleton):
         """Test detection of duplicate instances."""
         video = sio.Video.from_filename("test_video.mp4")

--- a/tests/qc/test_frame_level.py
+++ b/tests/qc/test_frame_level.py
@@ -5,6 +5,7 @@ import pytest
 
 from sleap.qc.frame_level import (
     InstanceCountChecker,
+    check_negative_frame,
     compute_instance_iou,
     compute_node_overlap,
     detect_duplicates,
@@ -262,3 +263,23 @@ class TestDetectDuplicates:
 
         # May or may not be detected as duplicate depending on thresholds
         assert isinstance(duplicates, list)
+
+
+class TestCheckNegativeFrame:
+    """Tests for check_negative_frame."""
+
+    def test_negative_frame_with_instances_is_flagged(self):
+        """A negative frame that still has instances is inconsistent."""
+        assert check_negative_frame(is_negative=True, instance_count=2)
+
+    def test_clean_negative_frame_passes(self):
+        """A negative frame with no instances is consistent."""
+        assert not check_negative_frame(is_negative=True, instance_count=0)
+
+    def test_normal_frame_with_instances_passes(self):
+        """A non-negative frame with instances is consistent."""
+        assert not check_negative_frame(is_negative=False, instance_count=3)
+
+    def test_normal_empty_frame_passes(self):
+        """A non-negative empty frame is consistent."""
+        assert not check_negative_frame(is_negative=False, instance_count=0)

--- a/tests/qc/test_results.py
+++ b/tests/qc/test_results.py
@@ -64,6 +64,21 @@ class TestFrameQC:
         assert frame_qc.expected_instance_count == 2
         assert len(frame_qc.duplicate_pairs) == 1
 
+    def test_negative_with_instances_default(self):
+        """is_negative_with_instances defaults to False."""
+        assert not FrameQC().is_negative_with_instances
+
+    def test_negative_with_instances_in_frame_issues(self):
+        """A negative frame with instances is surfaced by get_frame_issues."""
+        results = QCResults()
+        results.frame_results[FrameKey(0, 0)] = FrameQC()  # Clean frame.
+        results.frame_results[FrameKey(0, 1)] = FrameQC(is_negative_with_instances=True)
+
+        issues = results.get_frame_issues()
+        assert len(issues) == 1
+        assert issues[0][0] == FrameKey(0, 1)
+        assert issues[0][1].is_negative_with_instances
+
 
 class TestQCFlag:
     """Tests for QCFlag."""


### PR DESCRIPTION
## Summary

- Lets a SLEAP user explicitly mark a video frame as a **negative frame** — a background frame with no animals — so the model learns to predict *nothing* on empty frames, reducing false positives.
- Surfaces the feature end-to-end in the desktop GUI: marking, visual feedback, the two training-config options, and a QC safety net.
- Closes the long-standing UX gap that stalled #640 since Feb 2022. The data model (`sleap-io`) and training backend (`sleap-nn`) already support negative frames — **this PR is the GUI layer only**; no dependency bumps.

## Changes Made

**Marking a frame**
- New `ToggleNegativeFrame` command + `CommandContext.toggleCurrentFrameNegative` (`commands.py`).
  - Marking a frame that has instances shows a confirmation dialog before removing them.
  - Marking attaches a detached `LabeledFrame` to the project so the flag survives save/replot.
  - Unmarking an now-empty frame removes it (avoids orphan empty frames that training splits silently drop).
- `AddInstance` clears `is_negative` on its frame — a frame with a real instance is not a background frame.
- Entry points: **Labels → Mark Frame as Negative** (checkable), video right-click menu (checkable), and the **N** shortcut.

**Visual feedback**
- New `NegativeFrameOverlay` — a thick blue border around the frame periphery + a "Negative Frame" caption drawn on the canvas while the current frame is negative.
- New `negative` seekbar mark type — a blue tick (matching the overlay color), width 2, with a hover tooltip (`slider.py`).
- `[NEGATIVE FRAME]` status-bar tag; the Labels-menu checkmark stays in sync with the current frame (`app.py`).

**Training**
- Two new fields on the Data tab: **Use Negative Frames** (`data_config.use_negative_frames`) and **Negative Loss Weight** (`data_config.negative_loss_weight`, min `0.01` — sleap-nn requires `> 0`).
- The weight field is disabled until the checkbox is on; both fields are hidden for `centered_instance` / `multi_class_topdown` heads, which ignore negatives.
- Non-blocking launch-time warning when negatives are enabled but no frames are marked.

**Quality control**
- Label QC flags any negative frame that still has instances (`qc/frame_level.py`, `qc/detector.py`, `qc/results.py`) — a safety net for script-built projects.

**Docs**
- New guide: `docs/guides/negative-frames.md`, linked from the guides overview and `mkdocs.yml`.

## API Changes

- New: `sleap.gui.commands.ToggleNegativeFrame`, `CommandContext.toggleCurrentFrameNegative()`.
- New: `sleap.gui.overlays.negative_frame.NegativeFrameOverlay`.
- New: `sleap.qc.frame_level.check_negative_frame()`, `FrameQC.is_negative_with_instances`.
- `LabelQCDetector._check_frame()` gains an optional `is_negative` argument (defaults to `False`).
- New shortcut key `mark negative` (default **N**; replaces the unused `mark frame`).
- No breaking changes; no dependency version changes.

## Testing

21 new tests, all passing:

- `tests/gui/test_commands.py` — mark/unmark of a detached empty frame (attach + prune), confirm-clears-instances, declined-no-change, `AddInstance` clears the flag, and a **GUI-path save/load round-trip** (marks via the command, saves through `SaveProjectAs`, reloads through the `labels_load_file` helper — the same paths the Save As / Open menu actions use).
- `tests/gui/learning/test_learning_dialog.py::TestNegativeFrames` — fields present/visible on supported heads, hidden on `centered_instance` / `multi_class_topdown`, weight field gated by the checkbox, config-path round-trip, launch-time warning.
- `tests/gui/test_video_player.py` — `NegativeFrameOverlay` draws border + caption on a negative frame, nothing on a normal frame.
- `tests/gui/test_slider.py` — `set_slider_marks_from_labels` emits a `negative` mark.
- `tests/qc/` — `check_negative_frame`, `FrameQC.is_negative_with_instances` / `get_frame_issues`, end-to-end detector flagging.

Regression-checked the touched areas (`test_commands.py`, `test_app.py`, `test_learning_dialog.py`, `test_shortcuts.py`, `test_slider.py`, `test_video_player.py`, `tests/qc/*`, `test_formbuilder.py`, `test_qc.py`) — all green. `ruff` format + check clean. The on-canvas overlay was visually verified via an offscreen render.

## Design Decisions

- **User-facing term is "negative frame"** everywhere; the data attribute stays `is_negative` (matches the sleap-nn option/docs).
- **Confirm, don't silently destroy or refuse** when marking a frame that has instances — one path handles both predicted false positives and the legacy "all-invisible instance" workaround.
- **Prune empty frames on unmark** so the GUI never shows frames that training would discard.
- **Per-head gating** for the training fields — sleap-nn ignores negatives for `centered_instance` / `multi_class_topdown`. They remain available on the centroid stage of a top-down pipeline, where negatives *do* help.
- **The overlay border is inset and cosmetic** so it stays fully visible and a constant width when the view is fit exactly to the frame; the caption ignores view transforms so it stays a constant on-screen size. The seekbar tick uses the same blue for consistency.

## Future Considerations (follow-ups, out of scope)

- A dedicated Negative Frames review dock + next/prev-negative navigation.
- Training-monitor `loss_negative` charting (metrics already arrive over ZMQ).
- "Verify negatives by inference" QC action; batch migration of the legacy workaround.
- `sleap-io` [#431](https://github.com/talmolab/sleap-io/issues/431) (`LabeledFrame.merge()` drops `is_negative`) and `sleap-nn` [#577](https://github.com/talmolab/sleap-nn/issues/577) (validation-side negative metrics) — filed separately.

## Related Issues

Closes #640

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)