### PR TITLE
refactor(gui): rename Debug Mode menu to Experimental Features

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -204,7 +204,7 @@ class MainWindow(QMainWindow):
         self.state["propagate track labels"] = prefs["propagate track labels"]
         self.state["node label size"] = prefs["node label size"]
         self.state["share usage data"] = prefs["share usage data"]
-        self.state["debug mode"] = False
+        self.state["experimental features"] = False
         self.state["skeleton_preview_image"] = None
         self.state["skeleton_description"] = "No skeleton loaded yet"
         if no_usage_data:
@@ -1132,7 +1132,7 @@ class MainWindow(QMainWindow):
 
         helpMenu.addSeparator()
         helpMenu.addAction("Keyboard Shortcuts", self._show_keyboard_shortcuts_window)
-        add_menu_check_item(helpMenu, "debug mode", "Debug mode")
+        add_menu_check_item(helpMenu, "experimental features", "Experimental Features")
 
     def process_events_then(self, action: Callable):
         """Decorates a function with a call to first process events."""

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -286,9 +286,10 @@ class QtVideoPlayer(QWidget):
 
         # Create the worker thread
         self.worker_thread = FrameLoaderThread()
-        self.worker_thread.debug_mode = self.state["debug mode"]
+        self.worker_thread.debug_mode = self.state["experimental features"]
         self.state.connect(
-            "debug mode", lambda value: self.worker_thread.set_debug_mode(value)
+            "experimental features",
+            lambda value: self.worker_thread.set_debug_mode(value),
         )
 
         # Connect the result signal to display frames
@@ -2316,7 +2317,7 @@ class QtInstance(QGraphicsObject):
         """Duplicate the instance and add it to the scene."""
         # Add instance to the context
         if self.player.context is None:
-            if self.player.state["debug mode"]:
+            if self.player.state["experimental features"]:
                 print("self.player.context is None, cannot duplicate instance")
             return
 

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -461,3 +461,36 @@ def test_menu_actions(qtbot, centered_pair_predictions: Labels):
 
     # Toggle instance visibility with shortcut, showing instances
     toggle_and_verify_visibility(True)
+
+
+def test_experimental_features_menu(qtbot):
+    """The help-menu toggle is labeled "Experimental Features" and drives the
+    renamed GUI state key, which still gates the video-worker debug logging.
+    """
+    window: MainWindow = MainWindow(no_usage_data=True)
+
+    # State key was renamed from "debug mode" -> "experimental features".
+    assert "debug mode" not in window.state
+    assert window.state["experimental features"] is False
+
+    # The menu action exists under the renamed key, with the new label, and is
+    # checkable + synced with the state value.
+    action = window._menu_actions["experimental features"]
+    assert action.text() == "Experimental Features"
+    assert action.isCheckable()
+    assert action.isChecked() is False
+
+    # No leftover action labeled with the old name anywhere in the menu bar.
+    all_labels = [a.text() for a in window.menuBar().findChildren(type(action))]
+    assert "Debug mode" not in all_labels
+
+    # Toggling the state updates the menu check and feeds the (unchanged) video
+    # worker debug flag via the renamed state connection.
+    worker = window.player.worker_thread
+    window.state["experimental features"] = True
+    assert action.isChecked() is True
+    assert worker.debug_mode is True
+
+    window.state["experimental features"] = False
+    assert action.isChecked() is False
+    assert worker.debug_mode is False


### PR DESCRIPTION
## Summary

Renames the existing help-menu toggle from **"Debug mode"** to **"Experimental Features"** and its backing GUI state key from `"debug mode"` to `"experimental features"`.

This is a pure rename: **behavior is unchanged.** The toggle still controls the existing video-worker debug logging via `FrameLoaderThread.debug_mode` / `set_debug_mode`, which is now fed by the renamed state key. The worker's internal attribute/method names (`debug_mode`, `set_debug_mode` in `sleap/gui/widgets/video_worker.py`) are intentionally left untouched.

## Why

This is groundwork for gating experimental features behind a single toggle. The centroid-only models stack (#2723 / #2724) will wire into this `"experimental features"` state key. This PR is intentionally standalone and independent of that stack so it can land in `develop` first.

## Changes

- `sleap/gui/app.py`
  - State init: `self.state["debug mode"] = False` -> `self.state["experimental features"] = False`
  - Help menu: `add_menu_check_item(helpMenu, "debug mode", "Debug mode")` -> `add_menu_check_item(helpMenu, "experimental features", "Experimental Features")`
- `sleap/gui/widgets/video.py`
  - Worker init reads renamed state key; `state.connect("experimental features", ...)`; `duplicate_instance` debug guard reads renamed key.
- `tests/gui/test_app.py`
  - New `test_experimental_features_menu` verifying the menu action is labeled "Experimental Features" (no leftover "Debug mode"), the `"experimental features"` state key exists and defaults `False`, the menu check stays in sync with state, and toggling state still drives the unchanged video-worker `debug_mode` flag.

## Testing

- `uv run ruff check --fix sleap/gui/app.py sleap/gui/widgets/video.py tests/gui/test_app.py` — all checks passed
- `uv run pytest tests/gui/test_app.py -q` — 4 passed
- `uv run pytest tests/gui/test_video_player.py -q` — 9 passed (regression check for `video.py` edits)

## Notes

A grep of the `sleap/` tree confirms zero remaining occurrences of the `"debug mode"` state key string or `"Debug mode"` label. The only remaining `Debug mode` text is an unrelated code comment in `video_worker.py` describing the internal `debug_mode` attribute, which stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
