### PR TITLE
fix(qc): normalize per-video id to a hashable string for ImageVideo labels

### DIFF
--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -223,7 +223,7 @@ class LabelQCDetector:
         # Score all instances
         _report("Scoring instances", 0.80, f"0/{total_instances}")
         for video_idx, video in enumerate(labels.videos):
-            video_id = video.filename if video.filename else str(video_idx)
+            video_id = self._video_id(video, video_idx)
             labeled_frames = [lf for lf in labels if lf.video == video]
 
             for lf in labeled_frames:
@@ -514,6 +514,35 @@ class LabelQCDetector:
 
         return frame_qc
 
+    @staticmethod
+    def _video_id(video, video_idx: int) -> str:
+        """Compute a hashable, stable per-video identifier.
+
+        Some video backends (e.g. ``ImageVideo`` from sleap_io) store
+        ``filename`` as a ``list[str]`` (one entry per image frame) rather
+        than a single path. A list is unhashable and would crash the
+        downstream dict-key usage in ``InstanceCountChecker.fit()`` /
+        ``InstanceCountChecker.check()`` with
+        ``TypeError: unhashable type: 'list'``.
+
+        Normalize to a stable string so fit() and score() see the same key.
+
+        Args:
+            video: A ``sleap_io.Video`` (or compatible) object.
+            video_idx: Zero-based index of the video in ``labels.videos``,
+                used as a deterministic fallback identifier.
+
+        Returns:
+            A string that is safe to use as a dict key. For single-file
+            videos this is the filename; for image-sequence videos
+            (or any backend whose ``filename`` is not a non-empty string)
+            it is ``"video_<idx>"``.
+        """
+        filename = getattr(video, "filename", None)
+        if isinstance(filename, str) and filename:
+            return filename
+        return f"video_{video_idx}"
+
     def _collect_frame_counts(
         self, labels: "sio.Labels"
     ) -> tuple[list[int], list[str]]:
@@ -521,7 +550,7 @@ class LabelQCDetector:
         counts = []
         video_ids = []
         for video_idx, video in enumerate(labels.videos):
-            video_id = video.filename if video.filename else str(video_idx)
+            video_id = self._video_id(video, video_idx)
             labeled_frames = [lf for lf in labels if lf.video == video]
 
             for lf in labeled_frames:


### PR DESCRIPTION
Fixes #2738

## What was broken
`LabelQCDetector._collect_frame_counts()` and the per-video loop in `score()` both computed the per-video identifier as
`video.filename if video.filename else str(video_idx)`.

For sleap_io's `ImageVideo` backend (used for image-sequence projects, e.g. CVAT/COCO imports or `Video.from_filename([...])`), `video.filename` is a `list[str]` of per-frame paths, not a single string. That list was then handed to `InstanceCountChecker` and used as a dict key in two places:

- `_collect_frame_counts()` → `InstanceCountChecker.fit()` (`frame_level.py:50`): `video_counts[vid].append(count)`
- `score()` → `InstanceCountChecker.check()` (`frame_level.py:75`): `video_id in self.expected_counts`

Both `fit()` and `check()` hash `video_id`, so a list raises `TypeError: unhashable type: 'list'`. The crash surfaces at the end of `fit()` (the 'Fitting frame-level checkers' step), so QC analysis never produced any results for image-sequence labels.

## What I fixed
Added a `LabelQCDetector._video_id(video, video_idx)` static helper that:
- returns `video.filename` when it is a non-empty string (single-file videos keep their existing per-video identity), and
- otherwise returns the deterministic fallback `f"video_{video_idx}"`.

Both `_collect_frame_counts()` and the per-video loop in `score()` now use `self._video_id(video, video_idx)` so the two phases key their per-video stats identically.

## Testing
- `python3 -c "import ast; ast.parse(...)"` on the modified file: OK
- Unit-tested the helper directly with mock video objects covering: str filename, list filename (ImageVideo — the bug), empty list, `None`, empty string, and using the result as a dict key (the original crash path). All cases pass.
- Confirmed the resulting identifier is stable across `fit()` and `score()` (same `video_idx` → same key), so per-video expected counts survive into scoring.

Verified locally: with this change, the proposed regression test in the issue (`applyBackfill` analog for sleap — i.e. `LabelQCDetector().fit(labels)` on a 14-video ImageVideo project) completes instead of crashing on the frame-level checker step.