### PR TITLE
docs: split TL;DR install commands into per-command copy blocks

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,14 +3,16 @@
 SLEAP tracks animal poses in video. Three commands get you from zero to a running GUI.
 
 !!! abstract "TL;DR — already have `uv`?"
+    **Install** (auto-detects your GPU):
     ```bash
-    # Install (auto-detects your GPU)
     uv tool install --python 3.13 "sleap[nn]" --torch-backend auto
-
-    # Upgrade
+    ```
+    **Upgrade:**
+    ```bash
     uv tool upgrade sleap
-
-    # Develop (editable install of all three repos)
+    ```
+    **Develop** (editable install of all three repos):
+    ```bash
     git clone https://github.com/talmolab/sleap && git clone https://github.com/talmolab/sleap-io && git clone https://github.com/talmolab/sleap-nn && cd sleap && uv sync --extra nn --reinstall && uv pip install -e "../sleap-io[all]" && uv pip install -e "../sleap-nn[torch]" --torch-backend=auto
     ```
     New here? Follow the [step-by-step quick start](#quick-start) below — it installs `uv` first.


### PR DESCRIPTION
## Why

In the installation page's **TL;DR** box, the install / upgrade / develop commands were in a single fenced code block, so the code-copy button copied **all three at once** (including the `# Install` / `# Upgrade` / `# Develop` comment headers).

## What

Split them into three separate code blocks, each with a bold label above it. Now each command gets its own copy button (Material's `content.code.copy` adds one per block) and copies **only that command** — no neighboring commands, no comment lines.

Before (one block, one copy button for everything):
```bash
# Install (auto-detects your GPU)
uv tool install --python 3.13 "sleap[nn]" --torch-backend auto
# Upgrade
uv tool upgrade sleap
# Develop ...
```

After: **Install** / **Upgrade** / **Develop** labels, each followed by its own one-line code block.

Verified with `mkdocs build`: the TL;DR admonition renders three distinct `language-bash highlight` blocks, with the labels outside the blocks (so they aren't copied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)