### PR TITLE
fix(qc): Label QC only analyzes user-labeled instances (#2745)

### DIFF
--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -861,7 +861,7 @@ class QCWidget(QtWidgets.QWidget):
             )
             return
 
-        n_instances = sum(len(lf.instances) for lf in self._labels)
+        n_instances = sum(len(lf.user_instances) for lf in self._labels)
         if n_instances < 2:
             QtWidgets.QMessageBox.warning(
                 self,
@@ -995,7 +995,7 @@ class QCWidget(QtWidgets.QWidget):
             self._stats_label.setText("No labels loaded")
             return
 
-        n_instances = sum(len(lf.instances) for lf in self._labels)
+        n_instances = sum(len(lf.user_instances) for lf in self._labels)
         n_frames = len(self._labels)
 
         if self._results is None:

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -217,7 +217,7 @@ class LabelQCDetector:
         results = QCResults(feature_names=self.feature_names)
 
         # Count total instances for progress
-        total_instances = sum(len(lf.instances) for lf in labels)
+        total_instances = sum(len(lf.user_instances) for lf in labels)
         instance_count = 0
 
         # Score all instances
@@ -231,7 +231,7 @@ class LabelQCDetector:
 
                 # Collect instances for this frame
                 frame_instances = []
-                for inst_idx, inst in enumerate(lf.instances):
+                for inst_idx, inst in enumerate(lf.user_instances):
                     points = self._instance_to_array(inst)
                     frame_instances.append(points)
 
@@ -278,7 +278,7 @@ class LabelQCDetector:
         """Collect all instances as numpy arrays."""
         instances = []
         for lf in labels:
-            for inst in lf.instances:
+            for inst in lf.user_instances:
                 points = self._instance_to_array(inst)
                 instances.append(points)
         return instances
@@ -525,7 +525,7 @@ class LabelQCDetector:
             labeled_frames = [lf for lf in labels if lf.video == video]
 
             for lf in labeled_frames:
-                counts.append(len(lf.instances))
+                counts.append(len(lf.user_instances))
                 video_ids.append(video_id)
 
         return counts, video_ids

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -239,11 +239,12 @@ class TestQCWidget:
         mock_labels = MagicMock()
         mock_labels.__len__ = MagicMock(return_value=10)
 
-        # Create mock labeled frames with mock instances
+        # Create mock labeled frames with mock instances. Stats count only
+        # user-labeled instances, so mock `user_instances` (not `instances`).
         mock_lf1 = MagicMock()
-        mock_lf1.instances = [MagicMock(), MagicMock()]  # 2 instances
+        mock_lf1.user_instances = [MagicMock(), MagicMock()]  # 2 user instances
         mock_lf2 = MagicMock()
-        mock_lf2.instances = [MagicMock()]  # 1 instance
+        mock_lf2.user_instances = [MagicMock()]  # 1 user instance
         mock_labels.__iter__ = MagicMock(return_value=iter([mock_lf1, mock_lf2]))
 
         widget.set_labels(mock_labels)

--- a/tests/qc/test_detector.py
+++ b/tests/qc/test_detector.py
@@ -370,6 +370,91 @@ class TestLabelQCDetector:
         assert sa.n_edges == 4
         assert len(sa.symmetry_pairs) >= 1  # left-wing, right-wing
 
+    def test_predicted_instances_excluded(self, skeleton):
+        """Predicted instances are excluded from QC scoring (only user labels)."""
+        from sleap_io.model.instance import PredictedInstance
+
+        from sleap.qc.results import InstanceKey
+
+        video = sio.Video.from_filename("test_video.mp4")
+        labels = sio.Labels()
+
+        base_points = np.array(
+            [
+                [100, 100],  # head
+                [100, 120],  # thorax
+                [100, 150],  # abdomen
+                [80, 115],  # left-wing
+                [120, 115],  # right-wing
+            ],
+            dtype=float,
+        )
+
+        n_user_frames = 50
+        n_frames_with_predicted = 20  # subset of the user frames
+        n_predicted_only_frames = 5
+
+        # Track which frames have ONLY predicted instances.
+        predicted_only_frame_idxs = set()
+        # Track a frame that has both [user, predicted] to verify inst_idx range.
+        mixed_frame_idx = 5
+
+        # ~50 frames each with ONE user Instance; some also contain a predicted.
+        for frame_idx in range(n_user_frames):
+            points_array = base_points + np.random.randn(5, 2) * 2
+            instances = [Instance.from_numpy(points_array, skeleton=skeleton)]
+
+            if frame_idx < n_frames_with_predicted:
+                pred_points = base_points + np.random.randn(5, 2) * 2
+                instances.append(
+                    PredictedInstance.from_numpy(
+                        pred_points, skeleton=skeleton, score=0.9
+                    )
+                )
+
+            lf = LabeledFrame(video=video, frame_idx=frame_idx, instances=instances)
+            labels.append(lf)
+
+        # A few EXTRA frames containing ONLY predicted instance(s).
+        for i in range(n_predicted_only_frames):
+            frame_idx = n_user_frames + i
+            predicted_only_frame_idxs.add(frame_idx)
+            pred_points = base_points + np.random.randn(5, 2) * 2
+            instances = [
+                PredictedInstance.from_numpy(pred_points, skeleton=skeleton, score=0.9)
+            ]
+            lf = LabeledFrame(video=video, frame_idx=frame_idx, instances=instances)
+            labels.append(lf)
+
+        detector = LabelQCDetector()
+        detector.fit(labels)
+        results = detector.score(labels)
+
+        # (a) Number of scored instances == total USER instances (not total).
+        total_user_instances = sum(len(lf.user_instances) for lf in labels)
+        total_instances = sum(len(lf.instances) for lf in labels)
+        assert total_instances > total_user_instances  # sanity: predicteds exist
+        assert total_user_instances == n_user_frames  # one user inst per user frame
+        assert len(results.instance_scores) == total_user_instances
+
+        # (b) No scored InstanceKey references a predicted-only frame.
+        scored_frame_idxs = {key.frame_idx for key in results.instance_scores}
+        assert scored_frame_idxs.isdisjoint(predicted_only_frame_idxs)
+
+        # (c) For a mixed [user, predicted] frame, scored inst_idx values stay
+        # within range(len(user_instances)) for that frame.
+        mixed_lf = next(lf for lf in labels if lf.frame_idx == mixed_frame_idx)
+        assert len(mixed_lf.instances) == 2  # [user, predicted]
+        assert len(mixed_lf.user_instances) == 1
+        mixed_inst_idxs = [
+            key.instance_idx
+            for key in results.instance_scores
+            if isinstance(key, InstanceKey) and key.frame_idx == mixed_frame_idx
+        ]
+        assert mixed_inst_idxs == [0]
+        for inst_idx in mixed_inst_idxs:
+            assert inst_idx in range(len(mixed_lf.user_instances))
+
 
 class TestLabelQCDetectorWithRealData:
     """Integration tests using real data fixtures."""


### PR DESCRIPTION
## Problem

Reported in [discussion #2745](https://github.com/talmolab/sleap/discussions/2745): the **Label Quality Control** tool flags instances from frames the user never confirmed — unreviewed model predictions on suggested frames (gray skeletons with yellow dots) — instead of analyzing only manually-labeled ground truth.

The QC detector iterated `lf.instances`, which in sleap-io includes **both** user `Instance` **and** `PredictedInstance`. It never filtered to `lf.user_instances`, so predictions were scored and flagged. (The `fit()` docstring already claimed "uses user-labeled instances" — the behavior just didn't match.)

## Fix

Filter every instance-iteration/count site to `lf.user_instances`:

- **`sleap/qc/detector.py`** — `_collect_instances()` (used by `fit()`), the `score()` scoring loop + its `total_instances` progress count, and `_collect_frame_counts()` (frame-level instance-count checker).
- **`sleap/gui/widgets/qc.py`** — the two `n_instances` counts (pre-analysis warning + stats display) so the displayed counts match what's actually analyzed.

### Bonus: fixes a latent navigation-index bug

`score()` now produces `InstanceKey.inst_idx` values that index into `user_instances` — which is exactly what `GuiCommands.gotoVideoAndFrameAndInstance` already assumes (`user_instances[instance_idx]`, `commands.py:491`). Previously, predicted instances shifted the indices, so clicking a flagged row could highlight the wrong instance.

## Testing

- **New test** `tests/qc/test_detector.py::test_predicted_instances_excluded`: builds labels mixing user `Instance` and `PredictedInstance` (incl. frames with predictions only), then asserts (a) the number of scored instances equals the user-instance count, (b) predicted-only frames contribute no scores, and (c) `inst_idx` stays within `range(len(lf.user_instances))`.
- `tests/qc` — 111 passed.
- `tests/gui/widgets/test_qc.py` — updated `test_stats_with_labels_before_analysis` to mock `user_instances` (the stat now counts user instances). 47 passed.
- `ruff check` + `ruff format --check` clean.

> Note: `TestQCDockNavigation::test_is_active_for_navigation_no_flags` fails locally under `QT_QPA_PLATFORM=offscreen` (a matplotlib/Qt canvas-teardown race) — but it fails identically on clean `develop`, so it's pre-existing and unrelated to this change.

Closes the bug reported in #2745.

🤖 Generated with [Claude Code](https://claude.com/claude-code)