### PR TITLE
fix(gui): accept drag-and-drop file opens on Linux/macOS

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -317,17 +317,27 @@ class MainWindow(QMainWindow):
                 event.accept()
 
     def dragEnterEvent(self, event):
-        # TODO: Parse filenames and accept only if valid ext (or folder)
-        mime_format = 'application/x-qt-windows-mime;value="FileName"'
-        if mime_format in event.mimeData().formats():
-            # This only returns the first filename if multiple files are dropped:
-            event.mimeData().data(mime_format).data().decode()
+        # Accept the drag if it carries file URLs. Files dropped from a file
+        # manager are exposed as a "text/uri-list" payload on all platforms
+        # (Linux/macOS/Windows), which is what dropEvent() parses below.
+        # (Previously this only accepted a Windows-specific MIME type, so
+        # drag-and-drop silently did nothing on Linux and macOS.)
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+
+    def dragMoveEvent(self, event):
+        # Keep showing the "accept" cursor while a valid drag hovers the window.
+        if event.mimeData().hasUrls():
             event.acceptProposedAction()
 
     def dropEvent(self, event):
+        if not event.mimeData().hasUrls():
+            return
+
         # Parse filenames
         filenames = event.mimeData().data("text/uri-list").data().decode()
         filenames = [parse_uri_path(f.strip()) for f in filenames.strip().split("\n")]
+        filenames = [f for f in filenames if f]
 
         exts = [Path(f).suffix for f in filenames]
 
@@ -339,15 +349,21 @@ class MainWindow(QMainWindow):
                 # Load
                 self.commands.openProject(filename=filenames[0], first_open=True)
 
-        elif all([ext.lower()[1:] in available_video_exts() for ext in exts]):
+        elif exts and all(ext.lower()[1:] in available_video_exts() for ext in exts):
             # Import videos
             self.commands.showImportVideos(filenames=filenames)
 
         else:
-            raise TypeError(
-                f"Invalid file type(s) dropped: {', '.join(exts)} \n"
-                f"Supported formats: .slp, .{', .'.join(available_video_exts())}"
+            dropped = ", ".join(exts) or "(unknown)"
+            QMessageBox.warning(
+                self,
+                "Unsupported file type",
+                f"Couldn't open the dropped file(s): {dropped}\n\n"
+                f"Supported formats: .slp, .{', .'.join(available_video_exts())}",
             )
+            return
+
+        event.acceptProposedAction()
 
     @property
     def labels(self) -> Labels:

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -475,9 +475,7 @@ def test_app_drag_and_drop_open(qtbot, centered_pair_predictions_slp_path):
     assert enter.isAccepted()
 
     # Dropping the .slp loads it into the (empty) window.
-    drop = QDropEvent(
-        QPointF(0, 0), Qt.CopyAction, mime, Qt.LeftButton, Qt.NoModifier
-    )
+    drop = QDropEvent(QPointF(0, 0), Qt.CopyAction, mime, Qt.LeftButton, Qt.NoModifier)
     win.dropEvent(drop)
 
     assert win.state["project_loaded"]

--- a/tests/gui/test_app.py
+++ b/tests/gui/test_app.py
@@ -446,6 +446,46 @@ def test_app_new_window(qtbot, min_labels_slp_path, centered_pair_predictions_sl
     app.closeAllWindows()
 
 
+def test_app_drag_and_drop_open(qtbot, centered_pair_predictions_slp_path):
+    """Dropping a .slp file onto the window opens it (cross-platform).
+
+    Regression test for drag-and-drop only being accepted on Windows: the
+    drag-enter handler must accept any file-URL drag (``text/uri-list``), not
+    just a Windows-specific MIME type, and the drop handler must then load the
+    dropped ``.slp`` file. See https://github.com/talmolab/sleap/issues/2760.
+    """
+    from qtpy.QtCore import QMimeData, QUrl, QPoint, QPointF, Qt
+    from qtpy.QtGui import QDragEnterEvent, QDropEvent
+
+    app = QApplication.instance()
+    app.closeAllWindows()
+    win = MainWindow(no_usage_data=True)
+    assert not win.state["project_loaded"]
+
+    mime = QMimeData()
+    mime.setUrls([QUrl.fromLocalFile(centered_pair_predictions_slp_path)])
+
+    # Drag-enter must be accepted for a file-URL drag. This is what silently
+    # failed on Linux/macOS before the fix (it only accepted a Windows MIME
+    # type), so the drop was never delivered.
+    enter = QDragEnterEvent(
+        QPoint(0, 0), Qt.CopyAction, mime, Qt.LeftButton, Qt.NoModifier
+    )
+    win.dragEnterEvent(enter)
+    assert enter.isAccepted()
+
+    # Dropping the .slp loads it into the (empty) window.
+    drop = QDropEvent(
+        QPointF(0, 0), Qt.CopyAction, mime, Qt.LeftButton, Qt.NoModifier
+    )
+    win.dropEvent(drop)
+
+    assert win.state["project_loaded"]
+    assert win.state["filename"] == centered_pair_predictions_slp_path
+
+    app.closeAllWindows()
+
+
 @pytest.mark.skipif(
     sys.platform.startswith(("li", "darwin")),
     reason="qtbot.waitActive times out on ubuntu/macOS",


### PR DESCRIPTION
## Summary

Dragging a `.slp` file (or supported videos) onto the `sleap-label` main window did nothing on **Linux and macOS** — the OS showed a "no-drop" cursor and no project opened. It worked only on Windows.

The drop logic was fully implemented; the bug was in the *gate*. `dragEnterEvent()` only called `acceptProposedAction()` when a **Windows-specific** MIME type was present:

```python
mime_format = 'application/x-qt-windows-mime;value="FileName"'
if mime_format in event.mimeData().formats():
    ...
    event.acceptProposedAction()
```

On Linux/macOS, file drags arrive as `text/uri-list` and that Windows MIME type is absent, so the drag was rejected and `dropEvent()` (which already parses `text/uri-list` correctly) never fired.

Fixes #2760.

## Changes

- **`dragEnterEvent()` / new `dragMoveEvent()`** — accept the drag whenever it carries file URLs via the cross-platform `event.mimeData().hasUrls()` check, instead of the Windows-only MIME type.
- **`dropEvent()` hardening** — ignore drags without URLs, drop empty parsed paths, and show a `QMessageBox.warning` for unsupported file types instead of `raise`-ing a `TypeError` inside the Qt event handler (which previously surfaced as an unhandled exception).
- **Test** — `test_app_drag_and_drop_open` synthesizes a real file-URL drag-enter + drop of a `.slp` and asserts the drag is accepted and the project loads. This fails against the old Windows-only gate.

## Behavior

| Drop | Result |
|------|--------|
| Single `.slp`, no project open | Opens it |
| Single `.slp`, project already open | Merges into current project |
| Supported video file(s) | Import-videos dialog |
| Anything else | Warning dialog (was: unhandled exception) |

## Testing

- `tests/gui/test_app.py` — **6 passed, 1 skipped** (platform skipif), 0 failures (offscreen).
- `ruff check` clean on changed files.
- Manual drag-to-open verification on Linux is hard to automate headlessly; the new test exercises the real `QDragEnterEvent`/`QDropEvent` + `text/uri-list` parsing path that the OS drives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)