### PR TITLE
feat(gui): centroid-only models - training pipeline UX (2/2)

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -36,6 +36,7 @@ from sleap.gui.widgets.frame_target_selector import (
     FrameTargetSelection,
 )
 from sleap.gui.learning.main_tab import MainTabWidget
+from sleap.gui.learning.features import is_centroid_models_enabled
 from sleap.gui.learning.wandb_utils import check_wandb_login_status
 
 # List of fields which should show list of skeleton nodes
@@ -149,7 +150,22 @@ class LearningDialog(QtWidgets.QDialog):
         buttons_layout_widget = QtWidgets.QWidget()
         buttons_layout_widget.setLayout(buttons_layout)
 
-        self.pipeline_form_widget = MainTabWidget(mode=mode, skeleton=skeleton)
+        # Thread the Help-menu "Experimental Features" toggle from the parent
+        # main window's GUI state into the pipeline widget so it can gate the
+        # centroid-only pipeline. GuiState.__getitem__ returns None for missing
+        # keys, so standalone/no-parent dialogs safely fall back to False.
+        parent_state = getattr(parent, "state", None)
+        self._experimental_features = (
+            bool(parent_state["experimental features"])
+            if parent_state is not None
+            else False
+        )
+
+        self.pipeline_form_widget = MainTabWidget(
+            mode=mode,
+            skeleton=skeleton,
+            experimental_features=self._experimental_features,
+        )
         if mode == "training":
             tab_label = "Training Pipeline"
         elif mode == "inference":
@@ -689,6 +705,7 @@ class LearningDialog(QtWidgets.QDialog):
             "top-down-id": _mct,
             "bottom-up": _cen,
             "bottom-up-id": _cen,
+            "centroid": _cen,
         }
 
         # Determine the current pipeline's anchor key
@@ -772,6 +789,19 @@ class LearningDialog(QtWidgets.QDialog):
             if recent_cfg_info.head_name in ("multi_class_topdown",):
                 return "top-down-id"
             if recent_cfg_info.head_name in ("centroid", "centered_instance"):
+                # A lone trained centroid head (no centered_instance companion)
+                # maps to the centroid-only pipeline when that experimental
+                # feature is enabled; otherwise it is the top-down centroid
+                # stage. (See features.py; remove with the feature flag.)
+                if (
+                    self.mode == "training"
+                    and is_centroid_models_enabled(self._experimental_features)
+                    and recent_cfg_info.head_name == "centroid"
+                    and not self._cfg_getter.get_filtered_configs(
+                        head_filter="centered_instance", only_trained=True
+                    )
+                ):
+                    return "centroid"
                 return "top-down"
             if recent_cfg_info.head_name in ("bottomup",):
                 return "bottom-up"
@@ -796,6 +826,7 @@ class LearningDialog(QtWidgets.QDialog):
             "top-down-id": ["centroid", "multi_class_topdown"],
             "bottom-up-id": ["multi_class_bottomup"],
             "single": ["single_instance"],
+            "centroid": ["centroid"],
         }
         return pipeline_to_heads.get(pipeline, [])
 
@@ -997,6 +1028,8 @@ class LearningDialog(QtWidgets.QDialog):
                 self.add_tab("multi_class_bottomup")
             elif pipeline == "single":
                 self.add_tab("single_instance")
+            elif pipeline == "centroid":
+                self.add_tab("centroid")
 
             # Apply defaults from previous trained config or video analysis
             self._apply_pipeline_defaults(pipeline)

--- a/sleap/gui/learning/main_tab.py
+++ b/sleap/gui/learning/main_tab.py
@@ -13,7 +13,7 @@ Layout sections:
 - Output: grouped checkboxes (training only)
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Dict, List, Optional, Tuple
 
 from qtpy.QtCore import Qt, Signal
@@ -37,6 +37,7 @@ from qtpy.QtWidgets import (
 )
 
 from sleap.gui.widgets.frame_target_selector import FrameTargetSelector
+from sleap.gui.learning.features import is_centroid_models_enabled
 from sleap.gui.learning.wandb_utils import (
     check_wandb_login_status,
     get_wandb_api_key_help_text,
@@ -211,6 +212,33 @@ PIPELINE_OPTIONS_INFERENCE = PIPELINE_OPTIONS_TRAINING + [
     ),
 ]
 
+# Centroid-only models: training-only, behind a temporary feature flag. This
+# option is deliberately kept out of PIPELINE_OPTIONS_TRAINING /
+# PIPELINE_OPTIONS_INFERENCE and is added at runtime in MainTabWidget.__init__
+# only when the flag is enabled (see features.py).
+CENTROID_PIPELINE_OPTION = PipelineOption(
+    key="centroid",
+    label="centroid",
+    description=(
+        "This pipeline trains a single centroid model that detects one point "
+        "per animal across the full image. It works with single-node "
+        "skeletons. Note that running inference with a centroid-only model is "
+        "not yet supported and is coming in a future release."
+    ),
+    fields=[
+        (
+            "model_config.head_configs.centroid.confmaps.anchor_part",
+            "Anchor Part",
+            None,
+        ),
+        (
+            "model_config.head_configs.centroid.confmaps.sigma",
+            "Sigma for Centroids",
+            5.0,
+        ),
+    ],
+)
+
 
 # =============================================================================
 # MainTabWidget
@@ -239,6 +267,7 @@ class MainTabWidget(QWidget):
         mode: str = "training",
         skeleton: Optional[Any] = None,
         parent: Optional[QWidget] = None,
+        experimental_features: bool = False,
     ):
         """Initialize the main tab widget.
 
@@ -246,10 +275,14 @@ class MainTabWidget(QWidget):
             mode: "training" or "inference"
             skeleton: Skeleton object with node_names for anchor part dropdowns.
             parent: Parent widget.
+            experimental_features: Whether the "Experimental Features" toggle in
+                the Help menu is enabled. Gates the centroid-only pipeline (the
+                SLEAP_ENABLE_CENTROID_MODELS env var remains a developer override).
         """
         super().__init__(parent)
         self._mode = mode
         self._skeleton = skeleton
+        self._experimental_features = experimental_features
         self._fields: Dict[str, QWidget] = {}
         # Store pipeline-specific fields separately to handle duplicate keys
         # across pipelines (e.g., centroid.sigma in top-down and top-down-id)
@@ -259,6 +292,23 @@ class MainTabWidget(QWidget):
             if mode == "training"
             else PIPELINE_OPTIONS_INFERENCE
         )
+        # Centroid-only models: training-only, behind a temporary feature flag.
+        # Remove this block when centroid-only inference lands (see features.py).
+        if mode == "training" and is_centroid_models_enabled(
+            self._experimental_features
+        ):
+            centroid_opt = CENTROID_PIPELINE_OPTION
+            nodes = getattr(self._skeleton, "nodes", None)
+            if nodes is not None and len(nodes) == 1:
+                centroid_opt = replace(
+                    centroid_opt,
+                    fields=[
+                        f
+                        for f in CENTROID_PIPELINE_OPTION.fields
+                        if "anchor_part" not in f[0]
+                    ],
+                )
+            self._pipeline_options = self._pipeline_options + [centroid_opt]
         self._wandb_api_key_placeholder: Optional[str] = None
         self._setup_ui()
         self._connect_signals()
@@ -1191,6 +1241,8 @@ class MainTabWidget(QWidget):
             "top-down-id", or "bottom-up-id".
         """
         label = self._pipeline_combo.currentText()
+        if "centroid" in label:
+            return "centroid"
         if "top-down" in label:
             if "id" not in label:
                 return "top-down"
@@ -1218,6 +1270,7 @@ class MainTabWidget(QWidget):
             "single",
             "top-down-id",
             "bottom-up-id",
+            "centroid",
         ):
             return  # Ignore invalid values
 

--- a/tests/gui/learning/test_learning_dialog.py
+++ b/tests/gui/learning/test_learning_dialog.py
@@ -6,11 +6,13 @@ This module tests the main dialog for training/inference configuration.
 import pytest
 from unittest.mock import patch, MagicMock
 
+from qtpy.QtWidgets import QWidget
 
 from sleap_io import Labels, Skeleton, Video
 
 from sleap.gui.learning.dialog import LearningDialog, TrainingEditorWidget
 from sleap.gui.learning.main_tab import MainTabWidget
+from sleap.gui.state import GuiState
 from sleap.gui.widgets.frame_target_selector import (
     FrameTargetSelection,
 )
@@ -192,6 +194,16 @@ class TestPipelineSwitching:
         training_dialog.set_pipeline("bottom-up-id")
         assert training_dialog.current_pipeline == "bottom-up-id"
         assert "multi_class_bottomup" in training_dialog.shown_tab_names
+
+    def test_get_head_names_for_centroid_pipeline(self, training_dialog):
+        """Centroid pipeline should map to a single 'centroid' head."""
+        assert training_dialog._get_head_names_for_pipeline("centroid") == ["centroid"]
+
+    def test_set_pipeline_centroid(self, training_dialog):
+        """Setting centroid pipeline should add exactly one 'centroid' tab."""
+        training_dialog.set_pipeline("centroid")
+        assert training_dialog.current_pipeline == "centroid"
+        assert training_dialog.shown_tab_names == ["centroid"]
 
     def test_pipeline_switch_removes_old_tabs(self, training_dialog):
         """Switching pipelines should remove old tabs."""
@@ -783,3 +795,70 @@ class TestNegativeFrames:
         training_dialog._validate_pipeline()
 
         assert "negative" in training_dialog.message_widget.text().lower()
+
+
+# =============================================================================
+# Experimental Features (centroid-only pipeline gating) Tests
+# =============================================================================
+
+
+class TestExperimentalFeaturesGating:
+    """Tests that the Help-menu 'experimental features' state gates the
+    centroid-only pipeline through the dialog.
+    """
+
+    @staticmethod
+    def _pipeline_labels(dialog):
+        combo = dialog.pipeline_form_widget._pipeline_combo
+        return [combo.itemText(i) for i in range(combo.count())]
+
+    def test_parent_state_on_yields_centroid_option(
+        self,
+        qtbot,
+        minimal_labels,
+        minimal_skeleton,
+        tmp_path,
+        mock_cfg_getter,
+        monkeypatch,
+    ):
+        """A parent whose state['experimental features'] is True exposes a
+        centroid pipeline option (env var unset so only the state drives it).
+        """
+        monkeypatch.delenv("SLEAP_ENABLE_CENTROID_MODELS", raising=False)
+
+        # Parent main-window stub carrying the Help-menu GUI state. Only the
+        # parent is registered with qtbot; the dialog is its Qt child and is
+        # cleaned up via Qt ownership when the parent closes. Registering both
+        # would double-delete the dialog during teardown.
+        parent = QWidget()
+        qtbot.addWidget(parent)
+        parent.state = GuiState()
+        parent.state["experimental features"] = True
+
+        labels_file = tmp_path / "test.slp"
+        labels_file.touch()
+
+        with patch(
+            "sleap.gui.learning.dialog.configs.TrainingConfigsGetter.make_from_labels_filename",
+            return_value=mock_cfg_getter,
+        ):
+            dialog = LearningDialog(
+                mode="training",
+                labels_filename=str(labels_file),
+                labels=minimal_labels,
+                skeleton=minimal_skeleton,
+                parent=parent,
+            )
+
+        assert dialog._experimental_features is True
+        assert any("centroid" in label for label in self._pipeline_labels(dialog))
+
+    def test_no_parent_defaults_off(self, training_dialog, monkeypatch):
+        """A standalone dialog (no parent state) defaults the flag to False and
+        shows no centroid option.
+        """
+        monkeypatch.delenv("SLEAP_ENABLE_CENTROID_MODELS", raising=False)
+        assert training_dialog._experimental_features is False
+        assert not any(
+            "centroid" in label for label in self._pipeline_labels(training_dialog)
+        )

--- a/tests/gui/learning/test_main_tab.py
+++ b/tests/gui/learning/test_main_tab.py
@@ -885,3 +885,119 @@ class TestFrameTargetSelectorIntegration:
         with qtbot.waitSignal(training_widget.valueChanged, timeout=1000):
             # Toggle skip user labeled checkbox
             training_widget.frame_target_selector.skip_user_labeled_cb.setChecked(True)
+
+
+# =============================================================================
+# Centroid-Only Pipeline Tests (feature-flagged, training-only)
+# =============================================================================
+
+
+class TestCentroidPipeline:
+    """Tests for the experimental centroid-only training pipeline.
+
+    The pipeline is gated behind the SLEAP_ENABLE_CENTROID_MODELS feature flag
+    and is only offered in training mode. When the flag is off (the default),
+    behavior must be byte-identical to today.
+    """
+
+    @staticmethod
+    def _centroid_labels(combo):
+        """Return list of pipeline labels shown in a combo box."""
+        return [combo.itemText(i) for i in range(combo.count())]
+
+    def test_flag_on_training_has_centroid_option(self, monkeypatch, qtbot):
+        """Flag ON + training mode should expose a 'centroid' option."""
+        monkeypatch.setenv("SLEAP_ENABLE_CENTROID_MODELS", "1")
+        widget = MainTabWidget(mode="training")
+        qtbot.addWidget(widget)
+
+        labels = self._centroid_labels(widget._pipeline_combo)
+        assert any("centroid" in label for label in labels)
+        # The module-level constant must not be mutated by construction.
+        assert len(PIPELINE_OPTIONS_TRAINING) == 5
+
+    def test_flag_on_training_pipeline_round_trips(self, monkeypatch, qtbot):
+        """current_pipeline should set->read round-trip 'centroid'."""
+        monkeypatch.setenv("SLEAP_ENABLE_CENTROID_MODELS", "1")
+        widget = MainTabWidget(mode="training")
+        qtbot.addWidget(widget)
+
+        widget.current_pipeline = "centroid"
+        assert widget.current_pipeline == "centroid"
+
+    def test_flag_on_single_node_hides_anchor_part(self, monkeypatch, qtbot):
+        """Single-node skeleton => centroid page has NO anchor_part field."""
+        from sleap_io import Skeleton
+
+        monkeypatch.setenv("SLEAP_ENABLE_CENTROID_MODELS", "1")
+        single_node = Skeleton(nodes=["centroid"], name="centroid")
+        widget = MainTabWidget(mode="training", skeleton=single_node)
+        qtbot.addWidget(widget)
+
+        centroid_fields = widget._pipeline_fields["centroid"]
+        assert not any("anchor_part" in key for key in centroid_fields)
+        # Sigma field is always present.
+        assert any("sigma" in key for key in centroid_fields)
+
+    def test_flag_on_multi_node_shows_anchor_part(self, monkeypatch, qtbot, skeleton):
+        """Multi-node skeleton => centroid page DOES have anchor_part field."""
+        monkeypatch.setenv("SLEAP_ENABLE_CENTROID_MODELS", "1")
+        widget = MainTabWidget(mode="training", skeleton=skeleton)
+        qtbot.addWidget(widget)
+
+        centroid_fields = widget._pipeline_fields["centroid"]
+        assert any("anchor_part" in key for key in centroid_fields)
+
+    def test_flag_off_training_no_centroid_option(self, monkeypatch, qtbot):
+        """Flag OFF => no 'centroid' option (parity with current behavior)."""
+        monkeypatch.delenv("SLEAP_ENABLE_CENTROID_MODELS", raising=False)
+        widget = MainTabWidget(mode="training")
+        qtbot.addWidget(widget)
+
+        labels = self._centroid_labels(widget._pipeline_combo)
+        assert not any("centroid" in label for label in labels)
+        assert widget._pipeline_combo.count() == len(PIPELINE_OPTIONS_TRAINING)
+
+    def test_flag_on_inference_no_centroid_option(self, monkeypatch, qtbot):
+        """Flag ON + inference mode => no 'centroid' option (training-only)."""
+        monkeypatch.setenv("SLEAP_ENABLE_CENTROID_MODELS", "1")
+        widget = MainTabWidget(mode="inference")
+        qtbot.addWidget(widget)
+
+        labels = self._centroid_labels(widget._pipeline_combo)
+        assert not any("centroid" in label for label in labels)
+        assert widget._pipeline_combo.count() == len(PIPELINE_OPTIONS_INFERENCE)
+
+    def test_param_on_training_has_centroid_option(self, monkeypatch, qtbot):
+        """experimental_features=True + training mode shows a 'centroid' option.
+
+        The env var is cleared so only the parameter drives the gating.
+        """
+        monkeypatch.delenv("SLEAP_ENABLE_CENTROID_MODELS", raising=False)
+        widget = MainTabWidget(mode="training", experimental_features=True)
+        qtbot.addWidget(widget)
+
+        labels = self._centroid_labels(widget._pipeline_combo)
+        assert any("centroid" in label for label in labels)
+        # The module-level constant must not be mutated by construction.
+        assert len(PIPELINE_OPTIONS_TRAINING) == 5
+
+    def test_param_on_inference_no_centroid_option(self, monkeypatch, qtbot):
+        """experimental_features=True + inference mode => no option (training-only)."""
+        monkeypatch.delenv("SLEAP_ENABLE_CENTROID_MODELS", raising=False)
+        widget = MainTabWidget(mode="inference", experimental_features=True)
+        qtbot.addWidget(widget)
+
+        labels = self._centroid_labels(widget._pipeline_combo)
+        assert not any("centroid" in label for label in labels)
+        assert widget._pipeline_combo.count() == len(PIPELINE_OPTIONS_INFERENCE)
+
+    def test_param_off_env_unset_no_centroid_option(self, monkeypatch, qtbot):
+        """experimental_features=False + env unset => no 'centroid' option."""
+        monkeypatch.delenv("SLEAP_ENABLE_CENTROID_MODELS", raising=False)
+        widget = MainTabWidget(mode="training", experimental_features=False)
+        qtbot.addWidget(widget)
+
+        labels = self._centroid_labels(widget._pipeline_combo)
+        assert not any("centroid" in label for label in labels)
+        assert widget._pipeline_combo.count() == len(PIPELINE_OPTIONS_TRAINING)


### PR DESCRIPTION
## Do not merge yet

This is the training-UX half (2/2) of a two-PR stack adding **centroid-only model training** to the SLEAP GUI. It is a draft and should not be merged or marked ready until the stack is reviewed together and the upstream inference work has landed (see below).

## Stacked on PR 1

**This PR is STACKED on the foundation PR and its base is `centroid-models/01-foundation`, not `develop`.** It depends on the skeleton template and the `is_centroid_models_enabled()` feature flag introduced there. Review/merge PR 1 first. The diff shown here is only PR 2's changes relative to the foundation branch; once PR 1 merges, retarget this PR's base to `develop`.

See PR 1: feat(gui): centroid-only models foundation - skeleton template + feature flag (1/2).

## Summary

Adds a standalone centroid **training** pipeline to the training dialog, gated behind the temporary `is_centroid_models_enabled()` feature flag (default **OFF**, so default behavior is byte-identical to today).

A "centroid-only" model is a standalone multi-animal centroid detector with a single-node skeleton, distinct from centroid as the first stage of a top-down pipeline.

## What's in this PR

- **`main_tab.py`** — a new module-level `CENTROID_PIPELINE_OPTION` (kept out of the shared `PIPELINE_OPTIONS_*` lists) added to the training combo at runtime only when the flag is enabled. The Anchor Part field is hidden for single-node skeletons where the choice is degenerate. The `current_pipeline` getter/setter recognize the new `centroid` pipeline.
- **`dialog.py`** — wires `centroid` into `pipeline_anchor_keys`, `pipeline_to_heads`, and `set_pipeline` (a single `centroid` tab). `get_most_recent_pipeline_trained` auto-selects the centroid-only pipeline for a lone trained centroid head (no `centered_instance` companion), but only in training mode with the flag on.
- Tests covering the new pipeline option, the dialog wiring, and the anchor-part visibility behavior.

## Scope: training only

This adds **training** support only. Centroid-only **inference** is intentionally deferred — it is still blocked upstream on sleap-nn (epic talmolab/sleap-nn#508 / PR talmolab/sleap-nn#562), so the new pipeline is exposed in the training dialog only. Until inference lands, users can train and export a centroid-only model but not yet run it from the GUI.

## Feature flag (default off)

The entire feature remains gated behind one flag, `is_centroid_models_enabled()` (driven by `SLEAP_ENABLE_CENTROID_MODELS`, default off). With the flag off, `develop` is byte-identical for users. The flag and its call sites are designed to be deleted in a single, clean removal once inference lands.

## Companion sleap-io fix

There is a companion fix in sleap-io for a `SkeletonEncoder` bug where edge-less nodes (a single-node skeleton) get dropped during encoding — relevant to the centroid skeleton template shipped in PR 1.
