### PR TITLE
fix(gui): single-node skeleton new-instance IndexError (#2718)

### DIFF
--- a/sleap/info/align.py
+++ b/sleap/info/align.py
@@ -87,6 +87,12 @@ def get_most_stable_node_pair(
 ) -> Tuple[int, int]:
     """Returns pair of nodes which are at stable distance (over min threshold)."""
     all_pairs = get_stable_node_pairs(all_points_arrays, min_dist)
+    if not all_pairs:
+        # No usable pair (e.g. single-node skeleton, or all node distances
+        # below `min_dist`). Callers should short-circuit before this in
+        # normal flows; this guard prevents an IndexError on the degenerate
+        # case (#2718).
+        return 0, 0
     return all_pairs[0]["node_a"], all_pairs[0]["node_b"]
 
 
@@ -260,6 +266,12 @@ def get_instances_points(instances: List[Instance]) -> np.ndarray:
 def get_template_points_array(instances: List[Instance]) -> np.ndarray:
     """Returns mean of aligned points for instances."""
     points = get_instances_points(instances)
+
+    # Alignment via a stable node pair is undefined when the skeleton has
+    # fewer than two nodes. Return the nan-mean across instances directly
+    # so single-node skeletons work in the GUI new-instance flow (#2718).
+    if points.shape[1] < 2:
+        return np.nanmean(points, axis=0)
 
     node_a, node_b = get_most_stable_node_pair(points, min_dist=4.0)
 

--- a/tests/info/test_align.py
+++ b/tests/info/test_align.py
@@ -1,5 +1,7 @@
 from sleap.info import align
 import numpy as np
+from sleap_io import Skeleton
+from sleap_io.model.instance import Instance
 from sleap.sleap_io_adaptors.lf_labels_utils import instances
 
 
@@ -45,3 +47,30 @@ def test_align_points():
 
     assert np.allclose(mean[1], [-10, 0], atol=0.1)
     assert np.allclose(mean[2], [-24, -1], atol=0.1)
+
+
+def test_get_template_points_array_single_node():
+    """Single-node skeleton: short-circuit to nan-mean without raising.
+
+    Regression test for #2718 — `get_most_stable_node_pair` previously
+    crashed with IndexError for skeletons with fewer than 2 nodes, which
+    broke creating new instances after the first labeled one in the GUI.
+    """
+    skeleton = Skeleton(nodes=["centroid"])
+    instance_pts = [
+        Instance.from_numpy(np.array([[10.0, 20.0]]), skeleton=skeleton),
+        Instance.from_numpy(np.array([[12.0, 24.0]]), skeleton=skeleton),
+        Instance.from_numpy(np.array([[14.0, 22.0]]), skeleton=skeleton),
+    ]
+
+    out = align.get_template_points_array(instance_pts)
+
+    assert out.shape == (1, 2)
+    assert np.allclose(out, [[12.0, 22.0]])
+
+
+def test_get_most_stable_node_pair_empty_returns_zero():
+    """All-coincident points → no stable pair → (0, 0) instead of IndexError."""
+    points = np.zeros((3, 2, 2))  # 3 instances, 2 nodes, all at origin
+    node_a, node_b = align.get_most_stable_node_pair(points, min_dist=4.0)
+    assert (node_a, node_b) == (0, 0)


### PR DESCRIPTION
## Summary

- Fixes #2718 — creating a new instance via the GUI for a **single-node skeleton** crashed once at least one labeled instance existed.
- Short-circuit `get_template_points_array` for skeletons with `<2` nodes (alignment via a node pair is undefined for a single point — return the nan-mean across instances).
- Defensive guard in `get_most_stable_node_pair` returns `(0, 0)` instead of raising `IndexError` when `get_stable_node_pairs` produces an empty list.

## Why it broke

`get_stable_node_pairs` filters pairs with mean distance `<= min_dist` (default `4.0`). For a 1-node skeleton the only "pair" is node→itself with distance `0`, so the list is empty. `get_most_stable_node_pair` then did:

```python
return all_pairs[0]["node_a"], all_pairs[0]["node_b"]  # IndexError
```

The exception aborted `AddMissingInstanceNodes.add_best_nodes` before the random-placement fallback could run, so the GUI silently no-oped — the user saw the "create instance" menu/keybind appear to do nothing.

The "works on the first video, not the others" framing in the original report is a side effect of the empty-`labeled_frames` short-circuit in `get_template_instance_points` (which uses a networkx spring-layout fallback): the first instance the user ever creates always succeeds, then every subsequent one crashes regardless of video.

## Changes Made

### `sleap/info/align.py`

- `get_template_points_array`: early return `np.nanmean(points, axis=0)` when `points.shape[1] < 2`.
- `get_most_stable_node_pair`: return `(0, 0)` when `get_stable_node_pairs` returns `[]`.

### `tests/info/test_align.py`

- `test_get_template_points_array_single_node`: regression test using a 1-node `Skeleton` and three `Instance`s; asserts shape `(1, 2)` and the expected mean.
- `test_get_most_stable_node_pair_empty_returns_zero`: covers the defensive guard with all-coincident points.

## Testing

- `uv run pytest tests/info/test_align.py -v` — 4/4 pass (2 new + 2 existing).
- `uv run pytest tests/info/ tests/sleap_io_adaptors/test_lf_labels_utils.py tests/gui/test_commands.py` — all green; no regressions in adjacent test groups.
- End-to-end reproduction with the reporter's project file confirms `get_template_instance_points` now returns a `(1, 2)` array instead of raising:
  ```python
  labels = sio.load_slp("sleaptest.v002.slp")  # 1-node 'centroid', 1 labeled frame
  get_template_instance_points(labels, labels.skeletons[0])
  # → array([[960., 544.04]])  (was: IndexError)
  ```

## Design Decisions

- Fix is layered defensively: the early return in `get_template_points_array` handles the realistic GUI path cleanly, and the guard in `get_most_stable_node_pair` keeps any other future caller (e.g. `align_instances_on_most_stable`) from hitting the same crash on a degenerate input.
- No changes to `lf_labels_utils.py`, `commands.py`, or `align_instance_points`. The GUI's new-instance flow takes the no-aligning `(template_points - template_mean) + center` branch for fresh instances, which is shape-safe for `(1, 2)`. `get_mean_and_std_for_points` is shape-agnostic.

## Out of scope

- Broader single-node skeleton support gaps (training, `align_instance_points` brittleness when the source/target are 1-node) — tracked separately. This PR is just the GUI new-instance crash from #2718.
- Refactor of `add_nodes_from_template` to surface exceptions to the user instead of silent no-ops — worth doing but separate.

## Related Issues

Closes #2718.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)