### PR TITLE
fix(qc): refresh Label QC dock on project load

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -1375,6 +1375,15 @@ class MainWindow(QMainWindow):
         if _has_topic([UpdateTopic.project, UpdateTopic.on_frame]):
             self.instances_dock.table.model().items = self.state["labeled_frame"]
 
+        if _has_topic([UpdateTopic.project]):
+            # Keep the QC dock pointed at the currently loaded project. The dock
+            # is created once and persists across project loads, so without this
+            # it can hold a stale (or empty) Labels object and report "Need at
+            # least 2 instances" until something re-triggers its visibility sync.
+            # update_labels is a no-op when the labels object is unchanged.
+            if hasattr(self, "_qc_dock"):
+                self._qc_dock.update_labels(self.labels)
+
         if _has_topic([UpdateTopic.suggestions]):
             self.suggestions_dock.table.model().items = self.labels.suggestions
 

--- a/sleap/gui/dialogs/qc.py
+++ b/sleap/gui/dialogs/qc.py
@@ -283,6 +283,10 @@ class QCDockWidget(QtWidgets.QDockWidget):
         Args:
             labels: New Labels object.
         """
+        # No-op if the labels object is unchanged so that callers on hot paths
+        # (e.g. on_data_update) don't needlessly reset analysis results.
+        if labels is self._labels:
+            return
         self._labels = labels
         self._widget.set_labels(labels)
 

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -464,6 +464,62 @@ class TestQCDockWidget:
         assert not dock.isFloating()
         assert "Undock" in dock._dock_button.text()
 
+    def test_update_labels_noop_when_unchanged(self, qtbot):
+        """update_labels should not reset the widget when given the same object."""
+        from sleap.gui.dialogs.qc import QCDockWidget
+
+        mock_labels = MagicMock()
+        mock_labels.__len__ = MagicMock(return_value=10)
+        mock_labels.__iter__ = MagicMock(return_value=iter([]))
+
+        dock = QCDockWidget(labels=mock_labels)
+        qtbot.addWidget(dock)
+
+        # Passing the same object should not re-run set_labels (which would
+        # clear any existing analysis results).
+        with patch.object(dock._widget, "set_labels") as mock_set:
+            dock.update_labels(mock_labels)
+            mock_set.assert_not_called()
+
+        # A new object should propagate to the inner widget.
+        other_labels = MagicMock()
+        other_labels.__len__ = MagicMock(return_value=5)
+        other_labels.__iter__ = MagicMock(return_value=iter([]))
+        with patch.object(dock._widget, "set_labels") as mock_set:
+            dock.update_labels(other_labels)
+            mock_set.assert_called_once_with(other_labels)
+
+    def test_qc_dock_repoints_to_newly_loaded_project(self, qtbot, min_labels):
+        """The dock re-points to a project loaded while it holds stale labels.
+
+        Regression test: the dock is created once and persists across project
+        loads. Previously it only refreshed via the Analyze menu or a visibility
+        change, so opening a project while the dock was already visible left it
+        pointing at a stale/empty Labels object, and "Run Analysis" reported
+        "Need at least 2 instances" until something re-synced it.
+
+        ``MainWindow.on_data_update`` now calls ``update_labels`` on the
+        ``UpdateTopic.project`` path; this exercises that call directly (without
+        a full ``MainWindow``, whose video-backed teardown is flaky offscreen).
+        """
+        from sleap.gui.dialogs.qc import QCDockWidget
+        from sleap_io import Labels
+
+        # Start stale: an empty project, as the dock holds before a load.
+        stale = Labels()
+        dock = QCDockWidget(labels=stale)
+        qtbot.addWidget(dock)
+        assert sum(len(lf.user_instances) for lf in dock._widget._labels) == 0
+
+        # Mimic what on_data_update does when a project is loaded.
+        dock.update_labels(min_labels)
+
+        # The dock now tracks the loaded project, so Run Analysis would proceed.
+        assert dock._widget._labels is min_labels
+        n_user = sum(len(lf.user_instances) for lf in dock._widget._labels)
+        assert n_user == sum(len(lf.user_instances) for lf in min_labels)
+        assert n_user >= 2
+
 
 class TestExportToSuggestions:
     """Tests for export_to_suggestions functionality."""


### PR DESCRIPTION
## Problem

Fixes #2752.

The Label QC dock's **Run Analysis** button reports **"Need at least 2 instances to run QC analysis."** right after opening a project that clearly contains many user-labeled instances. It only starts working after interacting with the GUI for a bit (the reporter noticed it after "scrolling around the seekbar").

## Root cause

The QC dock (`QCDockWidget`) is created **once** at startup with `labels=None` and **persists across project loads**. Its `_labels` reference was only refreshed in two places:

1. `MainWindow._open_label_qc()` — the **Analyze ▸ Label QC…** menu action.
2. `QCDockWidget._on_visibility_changed()` — when the dock's tab becomes **visible**.

Crucially, `MainWindow.on_data_update()` — which runs on **every project load** via `on_data_update([UpdateTopic.project, UpdateTopic.all])` — never refreshed the dock.

So if the dock was already visible when a project loaded (Qt `restoreState()` restoring it open from a prior session, or a new window via `OPEN_IN_NEW=True` whose `showMaximized()` runs *before* the project loads), it kept a **stale/empty `Labels`** object. `QCWidget._on_run_analysis()` then computed `sum(len(lf.user_instances) for lf in self._labels)` on that stale object → `0` → the warning.

**The seekbar is a red herring.** The project's `Labels` is fully populated by `load_file` the moment it loads, and that count is stable across navigation. Headless reproduction confirmed scrolling neither re-syncs the dock nor changes `self.labels`. What actually un-sticks it is a `visibilityChanged(True)` event (activating the QC tab / reopening via the menu), which the user triggered incidentally.

### Headless evidence

| step | app `self.labels` | dock `_widget._labels` | Run Analysis |
|------|------------------|------------------------|--------------|
| dock shown, no project | 0 | 0 | — |
| after `loadProjectFile(centered_pair.slp)` | **140** | **0** (`is app.labels` → False) | ❌ warns |
| after a visibility re-fire | 140 | **140** | ✅ runs |

## Fix

- **`sleap/gui/app.py`** — `on_data_update` now calls `self._qc_dock.update_labels(self.labels)` on the `UpdateTopic.project` path, so the dock always tracks the loaded project. Keyed on `project` (not `frame`/`on_frame`) so normal frame navigation doesn't wipe analysis results.
- **`sleap/gui/dialogs/qc.py`** — `QCDockWidget.update_labels` is now idempotent (no-op when the labels object is unchanged), making it safe to call on the update path without needlessly resetting results.

## Testing

- New regression tests in `tests/gui/widgets/test_qc.py`:
  - `test_update_labels_noop_when_unchanged` — guards the idempotency behavior.
  - `test_qc_dock_repoints_to_newly_loaded_project` — stale empty dock → `update_labels(project)` → dock reports the real instance count (≥2).
- Full `tests/gui/widgets/test_qc.py` passes (50 tests), lint clean.

> Note: the regression test deliberately avoids constructing a full `MainWindow` — that path hangs in teardown offscreen (the known `multiprocessing.RLock` video-cleanup leak) — and instead exercises the dock-level behavior directly.
