### PR TITLE
Fix misleading error when running inference on empty project (#2749)

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1719,10 +1719,7 @@ class MainWindow(QMainWindow):
 
         if not self.state["filename"]:
             QMessageBox(
-                text=(
-                    "Please save your project before running training or "
-                    "inference."
-                )
+                text=("Please save your project before running training or inference.")
             ).exec_()
             return
 

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1708,7 +1708,25 @@ class MainWindow(QMainWindow):
             ).exec_()
             return
 
-        if not self.state["filename"] or self.state["has_changes"]:
+        if self.labels is None or len(self.labels.videos) == 0:
+            QMessageBox(
+                text=(
+                    "This project has no videos. Please add a video before "
+                    "running training or inference."
+                )
+            ).exec_()
+            return
+
+        if not self.state["filename"]:
+            QMessageBox(
+                text=(
+                    "Please save your project before running training or "
+                    "inference."
+                )
+            ).exec_()
+            return
+
+        if self.state["has_changes"]:
             QMessageBox(
                 text=(
                     "You have unsaved changes. Please save before running "

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -335,6 +335,61 @@ def test_app_workflow(
         assert sugg.video == video_clip
 
 
+def test_show_learning_dialog_guard_messages(
+    qtbot, monkeypatch, small_robot_mp4_vid: Video
+):
+    """Empty/unsaved projects show the correct guard message before the learning
+    dialog opens (issue #2749).
+
+    The pre-flight guard in ``_show_learning_dialog`` must distinguish three
+    distinct cases instead of reporting them all as "unsaved changes":
+
+    1. No videos in the project.
+    2. Project never saved (no filename).
+    3. Project saved but with unsaved changes.
+    """
+    from sleap.gui import app as app_module
+
+    shown_messages = []
+
+    class FakeMessageBox:
+        def __init__(self, *args, text="", **kwargs):
+            shown_messages.append(text)
+
+        def exec_(self):
+            return None
+
+    monkeypatch.setattr(app_module, "QMessageBox", FakeMessageBox)
+
+    # 1. Empty project (no videos) -> "no videos" message, dialog not opened.
+    win = MainWindow(no_usage_data=True)
+    qtbot.addWidget(win)
+    win._show_learning_dialog("inference")
+    assert "no videos" in shown_messages[-1].lower()
+    assert "inference" not in win._child_windows
+
+    # 2. Has a video but never saved (no filename) -> "save your project" message.
+    win2 = MainWindow(labels=Labels(videos=[small_robot_mp4_vid]), no_usage_data=True)
+    qtbot.addWidget(win2)
+    win2.state["filename"] = None
+    win2._show_learning_dialog("inference")
+    assert "save your project" in shown_messages[-1].lower()
+    assert "inference" not in win2._child_windows
+
+    # 3. Saved project with unsaved changes -> existing "unsaved changes" message.
+    win3 = MainWindow(labels=Labels(videos=[small_robot_mp4_vid]), no_usage_data=True)
+    qtbot.addWidget(win3)
+    win3.state["filename"] = "project.slp"
+    win3.state["has_changes"] = True
+    win3._show_learning_dialog("inference")
+    assert "unsaved changes" in shown_messages[-1].lower()
+    assert "inference" not in win3._child_windows
+
+    # Reset so windows close without a "save changes?" prompt during teardown.
+    for w in (win, win2, win3):
+        w.state["has_changes"] = False
+
+
 def test_app_new_window(qtbot, min_labels_slp_path, centered_pair_predictions_slp_path):
     app = QApplication.instance()
     app.closeAllWindows()


### PR DESCRIPTION
## Description

Fixes #2749.

When running `sleap-label` on a fresh, empty project and clicking **Predict → Run Inference** (or training), SLEAP showed the wrong error:

> You have unsaved changes. Please save before running training or inference.

…even though an empty project has no changes.

### Root cause

The pre-flight guard in `_show_learning_dialog` (`sleap/gui/app.py`) collapsed two distinct conditions into a single message:

```python
if not self.state["filename"] or self.state["has_changes"]:
    QMessageBox(text="You have unsaved changes. Please save before running training or inference.").exec_()
    return
```

A brand-new project trips the `not filename` case (it was never saved) while `has_changes` is `False`, so the user is incorrectly told they have unsaved changes.

### Fix

Split the guard into three ordered checks, each with an accurate message:

1. **No videos** → "This project has no videos. Please add a video before running training or inference."
2. **Never saved** (`not filename`) → "Please save your project before running training or inference."
3. **Unsaved changes** (`has_changes`) → original "You have unsaved changes…" message.

The no-videos check comes first so a fresh empty project gets the most relevant message, matching the expected behavior in the issue.

The underlying design is unchanged: saving is still required before running, since inference runs as a subprocess that reads the `.slp`/video from disk via `--data_path`. Only the messaging was corrected.

## Types of changes

- [x] Bugfix

## Testing

Added `test_show_learning_dialog_guard_messages` in `tests/gui/test_app.py`, which exercises all three branches via a patched `QMessageBox` and asserts the correct message fires and the learning dialog is not opened.

```
$ QT_QPA_PLATFORM=offscreen uv run pytest tests/gui/test_app.py -q -p no:xvfb
4 passed
```

🤖 Generated with the help of Claude.