### PR TITLE
docs: streamline installation page with one-liner commands and OS auto-detect

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -56,9 +56,9 @@ Generated: 2026-01-30 12:00:00
   ...
 
 [Packages]
-  sleap:          v1.6.0
-  sleap-io:       v0.6.3
-  sleap-nn:       v0.1.0a4
+  sleap:          v1.6.3
+  sleap-io:       v0.7.1
+  sleap-nn:       v0.2.0
   ...
 ```
 

--- a/docs/assets/javascripts/os-tabs.js
+++ b/docs/assets/javascripts/os-tabs.js
@@ -1,0 +1,181 @@
+/*
+ * os-tabs.js - Auto-select and sync the OS-matching content tab.
+ *
+ * Material for MkDocs + pymdownx.tabbed (alternate_style: true) renders each
+ * tab group as a set of CSS-driven radio inputs:
+ *
+ *   <div class="tabbed-set tabbed-alternate" data-tabs="N:3">
+ *     <input id="__tabbed_N_1" name="__tabbed_N" type="radio" checked>
+ *     <input id="__tabbed_N_2" name="__tabbed_N" type="radio">
+ *     <input id="__tabbed_N_3" name="__tabbed_N" type="radio">
+ *     <div class="tabbed-labels">
+ *       <label for="__tabbed_N_1">Windows</label>
+ *       <label for="__tabbed_N_2">macOS</label>
+ *       <label for="__tabbed_N_3">Linux</label>
+ *     </div>
+ *     <div class="tabbed-content"> ... </div>
+ *   </div>
+ *
+ * Which block is shown is pure CSS keyed on the checked radio, so selecting a
+ * tab is just `input.checked = true` - no Material/content.tabs.link needed.
+ *
+ * Scope (important): this script ONLY touches tab groups whose label set is
+ * EXACTLY {"Windows", "macOS", "Linux"} (case-sensitive). Every other OS-tabbed
+ * page in the docs uses different labels ("MacOS", "Mac (Apple Silicon)",
+ * "Linux (Fedora)", "macOS/Linux", ...), so none of them are affected. This is
+ * why we do NOT enable the global `content.tabs.link` theme feature, which would
+ * mis-link those pages.
+ *
+ * Behavior:
+ *  - On load, select the visitor's detected OS in every canonical group.
+ *  - A manual choice (clicking a canonical OS tab) is remembered in localStorage
+ *    and wins over detection on later loads; it also syncs the page's other
+ *    canonical groups so a Windows user only ever sees Windows commands.
+ *  - Progressive enhancement: with JS off, pymdownx's default-checked first tab
+ *    renders and everything still works.
+ */
+(function () {
+  "use strict";
+
+  // Exact, case-sensitive labels that opt a group into OS handling.
+  var OS_BY_LABEL = { Windows: "windows", macOS: "macos", Linux: "linux" };
+  var CANON = Object.keys(OS_BY_LABEL); // ["Windows", "macOS", "Linux"]
+  var PREF_KEY = "sleap-os-tab";
+  var BOUND_FLAG = "__sleapOsTabsBound";
+
+  function loadPref() {
+    try {
+      return localStorage.getItem(PREF_KEY);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function savePref(os) {
+    try {
+      localStorage.setItem(PREF_KEY, os);
+    } catch (e) {
+      /* storage unavailable (private mode / disabled) - ignore */
+    }
+  }
+
+  // Detect OS -> "windows" | "macos" | "linux" | null.
+  function detectOS() {
+    var p = "";
+    try {
+      if (navigator.userAgentData && navigator.userAgentData.platform) {
+        p = navigator.userAgentData.platform;
+      }
+    } catch (e) {
+      /* ignore */
+    }
+    if (!p && navigator.platform) p = navigator.platform;
+    var hay = (p + " " + (navigator.userAgent || "")).toLowerCase();
+
+    if (hay.indexOf("win") !== -1) return "windows";
+    // iOS / iPadOS / macOS all map to the macOS tab.
+    if (
+      hay.indexOf("mac") !== -1 ||
+      hay.indexOf("iphone") !== -1 ||
+      hay.indexOf("ipad") !== -1 ||
+      hay.indexOf("ipod") !== -1
+    ) {
+      return "macos";
+    }
+    // Android is Linux-based -> Linux tab.
+    if (hay.indexOf("linux") !== -1 || hay.indexOf("android") !== -1) {
+      return "linux";
+    }
+    return null;
+  }
+
+  // Tab groups whose label set is EXACTLY {Windows, macOS, Linux}.
+  function canonicalGroups() {
+    var out = [];
+    var sets = document.querySelectorAll(".tabbed-set");
+    for (var i = 0; i < sets.length; i++) {
+      var labels = sets[i].querySelectorAll(".tabbed-labels > label");
+      if (labels.length !== CANON.length) continue;
+      var texts = [];
+      for (var j = 0; j < labels.length; j++) {
+        texts.push((labels[j].textContent || "").trim());
+      }
+      var exact =
+        CANON.every(function (c) {
+          return texts.indexOf(c) !== -1;
+        }) &&
+        texts.every(function (t) {
+          return CANON.indexOf(t) !== -1;
+        });
+      if (exact) out.push(sets[i]);
+    }
+    return out;
+  }
+
+  // Select the radio for `os` in a single group. Setting `.checked` flips the
+  // CSS-driven display and, crucially, does NOT dispatch a change event, so the
+  // sync handler below can't recurse.
+  function selectInGroup(set, os) {
+    var labels = set.querySelectorAll(".tabbed-labels > label");
+    for (var i = 0; i < labels.length; i++) {
+      if (OS_BY_LABEL[(labels[i].textContent || "").trim()] !== os) continue;
+      var input = set.querySelector("#" + CSS.escape(labels[i].htmlFor));
+      if (input) input.checked = true;
+      return;
+    }
+  }
+
+  function applyToAll(os, groups) {
+    if (!os) return;
+    for (var i = 0; i < groups.length; i++) selectInGroup(groups[i], os);
+  }
+
+  // User clicked an OS tab in a canonical group -> remember it and sync the rest.
+  function onChange(event) {
+    var input = event.target;
+    if (!input || input.tagName !== "INPUT" || input.type !== "radio") return;
+    var set = input.closest(".tabbed-set");
+    if (!set) return;
+    var groups = canonicalGroups();
+    if (groups.indexOf(set) === -1) return;
+
+    var label = set.querySelector('label[for="' + CSS.escape(input.id) + '"]');
+    var os = label && OS_BY_LABEL[(label.textContent || "").trim()];
+    if (!os) return;
+
+    savePref(os);
+    for (var i = 0; i < groups.length; i++) {
+      if (groups[i] !== set) selectInGroup(groups[i], os);
+    }
+  }
+
+  function run() {
+    var groups = canonicalGroups();
+    if (!groups.length) return; // nothing on this page opts in
+    applyToAll(loadPref() || detectOS(), groups);
+    // Delegated, capture-phase listener bound once for the document's lifetime
+    // (survives Material instant navigation, which reuses the document).
+    if (!document[BOUND_FLAG]) {
+      document.addEventListener("change", onChange, true);
+      document[BOUND_FLAG] = true;
+    }
+  }
+
+  // Material exposes a global `document$` observable that emits on initial load
+  // and after each instant navigation; prefer it, else fall back to DOM ready.
+  function boot() {
+    if (window.document$ && typeof window.document$.subscribe === "function") {
+      window.document$.subscribe(function () {
+        requestAnimationFrame(run);
+      });
+    } else if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", function () {
+        requestAnimationFrame(run);
+      });
+    } else {
+      requestAnimationFrame(run);
+    }
+  }
+
+  boot();
+})();

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -26,7 +26,7 @@ Github has made it easy to separate issues from discussions. Generally speaking,
 
 ### Pull Requests
 
-1. Install from source using the [Development Setup](installation.md#development-setup) instructions.
+1. Install from source using the [Developer setup](installation.md#developer-setup) instructions.
 2. Create a fork from the `develop` branch.
    * Either work on the `develop` branch or create a new branch (recommended if tackling multiple issues at a time).
    * If creating a branch, use your name followed by a relevant keyword for your changes, eg: `git checkout -b john/some_issue`

--- a/docs/guides/creating-a-custom-training-profile.md
+++ b/docs/guides/creating-a-custom-training-profile.md
@@ -42,22 +42,27 @@ for each model you want to train (where `path/to/custom/profile.yaml` should be 
 !!! note
     If you exported the training package as a ZIP file, it contains both the `.pkg.slp` and `.yaml` files necessary to train with the configuration you selected in the GUI. Before running the [`sleap-nn train`](https://nn.sleap.ai/latest/guides/training/#using-cli) command, make sure to unzip this file:
 
-    === "macOS/Linux"
+    === "Windows"
+
+        PowerShell:
+        ```powershell
+        Expand-Archive -Path training_job.zip -DestinationPath training_job
+        ```
+        Command Prompt:
+        ```cmd
+        tar -xf training_job.zip -C training_job
+        ```
+
+    === "macOS"
 
         ```bash
         unzip training_job.zip -d training_job
         ```
 
-    === "Windows (PowerShell)"
+    === "Linux"
 
-        ```powershell
-        Expand-Archive -Path training_job.zip -DestinationPath training_job
-        ```
-
-    === "Windows (Command Prompt)"
-
-        ```cmd
-        tar -xf training_job.zip -C training_job
+        ```bash
+        unzip training_job.zip -d training_job
         ```
 
 ### Training Hardware support

--- a/docs/guides/creating-a-custom-training-profile.md
+++ b/docs/guides/creating-a-custom-training-profile.md
@@ -72,4 +72,4 @@ SLEAP supports training on:
 - AMD GPUs and older Macs (pre-M1) may fail during training.
 - Other GPU architectures or unsupported hardware configurations may lead to memory or allocation errors.
 
-GPU detection is automatic when you install SLEAP. Run `sleap doctor` to verify your GPU is detected. If you need to manually specify a backend, see the [Pre-release Versions](../installation.md#pre-release-versions) section.
+GPU detection is automatic when you install SLEAP. Run `sleap doctor` to verify your GPU is detected. If you need to manually specify a backend, see [Force a specific GPU backend](../installation.md#version-compatibility).

--- a/docs/guides/running-sleap-remotely.md
+++ b/docs/guides/running-sleap-remotely.md
@@ -40,22 +40,27 @@ The model will be saved in the `models/` directory within the same directory as 
 !!! note
     If you exported the training package as a ZIP file, it contains both the `.pkg.slp` and `.yaml` files necessary to train with the configuration you selected in the GUI. Before running the [`sleap-nn train`](https://nn.sleap.ai/latest/guides/training/#using-cli) command, make sure to unzip this file:
 
-    === "macOS/Linux"
+    === "Windows"
+
+        PowerShell:
+        ```powershell
+        Expand-Archive -Path training_job.zip -DestinationPath training_job
+        ```
+        Command Prompt:
+        ```cmd
+        tar -xf training_job.zip -C training_job
+        ```
+
+    === "macOS"
 
         ```bash
         unzip training_job.zip -d training_job
         ```
 
-    === "Windows (PowerShell)"
+    === "Linux"
 
-        ```powershell
-        Expand-Archive -Path training_job.zip -DestinationPath training_job
-        ```
-
-    === "Windows (Command Prompt)"
-
-        ```cmd
-        tar -xf training_job.zip -C training_job
+        ```bash
+        unzip training_job.zip -d training_job
         ```
 
 ## Remote inference

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ uv tool install --python 3.13 "sleap[nn]" --torch-backend auto
 Launch the GUI:
 
 ```bash
-sleap label
+sleap
 ```
 
 [:octicons-arrow-right-24: Full installation instructions](installation.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -140,6 +140,26 @@ uvx sleap labels.slp
 
     Add `--reinstall` to any install command for a completely fresh environment — use it when something is broken, or when installing from local source.
 
+??? note "Install development versions — latest fixes from GitHub"
+    To pull in unreleased fixes, install SLEAP directly from the `develop` branch:
+    ```bash
+    uv tool install --reinstall --python 3.13 "sleap[nn] @ git+https://github.com/talmolab/sleap@develop" --prerelease allow --torch-backend auto
+    ```
+    Re-run the same command to update to the latest `develop` commit (`--reinstall` re-fetches it).
+
+    To pull a fix from **sleap-io** or **sleap-nn** into your existing install *without* changing SLEAP, reinstall with a git override (their development branch is `main`):
+    ```bash
+    # latest sleap-io
+    uv tool install --reinstall --python 3.13 "sleap[nn]" --with "sleap-io[all] @ git+https://github.com/talmolab/sleap-io@main" --prerelease allow --torch-backend auto
+
+    # latest sleap-nn
+    uv tool install --reinstall --python 3.13 "sleap[nn]" --with "sleap-nn[torch] @ git+https://github.com/talmolab/sleap-nn@main" --prerelease allow --torch-backend auto
+
+    # both at once
+    uv tool install --reinstall --python 3.13 "sleap[nn]" --with "sleap-io[all] @ git+https://github.com/talmolab/sleap-io@main" --with "sleap-nn[torch] @ git+https://github.com/talmolab/sleap-nn@main" --prerelease allow --torch-backend auto
+    ```
+    Development versions may be unstable. If a dependency's dev version isn't compatible with the released SLEAP, install SLEAP from `develop` (first command) as well.
+
 ---
 
 ## Version compatibility
@@ -148,7 +168,7 @@ The SLEAP ecosystem is three packages that release together. Use compatible vers
 
 | SLEAP | sleap-io | sleap-nn |
 |-------|----------|----------|
-| 1.6.3 | 0.7.1 | 0.2.0 |
+| {{ sleap_version }} | {{ sleap_io_version }} | {{ sleap_nn_version }} |
 | 1.6.1 | 0.6.4 | 0.1.0 |
 
 ??? note "Older versions"
@@ -164,7 +184,7 @@ The SLEAP ecosystem is three packages that release together. Use compatible vers
 **Reproducible install** (exact versions — e.g. to match a collaborator):
 
 ```bash
-uv tool install --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.1" --with "sleap-nn==0.2.0" --torch-backend auto
+uv tool install --python 3.13 "sleap[nn]=={{ sleap_version }}" --with "sleap-io=={{ sleap_io_version }}" --with "sleap-nn=={{ sleap_nn_version }}" --torch-backend auto
 ```
 
 ??? note "Try a pre-release"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,255 +1,200 @@
-# Installation
+# Install SLEAP
 
-SLEAP is a tool for tracking animal poses in video. This guide will get you up and running.
+SLEAP tracks animal poses in video. Three commands get you from zero to a running GUI.
 
-!!! warning "Using SLEAP 1.4 or earlier?"
-    This guide is for SLEAP 1.5+. For older versions using conda, see the [legacy documentation](https://legacy.sleap.ai).
+!!! abstract "TL;DR — already have `uv`?"
+    ```bash
+    # Install (auto-detects your GPU)
+    uv tool install --python 3.13 "sleap[nn]" --torch-backend auto
 
-**What do you want to do?**
+    # Upgrade
+    uv tool upgrade sleap
 
-- [**Use SLEAP**](#install-sleap) (most users)
-- [**Update SLEAP**](#updating)
-- [**Try pre-release features**](#pre-release-versions)
-- [**Develop or contribute**](#development-setup)
-- [**Use SLEAP as a library**](#programmatic-usage)
-- [**Install with pip**](#pip-installation) (alternate method)
+    # Develop (editable install of all three repos)
+    git clone https://github.com/talmolab/sleap && git clone https://github.com/talmolab/sleap-io && git clone https://github.com/talmolab/sleap-nn && cd sleap && uv sync --extra nn --reinstall && uv pip install -e "../sleap-io[all]" && uv pip install -e "../sleap-nn[torch]" --torch-backend=auto
+    ```
+    New here? Follow the [step-by-step quick start](#quick-start) below — it installs `uv` first.
+
+!!! note "Using SLEAP 1.4 or earlier?"
+    This guide is for SLEAP 1.5+ (`uv`-based). For older conda installs, see the [legacy documentation](https://legacy.sleap.ai) or the [migration guide](guides/migrating-to-sleap-1-5.md).
 
 ---
 
-## Before You Start
+## Quick start
 
-??? question "Why do I need `uv`?"
-    **What is Python package management?**
+SLEAP installs with [`uv`](https://docs.astral.sh/uv/), a fast Python package manager that automatically detects your GPU. Install `uv` once, then install SLEAP.
 
-    Python packages often depend on other packages, which in turn have their own dependencies—each requiring specific versions. Without careful management, you can end up in "dependency hell" where different projects need conflicting versions. Package managers solve this by creating isolated environments where each project gets exactly the versions it needs.
-
-    **Why did SLEAP use `conda` before?**
-
-    SLEAP's neural networks required GPU libraries (CUDA) that were notoriously difficult to install correctly. Conda handled this by bundling CUDA inside isolated environments, making GPU-accelerated training "just work." For many years, this was the only reliable way to install SLEAP.
-
-    **What changed?**
-
-    Starting in SLEAP 1.5, we transitioned from TensorFlow to PyTorch. Unlike TensorFlow, PyTorch bundles all GPU dependencies directly in its `pip` package—no separate CUDA installation needed. This eliminated the main reason we needed conda.
-
-    Conda also had drawbacks: it was slow (environment creation could take 10+ minutes), and you had to remember to "activate" your environment every time you wanted to use SLEAP. If you forgot, you'd get confusing errors.
-
-    **What is `uv` and why use it?**
-
-    `uv` is a modern Python package manager that's blazingly fast (10-100x faster than pip or conda). Beyond speed, `uv` has a killer feature: it can install packages as **tools** that are available system-wide without needing to activate anything.
-
-    When you run `uv tool install sleap`, it creates an isolated environment behind the scenes, but exposes the `sleap` command globally. You just type `sleap` and it works—no activation, no environment management, no mental overhead.
-
-    Because `uv` is so fast, it's even practical to have multiple versions installed or switch between them. But for most users, the best part is that you can just install SLEAP once and forget about environments entirely.
-
-### Install uv
-
-SLEAP uses [`uv`](https://docs.astral.sh/uv/getting-started/installation/) to manage installation. It's a fast, modern package manager that handles everything automatically—including GPU detection.
+### 1. Install uv
 
 === "Windows"
-    1. Press the **Windows key**, type `PowerShell`, press **Enter**
-    2. Paste this command and press **Enter**:
+    Open **PowerShell** (press the **Windows key**, type `PowerShell`, press **Enter**), then run:
     ```powershell
     powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
     ```
-    3. **Close and reopen** PowerShell
-    4. Verify: `uv --version`
+    **Close and reopen** PowerShell, then check it worked:
+    ```powershell
+    uv --version
+    ```
+    You should see `uv 0.x.x`. If you instead see `uv is not recognized`, fully close all PowerShell windows and reopen (or restart your computer).
 
 === "macOS"
-    1. Press **Cmd+Space**, type `Terminal`, press **Enter**
-    2. Paste this command and press **Enter**:
+    Open **Terminal** (press **Cmd+Space**, type `Terminal`, press **Enter**), then run:
     ```bash
     curl -LsSf https://astral.sh/uv/install.sh | sh
     ```
-    3. **Close and reopen** Terminal
-    4. Verify: `uv --version`
+    **Close and reopen** Terminal, then check it worked:
+    ```bash
+    uv --version
+    ```
+    You should see `uv 0.x.x`.
 
 === "Linux"
-    1. Open a terminal (usually **Ctrl+Alt+T**)
-    2. Paste this command and press **Enter**:
+    Open a terminal (often **Ctrl+Alt+T**), then run:
     ```bash
     curl -LsSf https://astral.sh/uv/install.sh | sh
     ```
-    3. **Close and reopen** the terminal
-    4. Verify: `uv --version`
-
----
-
-## Install SLEAP
-
-One command works on all platforms. It automatically detects your GPU and installs the right version of PyTorch.
-
-!!! success "Quick Install"
+    **Close and reopen** the terminal, then check it worked:
     ```bash
-    uv tool install --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
+    uv --version
     ```
+    You should see `uv 0.x.x`.
 
-    Check the [version compatibility table](#version-compatibility) for the latest versions.
+### 2. Install SLEAP
 
-!!! warning "Python version matters"
-    If you don't have Python installed, `uv` will automatically download one. Without `--python 3.13`, it may download Python 3.14 which **SLEAP does not support yet**.
+One command works on all platforms — it auto-detects your GPU (NVIDIA, AMD, Intel, or CPU) and installs the matching PyTorch build:
 
-    Always include `--python 3.13` (or `--python 3.12`) in your install command.
+```bash
+uv tool install --python 3.13 "sleap[nn]" --torch-backend auto
+```
 
-That's it! SLEAP is now available system-wide. Run it from any terminal:
+SLEAP is now available system-wide — no environment to activate.
+
+??? info "What does this command do?"
+    - `--python 3.13` — pins Python 3.13. **Always include this.** Without it, `uv` may download Python 3.14, which SLEAP does not support yet. (Python 3.12 also works: use `--python 3.12`.)
+    - `sleap[nn]` — SLEAP plus neural-network support for training and inference.
+    - `--torch-backend auto` — detects your GPU and installs the right PyTorch build.
+
+    Need exact, reproducible versions instead? See [Version compatibility](#version-compatibility).
+
+### 3. Launch SLEAP
 
 ```bash
 sleap
 ```
 
-A window should open within a few seconds.
-
-??? info "What does this command do?"
-    - `--python 3.13` — Uses Python 3.13
-    - `sleap[nn]` — Installs SLEAP with neural network support for training
-    - `--with "sleap-io==..."` — Pins dependency versions for compatibility
-    - `--torch-backend auto` — Automatically detects your GPU (NVIDIA, AMD, Intel, or CPU)
-
-    For pre-release versions (e.g., `sleap-nn==0.1.0a4`), add `--prerelease allow`.
-
-??? tip "Getting an error about `--torch-backend`?"
-    Update uv to the latest version:
-    ```bash
-    uv self update
-    ```
-
-### Verify installation
+A window opens within a few seconds. To check your install — package versions and GPU detection:
 
 ```bash
 sleap doctor
 ```
 
-This shows your system info, package versions, and confirms GPU detection.
-
-### Just viewing or annotating (no training)
-
-!!! tip "Try SLEAP without installing"
-    If you only need to view and annotate data without training models, you don't even need to install anything:
-
+!!! tip "Just viewing or annotating? No install needed."
+    To view and label data without training models, run SLEAP straight from `uv`:
     ```bash
     uvx sleap labels.slp
     ```
-
-    This runs SLEAP directly without a permanent installation. Replace `labels.slp` with your file, or omit it to open SLEAP with an empty project.
+    Replace `labels.slp` with your file, or omit it to open an empty project. Training and inference need the full install (`sleap[nn]`) above.
 
 ---
 
-## Updating
+## Common commands
 
-### Check your current version
-
-```bash
-sleap doctor
-```
-
-### Upgrade everything to latest
+**Upgrade to the latest version:**
 
 ```bash
 uv tool upgrade sleap
 ```
 
-This upgrades SLEAP and all its dependencies to the latest compatible versions. It remembers your original settings (like `--prerelease allow` and `--torch-backend auto`).
+This upgrades SLEAP and its dependencies, keeping your original settings (like `--torch-backend auto`).
 
-### Upgrade just sleap-io or sleap-nn
-
-If there's a new release of a dependency but not SLEAP itself:
+**Set up a development install** (editable checkout of all three repos):
 
 ```bash
-uv tool upgrade sleap --upgrade-package sleap-io
+git clone https://github.com/talmolab/sleap && git clone https://github.com/talmolab/sleap-io && git clone https://github.com/talmolab/sleap-nn && cd sleap && uv sync --extra nn --reinstall && uv pip install -e "../sleap-io[all]" && uv pip install -e "../sleap-nn[torch]" --torch-backend=auto
 ```
+
+See [Developer setup](#developer-setup) for the step-by-step version.
+
+**Try without installing:**
 
 ```bash
-uv tool upgrade sleap --upgrade-package sleap-nn
+uvx sleap labels.slp
 ```
 
-```bash
-uv tool upgrade sleap --upgrade-package sleap-io --upgrade-package sleap-nn
-```
-
-### Upgrade to a specific version
-
-If you need specific versions (for reproducibility or to match a collaborator), reinstall:
-
-```bash
-uv tool install --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
-```
-
-This replaces the existing installation with the exact versions specified.
-
-### Downgrade
-
-Just reinstall with the older version:
-
-```bash
-uv tool install --python 3.13 "sleap[nn]==1.6.1" --torch-backend auto
-```
-
-### Uninstall
-
-```bash
-uv tool uninstall sleap
-```
-
-??? note "When to use `--reinstall`"
-    Most of the time, you don't need it. Use `--reinstall` when:
-
-    - Something is broken and you want a completely fresh environment
-    - Installing from local source code (to pick up changes)
-
+??? note "Manage your install — upgrade one package, pin, downgrade, uninstall"
+    **Upgrade just a dependency** (e.g. a new `sleap-io` release but not SLEAP itself):
     ```bash
-    uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
+    uv tool upgrade sleap --upgrade-package sleap-io
     ```
+    Repeat `--upgrade-package` for each one, e.g. `--upgrade-package sleap-io --upgrade-package sleap-nn`.
+
+    **Pin or downgrade to exact versions** — just reinstall, pinning all three packages (see the [compatibility table](#version-compatibility)):
+    ```bash
+    uv tool install --python 3.13 "sleap[nn]==1.6.1" --with "sleap-io==0.6.4" --with "sleap-nn==0.1.0" --torch-backend auto
+    ```
+
+    **Uninstall:**
+    ```bash
+    uv tool uninstall sleap
+    ```
+
+    Add `--reinstall` to any install command for a completely fresh environment — use it when something is broken, or when installing from local source.
 
 ---
 
-## Pre-release Versions
+## Version compatibility
 
-Pre-releases let you try new features before official release. They may have bugs, so use stable versions for important annotation work.
-
-### Latest pre-release
-
-```bash
-uv tool install --python 3.13 "sleap[nn]" --prerelease allow --torch-backend auto
-```
-
-### Version compatibility
-
-The SLEAP ecosystem has three packages that work together:
+The SLEAP ecosystem is three packages that release together. Use compatible versions when pinning.
 
 | SLEAP | sleap-io | sleap-nn |
 |-------|----------|----------|
-| 1.6.3 | 0.7.0 | 0.2.0 |
+| 1.6.3 | 0.7.1 | 0.2.0 |
 | 1.6.1 | 0.6.4 | 0.1.0 |
-| 1.6.0 | 0.6.4 | 0.1.0 |
-| 1.6.0a3 | 0.6.3 | 0.1.0a4 |
-| 1.6.0a2 | 0.6.2 | 0.1.0a2 |
-| 1.6.0a1 | 0.6.1 | 0.1.0a1 |
-| 1.6.0a0 | 0.6.0 | 0.1.0a0 |
-| 1.5.x | <0.6.0 | <0.1.0 |
 
-Always use compatible versions when pinning.
+??? note "Older versions"
+    | SLEAP | sleap-io | sleap-nn |
+    |-------|----------|----------|
+    | 1.6.0 | 0.6.4 | 0.1.0 |
+    | 1.6.0a3 | 0.6.3 | 0.1.0a4 |
+    | 1.6.0a2 | 0.6.2 | 0.1.0a2 |
+    | 1.6.0a1 | 0.6.1 | 0.1.0a1 |
+    | 1.6.0a0 | 0.6.0 | 0.1.0a0 |
+    | 1.5.x | <0.6.0 | <0.1.0 |
 
-??? note "Force a specific PyTorch backend"
-    If `--torch-backend auto` doesn't detect your GPU correctly, you can specify it manually:
+**Reproducible install** (exact versions — e.g. to match a collaborator):
+
+```bash
+uv tool install --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.1" --with "sleap-nn==0.2.0" --torch-backend auto
+```
+
+??? note "Try a pre-release"
+    Pre-releases let you try new features early. They may have bugs, so use stable versions for important annotation work.
+    ```bash
+    uv tool install --python 3.13 "sleap[nn]" --prerelease allow --torch-backend auto
+    ```
+
+??? note "Force a specific GPU backend"
+    If `--torch-backend auto` doesn't detect your hardware correctly, set it explicitly:
 
     | Backend | For |
     |---------|-----|
     | `cu128` | NVIDIA GPUs (CUDA 12.8) |
     | `cu130` | Newest NVIDIA GPUs (CUDA 13.0) |
+    | `cu118` | NVIDIA GPUs with older drivers (CUDA 11.8) |
     | `cpu` | No GPU / CPU only |
-    | `rocm` | AMD GPUs |
+    | `rocm6.4` | AMD GPUs (use the version matching your ROCm install) |
     | `xpu` | Intel GPUs |
 
     ```bash
-    uv tool install --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend cu128
+    uv tool install --python 3.13 "sleap[nn]" --torch-backend cu128
     ```
+    Run `uv tool install --help` for the current list of backend values.
 
 ---
 
-## Development Setup
+## Developer setup
 
-For contributors and developers who want to modify SLEAP's source code.
-
-### Full ecosystem setup (all three repos)
+For contributors who want to modify SLEAP's source. (A copy-paste one-liner is in [Common commands](#common-commands) above.)
 
 **1. Clone the repositories:**
 
@@ -268,158 +213,123 @@ uv pip install -e "../sleap-io[all]"
 uv pip install -e "../sleap-nn[torch]" --torch-backend=auto
 ```
 
-??? warning "Note about `uv sync`"
-    Running `uv sync` again will overwrite your local editable installs with PyPI versions. After any `uv sync`, re-run the `uv pip install -e` commands.
+??? warning "`uv sync` overwrites editable installs"
+    Running `uv sync` again replaces your local `-e` installs with PyPI versions. Re-run the two `uv pip install -e` commands after any `uv sync`.
 
-**3. Activate the environment:**
-
-=== "Linux/macOS"
-    ```bash
-    source .venv/bin/activate
-    ```
-
-=== "Windows (PowerShell)"
-    ```powershell
-    .venv\Scripts\Activate.ps1
-    ```
-
-=== "Windows (Command Prompt)"
-    ```cmd
-    .venv\Scripts\activate.bat
-    ```
-
-**4. Run commands:**
-
-```bash
-sleap
-pytest tests/
-```
-
-Or without activating the environment:
+**3. Run SLEAP** — without activating anything:
 
 ```bash
 uv run sleap
 uv run pytest tests/
 ```
 
-### Use local dev as system tool
+Or activate the environment first, then run `sleap` / `pytest tests/` directly:
 
-Want to run your modified SLEAP from anywhere without activating a venv? Install from local source:
+=== "Windows"
+    PowerShell:
+    ```powershell
+    .venv\Scripts\Activate.ps1
+    ```
+    Command Prompt:
+    ```bat
+    .venv\Scripts\activate.bat
+    ```
 
-```bash
-uv tool install --reinstall --python 3.13 ".[nn]" --with "../sleap-io[all]" --with "../sleap-nn" --prerelease allow --torch-backend auto
-```
+=== "macOS"
+    ```bash
+    source .venv/bin/activate
+    ```
 
-Now you can run `sleap` from anywhere and it uses your local code!
+=== "Linux"
+    ```bash
+    source .venv/bin/activate
+    ```
 
-Re-run with `--reinstall` after making changes to pick them up.
-
----
-
-## Programmatic Usage
-
-The `sleap` package is primarily the GUI application. For scripting and automation, use these libraries:
-
-| Library | Use for | Docs |
-|---------|---------|------|
-| **sleap-io** | Working with `.slp` files, labels, skeletons, videos, merging projects, custom analysis | [io.sleap.ai](https://io.sleap.ai) |
-| **sleap-nn** | Training models, running inference, evaluating predictions, batch processing | [nn.sleap.ai](https://nn.sleap.ai) |
-
----
-
-## Pip Installation
-
-For users who prefer pip over uv, or need to integrate SLEAP into an existing environment.
-
-### Create a conda environment
-
-```bash
-conda create -n sleap_env
-conda activate sleap_env
-```
-
-### Install with pip
-
-```bash
-# CPU only
-pip install "sleap[nn]" --extra-index-url https://download.pytorch.org/whl/cpu
-
-# NVIDIA GPU (CUDA 12.8)
-pip install "sleap[nn]" --extra-index-url https://download.pytorch.org/whl/cu128
-```
-
----
-
-## Model Export (ONNX)
-
-To export trained models to ONNX format for deployment, you need additional dependencies.
-
-[:octicons-arrow-right-24: Learn more about exporting models](https://nn.sleap.ai/latest/guides/export/)
-
-### Install export dependencies
-
-If you installed SLEAP as a tool:
-
-```bash
-# Add ONNX export support (CPU runtime)
-uv tool install --python 3.13 "sleap[nn,nn-export]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
-
-# Add ONNX export support (GPU runtime - faster inference)
-uv tool install --python 3.13 "sleap[nn,nn-export-gpu]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
-```
-
-If you're using a development setup:
-
-```bash
-# CPU ONNX runtime
-uv sync --extra nn --extra nn-export
-
-# GPU ONNX runtime (for faster inference)
-uv sync --extra nn --extra nn-export-gpu
-```
-
-### TensorRT (Linux/Windows only)
-
-For NVIDIA TensorRT support on Linux or Windows:
-
-```bash
-# Development setup
-uv sync --extra nn-cuda128 --extra nn-tensorrt
-
-# Tool install
-uv tool install --python 3.13 "sleap[nn,nn-tensorrt]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend cu128
-```
-
-!!! note
-    TensorRT is not supported on macOS.
-
+??? note "Run your local dev build from anywhere"
+    Install your working copy as a global tool, so `sleap` runs your local code from any terminal without activating a venv:
+    ```bash
+    uv tool install --reinstall --python 3.13 ".[nn]" --with "../sleap-io[all]" --with "../sleap-nn[torch]" --prerelease allow --torch-backend auto
+    ```
+    Re-run with `--reinstall` after making changes to pick them up.
 
 ---
 
 ## Troubleshooting
 
-**First step:** Run `sleap doctor` and check the output for errors.
+**First step:** run `sleap doctor` and read the output for errors.
 
 ??? note "`--torch-backend` not recognized"
-    Update uv to the latest version:
+    Update `uv` to the latest version:
     ```bash
     uv self update
     ```
 
-??? note "Force a clean reinstall"
-    If something is broken:
-    ```bash
-    uv tool install --reinstall --python 3.13 "sleap[nn]==1.6.3" --with "sleap-io==0.7.0" --with "sleap-nn==0.2.0" --torch-backend auto
-    ```
-
-??? note "Installation seems stuck"
-    Large packages like PyTorch take time. Installation can take 5-15 minutes on slower connections. Wait up to 30 minutes before cancelling.
-
 ??? note "GPU not detected"
     If `sleap doctor` shows no GPU:
 
-    1. **Check driver**: Run `nvidia-smi`. If it fails, [install drivers](https://www.nvidia.com/drivers)
-    2. **Driver version**: CUDA 12.8 requires driver 525+
-    3. **Try explicit backend**: Use `--torch-backend cu128` instead of `auto`
+    1. **Check the driver:** run `nvidia-smi`. If it fails, [install drivers](https://www.nvidia.com/drivers). CUDA 12.8 requires driver 525+.
+    2. **Set the backend explicitly:** reinstall with `--torch-backend cu128` instead of `auto` (see the GPU-backend table under [Version compatibility](#version-compatibility)).
 
-**Still stuck?** Run `sleap doctor`, copy output, and ask at [GitHub Discussions](https://github.com/talmolab/sleap/discussions)
+??? note "Installation seems stuck"
+    Large packages like PyTorch take time — 5–15 minutes is normal on slower connections. Wait up to 30 minutes before cancelling.
+
+??? note "Start over with a clean install"
+    ```bash
+    uv tool install --reinstall --python 3.13 "sleap[nn]" --torch-backend auto
+    ```
+
+**Still stuck?** Run `sleap doctor`, copy the output, and ask on [GitHub Discussions](https://github.com/talmolab/sleap/discussions).
+
+---
+
+## Advanced & alternatives
+
+??? note "Model export (ONNX / TensorRT)"
+    To export trained models for deployment, add the export extras. [Learn more about exporting models](https://nn.sleap.ai/latest/guides/export/).
+
+    **Tool install** — add the extra to your install command:
+    ```bash
+    # ONNX, CPU runtime
+    uv tool install --python 3.13 "sleap[nn,nn-export]" --torch-backend auto
+
+    # ONNX, GPU runtime (faster inference)
+    uv tool install --python 3.13 "sleap[nn,nn-export-gpu]" --torch-backend auto
+
+    # TensorRT (Linux/Windows only) — needs a CUDA backend
+    uv tool install --python 3.13 "sleap[nn,nn-tensorrt]" --torch-backend cu128
+    ```
+
+    **Developer setup** — add the extra to `uv sync`:
+    ```bash
+    uv sync --extra nn --extra nn-export            # ONNX CPU runtime
+    uv sync --extra nn --extra nn-export-gpu         # ONNX GPU runtime
+    uv sync --extra nn-cuda128 --extra nn-tensorrt   # TensorRT
+    ```
+
+    TensorRT is not supported on macOS.
+
+??? note "Install with pip (alternative)"
+    Prefer `pip`, or integrating SLEAP into an existing environment? Create a virtual environment, then install with the PyTorch index for your hardware:
+    ```bash
+    python3.13 -m venv sleap_env
+    # Windows:      sleap_env\Scripts\activate
+    # macOS/Linux:  source sleap_env/bin/activate
+
+    # CPU only
+    pip install "sleap[nn]" --extra-index-url https://download.pytorch.org/whl/cpu
+
+    # NVIDIA GPU (CUDA 12.8)
+    pip install "sleap[nn]" --extra-index-url https://download.pytorch.org/whl/cu128
+    ```
+    Unlike `uv --torch-backend`, pip can't guarantee which PyTorch build it picks — if you need a specific CPU/GPU build, prefer the `uv` install above. A conda environment works too, but `uv` (or a plain venv) is recommended.
+
+??? note "Use SLEAP as a library"
+    The `sleap` package is primarily the GUI application. For scripting and automation, use the libraries directly:
+
+    | Library | Use for | Docs |
+    |---------|---------|------|
+    | **sleap-io** | `.slp` files, labels, skeletons, videos, merging projects, custom analysis | [io.sleap.ai](https://io.sleap.ai) |
+    | **sleap-nn** | Training models, running inference, evaluating predictions, batch processing | [nn.sleap.ai](https://nn.sleap.ai) |
+
+??? question "Why `uv` instead of conda?"
+    SLEAP 1.5+ switched from TensorFlow to PyTorch, which bundles its own GPU libraries — so the conda/CUDA juggling that older versions needed is gone. `uv` installs SLEAP as a global tool (`uv tool install`) that works from any terminal with no environment to activate, and it's far faster than conda. Full background is in the [migration guide](guides/migrating-to-sleap-1-5.md).

--- a/docs/tutorial/importing-data.md
+++ b/docs/tutorial/importing-data.md
@@ -15,14 +15,14 @@ You will need to enter commands in a **terminal**. If you're unsure how to open 
 
 #### How to open a terminal:  
 !!! hint ""
-    === "Windows"  
-        Open the *Start menu* and search for  **Command Prompt**.
+    === "Windows"
+        Open the *Start menu* and search for **Command Prompt**.
 
-    === "Linux"  
-        Press <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd> to open a new terminal.  
+    === "macOS"
+        Press <kbd>Cmd</kbd> + <kbd>Space</kbd>, then type **Terminal** and open it.
 
-    === "MacOS"  
-        Press <kbd>Cmd</kbd> + <kbd>Space</kbd>, then type **Terminal** and open it.  
+    === "Linux"
+        Press <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd> to open a new terminal.
 
 ### 2. Check If Git Is Installed  
 
@@ -41,7 +41,7 @@ If you see a version number (e.g., git version 2.39.1), Git is installed, and yo
         2. Run the installer and follow the default settings.
         3. Once installed, restart your terminal and run 'git --version' in terminal to confirm the installation.
 
-    === "MacOS"  
+    === "macOS"
         1. Open a terminal and type:  
             ```sh  
             brew install git  
@@ -51,16 +51,14 @@ If you see a version number (e.g., git version 2.39.1), Git is installed, and yo
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"  
             ```  
 
-    === "Linux (Debian/Ubuntu)"  
-        Open a terminal and type:  
-        ```sh  
-        sudo apt update && sudo apt install git  
-        ```  
-
-    === "Linux (Fedora)"  
-        Open a terminal and type:  
-        ```sh  
-        sudo dnf install git  
+    === "Linux"
+        On **Debian/Ubuntu**:
+        ```sh
+        sudo apt update && sudo apt install git
+        ```
+        On **Fedora**:
+        ```sh
+        sudo dnf install git
         ```
 Once Git is installed, you're ready to proceed!
 
@@ -73,10 +71,15 @@ Navigate to **Desktop** folder, to clone the git repository. This step ensures t
     cd Desktop
     ```
 
-=== "MacOS & Linux"
+=== "macOS"
     ```sh
     cd ~/Desktop
-    ```  
+    ```
+
+=== "Linux"
+    ```sh
+    cd ~/Desktop
+    ```
 
 ### 4. Clone the Repository  
 

--- a/docs/tutorial/setup.md
+++ b/docs/tutorial/setup.md
@@ -16,66 +16,10 @@ If you know you have a GPU on your machine or have a [Mac with Apple Silicon](ht
 
     To check which PyTorch and CUDA versions you should have installed, see [here](https://nn.sleap.ai/dev/installation/).
 
-
 ## Install SLEAP locally
 
 **See the [main SLEAP installation instructions](../installation.md) for detailed installation instructions.**
 
 If you have either a Linux or Windows laptop with a GPU, or a [Mac with Apple Silicon](https://support.apple.com/en-us/116943), SLEAP will work natively with hardware acceleration.
-<!-- 
-1. Make sure that you have [Miniforge](https://github.com/conda-forge/miniforge) installed.
-
-    You can also use Miniconda or vanilla Anaconda, but we recommend Miniforge since it
-    is *much* faster to resolve dependencies, thus making the installation much faster.
-    If you use Anaconda, replace `mamba` with `conda` in the commands below.
-    
-    To install Miniforge:
-
-    === "Windows"
-
-        Open a new PowerShell terminal (does not need to be admin) and enter:
-
-        ```bash
-        Invoke-WebRequest -Uri "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe" -OutFile "$env:UserProfile/Downloads/Miniforge3-Windows-x86_64.exe"; Start-Process -FilePath "$env:UserProfile/Downloads/Miniforge3-Windows-x86_64.exe" -ArgumentList "/InstallationType=JustMe /RegisterPython=1 /S" -Wait; Remove-Item -Path "$env:UserProfile/Downloads/Miniforge3-Windows-x86_64.exe"
-        ```
-
-    === "Linux"
-
-        Open a new terminal and enter:
-
-        ```bash
-        curl -fsSL --compressed https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -o "~/Downloads/Miniforge3-Linux-x86_64.sh" && chmod +x "~/Downloads/Miniforge3-Linux-x86_64.sh" && "~/Downloads/Miniforge3-Linux-x86_64.sh" -b -p ~/miniforge3 && rm "~/Downloads/Miniforge3-Linux-x86_64.sh" && ~/miniforge3/bin/conda init "$(basename "${SHELL}")" && source "$HOME/.$(basename "${SHELL}")rc"
-        ```
-
-    === "Mac (Apple Silicon)"
-
-        Open a new terminal and enter:
-
-        ```bash
-        curl -fsSL --compressed https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh -o "~/Downloads/Miniforge3-MacOSX-arm64.sh" && chmod +x "~/Downloads/Miniforge3-MacOSX-arm64.sh" && "~/Downloads/Miniforge3-MacOSX-arm64.sh" -b -p ~/miniforge3 && rm "~/Downloads/Miniforge3-MacOSX-arm64.sh" && ~/miniforge3/bin/conda init "$(basename "${SHELL}")" && source "$HOME/.$(basename "${SHELL}")rc"
-        ```
-
-    === "Mac (Intel)"
-
-        Open a new terminal and enter:
-
-        ```bash
-        curl -fsSL --compressed https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-x86_64.sh -o "~/Downloads/Miniforge3-MacOSX-x86_64.sh" && chmod +x "~/Downloads/Miniforge3-MacOSX-x86_64.sh" && "~/Downloads/Miniforge3-MacOSX-x86_64.sh" -b -p ~/miniforge3 && rm "~/Downloads/Miniforge3-MacOSX-x86_64.sh" && ~/miniforge3/bin/conda init "$(basename "${SHELL}")" && source "$HOME/.$(basename "${SHELL}")rc"
-        ```
-
-2. Install SLEAP in a new environment.
-
-    === "Windows/Linux"
-
-        ```bash
-        mamba create -y -n sleap -c conda-forge -c nvidia -c sleap -c anaconda sleap=1.3.3
-        ```
-
-    === "Mac"
-
-        ```bash
-        mamba create -y -n sleap -c conda-forge -c anaconda -c sleap sleap=1.3.3
-        ``` -->
-
 
 [*Next up:* Importing data](importing-data.md)

--- a/hooks/inject_versions.py
+++ b/hooks/inject_versions.py
@@ -1,0 +1,92 @@
+"""MkDocs hook: inject current SLEAP ecosystem versions and the copyright year.
+
+Keeps the docs free of hand-maintained version strings (which silently drift on
+every release). Reads the SLEAP version from ``sleap/version.py`` and the
+``sleap-io`` / ``sleap-nn`` lower bounds from ``pyproject.toml``, then
+substitutes these placeholders anywhere they appear in a page's markdown:
+
+    {{ sleap_version }}     -> e.g. 1.6.3   (sleap.version.__version__)
+    {{ sleap_io_version }}  -> e.g. 0.7.1   (sleap-io[all] floor in core deps)
+    {{ sleap_nn_version }}  -> e.g. 0.2.0   (sleap-nn[torch] floor in the `nn` extra)
+
+It also sets the footer copyright to the current year on every build, so that
+never goes stale either.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from datetime import datetime
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_VERSIONS: dict[str, str] | None = None
+
+
+def _floor(spec: str) -> str:
+    """Return the lower-bound version from a PEP 508 spec like ``pkg>=1.2.3,<2``."""
+    m = re.search(r">=\s*([0-9][^,\s]*)", spec)
+    if not m:
+        raise ValueError(f"no lower bound (>=) found in requirement: {spec!r}")
+    return m.group(1)
+
+
+def _versions() -> dict[str, str]:
+    """Read the current ecosystem versions from version.py + pyproject.toml."""
+    pyproject = tomllib.loads((_ROOT / "pyproject.toml").read_text())
+    project = pyproject["project"]
+
+    version_py = (_ROOT / "sleap" / "version.py").read_text()
+    match = re.search(r'__version__\s*=\s*"([^"]+)"', version_py)
+    if match is None:
+        raise ValueError("could not find __version__ in sleap/version.py")
+    sleap_version = match.group(1)
+
+    sleap_io = next(d for d in project["dependencies"] if re.match(r"sleap-io\b", d))
+    sleap_nn = next(
+        d for d in project["optional-dependencies"]["nn"] if re.match(r"sleap-nn\b", d)
+    )
+
+    return {
+        "sleap_version": sleap_version,
+        "sleap_io_version": _floor(sleap_io),
+        "sleap_nn_version": _floor(sleap_nn),
+    }
+
+
+def on_config(config):
+    """Set the footer copyright to the current year on every build."""
+    config["copyright"] = f"Copyright &copy; {datetime.now().year} Talmo Lab"
+    return config
+
+
+def _substitute(text: str) -> str:
+    """Replace every version placeholder in ``text``."""
+    global _VERSIONS
+    if _VERSIONS is None:
+        _VERSIONS = _versions()
+    for key, value in _VERSIONS.items():
+        text = text.replace("{{ " + key + " }}", value)
+    return text
+
+
+def on_page_markdown(markdown: str, **kwargs) -> str:  # noqa: ARG001
+    """Substitute the version placeholders in each page before rendering."""
+    return _substitute(markdown)
+
+
+def on_post_build(config, **kwargs):  # noqa: ARG001
+    """Resolve placeholders in the ``.md`` sources copied by copy_source_markdown.
+
+    That hook copies raw markdown straight from ``docs_dir`` to ``site_dir``, so it
+    bypasses ``on_page_markdown``. Re-process the copied files in place so the
+    published source mirror shows resolved versions too. (This hook is registered
+    after copy_source_markdown, so its ``on_post_build`` has already run.)
+    """
+    site_dir = Path(config["site_dir"])
+    for md_file in site_dir.rglob("*.md"):
+        original = md_file.read_text(encoding="utf-8")
+        resolved = _substitute(original)
+        if resolved != original:
+            md_file.write_text(resolved, encoding="utf-8")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,12 @@ plugins:
 extra_css:
   - assets/stylesheets/extra.css
 
+extra_javascript:
+  # Auto-selects the Windows/macOS/Linux tab matching the visitor's OS on the
+  # installation page. Scoped to tab groups labeled exactly {Windows, macOS,
+  # Linux}; other OS-tabbed pages use different labels and are untouched.
+  - assets/javascripts/os-tabs.js
+
 markdown_extensions:
   - abbr
   - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ edit_uri: edit/develop/docs/
 # Custom hooks
 hooks:
   - hooks/copy_source_markdown.py  # Publish .md sources alongside HTML
+  - hooks/inject_versions.py  # Inject current versions + copyright year
 
 theme:
   name: material
@@ -128,8 +129,9 @@ extra:
       - icon: fontawesome/solid/envelope
         link: mailto:talmo@salk.edu
 
+# Static fallback; hooks/inject_versions.py overrides this with the current year at build time.
 copyright: >
-  Copyright &copy; 2025 Talmo Lab 
+  Copyright &copy; 2026 Talmo Lab
 
 nav:
   - Home: index.md

--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -22,7 +22,7 @@ import sys
 # Fix macOS Homebrew libpng conflict with ImageIO.
 # Homebrew's libpng can cause bus errors when Qt renders text via CoreText/ImageIO.
 # DYLD_* vars are read at process startup, so we must re-exec with a clean environment.
-# See: https://github.com/talmolab/sleap/issues/TBD
+# See: https://github.com/talmolab/sleap/pull/2571
 if (
     sys.platform == "darwin"
     and os.environ.get("DYLD_LIBRARY_PATH")


### PR DESCRIPTION
## Why

The installation page had grown long and hard to navigate. A first-time user couldn't find the happy path on the first screen — the install command was buried at line ~83 behind a 6-item "What do you want to do?" menu, a 1.4-version warning, and a ~250-word "why uv" essay. The same 130-character pinned command was copy-pasted **~8 times**.

Produced by red-teaming the page from five lenses (novice user, information architecture, technical correctness, best-practice benchmarking, platform-detector feasibility), synthesizing a redesign, and adversarially reviewing the implementation. A follow-up commit then extended the OS-tab feature site-wide and removed the remaining hand-maintained version strings.

`docs/installation.md`: **425 → ~340 lines**, long pinned command **8 → 1** occurrence.

## Installation page

- **TL;DR block** at the top with the three one-liners (install / upgrade / develop).
- Quick start is three numbered steps: install `uv` → install SLEAP → launch.
- **Default install is the short unpinned form** (`uv tool install --python 3.13 "sleap[nn]" --torch-backend auto`); SLEAP's metadata already constrains the deps, so the `--with` pins were redundant and drift-prone. The exact triple survives once, in a "Reproducible install" example by the table.
- Four near-identical "Updating" subsections → one **Manage your install** collapsible. Pre-release, GPU backends, ONNX/TensorRT, pip, programmatic usage, and the "why uv" essay → an **Advanced & alternatives** section.
- New **"Install development versions"** note: one-liners to install/upgrade SLEAP from the `develop` branch, and to pull a `sleap-io`/`sleap-nn` fix from their `main` branch into the `sleap` uv tool env via `--with` git overrides (`+ --prerelease allow`).
- Fixes: bare `rocm` → `rocm6.4`; pin/downgrade example now pins all three packages; pip note caveats that pip can't guarantee the torch build.

## OS tab auto-detection (site-wide)

`docs/assets/javascripts/os-tabs.js`: detects the visitor's OS and selects/syncs the matching **Windows / macOS / Linux** tab, remembering a manual choice.

- **Scoped to tab groups whose label set is exactly `{Windows, macOS, Linux}`.** All OS-tab pages were normalized to that set so auto-detect works everywhere:
  - `importing-data.md`: `"MacOS"`→`"macOS"`; merge Debian/Ubuntu + Fedora into one **Linux** tab; split `"MacOS & Linux"` into macOS + Linux.
  - `running-sleap-remotely.md`, `creating-a-custom-training-profile.md`: collapse `macOS/Linux` + the two Windows-shell tabs into Windows/macOS/Linux (Windows tab keeps both PowerShell and cmd).
  - `setup.md`: delete the dead HTML-commented conda block (also removes stale `sleap=1.3.3`).
- `content.tabs.link` is **deliberately not enabled** (the JS handles per-page sync), so no other behavior changes globally.
- **Progressive enhancement:** works with JS disabled. Verified headlessly against the real script (auto-select, cross-group sync, manual-preference persistence, non-canonical decoy untouched).

## Versions & copyright: single source of truth

`hooks/inject_versions.py` (mkdocs hook): reads the SLEAP version from `sleap/version.py` and the `sleap-io`/`sleap-nn` floors from `pyproject.toml`, and substitutes `{{ sleap_version }}` / `{{ sleap_io_version }}` / `{{ sleap_nn_version }}` in the compat table + reproducible command. It also sets the footer copyright to the current year, and an `on_post_build` pass resolves the placeholders in the `.md` source mirror that `copy_source_markdown.py` publishes. So the version table, reproducible command, and copyright year can no longer go stale.

- `bug_report.md`: refreshed the stale `sleap doctor` example versions.

## Other

- `index.md` launch verb `sleap label` → `sleap`.
- Fixed inbound anchor links in `contribute.md` and `creating-a-custom-training-profile.md`.
- Replaced the dead `issues/TBD` link in `sleap/cli.py` with a reference to PR #2571 (the fix it documents).
- `mkdocs build` passes clean — no warnings, no broken anchors, all placeholders resolve in both HTML and the `.md` mirror.

## Open for maintainer
- **Unpinned default install** — presented as canonical, with exact pins only in the "Reproducible install" example (matches `index.md`). Shout if you'd rather keep the fully-pinned default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
