### PR TITLE
fix(qc): force invisible_as_nan in Label QC geometry (#2753)

### DIFF
--- a/sleap/qc/config.py
+++ b/sleap/qc/config.py
@@ -48,7 +48,8 @@ class QCConfig:
     gmm_min_samples: int = 50
     gmm_percentile_threshold: float = 5.0
 
-    # Calibration
+    # Calibration (reserved: NOT consumed anywhere yet — no auto-calibration is
+    # implemented. Flagging uses the fixed instance_threshold / GUI slider value.)
     auto_calibrate: bool = True
     calibration_percentile: float = 95.0
 

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -33,7 +33,7 @@ V3_FEATURE_NAMES = [
     "curvature_std",
     "visibility_pattern_score",
     "nn_distance",
-    "hull_area",
+    "hull_area_zscore",
     "hull_compactness",
 ]
 
@@ -284,12 +284,21 @@ class LabelQCDetector:
         return instances
 
     def _instance_to_array(self, instance: "sio.Instance") -> np.ndarray:
-        """Convert instance to (n_nodes, 2) array.
+        """Convert instance to (n_nodes, 2) array with invisible points as NaN.
 
-        Uses Instance.numpy() which returns invisible points as NaN by default.
-        Feature extractors handle NaN values by skipping them in computations.
+        Explicitly passes ``invisible_as_nan=True`` instead of relying on the
+        sleap-io default. Invisible (``visible=False``) nodes must never
+        contribute their stored coordinates to QC geometry features: those
+        coordinates are display-only placeholders (the GUI has to draw an
+        invisible node *somewhere*), and older sleap-io versions defaulted to
+        returning them, which leaked far-off invisible-node coordinates into
+        the edge/angle/distance/hull statistics (see #2753).
+
+        Feature extractors treat NaN as "missing" and skip those nodes, while
+        the downstream visibility mask (``~np.isnan(...)``) still records that
+        the node is invisible, so the visibility-pattern features keep working.
         """
-        return instance.numpy()
+        return instance.numpy(invisible_as_nan=True)
 
     @staticmethod
     def _video_id(video: "sio.Video", video_idx: int) -> str:

--- a/sleap/qc/frame_level.py
+++ b/sleap/qc/frame_level.py
@@ -165,7 +165,8 @@ def compute_node_overlap(
         Dictionary with:
         - common_nodes: list of node indices visible in both
         - overlapping_nodes: list of nodes within threshold
-        - mean_distance: mean distance at common nodes
+        - mean_distance / min_distance / max_distance: distance stats at common
+          nodes (all ``inf`` when there are no commonly visible nodes)
         - overlap_ratio: overlapping_nodes / common_nodes
     """
     # Find commonly visible nodes
@@ -179,6 +180,8 @@ def compute_node_overlap(
             "common_nodes": [],
             "overlapping_nodes": [],
             "mean_distance": float("inf"),
+            "min_distance": float("inf"),
+            "max_distance": float("inf"),
             "overlap_ratio": 0.0,
         }
 

--- a/tests/qc/test_detector.py
+++ b/tests/qc/test_detector.py
@@ -359,6 +359,58 @@ class TestLabelQCDetector:
         assert len(detector.feature_names) > 0
         assert "max_edge_zscore" in detector.feature_names
         assert "nn_distance" in detector.feature_names
+        # PR-A: the hull feature name must match the issue_map key
+        # ("hull_area_zscore") so the "Unusual pose extent" label can fire.
+        assert "hull_area_zscore" in detector.feature_names
+        assert "hull_area" not in detector.feature_names
+
+    def test_instance_to_array_forces_invisible_as_nan(self, skeleton):
+        """#2753: invisible nodes are NaN'd regardless of the sleap-io default.
+
+        Invisible (visible=False) nodes keep display-only coordinates; QC must
+        never read them. ``_instance_to_array`` passes ``invisible_as_nan=True``
+        explicitly so this holds even if the sleap-io default changes.
+        """
+        pts = np.array(
+            [[100, 100], [100, 120], [100, 150], [80, 115], [120, 115]], dtype=float
+        )
+        inst = Instance.from_numpy(pts, skeleton=skeleton)
+        inst[3]["visible"] = False
+
+        arr = LabelQCDetector()._instance_to_array(inst)
+
+        assert np.all(np.isnan(arr[3]))
+        assert not np.any(np.isnan(arr[[0, 1, 2, 4]]))
+
+    def test_invisible_far_node_does_not_leak_into_geometry(
+        self, simple_labels, skeleton
+    ):
+        """#2753 regression: a far-away invisible node must not inflate geometry.
+
+        A node dragged far away leaks into edge/angle/distance features ONLY
+        when it is visible; when invisible it must be excluded entirely.
+        """
+        detector = LabelQCDetector()
+        detector.fit(simple_labels)
+        i_edge = detector.feature_names.index("max_edge_zscore")
+
+        far = np.array(
+            [[100, 100], [100, 120], [100, 150], [9999, 9999], [120, 115]],
+            dtype=float,
+        )
+        inst_visible = Instance.from_numpy(far, skeleton=skeleton)
+        inst_invisible = Instance.from_numpy(far, skeleton=skeleton)
+        inst_invisible[3]["visible"] = False
+
+        f_visible = detector._extract_features(
+            detector._instance_to_array(inst_visible)
+        )
+        f_invisible = detector._extract_features(
+            detector._instance_to_array(inst_invisible)
+        )
+
+        assert f_visible[i_edge] > 10.0
+        assert f_invisible[i_edge] < 5.0
 
     def test_skeleton_analyzer_properties(self, simple_labels):
         """Test skeleton analyzer extracts properties."""

--- a/tests/qc/test_frame_level.py
+++ b/tests/qc/test_frame_level.py
@@ -184,6 +184,10 @@ class TestComputeNodeOverlap:
 
         assert len(result["common_nodes"]) == 0
         assert result["overlap_ratio"] == 0.0
+        # Key parity with the normal-path return so callers never KeyError.
+        assert result["mean_distance"] == float("inf")
+        assert result["min_distance"] == float("inf")
+        assert result["max_distance"] == float("inf")
 
 
 class TestDetectDuplicates:


### PR DESCRIPTION
## What & why

`LabelQCDetector` converted each instance with a bare `instance.numpy()`, **relying on sleap-io's default** for `invisible_as_nan`. Older sleap-io versions defaulted to returning invisible nodes' stored coordinates — which are **display-only placeholders** (the GUI has to draw an invisible node *somewhere*). Those far-off coordinates then leaked into the edge / angle / distance / hull statistics, producing spurious **"unusual joint angle"** / **"unusual edge length"** flags. This is the mechanism behind #2753.

`sleap-io 0.7.1` (currently pinned) defaults to `True`, which masks the leak — but QC shouldn't depend on an external default that *was* unsafe and could change again.

## Change

- **`_instance_to_array`** now passes **`invisible_as_nan=True`** explicitly. Invisible (`visible=False`) nodes are always dropped from geometry features; the visibility mask (`~np.isnan(...)`) still records them, so the visibility-pattern features keep working.

Small cleanups found alongside #2753:
- **`hull_area` → `hull_area_zscore`** in `V3_FEATURE_NAMES` — the value is already a z-score, and `results.py` keys the issue map on `hull_area_zscore`, so the "Unusual pose extent" label never fired before this.
- **`compute_node_overlap`**: the no-common-nodes branch now returns the same `min_distance`/`max_distance` keys as the normal path (shape parity; not a live crash today).
- Documented the currently-unused `auto_calibrate` / `calibration_percentile` config (no auto-calibration is implemented).

## Tests

- `test_instance_to_array_forces_invisible_as_nan` — the guard holds regardless of the sleap-io default.
- `test_invisible_far_node_does_not_leak_into_geometry` — a far-away node inflates `max_edge_zscore` only when **visible**; invisible it does not.
- `test_feature_names` — asserts `hull_area_zscore` present, `hull_area` absent.
- `test_no_common_nodes` — asserts the new key parity.

All 113 `tests/qc` tests pass; `ruff` clean. Scoped to `sleap/qc/` only (no GUI changes).

Addresses #2753. (Broader QC over-flagging on multi-video datasets is tracked with the detector work in #2756.)
