### PR TITLE
feat(qc): add 5 label-error detectors to Label QC (#2756)

### DIFF
--- a/sleap/qc/config.py
+++ b/sleap/qc/config.py
@@ -48,7 +48,8 @@ class QCConfig:
     gmm_min_samples: int = 50
     gmm_percentile_threshold: float = 5.0
 
-    # Calibration
+    # Calibration (reserved: NOT consumed anywhere yet — no auto-calibration is
+    # implemented. Flagging uses the fixed instance_threshold / GUI slider value.)
     auto_calibrate: bool = True
     calibration_percentile: float = 95.0
 

--- a/sleap/qc/config.py
+++ b/sleap/qc/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 
@@ -17,11 +17,39 @@ class QCConfig:
         use_symmetry: Whether to compute symmetry features.
             If "auto", enables when skeleton has symmetry pairs defined.
         use_anatomical: Whether to compute anatomical features (signed angles).
+        use_chirality: Whether to compute the whole-instance left/right
+            mirror-flip (chirality) feature. If "auto", enables when the
+            skeleton has symmetry pairs (defined or inferred by name). Reliable
+            detector, default-ON.
+        use_split_detection: Whether to compute the pose-split (chimera) feature
+            that flags a single instance spanning two animals. Reliable
+            detector, default-ON.
+        use_duplicate_score: Whether to fold the complementary split-duplicate
+            signal into frame-level duplicate detection. Reliable detector,
+            default-ON.
+        use_chain_ordering: Whether to compute the keypoint chain-ordering
+            feature (wrong order along an ordered chain). If "auto", enables
+            when the longest chain has >= 4 nodes. Experimental, default-OFF.
+        use_missing_node_check: Whether to run the missing-node check (a node a
+            instance's peers usually keep is absent). Experimental, default-OFF.
         instance_threshold: Threshold for flagging instances (0-1).
             Higher = fewer flags, lower = more flags.
         frame_threshold: Threshold for frame-level checks.
         duplicate_iou_threshold: IOU threshold for duplicate detection.
         duplicate_node_overlap_ratio: Node overlap ratio for partial duplicates.
+        chirality_flip_threshold: ``chirality_wrong_fraction`` at/above which an
+            instance is force-flagged as a whole-instance L/R flip.
+        duplicate_score_threshold: Combined duplicate-score at/above which a
+            pair is flagged as a duplicate at the frame level.
+        chain_turn_angle_deg: Per-interior-node turning angle (degrees) above
+            which a chain node counts as an ordering inversion.
+        order_inversion_threshold: ``order_inversion_rate`` at/above which an
+            instance is force-flagged as having wrong keypoint order.
+        missing_node_prob_threshold: Minimum expected-visibility probability for
+            a missing node to be flagged as suspicious.
+        ordered_chains: User-defined ordered chains as lists of node *names*
+            (ground truth ordering for the chain-ordering detector). Empty =
+            fall back to auto-detected skeleton chains.
         gmm_n_components: Number of GMM components.
         gmm_min_samples: Minimum samples required for GMM fitting.
             Below this, falls back to z-score thresholding.
@@ -35,6 +63,12 @@ class QCConfig:
     use_curvature: Literal["auto"] | bool = "auto"
     use_symmetry: Literal["auto"] | bool = "auto"
     use_anatomical: bool = False
+    # New detectors: reliable ones default-ON, experimental ones default-OFF.
+    use_chirality: Literal["auto"] | bool = "auto"  # (c)
+    use_split_detection: bool = True  # (d)
+    use_duplicate_score: bool = True  # (a)
+    use_chain_ordering: Literal["auto"] | bool = False  # (b) experimental
+    use_missing_node_check: bool = False  # (f, Tier-1) experimental
 
     # Thresholds (validated in v4 investigation)
     instance_threshold: float = 0.7  # Default: balanced
@@ -42,6 +76,16 @@ class QCConfig:
     duplicate_iou_threshold: float = 0.5
     duplicate_node_overlap_ratio: float = 0.8
     duplicate_node_distance_threshold: float = 10.0
+
+    # New-detector thresholds.
+    chirality_flip_threshold: float = 0.5
+    duplicate_score_threshold: float = 0.5
+    chain_turn_angle_deg: float = 60.0
+    order_inversion_threshold: float = 0.3
+    missing_node_prob_threshold: float = 0.9
+
+    # User-defined ordered chains (lists of node NAMES) for chain-ordering.
+    ordered_chains: list = field(default_factory=list)
 
     # GMM settings
     gmm_n_components: int = 5
@@ -66,3 +110,17 @@ class QCConfig:
             return self.use_symmetry
         # Auto mode: enable if skeleton has symmetry pairs
         return has_symmetry
+
+    def should_use_chirality(self, has_symmetry: bool) -> bool:
+        """Determine if the chirality (L/R mirror-flip) feature should be used."""
+        if isinstance(self.use_chirality, bool):
+            return self.use_chirality
+        # Auto mode: enable if skeleton has symmetry pairs (defined or inferred).
+        return has_symmetry
+
+    def should_use_chain_ordering(self, max_chain_length: int) -> bool:
+        """Determine if the chain-ordering feature should be used."""
+        if isinstance(self.use_chain_ordering, bool):
+            return self.use_chain_ordering
+        # Auto mode: enable for chains >= 4 nodes (need an interior turning angle).
+        return max_chain_length >= 4

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -33,7 +33,7 @@ V3_FEATURE_NAMES = [
     "curvature_std",
     "visibility_pattern_score",
     "nn_distance",
-    "hull_area",
+    "hull_area_zscore",
     "hull_compactness",
 ]
 
@@ -284,12 +284,21 @@ class LabelQCDetector:
         return instances
 
     def _instance_to_array(self, instance: "sio.Instance") -> np.ndarray:
-        """Convert instance to (n_nodes, 2) array.
+        """Convert instance to (n_nodes, 2) array with invisible points as NaN.
 
-        Uses Instance.numpy() which returns invisible points as NaN by default.
-        Feature extractors handle NaN values by skipping them in computations.
+        Explicitly passes ``invisible_as_nan=True`` instead of relying on the
+        sleap-io default. Invisible (``visible=False``) nodes must never
+        contribute their stored coordinates to QC geometry features: those
+        coordinates are display-only placeholders (the GUI has to draw an
+        invisible node *somewhere*), and older sleap-io versions defaulted to
+        returning them, which leaked far-off invisible-node coordinates into
+        the edge/angle/distance/hull statistics (see #2753).
+
+        Feature extractors treat NaN as "missing" and skip those nodes, while
+        the downstream visibility mask (``~np.isnan(...)``) still records that
+        the node is invisible, so the visibility-pattern features keep working.
         """
-        return instance.numpy()
+        return instance.numpy(invisible_as_nan=True)
 
     @staticmethod
     def _video_id(video: "sio.Video", video_idx: int) -> str:

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -12,6 +12,14 @@ from sleap.qc.features.skeleton import SkeletonAnalyzer
 from sleap.qc.features.structural import compute_curvature, compute_convex_hull
 from sleap.qc.features.visibility import VisibilityModel
 from sleap.qc.features.reference import NearestNeighborScorer, normalize_pose
+from sleap.qc.features.chirality import (
+    fit_chirality,
+    compute_chirality,
+    infer_symmetry_pairs_by_name,
+)
+from sleap.qc.features.pose_split import compute_pose_split
+from sleap.qc.features.ordering import compute_chain_ordering, resolve_chains
+from sleap.qc.features.missing_node import score_missing_nodes
 from sleap.qc.frame_level import (
     InstanceCountChecker,
     check_negative_frame,
@@ -27,7 +35,13 @@ if TYPE_CHECKING:
 ProgressCallback = Callable[[str, float, Optional[str]], None]
 
 
-# Additional feature names for v3 features
+# Additional feature names for v3 features.
+#
+# IMPORTANT: the order here is load-bearing. ``_extract_features`` appends the
+# per-instance feature values in exactly this order, and ``_score_instance``
+# maps contributions back to names positionally. Any change here MUST be
+# mirrored by the append order in ``_extract_features`` or fit/score widths and
+# the contribution mapping will diverge.
 V3_FEATURE_NAMES = [
     "max_curvature",
     "curvature_std",
@@ -35,6 +49,11 @@ V3_FEATURE_NAMES = [
     "nn_distance",
     "hull_area_zscore",
     "hull_compactness",
+    # B1 detectors (appended after hull_compactness, in this exact order):
+    "chirality_wrong_fraction",  # (c) whole-instance L/R flip
+    "pose_split_score",  # (d) chimera / pose-split (log1p-compressed)
+    "order_inversion_rate",  # (b) chain ordering
+    "chain_intersection_count",  # (b) chain ordering
 ]
 
 
@@ -85,6 +104,16 @@ class LabelQCDetector:
 
         # Cache for computed statistics
         self._hull_stats: Optional[dict] = None
+
+        # B1 detector fit-time state (set in fit(), consumed in _extract_features
+        # and score()). Initialized empty so _extract_features is safe even if
+        # called before fit() sets them.
+        self._chirality_model: Optional[dict] = None
+        self._symmetry_pairs: list[tuple[int, int]] = []
+        self._axis_nodes: Optional[tuple[int, int]] = None
+        self._ordering_chains: list[list[int]] = []
+        self._adjacency: Optional[dict[int, list[int]]] = None
+        self._co_visibility: Optional[np.ndarray] = None
 
     def fit(
         self,
@@ -156,6 +185,36 @@ class LabelQCDetector:
             "mean": np.mean(hull_areas) if hull_areas else 1.0,
             "std": np.std(hull_areas) if hull_areas else 1.0,
         }
+
+        # B1 fit-time setup. These MUST exist before _extract_all_features runs,
+        # since _extract_features reads them while building the feature matrix.
+        _report("Fitting feature extractors", 0.16, "B1 detectors")
+        sa = self.skeleton_analyzer
+        self._symmetry_pairs = list(sa.symmetry_pairs) or infer_symmetry_pairs_by_name(
+            sa.node_names
+        )
+        # Body axis for chirality must run along MIDLINE (non-symmetric) nodes.
+        # The skeleton's longest graph path can end at a side node (e.g. a
+        # Haunch_left leaf), which biases the axis to one side and makes the
+        # signed-side chirality meaningless (-> false whole-instance-flip flags).
+        # Restrict the spine to non-symmetric nodes for the axis.
+        _sym_idxs = {i for pair in self._symmetry_pairs for i in pair}
+        _midline = [i for i in sa.spine if i not in _sym_idxs]
+        if len(_midline) >= 2:
+            self._axis_nodes = (_midline[0], _midline[-1])
+        elif len(sa.spine) >= 2:
+            self._axis_nodes = (sa.spine[0], sa.spine[-1])
+        else:
+            self._axis_nodes = None
+        self._adjacency = sa.get_adjacency()
+        self._ordering_chains = resolve_chains(
+            sa.node_names, self.config.ordered_chains or None, sa.get_curvature_chains()
+        )
+        self._co_visibility = self.visibility_model.co_visibility_matrix
+        if self.config.should_use_chirality(len(self._symmetry_pairs) >= 1):
+            self._chirality_model = fit_chirality(
+                instances, self._symmetry_pairs, self._axis_nodes
+            )
 
         # Build feature matrix (use LOO NN distances for training)
         _report("Extracting features", 0.20, f"0/{len(instances)}")
@@ -240,8 +299,33 @@ class LabelQCDetector:
                     features = self._extract_features(points)
                     score, contributions = self._score_instance(features)
 
+                    # Pop the forced-issue marker before contributions are
+                    # stored, so feature_contributions stays pure floats.
+                    forced_issue = contributions.pop("_forced_top_issue", None)
+
                     results.instance_scores[key] = score
                     results.feature_contributions[key] = contributions
+
+                    if forced_issue is not None:
+                        results.forced_issues[key] = forced_issue
+
+                    # Missing-node channel (experimental): scored separately from
+                    # the GMM and merged in QCResults.get_flagged.
+                    if (
+                        self.config.use_missing_node_check
+                        and self._co_visibility is not None
+                    ):
+                        _vmask = ~np.isnan(points).any(axis=1)
+                        _mn = score_missing_nodes(
+                            _vmask,
+                            self._co_visibility,
+                            self.skeleton_analyzer.edges,
+                            threshold=self.config.missing_node_prob_threshold,
+                        )
+                        if _mn["missing_node_score"] > 0:
+                            results.channel_scores.setdefault("missing_node", {})[
+                                key
+                            ] = _mn["missing_node_score"]
 
                     # Progress update (every 500 instances)
                     instance_count += 1
@@ -376,6 +460,55 @@ class LabelQCDetector:
         )
         v3_features.extend([hull_area_z, hull["compactness"]])
 
+        # --- B1 detectors. Each block ALWAYS appends a fixed number of values
+        # (emitting 0.0 defaults when its flag is off), so the feature-vector
+        # width is identical at fit and score time. The append order MUST match
+        # V3_FEATURE_NAMES exactly. ---
+
+        # (c) chirality / whole-instance L/R flip
+        if self._chirality_model is not None:
+            v3_features.append(
+                compute_chirality(
+                    points,
+                    self._symmetry_pairs,
+                    self._axis_nodes,
+                    self._chirality_model,
+                )["chirality_wrong_fraction"]
+            )
+        else:
+            v3_features.append(0.0)
+
+        # (d) chimera / pose-split — log1p to tame the unbounded dynamic range
+        # before the GMM
+        if self.config.use_split_detection:
+            _ps = compute_pose_split(
+                points,
+                self._adjacency,
+                self.baseline_extractor.stats.edge_means,
+                self.baseline_extractor.stats.edge_stds,
+            )["split_score"]
+            v3_features.append(float(np.log1p(max(_ps, 0.0))))
+        else:
+            v3_features.append(0.0)
+
+        # (b) chain ordering (experimental)
+        if (
+            self.config.should_use_chain_ordering(
+                self.skeleton_analyzer.max_chain_length
+            )
+            and self._ordering_chains
+        ):
+            _ord = compute_chain_ordering(
+                points,
+                self._ordering_chains,
+                max_turn_angle=np.deg2rad(self.config.chain_turn_angle_deg),
+            )
+            v3_features.extend(
+                [_ord["order_inversion_rate"], float(_ord["chain_intersection_count"])]
+            )
+        else:
+            v3_features.extend([0.0, 0.0])
+
         return np.concatenate([baseline, np.array(v3_features)])
 
     def _extract_all_features(
@@ -505,12 +638,42 @@ class LabelQCDetector:
             scores = self.zscore_detector.score_batch(features_clean.reshape(1, -1))
             score = scores[0] if len(scores) > 0 else 0.0
 
-        # Build contributions dict
+        score = float(score) if np.isfinite(score) else 0.0
+
+        # Build contributions dict (raw feature values keyed by name).
         contributions = {}
         for i, name in enumerate(self.feature_names):
             contributions[name] = float(features[i]) if i < len(features) else 0.0
 
-        return float(score) if np.isfinite(score) else 0.0, contributions
+        # Raise-only hard-rule overrides. These never lower the GMM score; they
+        # only force it up (and record a human-readable issue) when an
+        # unambiguous structural error is present. The chimera (d) detector gets
+        # NO hard rule for now — it relies on its GMM feature
+        # (pose_split_score), which is why there is no clause for it here.
+        forced = None
+        if (
+            self._chirality_model is not None
+            and contributions.get("chirality_wrong_fraction", 0.0)
+            >= self.config.chirality_flip_threshold
+        ):
+            forced = (
+                max(0.9, contributions["chirality_wrong_fraction"]),
+                "Whole-instance L/R flip",
+            )
+        elif self.config.should_use_chain_ordering(
+            self.skeleton_analyzer.max_chain_length
+        ) and (
+            contributions.get("chain_intersection_count", 0.0) >= 1
+            or contributions.get("order_inversion_rate", 0.0)
+            >= self.config.order_inversion_threshold
+        ):
+            forced = (0.9, "Wrong keypoint order along chain")
+
+        if forced is not None:
+            score = max(score, forced[0])
+            contributions["_forced_top_issue"] = forced[1]
+
+        return score, contributions
 
     def _check_frame(
         self,
@@ -534,15 +697,34 @@ class LabelQCDetector:
 
         # Duplicate detection
         if len(instances) >= 2:
-            duplicates = detect_duplicates(
-                instances,
-                iou_threshold=self.config.duplicate_iou_threshold,
-                node_distance_threshold=self.config.duplicate_node_distance_threshold,
-                node_overlap_ratio=self.config.duplicate_node_overlap_ratio,
-            )
+            if self.config.use_duplicate_score:
+                duplicates = detect_duplicates(
+                    instances,
+                    iou_threshold=self.config.duplicate_iou_threshold,
+                    node_distance_threshold=(
+                        self.config.duplicate_node_distance_threshold
+                    ),
+                    node_overlap_ratio=self.config.duplicate_node_overlap_ratio,
+                    edge_means=self.baseline_extractor.stats.edge_means,
+                    duplicate_score_threshold=self.config.duplicate_score_threshold,
+                )
+            else:
+                # Keep current behavior: IOU + node-overlap only. An
+                # unreachable score threshold (> the clamped [0, 1] max) keeps
+                # the always-computed split-duplicate signal from ever firing.
+                duplicates = detect_duplicates(
+                    instances,
+                    iou_threshold=self.config.duplicate_iou_threshold,
+                    node_distance_threshold=(
+                        self.config.duplicate_node_distance_threshold
+                    ),
+                    node_overlap_ratio=self.config.duplicate_node_overlap_ratio,
+                    duplicate_score_threshold=float("inf"),
+                )
             for dup in duplicates:
                 frame_qc.duplicate_pairs.append((dup["index_a"], dup["index_b"]))
                 frame_qc.duplicate_reasons.append(dup["reason"])
+                frame_qc.duplicate_scores.append(dup.get("duplicate_score", 1.0))
 
         return frame_qc
 

--- a/sleap/qc/features/chirality.py
+++ b/sleap/qc/features/chirality.py
@@ -1,0 +1,441 @@
+"""Chirality (left/right mirror flip) features.
+
+A whole-instance left/right mirror flip is invariant to every distance- and
+unsigned-angle-based feature (edge lengths, joint angles, pairwise distances,
+convex hull, ...), so it is invisible to those detectors. Detecting it requires
+a *signed* statistic that encodes which side of the body axis each landmark
+falls on, i.e. the chirality of the pose.
+
+This module learns, per symmetric landmark pair, the canonical (majority) side
+of the body axis on which the "left" member of the pair sits, then scores a new
+instance by the fraction of co-visible symmetric pairs whose observed side
+disagrees with that learned canonical side:
+
+- a clean pose scores ``~0``,
+- a whole-instance mirror flip scores ``~1`` (every pair disagrees),
+- a partial / subset swap scores an intermediate value.
+
+The signed side of a point ``p`` relative to the body axis is the sign of the
+2D cross product of the axis vector with ``(p - axis_origin)``. This is
+invariant to translation, uniform scaling, and rotation of the whole instance
+(it only flips under reflection), which is exactly the property needed to
+isolate mirror flips from ordinary pose variation.
+
+The body axis is derived from two midline / non-symmetric anchor nodes (e.g.
+spine endpoints) passed as ``axis_node_indices=(i, j)``; if those anchors are
+missing for a given instance it falls back to the first principal component of
+the visible non-symmetric points.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import numpy as np
+
+
+# Recognized left/right suffix and prefix tokens for name-based inference.
+# Each entry maps a "left" token to its "right" counterpart. Matching is
+# case-insensitive on the token, but the surrounding stem must match exactly so
+# that ``Ear_L``/``Ear_R`` pair up while ``Ear_L``/``Eye_R`` do not.
+_LR_SUFFIX_TOKENS: list[tuple[str, str]] = [
+    ("left", "right"),
+    ("l", "r"),
+]
+
+# Separators allowed between a stem and an L/R token, e.g. "Ear_L", "Ear-L",
+# "Ear.L", "EarL", "Ear L".
+_LR_SEPARATORS = r"[ _\-.]?"
+
+
+def _normalize_axis(
+    axis_vec: np.ndarray, min_norm: float = 1e-6
+) -> Optional[np.ndarray]:
+    """Return a unit axis vector, or ``None`` if it is degenerate.
+
+    Args:
+        axis_vec: A length-2 vector describing the body axis direction.
+        min_norm: Minimum norm below which the axis is considered degenerate.
+
+    Returns:
+        The unit-normalized axis vector, or ``None`` if its norm is below
+        ``min_norm`` or it contains NaN.
+    """
+    axis_vec = np.asarray(axis_vec, dtype=float)
+    if axis_vec.shape != (2,) or np.isnan(axis_vec).any():
+        return None
+    norm = float(np.linalg.norm(axis_vec))
+    if norm < min_norm:
+        return None
+    return axis_vec / norm
+
+
+def _pca_axis(
+    points: np.ndarray,
+    exclude_indices: set[int],
+    min_points: int = 2,
+    min_norm: float = 1e-6,
+) -> Optional[tuple[np.ndarray, np.ndarray]]:
+    """Estimate a body axis from the visible non-symmetric points via PCA.
+
+    Uses the first principal component (direction of maximum variance) of the
+    visible points that are *not* part of any symmetric pair as the body-axis
+    direction, anchored at their centroid.
+
+    Args:
+        points: ``(n_nodes, 2)`` array of coordinates (NaN for invisible).
+        exclude_indices: Node indices to exclude (members of symmetric pairs).
+        min_points: Minimum number of distinct visible points required.
+        min_norm: Minimum spread below which the axis is considered degenerate.
+
+    Returns:
+        Tuple of ``(axis_origin, unit_axis_vec)``, or ``None`` if a meaningful
+        axis cannot be estimated.
+    """
+    n_nodes = points.shape[0]
+    keep = [
+        i
+        for i in range(n_nodes)
+        if i not in exclude_indices and not np.isnan(points[i]).any()
+    ]
+    if len(keep) < min_points:
+        return None
+
+    pts = points[keep]
+    origin = pts.mean(axis=0)
+    centered = pts - origin
+
+    # Spread guard: all points effectively coincident -> no direction.
+    if float(np.max(np.abs(centered))) < min_norm:
+        return None
+
+    # First principal component via SVD (robust for 2 points too).
+    try:
+        _, _, vh = np.linalg.svd(centered, full_matrices=False)
+    except np.linalg.LinAlgError:
+        return None
+
+    axis_vec = _normalize_axis(vh[0], min_norm=min_norm)
+    if axis_vec is None:
+        return None
+    return origin, axis_vec
+
+
+def _resolve_axis(
+    points: np.ndarray,
+    axis_node_indices: Optional[tuple[int, int]],
+    exclude_indices: set[int],
+) -> Optional[tuple[np.ndarray, np.ndarray]]:
+    """Resolve the body axis for a single instance.
+
+    Prefers the two explicit anchor nodes; falls back to PCA of the visible
+    non-symmetric points if the anchors are unavailable or degenerate.
+
+    Args:
+        points: ``(n_nodes, 2)`` array of coordinates (NaN for invisible).
+        axis_node_indices: Optional ``(i, j)`` anchor node indices defining the
+            axis as ``points[j] - points[i]``.
+        exclude_indices: Symmetric-pair node indices to exclude from PCA.
+
+    Returns:
+        Tuple of ``(axis_origin, unit_axis_vec)``, or ``None`` if no usable axis
+        could be derived.
+    """
+    n_nodes = points.shape[0]
+
+    if axis_node_indices is not None:
+        i, j = axis_node_indices
+        if (
+            0 <= i < n_nodes
+            and 0 <= j < n_nodes
+            and i != j
+            and not np.isnan(points[i]).any()
+            and not np.isnan(points[j]).any()
+        ):
+            origin = points[i].astype(float)
+            axis_vec = _normalize_axis(points[j] - points[i])
+            if axis_vec is not None:
+                return origin, axis_vec
+
+    # Fall back to PCA of visible non-symmetric points.
+    return _pca_axis(points, exclude_indices=exclude_indices)
+
+
+def _signed_side(
+    point: np.ndarray, origin: np.ndarray, axis_vec: np.ndarray
+) -> Optional[float]:
+    """Signed side of ``point`` relative to the oriented body axis.
+
+    Computes ``sign(cross(axis_vec, point - origin))``, i.e. which side of the
+    directed axis the point lies on (+1 = left of the axis direction, -1 =
+    right, 0 = on the axis).
+
+    Args:
+        point: Length-2 coordinate of the node.
+        origin: Length-2 axis origin.
+        axis_vec: Length-2 (unit) axis direction.
+
+    Returns:
+        ``+1.0``, ``-1.0``, ``0.0``, or ``None`` if ``point`` is invisible.
+    """
+    point = np.asarray(point, dtype=float)
+    if np.isnan(point).any():
+        return None
+    rel = point - origin
+    cross = float(axis_vec[0] * rel[1] - axis_vec[1] * rel[0])
+    return float(np.sign(cross))
+
+
+def fit_chirality(
+    instances: list[np.ndarray],
+    symmetry_pairs: list[tuple[int, int]],
+    axis_node_indices: Optional[tuple[int, int]] = None,
+) -> dict:
+    """Learn the canonical signed side per symmetric pair from training poses.
+
+    For each symmetric pair ``(left, right)`` and each training instance where
+    the pair is co-visible and the body axis is resolvable, the signed side of
+    the *left* member relative to the axis is computed. The canonical side is
+    the majority sign across instances (sign of the mean of the per-instance
+    signs).
+
+    Args:
+        instances: List of ``(n_nodes, 2)`` pose arrays. NaN marks invisible
+            nodes. Should be clean / canonical labels (e.g. user-labeled).
+        symmetry_pairs: List of ``(left_idx, right_idx)`` symmetric node pairs.
+        axis_node_indices: Optional ``(i, j)`` anchor node indices defining the
+            body axis. If ``None`` (or unavailable for an instance), a PCA axis
+            over the visible non-symmetric points is used.
+
+    Returns:
+        A model dict with:
+
+        - ``"canonical_side"``: ``dict[tuple[int, int], float]`` mapping each
+          symmetric pair to its learned canonical side (``+1.0`` or ``-1.0``).
+          Pairs that were never observed with a resolvable axis are omitted.
+        - ``"pair_support"``: ``dict[tuple[int, int], int]`` mapping each pair to
+          the number of training instances that contributed to its estimate.
+        - ``"symmetry_pairs"``: the (normalized) list of pairs used.
+        - ``"axis_node_indices"``: the anchor indices supplied at fit time.
+        - ``"n_instances"``: number of training instances seen.
+    """
+    pairs = [tuple(p) for p in symmetry_pairs]
+    exclude_indices = {idx for pair in pairs for idx in pair}
+
+    # Accumulate signed sides of the left member per pair across instances.
+    side_sums: dict[tuple[int, int], float] = {p: 0.0 for p in pairs}
+    side_counts: dict[tuple[int, int], int] = {p: 0 for p in pairs}
+
+    for points in instances:
+        points = np.asarray(points, dtype=float)
+        axis = _resolve_axis(points, axis_node_indices, exclude_indices)
+        if axis is None:
+            continue
+        origin, axis_vec = axis
+
+        for left_idx, right_idx in pairs:
+            # Require BOTH members visible so the side reflects a genuine,
+            # co-visible pair rather than a lone node.
+            if (
+                left_idx >= points.shape[0]
+                or right_idx >= points.shape[0]
+                or np.isnan(points[left_idx]).any()
+                or np.isnan(points[right_idx]).any()
+            ):
+                continue
+
+            side = _signed_side(points[left_idx], origin, axis_vec)
+            if side is None or side == 0.0:
+                # On the axis: ambiguous, contributes no chirality information.
+                continue
+
+            side_sums[(left_idx, right_idx)] += side
+            side_counts[(left_idx, right_idx)] += 1
+
+    canonical_side: dict[tuple[int, int], float] = {}
+    pair_support: dict[tuple[int, int], int] = {}
+    for pair in pairs:
+        count = side_counts[pair]
+        if count == 0:
+            continue
+        mean_side = side_sums[pair] / count
+        # Sign of the mean = majority side. Break exact ties toward +1.
+        canonical_side[pair] = 1.0 if mean_side >= 0.0 else -1.0
+        pair_support[pair] = count
+
+    return {
+        "canonical_side": canonical_side,
+        "pair_support": pair_support,
+        "symmetry_pairs": pairs,
+        "axis_node_indices": axis_node_indices,
+        "n_instances": len(instances),
+    }
+
+
+def compute_chirality(
+    points: np.ndarray,
+    symmetry_pairs: list[tuple[int, int]],
+    axis_node_indices: Optional[tuple[int, int]],
+    model: dict,
+    min_pairs: int = 2,
+) -> dict[str, float]:
+    """Score a single instance for a left/right mirror flip.
+
+    For each co-visible symmetric pair with a learned canonical side, the signed
+    side of the *left* member relative to the body axis is compared to the
+    learned canonical side. The returned ``chirality_wrong_fraction`` is the
+    fraction of such pairs whose observed side disagrees with the canonical one.
+
+    Args:
+        points: ``(n_nodes, 2)`` array of coordinates (NaN for invisible).
+        symmetry_pairs: List of ``(left_idx, right_idx)`` symmetric node pairs.
+        axis_node_indices: Optional ``(i, j)`` anchor node indices for the body
+            axis. If ``None`` (or unavailable), a PCA axis is used.
+        model: Model dict returned by :func:`fit_chirality`.
+        min_pairs: Minimum number of scorable co-visible pairs required for a
+            meaningful score. Below this, ``chirality_wrong_fraction`` is 0.0.
+
+    Returns:
+        Dictionary with:
+
+        - ``"chirality_wrong_fraction"``: float in ``[0, 1]`` (0 = consistent
+          with the canonical chirality, 1 = fully flipped).
+        - ``"n_pairs"``: number of co-visible pairs that were actually scored.
+    """
+    points = np.asarray(points, dtype=float)
+    canonical_side: dict[tuple[int, int], float] = model.get("canonical_side", {})
+
+    pairs = [tuple(p) for p in symmetry_pairs]
+    exclude_indices = {idx for pair in pairs for idx in pair}
+
+    axis = _resolve_axis(points, axis_node_indices, exclude_indices)
+    if axis is None:
+        return {"chirality_wrong_fraction": 0.0, "n_pairs": 0}
+    origin, axis_vec = axis
+
+    n_pairs = 0
+    n_wrong = 0
+    for left_idx, right_idx in pairs:
+        canonical = canonical_side.get((left_idx, right_idx))
+        if canonical is None:
+            # No learned canonical side for this pair -> cannot judge.
+            continue
+        if (
+            left_idx >= points.shape[0]
+            or right_idx >= points.shape[0]
+            or np.isnan(points[left_idx]).any()
+            or np.isnan(points[right_idx]).any()
+        ):
+            continue
+
+        side = _signed_side(points[left_idx], origin, axis_vec)
+        if side is None or side == 0.0:
+            # On the axis: ambiguous, do not count for or against a flip.
+            continue
+
+        n_pairs += 1
+        if side != canonical:
+            n_wrong += 1
+
+    if n_pairs < min_pairs:
+        return {"chirality_wrong_fraction": 0.0, "n_pairs": n_pairs}
+
+    return {
+        "chirality_wrong_fraction": float(n_wrong) / float(n_pairs),
+        "n_pairs": n_pairs,
+    }
+
+
+def _split_lr_token(name: str) -> Optional[tuple[str, str, bool]]:
+    """Split a node name into ``(stem, canonical_side, is_left)`` if it carries
+    a recognized left/right token.
+
+    Recognizes both suffix forms (``Ear_L``, ``ear_left``, ``EarLeft``) and
+    prefix forms (``L_Ear``, ``left_ear``). The stem is the remaining text with
+    the separator stripped; ``canonical_side`` is ``"left"`` or ``"right"``.
+
+    Args:
+        name: The node name.
+
+    Returns:
+        ``(stem, side, is_left)`` where ``side`` is ``"left"`` or ``"right"`` and
+        ``is_left`` is ``True`` for left tokens, or ``None`` if no L/R token is
+        found.
+    """
+    for left_tok, right_tok in _LR_SUFFIX_TOKENS:
+        for tok, is_left, side in (
+            (left_tok, True, "left"),
+            (right_tok, False, "right"),
+        ):
+            # Suffix form: <stem><sep><tok>, e.g. "Ear_L", "EarLeft".
+            suffix_re = re.compile(
+                rf"^(?P<stem>.+?){_LR_SEPARATORS}{tok}$", re.IGNORECASE
+            )
+            m = suffix_re.match(name)
+            if m is not None:
+                stem = m.group("stem")
+                if stem:
+                    return f"S:{stem.lower()}", side, is_left
+
+            # Prefix form: <tok><sep><stem>, e.g. "L_Ear", "left_ear".
+            prefix_re = re.compile(
+                rf"^{tok}{_LR_SEPARATORS}(?P<stem>.+)$", re.IGNORECASE
+            )
+            m = prefix_re.match(name)
+            if m is not None:
+                stem = m.group("stem")
+                if stem:
+                    return f"P:{stem.lower()}", side, is_left
+
+    return None
+
+
+def infer_symmetry_pairs_by_name(
+    node_names: list[str],
+) -> list[tuple[int, int]]:
+    """Infer left/right symmetric pairs from node-name suffixes/prefixes.
+
+    Used when a skeleton has no symmetries defined (e.g. CVAT-style imports), so
+    that mirror-flip detection still works. Pairs nodes whose names share a stem
+    but differ by a left/right token, e.g. ``Ear_L``/``Ear_R``,
+    ``Shoulder_left``/``Shoulder_right``, ``Haunch_left``/``Haunch_right``,
+    ``L_Eye``/``R_Eye``.
+
+    The single-letter ``_L``/``_R`` form is only honored when a matching stem
+    exists on the other side, which avoids spuriously treating e.g. a lone
+    ``tail`` ending in no token as symmetric.
+
+    Args:
+        node_names: Ordered list of node names (index = node index).
+
+    Returns:
+        List of ``(left_idx, right_idx)`` index pairs, ordered by left index.
+        Each node appears in at most one pair.
+    """
+    # Map (orientation:stem) -> {"left": idx, "right": idx}.
+    groups: dict[str, dict[str, int]] = {}
+
+    for idx, name in enumerate(node_names):
+        parsed = _split_lr_token(name)
+        if parsed is None:
+            continue
+        key, side, _is_left = parsed
+        bucket = groups.setdefault(key, {})
+        # First occurrence wins for a given side (deterministic, stable order).
+        bucket.setdefault(side, idx)
+
+    pairs: list[tuple[int, int]] = []
+    used: set[int] = set()
+    for bucket in groups.values():
+        if "left" in bucket and "right" in bucket:
+            left_idx = bucket["left"]
+            right_idx = bucket["right"]
+            if left_idx in used or right_idx in used or left_idx == right_idx:
+                continue
+            pairs.append((left_idx, right_idx))
+            used.add(left_idx)
+            used.add(right_idx)
+
+    pairs.sort(key=lambda p: p[0])
+    return pairs

--- a/sleap/qc/features/duplicate_split.py
+++ b/sleap/qc/features/duplicate_split.py
@@ -1,0 +1,360 @@
+"""Split/duplicate instance features for frame-level QC.
+
+This module provides pure helpers used by ``sleap.qc.frame_level`` to
+strengthen duplicate-instance detection. The existing IoU and co-visible
+node-overlap signals catch *near-identical overlapping copies* (one animal
+labeled twice on the same nodes), but they miss the complementary
+**split** case: a single animal split across two instances that each label a
+*largely disjoint* set of nodes (e.g. instance A labels head/front, instance
+B labels tail/back). Together the two "halves" form one coherent animal.
+
+The functions here are deliberately scale-normalized (by the median edge
+length learned from the dataset, or the bounding-box diagonal of the larger
+instance as a fallback) so a single threshold works across recordings, and
+they NaN-guard every coordinate so absent/invisible nodes never leak into a
+score.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+# --- Tunable constants -------------------------------------------------------
+# These are interpreted in units of the pose scale (typical edge length), so
+# they are resolution-independent.
+
+# Two instances are considered to label "largely disjoint" node sets once the
+# disjointness ratio (see ``_disjointness``) climbs from this floor toward
+# ``_DISJOINT_FULL``. A disjointness of 0.5 means the two visible-node sets are
+# identical (no split); 1.0 means perfectly complementary.
+_DISJOINT_MIN = 0.55
+_DISJOINT_FULL = 0.85
+
+# Nearest visible node of A to nearest visible node of B, in scale units. Split
+# halves of one animal meet at the body, so the gap is tiny; two separate
+# animals leave a clear gap. The proximity score decays linearly to 0 at this
+# many scale units.
+_GAP_TOL = 2.5
+
+# Inter-instance gap measured relative to the instances' OWN internal node
+# spacing (coherence / "nested rather than side-by-side"). When one animal is
+# split, the two halves abut like a normal skeleton edge, so the join is about
+# one internal spacing; two animals side by side are several spacings apart.
+# Scores 1.0 at <= _COHERENCE_OK internal spacings, decaying to 0 at
+# _COHERENCE_MAX. This is scale-free and does not need edge_means.
+_COHERENCE_OK = 1.5
+_COHERENCE_MAX = 3.0
+
+# Minimum number of visible nodes required (per instance and in the union) to
+# attempt a split judgement at all.
+_MIN_VISIBLE = 2
+
+
+def _visible_mask(points: np.ndarray) -> np.ndarray:
+    """Boolean mask of nodes with finite (visible) coordinates."""
+    return ~np.isnan(points).any(axis=1)
+
+
+def _bbox_diagonal(points: np.ndarray) -> float:
+    """Bounding-box diagonal of the visible nodes (0.0 if < 2 visible)."""
+    visible = points[_visible_mask(points)]
+    if len(visible) < 2:
+        return 0.0
+    span = visible.max(axis=0) - visible.min(axis=0)
+    return float(np.linalg.norm(span))
+
+
+def _median_edge_length(edge_means: Optional[dict]) -> float:
+    """Median of learned edge lengths, or 0.0 if unavailable.
+
+    Args:
+        edge_means: Mapping of edge ``(src, dst)`` tuples to mean edge length,
+            as produced by :class:`~sleap.qc.features.baseline.DatasetStats`.
+            May be ``None`` or empty.
+
+    Returns:
+        Median of the positive edge lengths, else ``0.0``.
+    """
+    if not edge_means:
+        return 0.0
+    values = np.array([v for v in edge_means.values() if np.isfinite(v) and v > 0])
+    if values.size == 0:
+        return 0.0
+    return float(np.median(values))
+
+
+def _resolve_scale(
+    points_a: np.ndarray,
+    points_b: np.ndarray,
+    edge_means: Optional[dict],
+) -> float:
+    """Pick a positive length scale to normalize distances.
+
+    Prefers the dataset-wide median edge length (translation/rotation/scale
+    invariant and stable across instances); falls back to the bounding-box
+    diagonal of the *larger* instance when no edge stats are available.
+
+    Returns:
+        A strictly positive scale (defaults to ``1.0`` if nothing is usable).
+    """
+    scale = _median_edge_length(edge_means)
+    if scale > 1e-8:
+        return scale
+
+    # Fallback: bbox diagonal of the larger (more spatially extended) instance.
+    diag = max(_bbox_diagonal(points_a), _bbox_diagonal(points_b))
+    return diag if diag > 1e-8 else 1.0
+
+
+def _disjointness(visible_a: np.ndarray, visible_b: np.ndarray) -> float:
+    """Fraction of the visible-node union that is NOT shared.
+
+    Defined as ``|A ∪ B| / (|A| + |B|)``:
+
+    - ``0.5`` when the two instances label exactly the same nodes (full
+      overlap; the identical/duplicate case).
+    - ``1.0`` when the two instances label completely disjoint node sets (the
+      complementary split case).
+
+    Returns ``0.0`` when neither instance has visible nodes.
+    """
+    n_a = int(visible_a.sum())
+    n_b = int(visible_b.sum())
+    if n_a == 0 or n_b == 0:
+        return 0.0
+    n_union = int((visible_a | visible_b).sum())
+    return n_union / (n_a + n_b)
+
+
+def _nearest_node_distance(
+    points_a: np.ndarray,
+    points_b: np.ndarray,
+    visible_a: np.ndarray,
+    visible_b: np.ndarray,
+) -> float:
+    """Minimum distance between any visible node of A and any of B.
+
+    This is the inter-instance proximity used to tell a contiguous split
+    (halves touching at the body) from two separated animals. Returns
+    ``inf`` if either instance has no visible nodes.
+    """
+    pts_a = points_a[visible_a]
+    pts_b = points_b[visible_b]
+    if len(pts_a) == 0 or len(pts_b) == 0:
+        return float("inf")
+    # Pairwise distances between the two (small) visible point sets.
+    diffs = pts_a[:, None, :] - pts_b[None, :, :]
+    dists = np.linalg.norm(diffs, axis=2)
+    return float(dists.min())
+
+
+def _internal_spacing(points: np.ndarray, visible: np.ndarray) -> float:
+    """Typical spacing between adjacent visible nodes of one instance.
+
+    Estimated as the median nearest-neighbor distance among the instance's own
+    visible nodes. Used as a scale-free reference: a split animal's two halves
+    abut at roughly one such spacing, while two side-by-side animals are
+    several spacings apart.
+
+    Returns ``nan`` if fewer than two nodes are visible.
+    """
+    pts = points[visible]
+    if len(pts) < 2:
+        return float("nan")
+    diffs = pts[:, None, :] - pts[None, :, :]
+    dists = np.linalg.norm(diffs, axis=2)
+    np.fill_diagonal(dists, np.inf)
+    return float(np.median(dists.min(axis=1)))
+
+
+def _linear_score(value: float, lo: float, hi: float) -> float:
+    """Linearly ramp ``value`` from 0 at ``lo`` to 1 at ``hi`` (clamped).
+
+    Works for both increasing (``lo < hi``) and decreasing (``lo > hi``)
+    ramps.
+    """
+    if hi == lo:
+        return 1.0 if value >= hi else 0.0
+    frac = (value - lo) / (hi - lo)
+    return float(np.clip(frac, 0.0, 1.0))
+
+
+def compute_split_duplicate(
+    points_a: np.ndarray,
+    points_b: np.ndarray,
+    edge_means: Optional[dict] = None,
+) -> dict:
+    """Score whether two instances are one animal split across both.
+
+    Detects the *complementary split* failure mode that bbox-IoU and
+    co-visible node overlap miss: the two instances are visible on **largely
+    disjoint** node sets (few co-visible nodes), yet together their union pose
+    forms a single coherent animal -- the two "halves" are spatially
+    contiguous (small inter-instance nearest-node distance relative to scale)
+    and the union's extent matches a single animal rather than two side by
+    side.
+
+    The score is the product of three graded, scale-normalized signals:
+
+    1. **Disjointness** -- the two visible-node sets must be largely
+       complementary (this is the precondition that distinguishes a split from
+       an identical overlapping copy, which shares nodes).
+    2. **Proximity** -- the nearest node of A must be close to the nearest node
+       of B (the halves meet at the body). This is the key signal that keeps
+       the detector from firing on two genuinely distinct animals labeled on
+       disjoint nodes, which leave a clear gap between them.
+    3. **Coherence** -- the inter-instance gap must be small relative to the
+       instances' own internal node spacing, i.e. the two halves join like a
+       normal skeleton edge ("nested") rather than sitting several body-widths
+       apart as two animals side by side would.
+
+    Distances are normalized by the median edge length from ``edge_means`` (or
+    the larger instance's bbox diagonal as a fallback), so the result is
+    translation-, rotation-, and scale-invariant and thresholdable with a
+    single cutoff.
+
+    Args:
+        points_a: ``(n_nodes, 2)`` coordinates of instance A (NaN = invisible).
+        points_b: ``(n_nodes, 2)`` coordinates of instance B (NaN = invisible).
+        edge_means: Optional mapping of edge ``(src, dst)`` -> mean edge length
+            (from learned dataset stats) used to set the length scale. If
+            ``None``/empty, the bbox diagonal of the larger instance is used.
+
+    Returns:
+        Dictionary with:
+
+        - ``split_duplicate_score``: float in ``[0, 1]``. High = likely one
+          animal split across the two instances.
+        - ``reason``: short human-readable explanation of the score.
+    """
+    points_a = np.asarray(points_a, dtype=float)
+    points_b = np.asarray(points_b, dtype=float)
+
+    visible_a = _visible_mask(points_a)
+    visible_b = _visible_mask(points_b)
+    n_a = int(visible_a.sum())
+    n_b = int(visible_b.sum())
+
+    # Degenerate: need enough visible nodes in each instance to judge a split.
+    if n_a < _MIN_VISIBLE or n_b < _MIN_VISIBLE:
+        return {
+            "split_duplicate_score": 0.0,
+            "reason": "too few visible nodes",
+        }
+
+    union_visible = visible_a | visible_b
+    if int(union_visible.sum()) < _MIN_VISIBLE:
+        return {
+            "split_duplicate_score": 0.0,
+            "reason": "too few visible nodes",
+        }
+
+    scale = _resolve_scale(points_a, points_b, edge_means)
+
+    # (1) Disjointness precondition: a split labels complementary node sets.
+    # High co-visibility (shared nodes) means this is the identical/overlap
+    # case, not a split -> disjoint score collapses to 0.
+    disjointness = _disjointness(visible_a, visible_b)
+    s_disjoint = _linear_score(disjointness, _DISJOINT_MIN, _DISJOINT_FULL)
+    if s_disjoint <= 0.0:
+        return {
+            "split_duplicate_score": 0.0,
+            "reason": (
+                f"node sets overlap (disjointness={disjointness:.2f}); "
+                "not a split"
+            ),
+        }
+
+    # (2) Proximity: the two halves of one animal touch at the body. Two
+    # distinct animals labeled on disjoint nodes leave a clear gap.
+    gap = _nearest_node_distance(points_a, points_b, visible_a, visible_b)
+    gap_norm = gap / scale
+    s_gap = _linear_score(gap_norm, _GAP_TOL, 0.0)
+    if s_gap <= 0.0:
+        return {
+            "split_duplicate_score": 0.0,
+            "reason": (
+                f"instances too far apart (gap={gap_norm:.2f} scale units); "
+                "likely distinct animals"
+            ),
+        }
+
+    # (3) Coherence ("nested rather than side-by-side"): the two halves of one
+    # animal join like a normal skeleton edge, so the inter-instance gap is
+    # about one of the instances' own internal node spacings. Two animals side
+    # by side sit several internal spacings apart. This is scale-free and so
+    # complements the absolute-scale proximity check above.
+    spacing_a = _internal_spacing(points_a, visible_a)
+    spacing_b = _internal_spacing(points_b, visible_b)
+    spacings = [s for s in (spacing_a, spacing_b) if np.isfinite(s) and s > 1e-8]
+    if spacings:
+        rel_gap = gap / float(np.mean(spacings))
+        s_coherent = _linear_score(rel_gap, _COHERENCE_MAX, _COHERENCE_OK)
+    else:
+        # Each instance is a single point (no internal spacing to compare to);
+        # the absolute proximity check already governs, so don't penalize.
+        rel_gap = float("nan")
+        s_coherent = 1.0
+
+    score = float(s_disjoint * s_gap * s_coherent)
+
+    reason = (
+        f"complementary split: disjointness={disjointness:.2f}, "
+        f"gap={gap_norm:.2f} scale units, relative gap={rel_gap:.2f} spacings"
+    )
+    if s_coherent <= 0.0:
+        reason = (
+            f"instances form separate clusters (relative gap={rel_gap:.2f} "
+            "spacings); likely two animals side by side"
+        )
+
+    return {
+        "split_duplicate_score": score,
+        "reason": reason,
+    }
+
+
+def duplicate_score(
+    iou: float,
+    node_overlap_ratio: float,
+    split_duplicate_score: float,
+) -> float:
+    """Combine duplicate signals into one graded confidence in ``[0, 1]``.
+
+    Merges the three complementary duplicate signals so a caller can apply a
+    single threshold and get a graded confidence instead of three booleans:
+
+    - ``iou`` -- bbox intersection-over-union (overlapping copies).
+    - ``node_overlap_ratio`` -- fraction of co-visible nodes that coincide
+      (partial overlapping copies, even at low IoU).
+    - ``split_duplicate_score`` -- the complementary split signal from
+      :func:`compute_split_duplicate` (one animal split on disjoint nodes).
+
+    A saturating ``max`` is used: any one signal firing strongly is enough to
+    flag a duplicate, and the score never exceeds 1. Inputs are individually
+    clamped to ``[0, 1]`` and NaN inputs are treated as ``0`` so a missing
+    signal cannot inflate or corrupt the result.
+
+    Args:
+        iou: Bounding-box IoU between the two instances.
+        node_overlap_ratio: Co-visible node overlap ratio.
+        split_duplicate_score: Split-duplicate score.
+
+    Returns:
+        Combined duplicate confidence in ``[0, 1]``.
+    """
+
+    def _clean(x: float) -> float:
+        x = float(x)
+        if not np.isfinite(x):
+            return 0.0
+        return float(np.clip(x, 0.0, 1.0))
+
+    return max(
+        _clean(iou),
+        _clean(node_overlap_ratio),
+        _clean(split_duplicate_score),
+    )

--- a/sleap/qc/features/duplicate_split.py
+++ b/sleap/qc/features/duplicate_split.py
@@ -263,8 +263,7 @@ def compute_split_duplicate(
         return {
             "split_duplicate_score": 0.0,
             "reason": (
-                f"node sets overlap (disjointness={disjointness:.2f}); "
-                "not a split"
+                f"node sets overlap (disjointness={disjointness:.2f}); not a split"
             ),
         }
 

--- a/sleap/qc/features/missing_node.py
+++ b/sleap/qc/features/missing_node.py
@@ -1,0 +1,162 @@
+"""Missing-node detection: labelable points left unlabeled.
+
+This module implements a *geometry/visibility-only* heuristic (Tier-1) for
+detector (f): "labelable points left unlabeled". The idea is to flag instances
+that are missing a node which their *peers* (instances where the same
+co-visible nodes are present) usually keep visible.
+
+The detector reuses the co-visibility statistics learned by
+:class:`sleap.qc.features.visibility.VisibilityModel`: the integration layer
+fits that model on the labeled dataset and passes the learned
+``co_visibility_matrix`` (``P(node_j visible | node_i visible)``) here. This
+module itself is a pure function and learns nothing.
+
+Honest scope / limitations:
+    This only catches *outlier* drops -- an individual instance that is missing
+    a node its co-visible peers keep. It does NOT catch dataset-wide systematic
+    under-labeling (e.g. nobody in the project ever labels the tail tip). When a
+    node is rarely labeled, the co-visibility column for that node is small for
+    everyone, so its expected probability stays low and it is never flagged.
+    Detecting systematic under-labeling requires a model-based (Tier-2)
+    approach that compares against learned appearance/geometry rather than only
+    the project's own visibility statistics.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def score_missing_nodes(
+    visibility_mask: np.ndarray,
+    co_visibility_matrix: np.ndarray,
+    edges: list[tuple[int, int]],
+    threshold: float = 0.9,
+    require_neighbors_visible: bool = False,
+) -> dict:
+    """Score whether an instance is missing nodes its peers usually keep.
+
+    For each *invisible* node ``k`` we estimate the probability that it
+    *should* be visible given the nodes that are actually present::
+
+        p_expected[k] = mean over visible nodes i of co_visibility_matrix[i, k]
+
+    where ``co_visibility_matrix[i, k] = P(node k visible | node i visible)``
+    (the convention used by :class:`VisibilityModel`). A node is flagged as
+    suspiciously-missing when ``p_expected[k] >= threshold`` -- i.e. nodes that
+    co-occur with the visible nodes nearly always also bring ``k`` along, yet
+    ``k`` is absent here.
+
+    Optionally (``require_neighbors_visible=True``) a node is only flagged when
+    *all* of its skeleton neighbors (from ``edges``) are visible, which makes
+    the heuristic stricter: an isolated missing node surrounded by present
+    neighbors is a much stronger signal of an accidental drop than a node on
+    the boundary of an occluded region.
+
+    Args:
+        visibility_mask: ``(n_nodes,)`` boolean (or boolean-like) array. ``True``
+            = node visible/labeled, ``False`` = invisible/missing. Non-boolean
+            input is coerced with :func:`numpy.asarray(..., dtype=bool)`.
+        co_visibility_matrix: ``(n_nodes, n_nodes)`` array where entry
+            ``[i, j] = P(node j visible | node i visible)``, as learned by
+            :meth:`VisibilityModel.fit`.
+        edges: List of ``(src, dst)`` node-index pairs describing the skeleton
+            graph. Only used when ``require_neighbors_visible`` is set. May be
+            empty.
+        threshold: Minimum expected visibility probability for a missing node to
+            be flagged as suspicious. Defaults to ``0.9``.
+        require_neighbors_visible: If ``True``, only flag a missing node when all
+            of its skeleton neighbors are visible. Defaults to ``False``.
+
+    Returns:
+        Dictionary with:
+
+        - ``missing_node_score``: ``float`` in ``[0, 1]``. The maximum expected
+          visibility probability over all invisible nodes (0.0 if no node is
+          invisible). High values mean at least one missing node is one the
+          peers almost always keep.
+        - ``suspicious_nodes``: ``list[int]`` of node indices that were flagged
+          (``p_expected >= threshold`` and, if requested, all-neighbors-visible),
+          sorted ascending. Useful for naming the nodes in an explanation.
+        - ``n_suspicious``: ``int`` count of flagged nodes.
+    """
+    visibility_mask = np.asarray(visibility_mask, dtype=bool).ravel()
+    co_visibility_matrix = np.asarray(co_visibility_matrix, dtype=float)
+    n_nodes = visibility_mask.shape[0]
+
+    # Guard against an empty skeleton or a co-visibility matrix that does not
+    # match the mask -- there is nothing meaningful to flag in either case.
+    if (
+        n_nodes == 0
+        or co_visibility_matrix.shape != (n_nodes, n_nodes)
+    ):
+        return {
+            "missing_node_score": 0.0,
+            "suspicious_nodes": [],
+            "n_suspicious": 0,
+        }
+
+    visible_indices = np.where(visibility_mask)[0]
+    invisible_indices = np.where(~visibility_mask)[0]
+
+    # All nodes visible (nothing missing) or no visible node to condition on
+    # (we have no evidence about what *should* be present). Either way: score 0.
+    if len(invisible_indices) == 0 or len(visible_indices) == 0:
+        return {
+            "missing_node_score": 0.0,
+            "suspicious_nodes": [],
+            "n_suspicious": 0,
+        }
+
+    # Build neighbor adjacency only if we need it (avoids work in the common
+    # require_neighbors_visible=False path).
+    neighbors: list[list[int]] = []
+    if require_neighbors_visible:
+        neighbors = [[] for _ in range(n_nodes)]
+        for src, dst in edges:
+            # Ignore edges that reference nodes outside this skeleton.
+            if 0 <= src < n_nodes and 0 <= dst < n_nodes:
+                neighbors[src].append(dst)
+                neighbors[dst].append(src)
+
+    # Expected visibility for each invisible node: mean over visible nodes i of
+    # P(node k visible | node i visible) = column k restricted to visible rows.
+    # NaN-guard: a co-visibility column may contain NaN if VisibilityModel ever
+    # saw a node that was never visible; nanmean keeps the estimate finite and
+    # treats such entries as "no evidence" rather than poisoning the mean.
+    suspicious: list[int] = []
+    p_expected_values: list[float] = []
+    for k in invisible_indices:
+        col = co_visibility_matrix[visible_indices, k]
+        finite = col[np.isfinite(col)]
+        if len(finite) == 0:
+            # No usable evidence for this node; cannot be suspicious.
+            p_expected = 0.0
+        else:
+            p_expected = float(np.mean(finite))
+
+        p_expected_values.append(p_expected)
+
+        if p_expected < threshold:
+            continue
+
+        if require_neighbors_visible:
+            node_neighbors = neighbors[k]
+            # A node with no neighbors cannot have "all neighbors visible" in a
+            # meaningful sense; skip it under the stricter rule.
+            if not node_neighbors:
+                continue
+            if not all(visibility_mask[n] for n in node_neighbors):
+                continue
+
+        suspicious.append(int(k))
+
+    missing_node_score = float(np.max(p_expected_values)) if p_expected_values else 0.0
+    # Clamp defensively in case of tiny floating-point overshoot above 1.0.
+    missing_node_score = float(np.clip(missing_node_score, 0.0, 1.0))
+
+    return {
+        "missing_node_score": missing_node_score,
+        "suspicious_nodes": sorted(suspicious),
+        "n_suspicious": len(suspicious),
+    }

--- a/sleap/qc/features/missing_node.py
+++ b/sleap/qc/features/missing_node.py
@@ -86,10 +86,7 @@ def score_missing_nodes(
 
     # Guard against an empty skeleton or a co-visibility matrix that does not
     # match the mask -- there is nothing meaningful to flag in either case.
-    if (
-        n_nodes == 0
-        or co_visibility_matrix.shape != (n_nodes, n_nodes)
-    ):
+    if n_nodes == 0 or co_visibility_matrix.shape != (n_nodes, n_nodes):
         return {
             "missing_node_score": 0.0,
             "suspicious_nodes": [],

--- a/sleap/qc/features/ordering.py
+++ b/sleap/qc/features/ordering.py
@@ -1,0 +1,285 @@
+"""Keypoint ordering features: turning angles along chains.
+
+Detects nodes that are labeled out of order along an ordered chain
+(e.g. a tail ``TTI -> Tail_0 -> Tail_1 -> Tail_2 -> TailTip``).
+
+The core idea (maintainer's design): treat consecutive chain segments as
+vectors ``v_i = node_i - node_{i-1}`` and look at the *turning angle* between
+consecutive segments at each interior node (the angle between ``v_i`` and
+``v_{i+1}``). A correctly ordered chain -- even one that is naturally curled --
+has gentle turning angles. A mislabel (e.g. an adjacent swap) produces a sharp
+direction reversal, which shows up as one or two large turning angles. An
+out-of-order pair that is not adjacent (e.g. ``Tail_1`` swapped with
+``Tail_3``) additionally makes two non-adjacent segments geometrically cross,
+which is a strong, unambiguous signal.
+
+The turning angle is invariant to translation, rotation, and uniform scale, so
+these features do not need any learned per-dataset statistics.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Default per-chain threshold (radians) above which a turning angle at an
+# interior node is considered a sharp reversal / likely mislabel. 60 degrees is
+# permissive enough that a smoothly curled chain is not flagged while still
+# catching adjacent swaps (which approach 180 degrees).
+DEFAULT_MAX_TURN_ANGLE = np.deg2rad(60.0)
+
+# Numerical tolerance for zero-length segments.
+_EPS = 1e-8
+
+
+def _turning_angle(v1: np.ndarray, v2: np.ndarray) -> float:
+    """Turning (deflection) angle between two consecutive segment vectors.
+
+    The turning angle is ``pi - interior_angle``: it is 0 when the two segments
+    point in the same direction (the chain continues straight) and approaches
+    ``pi`` when the chain reverses direction (a sharp hairpin).
+
+    Args:
+        v1: First segment vector ``node_i - node_{i-1}``.
+        v2: Second segment vector ``node_{i+1} - node_i``.
+
+    Returns:
+        Turning angle in radians in ``[0, pi]``, or NaN if either segment has
+        (near) zero length.
+    """
+    norm1 = float(np.linalg.norm(v1))
+    norm2 = float(np.linalg.norm(v2))
+    if norm1 < _EPS or norm2 < _EPS:
+        return np.nan
+
+    # Angle between the two segment directions. cos = v1.v2 / (|v1||v2|).
+    cos_angle = float(np.dot(v1, v2) / (norm1 * norm2))
+    cos_angle = float(np.clip(cos_angle, -1.0, 1.0))
+    return float(np.arccos(cos_angle))
+
+
+def _segments_intersect(
+    p1: np.ndarray,
+    p2: np.ndarray,
+    p3: np.ndarray,
+    p4: np.ndarray,
+) -> bool:
+    """Whether segment ``p1->p2`` properly intersects segment ``p3->p4``.
+
+    Uses the orientation (signed-area) test. Collinear/touching configurations
+    are treated as non-intersecting to avoid false positives from shared
+    endpoints or numerically borderline cases.
+
+    Args:
+        p1: First endpoint of segment A (2,).
+        p2: Second endpoint of segment A (2,).
+        p3: First endpoint of segment B (2,).
+        p4: Second endpoint of segment B (2,).
+
+    Returns:
+        True if the two open segments cross.
+    """
+
+    def orient(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> float:
+        # Signed area * 2 of triangle (a, b, c). Sign gives turn direction.
+        return float((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]))
+
+    d1 = orient(p3, p4, p1)
+    d2 = orient(p3, p4, p2)
+    d3 = orient(p1, p2, p3)
+    d4 = orient(p1, p2, p4)
+
+    # Strict straddle on both segments => proper crossing. Using strict
+    # inequalities avoids flagging collinear or endpoint-touching segments
+    # (which arise naturally for a straight, correctly ordered chain).
+    if ((d1 > 0) != (d2 > 0)) and ((d3 > 0) != (d4 > 0)):
+        # Guard against the degenerate case where an orientation is exactly 0
+        # (collinear point): that is a touch, not a proper crossing.
+        if min(abs(d1), abs(d2), abs(d3), abs(d4)) > _EPS:
+            return True
+    return False
+
+
+def resolve_chains(
+    skeleton_node_names: list[str],
+    ordered_chains_by_name: list[list[str]] | None,
+    auto_chains: list[list[int]] | None,
+) -> list[list[int]]:
+    """Resolve ordered chains to node-index sequences.
+
+    A user-declared ordering is treated as ground truth: when
+    ``ordered_chains_by_name`` is provided, those chains (given as lists of node
+    *names*) are resolved to node indices and used directly. This makes the
+    turning-angle rule deterministic, since the intended order is known.
+
+    When no user-defined chains are given, falls back to ``auto_chains`` (chain
+    index sequences inferred from the skeleton graph, e.g. from
+    ``SkeletonAnalyzer.get_curvature_chains()``).
+
+    Args:
+        skeleton_node_names: Ordered list of node names; index ``i`` is the node
+            index of name ``skeleton_node_names[i]``.
+        ordered_chains_by_name: Optional list of user-defined chains, each a
+            list of node names in the intended order (e.g.
+            ``[["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]]``). Names not
+            present in the skeleton are skipped; chains with fewer than 3
+            resolvable nodes are dropped.
+        auto_chains: Optional fallback list of chains as node-index sequences.
+
+    Returns:
+        List of chains as node-index sequences. Empty if nothing resolves.
+    """
+    name_to_idx = {name: i for i, name in enumerate(skeleton_node_names)}
+
+    if ordered_chains_by_name:
+        resolved: list[list[int]] = []
+        for chain_names in ordered_chains_by_name:
+            idx_chain = [
+                name_to_idx[name] for name in chain_names if name in name_to_idx
+            ]
+            # A chain needs at least 3 nodes to have an interior turning angle.
+            if len(idx_chain) >= 3:
+                resolved.append(idx_chain)
+        if resolved:
+            return resolved
+        # If user-defined chains were given but none resolved (e.g. all names
+        # missing or too short), fall through to auto chains below.
+
+    if auto_chains:
+        return [list(chain) for chain in auto_chains if len(chain) >= 3]
+
+    return []
+
+
+def compute_chain_ordering(
+    points: np.ndarray,
+    chains: list[list[int]],
+    max_turn_angle: float = DEFAULT_MAX_TURN_ANGLE,
+) -> dict:
+    """Detect wrong keypoint order along ordered chains via turning angles.
+
+    For each chain, the turning angle is computed at every interior node from
+    the two adjacent segment vectors. The ``order_inversion_rate`` is the
+    fraction of interior nodes whose turning angle exceeds ``max_turn_angle``
+    (a sharp reversal). The ``chain_intersection_count`` is the number of
+    non-adjacent segment pairs that geometrically cross -- a strong signal of a
+    non-local swap (e.g. ``Tail_1`` <-> ``Tail_3``). Results are aggregated as
+    the maximum over all chains, and the worst chain/node are recorded for use
+    in an explanation.
+
+    All metrics are invariant to translation, rotation, and uniform scale, and
+    NaN (invisible/missing) nodes are skipped without leaking into results.
+
+    Args:
+        points: ``(N_nodes, 2)`` array of node coordinates; NaN marks
+            invisible/missing nodes.
+        chains: List of chains, each an ordered list of node indices. Use
+            :func:`resolve_chains` to obtain these from user-defined names or
+            auto-detected chains.
+        max_turn_angle: Per-interior-node turning-angle threshold in radians
+            above which a node is counted as an inversion. Default ~60 degrees.
+
+    Returns:
+        Dictionary with:
+        - ``order_inversion_rate``: float in ``[0, 1]``, max over chains of the
+          fraction of interior nodes whose turning angle exceeds the threshold.
+        - ``chain_intersection_count``: int, max over chains of the number of
+          crossing non-adjacent segment pairs.
+        - ``max_turn_angle``: float (radians), largest turning angle seen at any
+          interior node across all chains.
+        - ``worst_chain``: tuple of node indices for the chain with the largest
+          turning angle (empty tuple if none evaluable).
+        - ``worst_node``: int, the interior node index (into ``points``) with
+          the largest turning angle, or ``-1`` if none evaluable.
+    """
+    default = {
+        "order_inversion_rate": 0.0,
+        "chain_intersection_count": 0,
+        "max_turn_angle": 0.0,
+        "worst_chain": (),
+        "worst_node": -1,
+    }
+
+    if not chains:
+        return default
+
+    points = np.asarray(points, dtype=float)
+
+    best_inversion_rate = 0.0
+    best_intersection_count = 0
+    overall_max_angle = 0.0
+    worst_chain: tuple[int, ...] = ()
+    worst_node = -1
+
+    for chain in chains:
+        if len(chain) < 3:
+            continue
+
+        # --- Turning angles at interior nodes ---
+        n_interior = 0
+        n_inversions = 0
+        for i in range(1, len(chain) - 1):
+            prev_idx, curr_idx, next_idx = chain[i - 1], chain[i], chain[i + 1]
+            p_prev = points[prev_idx]
+            p_curr = points[curr_idx]
+            p_next = points[next_idx]
+
+            # Skip interior node if any of the three involved nodes is missing.
+            if (
+                np.isnan(p_prev).any()
+                or np.isnan(p_curr).any()
+                or np.isnan(p_next).any()
+            ):
+                continue
+
+            v1 = p_curr - p_prev  # incoming segment direction
+            v2 = p_next - p_curr  # outgoing segment direction
+            theta = _turning_angle(v1, v2)
+            if np.isnan(theta):
+                # Degenerate (coincident nodes); not an evaluable turn.
+                continue
+
+            n_interior += 1
+            if theta > max_turn_angle:
+                n_inversions += 1
+
+            if theta > overall_max_angle:
+                overall_max_angle = theta
+                worst_chain = tuple(chain)
+                worst_node = int(curr_idx)
+
+        inversion_rate = (n_inversions / n_interior) if n_interior > 0 else 0.0
+        if inversion_rate > best_inversion_rate:
+            best_inversion_rate = inversion_rate
+
+        # --- Non-adjacent segment crossings ---
+        # Build the list of visible segments (consecutive node pairs in chain).
+        segments: list[tuple[int, np.ndarray, np.ndarray]] = []
+        for i in range(len(chain) - 1):
+            a_idx, b_idx = chain[i], chain[i + 1]
+            pa, pb = points[a_idx], points[b_idx]
+            if np.isnan(pa).any() or np.isnan(pb).any():
+                continue
+            segments.append((i, pa, pb))
+
+        intersection_count = 0
+        for si in range(len(segments)):
+            i_pos, pa, pb = segments[si]
+            for sj in range(si + 1, len(segments)):
+                j_pos, pc, pd = segments[sj]
+                # Only non-adjacent segments: adjacent segments share an
+                # endpoint by construction and would always "touch".
+                if abs(i_pos - j_pos) <= 1:
+                    continue
+                if _segments_intersect(pa, pb, pc, pd):
+                    intersection_count += 1
+
+        if intersection_count > best_intersection_count:
+            best_intersection_count = intersection_count
+
+    return {
+        "order_inversion_rate": float(best_inversion_rate),
+        "chain_intersection_count": int(best_intersection_count),
+        "max_turn_angle": float(overall_max_angle),
+        "worst_chain": worst_chain,
+        "worst_node": worst_node,
+    }

--- a/sleap/qc/features/pose_split.py
+++ b/sleap/qc/features/pose_split.py
@@ -169,9 +169,7 @@ def compute_pose_split_fallback(
     # (nearest pair of points from opposite clusters) to the typical *within*
     # cluster spacing. For two genuine blobs the boundary gap dominates; for a
     # uniform spread they are comparable.
-    cross = np.linalg.norm(
-        pts_a[:, None, :] - pts_b[None, :, :], axis=2
-    )
+    cross = np.linalg.norm(pts_a[:, None, :] - pts_b[None, :, :], axis=2)
     boundary_gap = float(cross.min())
 
     within = _typical_within_spacing(pts_a, pts_b)
@@ -243,9 +241,7 @@ def _silhouette_like(pts_a: np.ndarray, pts_b: np.ndarray) -> float:
         for k in range(len(own)):
             p = own[k]
             if len(own) > 1:
-                a = float(
-                    np.sum(np.linalg.norm(own - p, axis=1)) / (len(own) - 1)
-                )
+                a = float(np.sum(np.linalg.norm(own - p, axis=1)) / (len(own) - 1))
             else:
                 a = 0.0
             b = float(np.mean(np.linalg.norm(other - p, axis=1)))
@@ -427,8 +423,10 @@ def compute_pose_split(
     # many leaves) cannot be split into two balanced clusters by cutting one
     # edge, and very few internal edges also make the bridging test unreliable.
     # In those cases, defer to the geometry-only fallback.
-    if best_edge is None or len(visible_edges) < 2 or _is_star_like(
-        visible_edges, vis_idx
+    if (
+        best_edge is None
+        or len(visible_edges) < 2
+        or _is_star_like(visible_edges, vis_idx)
     ):
         return compute_pose_split_fallback(points, min_visible=min_visible)
 

--- a/sleap/qc/features/pose_split.py
+++ b/sleap/qc/features/pose_split.py
@@ -1,0 +1,499 @@
+"""Pose-split (chimera) features.
+
+A *chimera* is a single labeled instance whose keypoints actually span two
+different animals: e.g. the head/thorax of animal A connected to the abdomen of
+animal B. This typically shows up as a skeleton that is internally consistent in
+two tight clusters joined by a single, abnormally stretched "bridging" edge.
+
+This module provides a pure function :func:`compute_pose_split` that scores how
+chimera-like a single pose is. It is deliberately argument-driven (points,
+adjacency, learned edge-length stats) so it can be unit-tested in isolation and
+so the detector's already-computed baseline statistics can be reused.
+
+The primary signal is graph-based:
+
+1. On the subgraph induced by the *visible* nodes, find the connected bridging
+   edge whose normalized length z-score ``z = (len - mean) / std`` is largest.
+2. Cut that edge. If the visible subgraph splits cleanly into two components,
+   measure how *balanced* the split is (``split_ratio = smaller / total``).
+3. Measure how far apart the two clusters sit relative to their own internal
+   spread (``gap_ratio``). A real chimera has two compact clusters separated by
+   a wide gap.
+
+A high ``split_score`` requires *all three* (large bridging z, balanced split,
+large gap). This gating is what keeps it from firing on a normal pose or on a
+partially-occluded single animal (whose visible subgraph is merely disconnected
+without an abnormally long bridging edge).
+
+For skeletons where the graph signal is weak or unavailable (star skeletons,
+very short skeletons, or missing adjacency), a skeleton-agnostic 2-means
+bimodality :func:`compute_pose_split_fallback` is used instead.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+# Minimum number of visible nodes required for a meaningful split analysis.
+# With fewer points a "split" is not distinguishable from a normal small pose.
+MIN_VISIBLE_NODES = 4
+
+# Floors to keep ratios finite/stable.
+_EPS = 1e-9
+
+
+def _visible_mask(points: np.ndarray) -> np.ndarray:
+    """Return a boolean (N_nodes,) mask of visible (non-NaN) nodes."""
+    return ~np.isnan(points).any(axis=1)
+
+
+def _cluster_spread(points: np.ndarray, indices: np.ndarray) -> float:
+    """Mean distance of a cluster's points to their centroid.
+
+    Args:
+        points: (N_nodes, 2) coordinate array (may contain NaN).
+        indices: 1-D array of node indices belonging to the cluster.
+
+    Returns:
+        Mean radial spread of the cluster. ``0.0`` for a single-point cluster.
+    """
+    pts = points[indices]
+    if len(pts) < 2:
+        return 0.0
+    centroid = pts.mean(axis=0)
+    return float(np.mean(np.linalg.norm(pts - centroid, axis=1)))
+
+
+def _components_after_cut(
+    nodes: list[int],
+    edges: list[tuple[int, int]],
+    cut_edge: tuple[int, int],
+) -> list[set[int]]:
+    """Connected components of a node set after removing one edge.
+
+    A tiny union-find over the visible subgraph (so we don't require networkx
+    here and stay dependency-light, matching the pure-function contract).
+
+    Args:
+        nodes: Node indices present in the subgraph.
+        edges: Undirected edges (i, j) within the subgraph.
+        cut_edge: The edge to remove, as a sorted (i, j) tuple.
+
+    Returns:
+        List of components, each a set of node indices.
+    """
+    parent = {n: n for n in nodes}
+
+    def find(x: int) -> int:
+        root = x
+        while parent[root] != root:
+            root = parent[root]
+        # Path compression.
+        while parent[x] != root:
+            parent[x], x = root, parent[x]
+        return root
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for i, j in edges:
+        if tuple(sorted((i, j))) == cut_edge:
+            continue
+        union(i, j)
+
+    groups: dict[int, set[int]] = {}
+    for n in nodes:
+        groups.setdefault(find(n), set()).add(n)
+    return list(groups.values())
+
+
+def compute_pose_split_fallback(
+    points: np.ndarray,
+    min_visible: int = MIN_VISIBLE_NODES,
+) -> dict[str, float]:
+    """Skeleton-agnostic 2-means bimodality fallback.
+
+    Used for star/short skeletons or when adjacency is unavailable. Splits the
+    visible nodes into two clusters with 2-means and reports a silhouette-like
+    separation score. This intentionally ignores skeleton edges, so it cannot
+    use a bridging-edge z-score; the gate therefore relies entirely on geometry
+    (balanced split + wide gap).
+
+    Args:
+        points: (N_nodes, 2) coordinate array (NaN for invisible nodes).
+        min_visible: Minimum visible nodes required to attempt a split.
+
+    Returns:
+        Dictionary with keys ``split_score``, ``split_ratio``, ``gap_ratio``
+        (all floats, ``split_score >= 0``).
+    """
+    zero = {"split_score": 0.0, "split_ratio": 0.0, "gap_ratio": 0.0}
+
+    vis = _visible_mask(points)
+    vis_idx = np.where(vis)[0]
+    n_vis = len(vis_idx)
+    if n_vis < min_visible:
+        return dict(zero)
+
+    coords = points[vis_idx]
+
+    # 2-means via KMeans (deterministic seeding for test stability).
+    try:
+        from sklearn.cluster import KMeans
+
+        km = KMeans(n_clusters=2, n_init=10, random_state=0)
+        labels = km.fit_predict(coords)
+    except Exception:
+        return dict(zero)
+
+    idx_a = vis_idx[labels == 0]
+    idx_b = vis_idx[labels == 1]
+    if len(idx_a) == 0 or len(idx_b) == 0:
+        return dict(zero)
+
+    n_small = min(len(idx_a), len(idx_b))
+    split_ratio = n_small / n_vis
+
+    pts_a = points[idx_a]
+    pts_b = points[idx_b]
+
+    # Bimodality via a boundary-gap test rather than a centroid-distance test.
+    # A *uniformly* spread pose (e.g. an evenly spaced line) trivially splits in
+    # half with a large centroid distance, so centroid distance alone gives
+    # false positives. Instead compare the gap *across the cluster boundary*
+    # (nearest pair of points from opposite clusters) to the typical *within*
+    # cluster spacing. For two genuine blobs the boundary gap dominates; for a
+    # uniform spread they are comparable.
+    cross = np.linalg.norm(
+        pts_a[:, None, :] - pts_b[None, :, :], axis=2
+    )
+    boundary_gap = float(cross.min())
+
+    within = _typical_within_spacing(pts_a, pts_b)
+    gap_ratio = boundary_gap / max(within, _EPS)
+
+    # Silhouette-like separation: how much closer points are to their own
+    # cluster than to the other. ~1 for well-separated blobs, ~0 for a uniform
+    # spread that was split arbitrarily.
+    silhouette = _silhouette_like(pts_a, pts_b)
+
+    split_score = _combine_score(
+        bridge_z=gap_ratio,  # No edge z available; use gap as the strength term.
+        split_ratio=split_ratio,
+        gap_ratio=gap_ratio,
+        is_fallback=True,
+        silhouette=silhouette,
+    )
+
+    return {
+        "split_score": float(split_score),
+        "split_ratio": float(split_ratio),
+        "gap_ratio": float(gap_ratio),
+    }
+
+
+def _typical_within_spacing(pts_a: np.ndarray, pts_b: np.ndarray) -> float:
+    """Typical nearest-neighbor spacing within clusters.
+
+    For each cluster with >= 2 points, take each point's distance to its
+    nearest same-cluster neighbor; the typical (median) of those is the
+    "within" scale. Used to normalize the boundary gap.
+
+    Args:
+        pts_a: (Na, 2) points of cluster A.
+        pts_b: (Nb, 2) points of cluster B.
+
+    Returns:
+        Median within-cluster nearest-neighbor distance (>= 0).
+    """
+    nn_dists: list[float] = []
+    for pts in (pts_a, pts_b):
+        if len(pts) < 2:
+            continue
+        d = np.linalg.norm(pts[:, None, :] - pts[None, :, :], axis=2)
+        np.fill_diagonal(d, np.inf)
+        nn_dists.extend(d.min(axis=1).tolist())
+    if not nn_dists:
+        return 0.0
+    return float(np.median(nn_dists))
+
+
+def _silhouette_like(pts_a: np.ndarray, pts_b: np.ndarray) -> float:
+    """Mean silhouette coefficient for a 2-cluster split (simplified).
+
+    For each point, ``s = (b - a) / max(a, b)`` where ``a`` is the mean
+    distance to other points in its own cluster and ``b`` is the mean distance
+    to the other cluster. Ranges in [-1, 1]; ~1 means tight, well-separated
+    clusters; ~0 means the split is arbitrary (uniform data).
+
+    Args:
+        pts_a: (Na, 2) points of cluster A.
+        pts_b: (Nb, 2) points of cluster B.
+
+    Returns:
+        Mean silhouette coefficient over all points.
+    """
+    scores: list[float] = []
+    for own, other in ((pts_a, pts_b), (pts_b, pts_a)):
+        for k in range(len(own)):
+            p = own[k]
+            if len(own) > 1:
+                a = float(
+                    np.sum(np.linalg.norm(own - p, axis=1)) / (len(own) - 1)
+                )
+            else:
+                a = 0.0
+            b = float(np.mean(np.linalg.norm(other - p, axis=1)))
+            denom = max(a, b)
+            scores.append((b - a) / denom if denom > _EPS else 0.0)
+    return float(np.mean(scores)) if scores else 0.0
+
+
+def _balance_factor(split_ratio: float) -> float:
+    """Map split_ratio to a 0..1 balance weight peaking in [0.3, 0.5].
+
+    A genuine chimera divides the keypoints into two non-trivial groups. A
+    ratio near 0.5 is perfectly balanced; near 0 means one stray node (the
+    occlusion / mislabel-of-a-single-node case, which we do *not* want to flag
+    as a chimera). The factor is 0 below ~0.18 and ramps to 1 by ~0.3.
+
+    Args:
+        split_ratio: smaller_cluster_size / total_visible (in [0, 0.5]).
+
+    Returns:
+        Weight in [0, 1].
+    """
+    lo, hi = 0.18, 0.30
+    if split_ratio <= lo:
+        return 0.0
+    if split_ratio >= hi:
+        return 1.0
+    return (split_ratio - lo) / (hi - lo)
+
+
+# Minimum mean-silhouette for the fallback to treat a split as truly bimodal.
+# A uniformly spread pose split in half scores well below this.
+_FALLBACK_SILHOUETTE_FLOOR = 0.5
+
+
+def _combine_score(
+    bridge_z: float,
+    split_ratio: float,
+    gap_ratio: float,
+    is_fallback: bool = False,
+    silhouette: float = 1.0,
+) -> float:
+    """Combine the sub-signals into a gated split score.
+
+    The score is multiplicative so that *all* conditions must hold: a large
+    bridging stretch, a balanced split, and a wide gap. Any one being small
+    drives the score toward zero.
+
+    Args:
+        bridge_z: Normalized stretch of the bridging edge (or boundary-gap ratio
+            in the fallback path). Clamped at 0.
+        split_ratio: smaller / total visible nodes.
+        gap_ratio: graph path: inter-cluster distance / max intra-cluster
+            spread. Fallback path: boundary gap / within-cluster spacing.
+        is_fallback: Whether this is the geometry-only fallback path.
+        silhouette: Mean silhouette coefficient (fallback only); used to gate
+            out arbitrary splits of uniformly spread points.
+
+    Returns:
+        Non-negative split score.
+    """
+    bridge_term = max(bridge_z, 0.0)
+    balance = _balance_factor(split_ratio)
+
+    # Gap must clear a floor before it contributes (two clusters whose gap is
+    # comparable to their own internal scale are just one diffuse animal).
+    gap_floor = 1.5
+    gap_term = max(gap_ratio - gap_floor, 0.0)
+
+    if is_fallback:
+        # Geometry-only: additionally require a genuinely bimodal split so we do
+        # not fire on uniformly spread points (which 2-means always halves with
+        # a large centroid gap but a near-zero silhouette).
+        if silhouette < _FALLBACK_SILHOUETTE_FLOOR:
+            return 0.0
+        return float(balance * gap_term)
+
+    return float(bridge_term * balance * gap_term)
+
+
+def compute_pose_split(
+    points: np.ndarray,
+    adjacency: Optional[dict[int, list[int]]],
+    edge_means: dict[tuple[int, int], float],
+    edge_stds: dict[tuple[int, int], float],
+    min_visible: int = MIN_VISIBLE_NODES,
+) -> dict[str, float]:
+    """Score how *chimera-like* a single pose is (one instance, two animals).
+
+    Operates on the subgraph induced by the visible nodes:
+
+    1. **Bridging edge.** Among visible edges with learned length stats, find
+       the one with the largest normalized stretch ``z = (len - mean) / std``.
+    2. **Balanced split.** Remove that edge; if the visible subgraph splits into
+       exactly two components, ``split_ratio = smaller / total`` measures
+       balance (ideal ~0.3-0.5).
+    3. **Gap.** ``gap_ratio = ||centroidA - centroidB|| / max(spread_A, spread_B)``
+       measures how far the clusters sit relative to their own internal spread.
+
+    The returned ``split_score`` is the *gated product* of these signals, so it
+    is only high when a long bridging edge separates two balanced, well-spaced
+    clusters. This is what prevents false positives on:
+
+    - a **normal pose** (no bridging edge with a large z; small gap_ratio),
+    - a **partially occluded** single animal (the visible subgraph may be
+      disconnected, but there is no abnormally stretched bridging edge joining
+      two balanced clusters), and
+    - two genuinely close, correctly-merged animals (small gap relative to
+      spread).
+
+    If adjacency is unavailable, or the skeleton is too star-like / short for a
+    bridging edge to be meaningful, falls back to
+    :func:`compute_pose_split_fallback` (2-means bimodality).
+
+    Args:
+        points: (N_nodes, 2) coordinate array (NaN for invisible nodes).
+        adjacency: Maps node_index -> list of neighbor indices (skeleton
+            edges). Pass ``SkeletonAnalyzer.get_adjacency()``. If ``None``, the
+            geometry-only fallback is used.
+        edge_means: Maps sorted ``(i, j)`` edge tuples -> learned mean edge
+            length (reuse ``DatasetStats.edge_means``).
+        edge_stds: Maps sorted ``(i, j)`` edge tuples -> learned edge-length std
+            (reuse ``DatasetStats.edge_stds``). Values should be floored away
+            from zero by the caller (the baseline extractor already does this).
+        min_visible: Minimum visible nodes required to attempt a split.
+
+    Returns:
+        Dictionary with:
+
+        - ``split_score``: non-negative chimera score (0 = not a chimera; the
+          integration layer thresholds this, e.g. on the training distribution).
+        - ``split_ratio``: smaller-cluster fraction of visible nodes (0..0.5).
+        - ``gap_ratio``: inter-cluster distance / max intra-cluster spread.
+    """
+    zero = {"split_score": 0.0, "split_ratio": 0.0, "gap_ratio": 0.0}
+
+    vis = _visible_mask(points)
+    vis_idx = set(np.where(vis)[0].tolist())
+    n_vis = len(vis_idx)
+
+    # Too few visible nodes -> not analyzable.
+    if n_vis < min_visible:
+        return dict(zero)
+
+    # No adjacency -> geometry-only fallback.
+    if not adjacency:
+        return compute_pose_split_fallback(points, min_visible=min_visible)
+
+    # Build the visible subgraph's edge list with z-scores, deduplicating
+    # undirected edges via sorted tuples.
+    visible_edges: list[tuple[int, int]] = []
+    seen: set[tuple[int, int]] = set()
+    best_z = -np.inf
+    best_edge: Optional[tuple[int, int]] = None
+
+    for node, neighbors in adjacency.items():
+        if node not in vis_idx:
+            continue
+        for nb in neighbors:
+            if nb not in vis_idx:
+                continue
+            key = tuple(sorted((int(node), int(nb))))
+            if key in seen:
+                continue
+            seen.add(key)
+            visible_edges.append(key)
+
+            mean = edge_means.get(key)
+            std = edge_stds.get(key)
+            if mean is None or std is None:
+                continue
+            length = float(np.linalg.norm(points[key[1]] - points[key[0]]))
+            z = (length - mean) / max(std, _EPS)
+            if z > best_z:
+                best_z = z
+                best_edge = key
+
+    # Decide whether the graph signal is usable. A star skeleton (a hub with
+    # many leaves) cannot be split into two balanced clusters by cutting one
+    # edge, and very few internal edges also make the bridging test unreliable.
+    # In those cases, defer to the geometry-only fallback.
+    if best_edge is None or len(visible_edges) < 2 or _is_star_like(
+        visible_edges, vis_idx
+    ):
+        return compute_pose_split_fallback(points, min_visible=min_visible)
+
+    nodes_list = sorted(vis_idx)
+    components = _components_after_cut(nodes_list, visible_edges, best_edge)
+
+    # We require the cut to produce exactly two components (a clean bridge). If
+    # the subgraph was already disconnected (occlusion) the cut yields >2
+    # components; if the edge was redundant (a cycle) it yields 1. Either way it
+    # is not a clean chimera bridge.
+    if len(components) != 2:
+        return dict(zero)
+
+    comp_a, comp_b = components
+    idx_a = np.array(sorted(comp_a))
+    idx_b = np.array(sorted(comp_b))
+
+    n_small = min(len(idx_a), len(idx_b))
+    split_ratio = n_small / n_vis
+
+    centroid_a = points[idx_a].mean(axis=0)
+    centroid_b = points[idx_b].mean(axis=0)
+    gap = float(np.linalg.norm(centroid_a - centroid_b))
+
+    spread_a = _cluster_spread(points, idx_a)
+    spread_b = _cluster_spread(points, idx_b)
+    max_spread = max(spread_a, spread_b)
+    gap_ratio = gap / max(max_spread, _EPS)
+
+    split_score = _combine_score(
+        bridge_z=best_z,
+        split_ratio=split_ratio,
+        gap_ratio=gap_ratio,
+        is_fallback=False,
+    )
+
+    return {
+        "split_score": float(split_score),
+        "split_ratio": float(split_ratio),
+        "gap_ratio": float(gap_ratio),
+    }
+
+
+def _is_star_like(edges: list[tuple[int, int]], vis_idx: set[int]) -> bool:
+    """Heuristic: is the visible subgraph a star (one hub, many leaves)?
+
+    A star cannot be split into two balanced clusters by removing a single
+    edge, so the bridging-edge test is meaningless and we should fall back to
+    geometry. We call the subgraph star-like when a single node touches almost
+    all edges.
+
+    Args:
+        edges: Undirected edges within the visible subgraph.
+        vis_idx: Set of visible node indices.
+
+    Returns:
+        True if the subgraph looks like a star.
+    """
+    if len(vis_idx) < 4 or len(edges) == 0:
+        return False
+    degree: dict[int, int] = {}
+    for i, j in edges:
+        degree[i] = degree.get(i, 0) + 1
+        degree[j] = degree.get(j, 0) + 1
+    max_deg = max(degree.values())
+    # If one hub touches (n_visible - 1) edges, it's a pure star. Allow one
+    # extra edge of slack for near-stars.
+    return max_deg >= (len(vis_idx) - 1) and max_deg >= len(edges) - 1

--- a/sleap/qc/frame_level.py
+++ b/sleap/qc/frame_level.py
@@ -165,7 +165,8 @@ def compute_node_overlap(
         Dictionary with:
         - common_nodes: list of node indices visible in both
         - overlapping_nodes: list of nodes within threshold
-        - mean_distance: mean distance at common nodes
+        - mean_distance / min_distance / max_distance: distance stats at common
+          nodes (all ``inf`` when there are no commonly visible nodes)
         - overlap_ratio: overlapping_nodes / common_nodes
     """
     # Find commonly visible nodes
@@ -179,6 +180,8 @@ def compute_node_overlap(
             "common_nodes": [],
             "overlapping_nodes": [],
             "mean_distance": float("inf"),
+            "min_distance": float("inf"),
+            "max_distance": float("inf"),
             "overlap_ratio": 0.0,
         }
 

--- a/sleap/qc/frame_level.py
+++ b/sleap/qc/frame_level.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 import numpy as np
 
+from sleap.qc.features.duplicate_split import compute_split_duplicate, duplicate_score
+
 
 class InstanceCountChecker:
     """Detect frames with unusual instance counts (incomplete annotation).
@@ -209,23 +211,40 @@ def detect_duplicates(
     iou_threshold: float = 0.5,
     node_distance_threshold: float = 10.0,
     node_overlap_ratio: float = 0.8,
+    edge_means: Optional[dict] = None,
+    duplicate_score_threshold: float = 0.5,
 ) -> list[dict]:
     """Detect duplicate instances in a frame.
 
-    Uses both IOU and node-wise overlap to catch partial duplicates.
+    Uses three complementary signals: bbox IOU and node-wise overlap (both catch
+    overlapping copies), plus the complementary split-duplicate signal (one
+    animal split across two instances labeled on largely disjoint nodes). The
+    three are combined by :func:`~sleap.qc.features.duplicate_split.duplicate_score`
+    into a single graded confidence.
+
+    A pair is flagged when the combined ``dscore >= duplicate_score_threshold``
+    OR the existing IOU / node-overlap criteria fire, so this remains additive
+    and never drops a pair the previous logic would have flagged.
 
     Args:
         instances: List of (N_nodes, 2) arrays.
         iou_threshold: IOU above this = duplicate.
         node_distance_threshold: Distance for node overlap.
         node_overlap_ratio: Min overlap ratio to flag as duplicate.
+        edge_means: Optional learned mean edge lengths (sorted ``(i, j)`` ->
+            length) used to scale the split-duplicate signal. ``None`` falls
+            back to the bbox-diagonal scale inside ``compute_split_duplicate``.
+        duplicate_score_threshold: Combined-score cutoff at/above which a pair is
+            flagged as a duplicate.
 
     Returns:
         List of duplicate pair dictionaries with:
         - index_a, index_b: instance indices
         - iou: IOU value
         - node_overlap: node overlap info
-        - reason: "iou" or "node_overlap"
+        - split_duplicate_score: complementary-split signal (0-1)
+        - duplicate_score: combined graded confidence (0-1)
+        - reason: "iou", "node_overlap", or "split_duplicate"
     """
     duplicates = []
     n_instances = len(instances)
@@ -236,6 +255,11 @@ def detect_duplicates(
             node_overlap = compute_node_overlap(
                 instances[i], instances[j], node_distance_threshold
             )
+
+            sd = compute_split_duplicate(
+                instances[i], instances[j], edge_means
+            )["split_duplicate_score"]
+            dscore = duplicate_score(iou, node_overlap["overlap_ratio"], sd)
 
             is_duplicate = False
             reason = None
@@ -253,6 +277,12 @@ def detect_duplicates(
                 is_duplicate = True
                 reason = "node_overlap"
 
+            # Check the combined/split signal (catches complementary splits that
+            # neither IOU nor node-overlap fire on).
+            elif dscore >= duplicate_score_threshold:
+                is_duplicate = True
+                reason = "split_duplicate"
+
             if is_duplicate:
                 duplicates.append(
                     {
@@ -260,6 +290,8 @@ def detect_duplicates(
                         "index_b": j,
                         "iou": iou,
                         "node_overlap": node_overlap,
+                        "split_duplicate_score": sd,
+                        "duplicate_score": dscore,
                         "reason": reason,
                     }
                 )

--- a/sleap/qc/frame_level.py
+++ b/sleap/qc/frame_level.py
@@ -256,9 +256,9 @@ def detect_duplicates(
                 instances[i], instances[j], node_distance_threshold
             )
 
-            sd = compute_split_duplicate(
-                instances[i], instances[j], edge_means
-            )["split_duplicate_score"]
+            sd = compute_split_duplicate(instances[i], instances[j], edge_means)[
+                "split_duplicate_score"
+            ]
             dscore = duplicate_score(iou, node_overlap["overlap_ratio"], sd)
 
             is_duplicate = False

--- a/sleap/qc/results.py
+++ b/sleap/qc/results.py
@@ -25,6 +25,11 @@ class FrameKey(NamedTuple):
     frame_idx: int
 
 
+# Human-readable labels for channel-only issues (scored outside the GMM and
+# merged into get_flagged). Keyed by channel name.
+CHANNEL_ISSUE_LABELS = {"missing_node": "Missing labelable node"}
+
+
 @dataclass
 class FrameQC:
     """Quality check results for a single frame."""
@@ -34,6 +39,8 @@ class FrameQC:
     actual_instance_count: int = 0
     duplicate_pairs: list[tuple[int, int]] = field(default_factory=list)
     duplicate_reasons: list[str] = field(default_factory=list)
+    # Combined duplicate confidence (0-1) parallel to duplicate_pairs/reasons.
+    duplicate_scores: list[float] = field(default_factory=list)
     is_negative_with_instances: bool = False
 
 
@@ -73,6 +80,12 @@ class QCResults:
         frame_results: Mapping from frame key to frame-level QC results.
         feature_contributions: Mapping from instance key to per-feature scores.
         feature_names: List of feature names used.
+        forced_issues: Mapping from instance key to a forced top-issue label set
+            by a detector hard rule (e.g. "Whole-instance L/R flip"). Takes
+            precedence over inferred/channel issues in ``get_flagged``.
+        channel_scores: Mapping from channel name (e.g. "missing_node") to a
+            ``{InstanceKey: float}`` of per-instance scores produced outside the
+            GMM. Merged with the GMM score in ``get_flagged``.
     """
 
     instance_scores: dict[InstanceKey, float] = field(default_factory=dict)
@@ -81,37 +94,76 @@ class QCResults:
         default_factory=dict
     )
     feature_names: list[str] = field(default_factory=list)
+    forced_issues: dict[InstanceKey, str] = field(default_factory=dict)
+    channel_scores: dict[str, dict[InstanceKey, float]] = field(default_factory=dict)
 
     def get_flagged(self, threshold: float = 0.7) -> list[QCFlag]:
         """Get instances flagged above threshold.
 
+        Merges the GMM-based ``instance_scores`` with any per-channel scores
+        (e.g. the missing-node channel) scored outside the GMM: the final score
+        for an instance is the max of its GMM score and its best channel score.
+        An instance can therefore be flagged purely on a channel even if it had
+        no GMM score (its ``feature_contributions`` may be absent, in which case
+        an empty dict is used safely).
+
         Args:
-            threshold: Score threshold (0-1). Instances with scores >= threshold
-                are flagged.
+            threshold: Score threshold (0-1). Instances with a final score
+                >= threshold are flagged.
 
         Returns:
             List of QCFlag objects, sorted by score descending.
         """
-        flagged = []
-        for key, score in self.instance_scores.items():
-            if score >= threshold:
-                contributions = self.feature_contributions.get(key, {})
-                top_issue = self._infer_top_issue(contributions)
-                confidence = self._get_confidence(score, contributions)
-                explanation = self._generate_explanation(
-                    score, top_issue, contributions
-                )
+        # Union of all keys: GMM-scored instances plus any channel-only ones.
+        keys = set(self.instance_scores)
+        for channel in self.channel_scores.values():
+            keys.update(channel)
 
-                flagged.append(
-                    QCFlag(
-                        instance_key=key,
-                        score=score,
-                        confidence=confidence,
-                        top_issue=top_issue,
-                        feature_contributions=contributions,
-                        explanation=explanation,
-                    )
+        flagged = []
+        for key in keys:
+            gmm_score = self.instance_scores.get(key, 0.0)
+
+            # Best channel score (and which channel won) for this key.
+            chan = float("-inf")
+            winning_channel = None
+            for channel_name, channel in self.channel_scores.items():
+                value = channel.get(key)
+                if value is not None and value > chan:
+                    chan = value
+                    winning_channel = channel_name
+
+            final = max(gmm_score, chan)
+            if final < threshold:
+                continue
+
+            contributions = self.feature_contributions.get(key, {})
+
+            # Top-issue precedence: a forced hard-rule issue wins; otherwise, if
+            # a channel out-scored the GMM, use that channel's label; otherwise
+            # infer from feature contributions.
+            forced = self.forced_issues.get(key)
+            if forced is not None:
+                top_issue = forced
+            elif winning_channel is not None and chan > gmm_score:
+                top_issue = CHANNEL_ISSUE_LABELS.get(
+                    winning_channel, f"High {winning_channel}"
                 )
+            else:
+                top_issue = self._infer_top_issue(contributions)
+
+            confidence = self._get_confidence(final, contributions)
+            explanation = self._generate_explanation(final, top_issue, contributions)
+
+            flagged.append(
+                QCFlag(
+                    instance_key=key,
+                    score=final,
+                    confidence=confidence,
+                    top_issue=top_issue,
+                    feature_contributions=contributions,
+                    explanation=explanation,
+                )
+            )
 
         # Sort by score descending
         flagged.sort(key=lambda f: f.score, reverse=True)

--- a/tests/qc/test_b1_integration.py
+++ b/tests/qc/test_b1_integration.py
@@ -1,0 +1,708 @@
+"""Integration tests for the B1 detector wiring in LabelQCDetector.
+
+These cover the five detector modules (chirality, pose-split, chain-ordering,
+missing-node, split-duplicate) once they are wired into the detector scaffold:
+
+- the fixed-width feature vector (width invariance under config toggles),
+- the positional coupling between ``_extract_features`` and
+  ``V3_FEATURE_NAMES`` (contributions must map to the right names),
+- end-to-end flagging via the forced hard rules (flip, chain order),
+- the GMM-feature path for the chimera detector,
+- the missing-node channel surfacing through ``QCResults.get_flagged``, and
+- the complementary-split signal in frame-level duplicate detection.
+
+Note on GMM scores: for the small synthetic datasets used here the GMM's
+percentile-normalized score is degenerate (most instances saturate at ~1.0),
+exactly as in the existing ``test_detector`` suite. These tests therefore assert
+on the *forced* hard-rule issues, on the raw feature values, and on the channel
+merge -- none of which depend on the GMM cleanly separating instances by score.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import sleap_io as sio
+from sleap_io import LabeledFrame
+from sleap_io.model.instance import Instance
+
+from sleap.qc import LabelQCDetector, QCConfig, QCResults
+from sleap.qc.detector import V3_FEATURE_NAMES
+from sleap.qc.features.baseline import BASELINE_FEATURE_NAMES
+from sleap.qc.features.chirality import (
+    compute_chirality,
+    infer_symmetry_pairs_by_name,
+)
+from sleap.qc.features.pose_split import compute_pose_split
+from sleap.qc.features.ordering import compute_chain_ordering
+from sleap.qc.frame_level import detect_duplicates
+from sleap.qc.results import CHANNEL_ISSUE_LABELS, FrameKey, InstanceKey
+
+
+# ---------------------------------------------------------------------------
+# Skeleton / pose fixtures
+# ---------------------------------------------------------------------------
+#
+# Quadruped midline-chain skeleton. The longest path (the SkeletonAnalyzer
+# "spine") runs nose -> ... -> tailtip, so the chirality axis nodes
+# (spine[0], spine[-1]) are the true body midline endpoints, and there are two
+# symmetric pairs (ear_L/R, hip_L/R) -- enough for compute_chirality's
+# min_pairs=2. Symmetry is left UNdefined on the skeleton so the detector must
+# infer it from the _L/_R node names.
+QUAD_NAMES = [
+    "nose",
+    "head",
+    "spine1",
+    "spine2",
+    "tailbase",
+    "tailtip",
+    "ear_L",
+    "ear_R",
+    "hip_L",
+    "hip_R",
+]
+
+QUAD_CANONICAL = np.array(
+    [
+        [0.0, 20.0],  # nose
+        [0.0, 16.0],  # head
+        [0.0, 11.0],  # spine1
+        [0.0, 6.0],  # spine2
+        [0.0, 2.0],  # tailbase
+        [0.0, -2.0],  # tailtip
+        [-3.0, 16.0],  # ear_L
+        [3.0, 16.0],  # ear_R
+        [-3.0, 2.0],  # hip_L
+        [3.0, 2.0],  # hip_R
+    ],
+    dtype=float,
+)
+
+
+def _quad_skeleton() -> sio.Skeleton:
+    # sio.Skeleton mutates the names list in place (strings -> Node objects), so
+    # pass a copy to keep the shared QUAD_NAMES constant pristine for tests that
+    # use it directly (e.g. name-based symmetry inference).
+    skel = sio.Skeleton(list(QUAD_NAMES))
+    skel.add_edges(
+        [
+            ("nose", "head"),
+            ("head", "spine1"),
+            ("spine1", "spine2"),
+            ("spine2", "tailbase"),
+            ("tailbase", "tailtip"),
+            ("head", "ear_L"),
+            ("head", "ear_R"),
+            ("tailbase", "hip_L"),
+            ("tailbase", "hip_R"),
+        ]
+    )
+    return skel
+
+
+def _line_skeleton(n: int = 6) -> sio.Skeleton:
+    """A simple ``n``-node line graph 0-1-...-(n-1) (tail-like chain)."""
+    names = [f"n{i}" for i in range(n)]  # fresh list each call (safe to mutate)
+    skel = sio.Skeleton(names)
+    skel.add_edges([(f"n{i}", f"n{i + 1}") for i in range(n - 1)])
+    return skel
+
+
+def _line_base(n: int = 6, spacing: float = 10.0) -> np.ndarray:
+    return np.array([[i * spacing, 0.0] for i in range(n)], dtype=float)
+
+
+def _mirror_x(points: np.ndarray) -> np.ndarray:
+    """Whole-instance left/right mirror flip about the x = 0 midline."""
+    out = points.copy()
+    out[:, 0] *= -1.0
+    return out
+
+
+def _labels_from_poses(
+    skeleton: sio.Skeleton, poses: list[np.ndarray]
+) -> sio.Labels:
+    """Build a single-video Labels with one instance per frame."""
+    video = sio.Video.from_filename("test_video.mp4")
+    labels = sio.Labels()
+    for frame_idx, pts in enumerate(poses):
+        inst = Instance.from_numpy(pts, skeleton=skeleton)
+        labels.append(LabeledFrame(video=video, frame_idx=frame_idx, instances=[inst]))
+    return labels
+
+
+# ---------------------------------------------------------------------------
+# Width invariance
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureWidthInvariance:
+    """The fitted feature vector must always be the same fixed width."""
+
+    EXPECTED_WIDTH = 22  # 12 baseline + 10 v3 (incl. the 4 B1 features).
+
+    def test_feature_names_width(self):
+        """feature_names == 12 baseline + 10 v3 == 22."""
+        assert len(BASELINE_FEATURE_NAMES) == 12
+        assert len(V3_FEATURE_NAMES) == 10
+        total = len(BASELINE_FEATURE_NAMES) + len(V3_FEATURE_NAMES)
+        assert total == self.EXPECTED_WIDTH
+
+    def test_v3_feature_order_is_pinned(self):
+        """The B1 names append after hull_compactness in the documented order."""
+        assert V3_FEATURE_NAMES == [
+            "max_curvature",
+            "curvature_std",
+            "visibility_pattern_score",
+            "nn_distance",
+            "hull_area_zscore",
+            "hull_compactness",
+            "chirality_wrong_fraction",
+            "pose_split_score",
+            "order_inversion_rate",
+            "chain_intersection_count",
+        ]
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            QCConfig(),  # defaults: reliable ON, experimental OFF
+            QCConfig(use_chirality=True),
+            QCConfig(use_chirality=False),
+            QCConfig(use_split_detection=False),
+            QCConfig(use_chain_ordering=True),
+            QCConfig(use_missing_node_check=True),
+            QCConfig(
+                use_chirality=True,
+                use_split_detection=True,
+                use_chain_ordering=True,
+                use_missing_node_check=True,
+            ),
+        ],
+    )
+    def test_extracted_vector_matches_feature_names(self, config):
+        """fit() + a single _extract_features always yield width-22 vectors.
+
+        Holds for the default config and with every experimental flag toggled.
+        """
+        skel = _quad_skeleton()
+        rng = np.random.default_rng(0)
+        poses = [
+            QUAD_CANONICAL + rng.normal(0, 0.3, size=QUAD_CANONICAL.shape)
+            for _ in range(60)
+        ]
+        detector = LabelQCDetector(config)
+        detector.fit(_labels_from_poses(skel, poses))
+
+        assert len(detector.feature_names) == self.EXPECTED_WIDTH
+        feats = detector._extract_features(QUAD_CANONICAL)
+        assert feats.shape == (self.EXPECTED_WIDTH,)
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            QCConfig(),
+            QCConfig(use_chirality=True),
+            QCConfig(use_chain_ordering=True),
+            QCConfig(use_missing_node_check=True),
+        ],
+    )
+    def test_fit_and_score_round_trip(self, config):
+        """fit() then score() works under default and experimental configs."""
+        skel = _quad_skeleton()
+        rng = np.random.default_rng(1)
+        poses = [
+            QUAD_CANONICAL + rng.normal(0, 0.3, size=QUAD_CANONICAL.shape)
+            for _ in range(60)
+        ]
+        labels = _labels_from_poses(skel, poses)
+        detector = LabelQCDetector(config)
+        detector.fit(labels)
+        results = detector.score(labels)
+
+        assert len(results.instance_scores) == 60
+        # Every contribution dict is exactly the fixed feature width and holds
+        # only finite floats (the forced marker is popped before storage).
+        for contributions in results.feature_contributions.values():
+            assert len(contributions) == self.EXPECTED_WIDTH
+            assert "_forced_top_issue" not in contributions
+            assert all(np.isfinite(v) for v in contributions.values())
+
+
+# ---------------------------------------------------------------------------
+# Positional contribution mapping (order coupling guard)
+# ---------------------------------------------------------------------------
+
+
+class TestPositionalContributionMapping:
+    """Each new contribution must equal the independently-computed module value."""
+
+    def test_contributions_match_module_outputs(self):
+        """For a known instance, the B1 contributions equal the module values.
+
+        This guards the order coupling between the append order in
+        ``_extract_features`` and the name order in ``V3_FEATURE_NAMES``: if the
+        two ever drift, the contribution under a name would no longer equal the
+        value that name's module produces.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(2)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        labels = _labels_from_poses(skel, poses)
+
+        # Turn on chain ordering so order_inversion_rate / chain_intersection
+        # are exercised on the genuine module path (not the 0.0 default).
+        config = QCConfig(use_chain_ordering=True)
+        detector = LabelQCDetector(config)
+        detector.fit(labels)
+
+        # A swapped-tail instance has a non-trivial value for several channels.
+        probe = base.copy()
+        probe[[2, 3]] = probe[[3, 2]]
+
+        features = detector._extract_features(probe)
+        score, contributions = detector._score_instance(features)
+
+        # (d) chimera / pose-split: log1p(raw split_score).
+        raw_ps = compute_pose_split(
+            probe,
+            detector._adjacency,
+            detector.baseline_extractor.stats.edge_means,
+            detector.baseline_extractor.stats.edge_stds,
+        )["split_score"]
+        assert contributions["pose_split_score"] == pytest.approx(
+            float(np.log1p(max(raw_ps, 0.0)))
+        )
+
+        # (b) chain ordering: order_inversion_rate + chain_intersection_count.
+        ord_result = compute_chain_ordering(
+            probe,
+            detector._ordering_chains,
+            max_turn_angle=np.deg2rad(config.chain_turn_angle_deg),
+        )
+        assert contributions["order_inversion_rate"] == pytest.approx(
+            ord_result["order_inversion_rate"]
+        )
+        assert contributions["chain_intersection_count"] == pytest.approx(
+            float(ord_result["chain_intersection_count"])
+        )
+
+        # The line skeleton has no symmetry, so chirality is the fixed default.
+        assert contributions["chirality_wrong_fraction"] == 0.0
+
+    def test_chirality_contribution_matches_module(self):
+        """On a symmetric skeleton the chirality contribution matches the module."""
+        skel = _quad_skeleton()
+        rng = np.random.default_rng(3)
+        poses = [
+            QUAD_CANONICAL + rng.normal(0, 0.3, size=QUAD_CANONICAL.shape)
+            for _ in range(60)
+        ]
+        detector = LabelQCDetector(QCConfig())  # auto chirality -> ON (has symmetry)
+        detector.fit(_labels_from_poses(skel, poses))
+        assert detector._chirality_model is not None
+
+        flipped = _mirror_x(QUAD_CANONICAL)
+        features = detector._extract_features(flipped)
+        _, contributions = detector._score_instance(features)
+
+        expected = compute_chirality(
+            flipped,
+            detector._symmetry_pairs,
+            detector._axis_nodes,
+            detector._chirality_model,
+        )["chirality_wrong_fraction"]
+        assert contributions["chirality_wrong_fraction"] == pytest.approx(expected)
+        # A clean whole-instance mirror flip should disagree on every pair.
+        assert expected == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Flip end-to-end (chirality, default config, name-inferred symmetry)
+# ---------------------------------------------------------------------------
+
+
+class TestFlipEndToEnd:
+    """A whole-instance mirror flip is flagged 'Whole-instance L/R flip'."""
+
+    def _flip_dataset(self):
+        skel = _quad_skeleton()
+        rng = np.random.default_rng(4)
+        poses = [
+            QUAD_CANONICAL + rng.normal(0, 0.3, size=QUAD_CANONICAL.shape)
+            for _ in range(60)
+        ]
+        flip_frame = len(poses)
+        poses.append(_mirror_x(QUAD_CANONICAL))
+        return _labels_from_poses(skel, poses), flip_frame
+
+    def test_symmetry_inferred_by_name(self):
+        """The detector infers ear/hip L-R pairs purely from node names."""
+        assert infer_symmetry_pairs_by_name(QUAD_NAMES) == [(6, 7), (8, 9)]
+
+    def test_flip_flagged_with_lr_issue(self):
+        """The flipped instance is flagged with the L/R-flip top issue."""
+        labels, flip_frame = self._flip_dataset()
+        detector = LabelQCDetector(QCConfig())  # default config
+        detector.fit(labels)
+
+        # Symmetry inferred from names; axis is the spine midline endpoints.
+        assert detector._chirality_model is not None
+        assert detector._symmetry_pairs == [(6, 7), (8, 9)]
+
+        results = detector.score(labels)
+        flip_key = InstanceKey(0, flip_frame, 0)
+
+        assert results.forced_issues.get(flip_key) == "Whole-instance L/R flip"
+        assert results.feature_contributions[flip_key][
+            "chirality_wrong_fraction"
+        ] == pytest.approx(1.0)
+
+        flagged = results.get_flagged(threshold=0.7)
+        flip_flags = [f for f in flagged if f.instance_key == flip_key]
+        assert len(flip_flags) == 1
+        assert flip_flags[0].top_issue == "Whole-instance L/R flip"
+        assert flip_flags[0].score >= 0.9
+
+        # Normal instances are never given the L/R-flip label.
+        for f in flagged:
+            if f.instance_key != flip_key:
+                assert f.top_issue != "Whole-instance L/R flip"
+
+    def test_flip_not_flagged_when_chirality_disabled(self):
+        """With use_chirality=False there is no chirality model or forced flip."""
+        labels, flip_frame = self._flip_dataset()
+        detector = LabelQCDetector(QCConfig(use_chirality=False))
+        detector.fit(labels)
+
+        assert detector._chirality_model is None
+        results = detector.score(labels)
+        flip_key = InstanceKey(0, flip_frame, 0)
+        assert flip_key not in results.forced_issues
+        # The chirality feature falls back to its fixed 0.0 default.
+        contrib = results.feature_contributions[flip_key]
+        assert contrib["chirality_wrong_fraction"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Chimera (pose-split) feature
+# ---------------------------------------------------------------------------
+
+
+class TestChimeraFeature:
+    """A split pose yields a high pose_split_score feature."""
+
+    def test_split_pose_high_feature(self):
+        """The chimera's pose_split_score far exceeds the normal-pose mean."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(5)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        # Chimera: nodes 0-2 near origin, nodes 3-5 displaced far -> one long
+        # bridging edge (n2-n3) joining two balanced, well-separated clusters.
+        chimera = base.copy()
+        chimera[3:, 0] += 200.0
+        labels = _labels_from_poses(skel, poses)
+
+        detector = LabelQCDetector(QCConfig())  # split detection ON by default
+        detector.fit(labels)
+
+        chimera_feat = detector._extract_features(chimera)
+        _, chim_contrib = detector._score_instance(chimera_feat)
+
+        normal_vals = [
+            detector._score_instance(detector._extract_features(p))[1][
+                "pose_split_score"
+            ]
+            for p in poses
+        ]
+        normal_mean = float(np.mean(normal_vals))
+
+        assert chim_contrib["pose_split_score"] > 1.0
+        assert chim_contrib["pose_split_score"] > 5 * (normal_mean + 1e-6)
+
+    def test_split_detection_off_zeroes_feature(self):
+        """With use_split_detection=False the feature is the fixed 0.0 default."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(6)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        chimera = base.copy()
+        chimera[3:, 0] += 200.0
+
+        detector = LabelQCDetector(QCConfig(use_split_detection=False))
+        detector.fit(_labels_from_poses(skel, poses))
+        _, contrib = detector._score_instance(detector._extract_features(chimera))
+        assert contrib["pose_split_score"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Chain ordering (experimental flag ON)
+# ---------------------------------------------------------------------------
+
+
+class TestChainOrdering:
+    """A swapped-tail instance is flagged 'Wrong keypoint order along chain'."""
+
+    def _swap_dataset(self, config):
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(7)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        swap_frame = len(poses)
+        swapped = base.copy()
+        swapped[[2, 3]] = swapped[[3, 2]]  # adjacent label swap
+        poses.append(swapped)
+        return skel, _labels_from_poses(skel, poses), swap_frame
+
+    def test_swapped_tail_flagged(self):
+        """With chain ordering on, the swap is force-flagged."""
+        config = QCConfig(use_chain_ordering=True)
+        _, labels, swap_frame = self._swap_dataset(config)
+        detector = LabelQCDetector(config)
+        detector.fit(labels)
+        assert detector._ordering_chains == [[0, 1, 2, 3, 4, 5]]
+
+        results = detector.score(labels)
+        swap_key = InstanceKey(0, swap_frame, 0)
+        assert results.forced_issues.get(swap_key) == "Wrong keypoint order along chain"
+
+        flagged = results.get_flagged(threshold=0.7)
+        swap_flags = [f for f in flagged if f.instance_key == swap_key]
+        assert len(swap_flags) == 1
+        assert swap_flags[0].top_issue == "Wrong keypoint order along chain"
+
+    def test_chain_ordering_off_by_default(self):
+        """Default config (chain ordering OFF) does not force the order issue."""
+        _, labels, swap_frame = self._swap_dataset(QCConfig())
+        detector = LabelQCDetector(QCConfig())  # default: use_chain_ordering=False
+        detector.fit(labels)
+        results = detector.score(labels)
+        swap_key = InstanceKey(0, swap_frame, 0)
+        assert swap_key not in results.forced_issues
+        # Feature falls back to fixed defaults.
+        contrib = results.feature_contributions[swap_key]
+        assert contrib["order_inversion_rate"] == 0.0
+        assert contrib["chain_intersection_count"] == 0.0
+
+    def test_user_defined_ordered_chains_by_name_honored(self):
+        """User-defined ordered_chains (by NAME) resolve to node indices."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(8)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+
+        # A user-declared partial chain by name (subset, reordered names).
+        config = QCConfig(
+            use_chain_ordering=True,
+            ordered_chains=[["n1", "n2", "n3", "n4"]],
+        )
+        detector = LabelQCDetector(config)
+        detector.fit(_labels_from_poses(skel, poses))
+
+        # The user-defined chain (by name) is used verbatim, overriding the
+        # auto-detected full-line chain.
+        assert detector._ordering_chains == [[1, 2, 3, 4]]
+
+
+# ---------------------------------------------------------------------------
+# Missing-node channel (experimental flag ON)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingNodeChannel:
+    """An outlier missing-node instance surfaces with 'Missing labelable node'."""
+
+    def test_detector_populates_missing_node_channel(self):
+        """The detector records a missing_node channel score for the outlier.
+
+        All training instances are fully visible, so the co-visibility column
+        for any node is ~1.0; an instance that drops node n3 then exceeds the
+        probability threshold and is recorded in channel_scores.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(11)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        outlier = base + rng.normal(0, 0.4, size=base.shape)
+        outlier[3] = np.nan  # drop a node the peers always keep
+        out_frame = len(poses)
+        poses.append(outlier)
+
+        detector = LabelQCDetector(QCConfig(use_missing_node_check=True))
+        detector.fit(_labels_from_poses(skel, poses))
+        results = detector.score(_labels_from_poses(skel, poses))
+
+        out_key = InstanceKey(0, out_frame, 0)
+        assert "missing_node" in results.channel_scores
+        chan = results.channel_scores["missing_node"]
+        assert out_key in chan
+        assert chan[out_key] >= detector.config.missing_node_prob_threshold
+
+        # Fully-visible instances are never recorded on the channel.
+        for frame_idx in range(60):
+            assert InstanceKey(0, frame_idx, 0) not in chan
+
+    def test_missing_node_check_off_by_default(self):
+        """Default config does not populate the missing_node channel."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(12)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        outlier = base + rng.normal(0, 0.4, size=base.shape)
+        outlier[3] = np.nan
+        poses.append(outlier)
+
+        detector = LabelQCDetector(QCConfig())  # missing-node check OFF
+        detector.fit(_labels_from_poses(skel, poses))
+        results = detector.score(_labels_from_poses(skel, poses))
+        assert "missing_node" not in results.channel_scores
+
+    def test_get_flagged_surfaces_missing_node_label(self):
+        """A channel-dominant key surfaces via get_flagged with the channel label.
+
+        Mirrors the documented merge: the final score is max(gmm, channel) and,
+        when the channel wins (chan > gmm), its CHANNEL_ISSUE_LABELS label is the
+        top issue. A channel-only key (no GMM score, so no feature
+        contributions) must also be handled safely.
+        """
+        results = QCResults(feature_names=["max_edge_zscore"])
+        gmm_key = InstanceKey(0, 0, 0)  # GMM-only
+        chan_only_key = InstanceKey(0, 1, 0)  # channel-only, no GMM score
+        both_key = InstanceKey(0, 2, 0)  # both, channel dominant
+
+        results.instance_scores = {gmm_key: 0.9, both_key: 0.4}
+        results.feature_contributions = {
+            gmm_key: {"max_edge_zscore": 5.0},
+            both_key: {"max_edge_zscore": 1.0},
+        }
+        results.channel_scores = {
+            "missing_node": {chan_only_key: 0.85, both_key: 0.95}
+        }
+
+        flagged = results.get_flagged(threshold=0.7)
+        by_key = {f.instance_key: f for f in flagged}
+
+        # Channel-only key: flagged on the channel, with the channel label.
+        assert chan_only_key in by_key
+        assert by_key[chan_only_key].score == pytest.approx(0.85)
+        assert by_key[chan_only_key].top_issue == CHANNEL_ISSUE_LABELS["missing_node"]
+        # Absent feature contributions are tolerated (empty dict).
+        assert by_key[chan_only_key].feature_contributions == {}
+
+        # Both present, channel wins -> channel label and the higher score.
+        assert by_key[both_key].score == pytest.approx(0.95)
+        assert by_key[both_key].top_issue == CHANNEL_ISSUE_LABELS["missing_node"]
+
+        # GMM-only key keeps its inferred (feature-based) issue.
+        assert by_key[gmm_key].top_issue != CHANNEL_ISSUE_LABELS["missing_node"]
+
+
+# ---------------------------------------------------------------------------
+# Duplicate (complementary split) at the frame level
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateSplit:
+    """A complementary split pair raises the frame-level duplicate score."""
+
+    def test_complementary_split_flagged_by_score(self):
+        """Two disjoint contiguous halves flag via the split_duplicate reason."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(13)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        detector = LabelQCDetector(QCConfig())  # use_duplicate_score ON by default
+        detector.fit(_labels_from_poses(skel, poses))
+        edge_means = detector.baseline_extractor.stats.edge_means
+
+        # Instance A labels the front half, B labels the back half; together
+        # they form one coherent animal (no shared nodes, abutting at the body).
+        inst_a = base.copy()
+        inst_a[3:] = np.nan
+        inst_b = base.copy()
+        inst_b[:3] = np.nan
+
+        # IoU/node-overlap thresholds set high so only the split signal can fire.
+        dups = detect_duplicates(
+            [inst_a, inst_b],
+            iou_threshold=0.99,
+            node_overlap_ratio=0.99,
+            edge_means=edge_means,
+            duplicate_score_threshold=0.5,
+        )
+        assert len(dups) == 1
+        assert dups[0]["reason"] == "split_duplicate"
+        assert dups[0]["duplicate_score"] >= 0.5
+        assert dups[0]["split_duplicate_score"] >= 0.5
+
+    def test_detector_records_duplicate_scores_in_frameqc(self):
+        """_check_frame stores a duplicate_score parallel to pairs/reasons."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(14)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        detector = LabelQCDetector(QCConfig())
+        detector.fit(_labels_from_poses(skel, poses))
+
+        inst_a = base.copy()
+        inst_a[3:] = np.nan
+        inst_b = base.copy()
+        inst_b[:3] = np.nan
+        video = sio.Video.from_filename("dup.mp4")
+        dup_labels = sio.Labels()
+        dup_labels.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    Instance.from_numpy(inst_a, skeleton=skel),
+                    Instance.from_numpy(inst_b, skeleton=skel),
+                ],
+            )
+        )
+        results = detector.score(dup_labels)
+        frame_qc = results.frame_results[FrameKey(0, 0)]
+
+        assert len(frame_qc.duplicate_pairs) == 1
+        # The new parallel list stays aligned with pairs/reasons.
+        assert len(frame_qc.duplicate_scores) == len(frame_qc.duplicate_pairs)
+        assert len(frame_qc.duplicate_reasons) == len(frame_qc.duplicate_pairs)
+        assert frame_qc.duplicate_reasons[0] == "split_duplicate"
+        assert frame_qc.duplicate_scores[0] >= 0.5
+
+    def test_duplicate_score_off_keeps_legacy_behavior(self):
+        """With use_duplicate_score off, the split pair is NOT flagged.
+
+        The legacy IoU + node-overlap path does not catch a complementary
+        split (disjoint nodes, near-zero IoU and node overlap), so no duplicate
+        is recorded and duplicate_scores stays empty.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(15)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        detector = LabelQCDetector(QCConfig(use_duplicate_score=False))
+        detector.fit(_labels_from_poses(skel, poses))
+
+        inst_a = base.copy()
+        inst_a[3:] = np.nan
+        inst_b = base.copy()
+        inst_b[:3] = np.nan
+        video = sio.Video.from_filename("dup.mp4")
+        dup_labels = sio.Labels()
+        dup_labels.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    Instance.from_numpy(inst_a, skeleton=skel),
+                    Instance.from_numpy(inst_b, skeleton=skel),
+                ],
+            )
+        )
+        results = detector.score(dup_labels)
+        frame_qc = results.frame_results[FrameKey(0, 0)]
+        assert frame_qc.duplicate_pairs == []
+        assert frame_qc.duplicate_scores == []

--- a/tests/qc/test_b1_integration.py
+++ b/tests/qc/test_b1_integration.py
@@ -119,9 +119,7 @@ def _mirror_x(points: np.ndarray) -> np.ndarray:
     return out
 
 
-def _labels_from_poses(
-    skeleton: sio.Skeleton, poses: list[np.ndarray]
-) -> sio.Labels:
+def _labels_from_poses(skeleton: sio.Skeleton, poses: list[np.ndarray]) -> sio.Labels:
     """Build a single-video Labels with one instance per frame."""
     video = sio.Video.from_filename("test_video.mp4")
     labels = sio.Labels()
@@ -577,9 +575,7 @@ class TestMissingNodeChannel:
             gmm_key: {"max_edge_zscore": 5.0},
             both_key: {"max_edge_zscore": 1.0},
         }
-        results.channel_scores = {
-            "missing_node": {chan_only_key: 0.85, both_key: 0.95}
-        }
+        results.channel_scores = {"missing_node": {chan_only_key: 0.85, both_key: 0.95}}
 
         flagged = results.get_flagged(threshold=0.7)
         by_key = {f.instance_key: f for f in flagged}

--- a/tests/qc/test_chirality.py
+++ b/tests/qc/test_chirality.py
@@ -416,8 +416,14 @@ class TestWithSleapIO:
     def test_skeleton_without_symmetries_uses_name_inference(self):
         """CVAT-style skeleton with no symmetries -> infer pairs from names."""
         skel = sio.Skeleton(
-            ["spine_front", "spine_back", "Ear_L", "Ear_R", "Haunch_left",
-             "Haunch_right"]
+            [
+                "spine_front",
+                "spine_back",
+                "Ear_L",
+                "Ear_R",
+                "Haunch_left",
+                "Haunch_right",
+            ]
         )
         assert skel.symmetries == []  # none defined
 

--- a/tests/qc/test_chirality.py
+++ b/tests/qc/test_chirality.py
@@ -1,0 +1,448 @@
+"""Tests for sleap.qc.features.chirality (left/right mirror flip detection)."""
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap.qc.features.chirality import (
+    compute_chirality,
+    fit_chirality,
+    infer_symmetry_pairs_by_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a quadruped-like layout.
+#
+# Node layout (index : name):
+#   0 : spine_front  (axis anchor, "head" end)
+#   1 : spine_back   (axis anchor, "tail" end)
+#   2 : ear_L        3 : ear_R
+#   4 : shoulder_L   5 : shoulder_R
+#   6 : hip_L        7 : hip_R
+#
+# The body axis runs from spine_front (top) to spine_back (bottom) along -y.
+# Left nodes have x < 0, right nodes have x > 0 in the canonical pose.
+# ---------------------------------------------------------------------------
+
+CANONICAL = np.array(
+    [
+        [0.0, 12.0],  # 0 spine_front
+        [0.0, 0.0],  # 1 spine_back
+        [-3.0, 10.0],  # 2 ear_L
+        [3.0, 10.0],  # 3 ear_R
+        [-4.0, 7.0],  # 4 shoulder_L
+        [4.0, 7.0],  # 5 shoulder_R
+        [-4.0, 2.0],  # 6 hip_L
+        [4.0, 2.0],  # 7 hip_R
+    ],
+    dtype=float,
+)
+
+SYM_PAIRS = [(2, 3), (4, 5), (6, 7)]
+AXIS = (0, 1)
+
+
+def _rotate(points: np.ndarray, degrees: float) -> np.ndarray:
+    """Rotate points about the origin by ``degrees``."""
+    t = np.deg2rad(degrees)
+    rot = np.array([[np.cos(t), -np.sin(t)], [np.sin(t), np.cos(t)]])
+    return points @ rot.T
+
+
+def _jitter(points: np.ndarray, scale: float, seed: int) -> np.ndarray:
+    """Add small Gaussian jitter (deterministic via seed)."""
+    rng = np.random.default_rng(seed)
+    return points + rng.normal(scale=scale, size=points.shape)
+
+
+def _mirror_about_axis(points: np.ndarray) -> np.ndarray:
+    """Whole-instance mirror flip about the body axis (the line x = 0).
+
+    Keeps node identities/labels fixed (so the left ear point now sits on the
+    right side), which is exactly the mislabel a chirality detector must catch.
+    """
+    flipped = points.copy()
+    flipped[:, 0] *= -1
+    return flipped
+
+
+@pytest.fixture
+def clean_model():
+    """A chirality model fit on jittered copies of the canonical pose."""
+    instances = [_jitter(CANONICAL, scale=0.3, seed=i) for i in range(20)]
+    return fit_chirality(instances, SYM_PAIRS, AXIS)
+
+
+# ---------------------------------------------------------------------------
+# fit_chirality
+# ---------------------------------------------------------------------------
+
+
+class TestFitChirality:
+    def test_learns_canonical_side_for_all_pairs(self, clean_model):
+        """All co-visible pairs should get a learned canonical side."""
+        assert set(clean_model["canonical_side"].keys()) == set(SYM_PAIRS)
+        for side in clean_model["canonical_side"].values():
+            assert side in (-1.0, 1.0)
+
+    def test_records_support_counts(self, clean_model):
+        """Support count equals the number of contributing instances."""
+        assert all(c == 20 for c in clean_model["pair_support"].values())
+        assert clean_model["n_instances"] == 20
+
+    def test_canonical_side_is_consistent_left_member(self, clean_model):
+        """Left members sit on a single consistent side of the downward axis.
+
+        With the axis pointing from spine_front (top) to spine_back (bottom),
+        a left node (x < 0) lies on a fixed side; all left members must share
+        that canonical sign.
+        """
+        sides = set(clean_model["canonical_side"].values())
+        assert len(sides) == 1
+
+    def test_no_pairs_yields_empty_model(self):
+        """No symmetry pairs -> empty canonical map, but valid model dict."""
+        model = fit_chirality([CANONICAL], [], AXIS)
+        assert model["canonical_side"] == {}
+        assert model["pair_support"] == {}
+
+    def test_pairs_never_covisible_are_omitted(self):
+        """A pair that is never co-visible gets no canonical side."""
+        pts = CANONICAL.copy()
+        pts[6] = np.nan  # hip_L invisible in every instance
+        model = fit_chirality([pts] * 5, SYM_PAIRS, AXIS)
+        assert (6, 7) not in model["canonical_side"]
+        assert (2, 3) in model["canonical_side"]
+
+
+# ---------------------------------------------------------------------------
+# compute_chirality: positive / negative / intermediate cases
+# ---------------------------------------------------------------------------
+
+
+class TestComputeChirality:
+    def test_clean_pose_scores_zero(self, clean_model):
+        """A clean canonical pose -> wrong_fraction ~ 0."""
+        result = compute_chirality(CANONICAL, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+        assert result["n_pairs"] == 3
+
+    def test_jittered_clean_pose_scores_zero(self, clean_model):
+        """Small noise must not trip the detector."""
+        noisy = _jitter(CANONICAL, scale=0.4, seed=999)
+        result = compute_chirality(noisy, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+
+    def test_whole_mirror_flip_scores_one(self, clean_model):
+        """A whole-instance mirror flip -> wrong_fraction ~ 1.0."""
+        flipped = _mirror_about_axis(CANONICAL)
+        result = compute_chirality(flipped, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(1.0)
+        assert result["n_pairs"] == 3
+
+    def test_subset_swap_is_intermediate(self, clean_model):
+        """Swapping one of three pairs -> intermediate (0 < frac < 1)."""
+        swapped = CANONICAL.copy()
+        swapped[[2, 3]] = swapped[[3, 2]]  # swap ear_L/ear_R coordinates
+        result = compute_chirality(swapped, SYM_PAIRS, AXIS, clean_model)
+        assert 0.0 < result["chirality_wrong_fraction"] < 1.0
+        assert result["chirality_wrong_fraction"] == pytest.approx(1.0 / 3.0)
+        assert result["n_pairs"] == 3
+
+    def test_two_of_three_swapped(self, clean_model):
+        """Swapping two of three pairs -> 2/3."""
+        swapped = CANONICAL.copy()
+        swapped[[2, 3]] = swapped[[3, 2]]
+        swapped[[4, 5]] = swapped[[5, 4]]
+        result = compute_chirality(swapped, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(2.0 / 3.0)
+
+
+class TestInvariance:
+    """Chirality must be invariant to translation, rotation, and scale,
+    but must flip under reflection."""
+
+    def test_translation_invariant(self, clean_model):
+        moved = CANONICAL + np.array([123.0, -45.0])
+        result = compute_chirality(moved, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+
+    def test_rotation_invariant(self, clean_model):
+        for deg in (15.0, 90.0, 137.0, -60.0, 180.0):
+            rotated = _rotate(CANONICAL, deg)
+            result = compute_chirality(rotated, SYM_PAIRS, AXIS, clean_model)
+            assert result["chirality_wrong_fraction"] == pytest.approx(0.0), deg
+
+    def test_scale_invariant(self, clean_model):
+        scaled = CANONICAL * 3.7
+        result = compute_chirality(scaled, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+
+    def test_combined_similarity_transform_clean_and_flip(self, clean_model):
+        """Rotation+scale+translation: clean stays 0, mirror stays 1."""
+
+        def transform(p):
+            return _rotate(p, 53.0) * 2.1 + np.array([10.0, 200.0])
+
+        clean = transform(CANONICAL)
+        flipped = transform(_mirror_about_axis(CANONICAL))
+        assert compute_chirality(clean, SYM_PAIRS, AXIS, clean_model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(0.0)
+        assert compute_chirality(flipped, SYM_PAIRS, AXIS, clean_model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Degenerate cases
+# ---------------------------------------------------------------------------
+
+
+class TestDegenerate:
+    def test_fewer_than_min_pairs_returns_zero(self, clean_model):
+        """Only one co-visible pair -> below min_pairs -> 0.0."""
+        pts = CANONICAL.copy()
+        pts[4:] = np.nan  # only the ear pair (2, 3) remains co-visible
+        result = compute_chirality(pts, SYM_PAIRS, AXIS, clean_model)
+        assert result["n_pairs"] == 1
+        assert result["chirality_wrong_fraction"] == 0.0
+
+    def test_even_a_flip_with_too_few_pairs_returns_zero(self, clean_model):
+        """A real flip but with <2 visible pairs is not scored (safety)."""
+        flipped = _mirror_about_axis(CANONICAL)
+        flipped[4:] = np.nan
+        result = compute_chirality(flipped, SYM_PAIRS, AXIS, clean_model)
+        assert result["n_pairs"] == 1
+        assert result["chirality_wrong_fraction"] == 0.0
+
+    def test_pca_axis_when_no_anchors_given(self):
+        """With axis_node_indices=None, the axis is taken from PCA of the
+        visible non-symmetric points (here the two spine nodes)."""
+        model = fit_chirality(
+            [_jitter(CANONICAL, 0.2, i) for i in range(10)], SYM_PAIRS, None
+        )
+        # PCA axis from the two visible spine nodes; clean -> 0, flip -> 1.
+        clean = compute_chirality(CANONICAL, SYM_PAIRS, None, model)
+        flipped = compute_chirality(
+            _mirror_about_axis(CANONICAL), SYM_PAIRS, None, model
+        )
+        assert clean["chirality_wrong_fraction"] == pytest.approx(0.0)
+        assert flipped["chirality_wrong_fraction"] == pytest.approx(1.0)
+
+    def test_no_usable_axis_returns_zero(self, clean_model):
+        """No anchors and no non-symmetric points -> no axis -> 0.0."""
+        pts = CANONICAL.copy()
+        pts[0] = np.nan  # spine_front
+        pts[1] = np.nan  # spine_back (only non-symmetric nodes)
+        # axis_node_indices given but NaN -> PCA fallback, which has 0 non-sym
+        # visible points -> no axis.
+        result = compute_chirality(pts, SYM_PAIRS, AXIS, clean_model)
+        assert result["n_pairs"] == 0
+        assert result["chirality_wrong_fraction"] == 0.0
+
+    def test_all_nan_instance_returns_zero(self, clean_model):
+        pts = np.full_like(CANONICAL, np.nan)
+        result = compute_chirality(pts, SYM_PAIRS, AXIS, clean_model)
+        assert result == {"chirality_wrong_fraction": 0.0, "n_pairs": 0}
+
+    def test_pair_without_learned_side_is_skipped(self, clean_model):
+        """A symmetry pair absent from the model is not scored."""
+        extra_pairs = SYM_PAIRS + [(0, 1)]  # (0, 1) has no canonical side
+        result = compute_chirality(CANONICAL, extra_pairs, AXIS, clean_model)
+        # Only the three learned pairs contribute.
+        assert result["n_pairs"] == 3
+
+    def test_no_symmetry_no_pairs(self, clean_model):
+        """No symmetry pairs at all -> trivially 0.0 with n_pairs 0."""
+        result = compute_chirality(CANONICAL, [], AXIS, clean_model)
+        assert result == {"chirality_wrong_fraction": 0.0, "n_pairs": 0}
+
+    def test_never_emits_nan(self, clean_model):
+        """Output must never contain NaN even for ragged inputs."""
+        for pts in (
+            CANONICAL,
+            _mirror_about_axis(CANONICAL),
+            _jitter(CANONICAL, 5.0, 1),
+            np.full_like(CANONICAL, np.nan),
+        ):
+            res = compute_chirality(pts, SYM_PAIRS, AXIS, clean_model)
+            assert np.isfinite(res["chirality_wrong_fraction"])
+            assert 0.0 <= res["chirality_wrong_fraction"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# infer_symmetry_pairs_by_name
+# ---------------------------------------------------------------------------
+
+
+class TestInferSymmetryPairsByName:
+    def test_underscore_l_r_suffix(self):
+        names = ["spine_front", "spine_back", "Ear_L", "Ear_R"]
+        assert infer_symmetry_pairs_by_name(names) == [(2, 3)]
+
+    def test_left_right_suffix(self):
+        names = ["Shoulder_left", "Shoulder_right"]
+        assert infer_symmetry_pairs_by_name(names) == [(0, 1)]
+
+    def test_haunch_left_right(self):
+        names = ["nose", "Haunch_left", "Haunch_right", "tail"]
+        assert infer_symmetry_pairs_by_name(names) == [(1, 2)]
+
+    def test_camelcase_left_right(self):
+        names = ["EarLeft", "EarRight", "Snout"]
+        assert infer_symmetry_pairs_by_name(names) == [(0, 1)]
+
+    def test_prefix_l_r(self):
+        names = ["L_Eye", "R_Eye", "Nose"]
+        assert infer_symmetry_pairs_by_name(names) == [(0, 1)]
+
+    def test_prefix_left_right_word(self):
+        names = ["left_paw", "right_paw"]
+        assert infer_symmetry_pairs_by_name(names) == [(0, 1)]
+
+    def test_dash_and_dot_separators(self):
+        assert infer_symmetry_pairs_by_name(["Ear-L", "Ear-R"]) == [(0, 1)]
+        assert infer_symmetry_pairs_by_name(["Ear.L", "Ear.R"]) == [(0, 1)]
+
+    def test_multiple_pairs_ordered_by_left_index(self):
+        names = [
+            "spine_front",
+            "spine_back",
+            "Ear_L",
+            "Ear_R",
+            "Shoulder_left",
+            "Shoulder_right",
+            "Haunch_left",
+            "Haunch_right",
+        ]
+        assert infer_symmetry_pairs_by_name(names) == [(2, 3), (4, 5), (6, 7)]
+
+    def test_lone_left_token_no_partner(self):
+        """A single-letter L with no matching R must not form a pair."""
+        assert infer_symmetry_pairs_by_name(["paw_L", "head", "tail"]) == []
+
+    def test_midline_names_not_paired(self):
+        """Names without L/R tokens are never paired."""
+        assert infer_symmetry_pairs_by_name(["spine", "nose", "tail_base"]) == []
+
+    def test_each_node_in_at_most_one_pair(self):
+        """Duplicate stems do not cause a node to be reused."""
+        names = ["Ear_L", "Ear_R", "Ear_L", "Ear_R"]
+        pairs = infer_symmetry_pairs_by_name(names)
+        used = [i for pair in pairs for i in pair]
+        assert len(used) == len(set(used))
+
+    def test_distinct_stems_do_not_cross_pair(self):
+        """Ear_L should not pair with Eye_R."""
+        names = ["Ear_L", "Eye_R"]
+        assert infer_symmetry_pairs_by_name(names) == []
+
+    def test_empty_node_names(self):
+        assert infer_symmetry_pairs_by_name([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration with sleap_io: the path the integration layer actually uses.
+# ---------------------------------------------------------------------------
+
+
+class TestWithSleapIO:
+    """Build skeletons/instances via sleap_io to mirror real usage."""
+
+    @pytest.fixture
+    def skeleton(self):
+        skel = sio.Skeleton(
+            [
+                "spine_front",
+                "spine_back",
+                "ear_L",
+                "ear_R",
+                "shoulder_L",
+                "shoulder_R",
+                "hip_L",
+                "hip_R",
+            ]
+        )
+        skel.add_symmetry("ear_L", "ear_R")
+        skel.add_symmetry("shoulder_L", "shoulder_R")
+        skel.add_symmetry("hip_L", "hip_R")
+        return skel
+
+    def test_symmetry_inds_drive_detection(self, skeleton):
+        """Use sleap_io's symmetry_inds as the symmetry_pairs argument."""
+        sym_pairs = [tuple(p) for p in skeleton.symmetry_inds]
+        assert len(sym_pairs) == 3
+
+        instances = [
+            sio.Instance.from_numpy(
+                _jitter(CANONICAL, 0.25, i), skeleton=skeleton
+            ).numpy()
+            for i in range(15)
+        ]
+        model = fit_chirality(instances, sym_pairs, AXIS)
+
+        clean = sio.Instance.from_numpy(CANONICAL, skeleton=skeleton).numpy()
+        flipped = sio.Instance.from_numpy(
+            _mirror_about_axis(CANONICAL), skeleton=skeleton
+        ).numpy()
+
+        assert compute_chirality(clean, sym_pairs, AXIS, model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(0.0)
+        assert compute_chirality(flipped, sym_pairs, AXIS, model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(1.0)
+
+    def test_invisible_node_via_instance(self, skeleton):
+        """An invisible node (NaN through .numpy()) is handled cleanly."""
+        sym_pairs = [tuple(p) for p in skeleton.symmetry_inds]
+        instances = [
+            sio.Instance.from_numpy(
+                _jitter(CANONICAL, 0.25, i), skeleton=skeleton
+            ).numpy()
+            for i in range(15)
+        ]
+        model = fit_chirality(instances, sym_pairs, AXIS)
+
+        partial = CANONICAL.copy()
+        partial[2] = np.nan  # ear_L invisible -> ear pair not scorable
+        inst = sio.Instance.from_numpy(partial, skeleton=skeleton).numpy()
+        result = compute_chirality(inst, sym_pairs, AXIS, model)
+        assert result["n_pairs"] == 2  # shoulder + hip pairs only
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+
+    def test_skeleton_without_symmetries_uses_name_inference(self):
+        """CVAT-style skeleton with no symmetries -> infer pairs from names."""
+        skel = sio.Skeleton(
+            ["spine_front", "spine_back", "Ear_L", "Ear_R", "Haunch_left",
+             "Haunch_right"]
+        )
+        assert skel.symmetries == []  # none defined
+
+        sym_pairs = infer_symmetry_pairs_by_name([n.name for n in skel.nodes])
+        assert sym_pairs == [(2, 3), (4, 5)]
+
+        layout = np.array(
+            [
+                [0.0, 10.0],
+                [0.0, 0.0],
+                [-3.0, 8.0],
+                [3.0, 8.0],
+                [-3.0, 2.0],
+                [3.0, 2.0],
+            ],
+            dtype=float,
+        )
+        instances = [_jitter(layout, 0.2, i) for i in range(10)]
+        model = fit_chirality(instances, sym_pairs, AXIS)
+
+        assert compute_chirality(layout, sym_pairs, AXIS, model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(0.0)
+        flipped = layout.copy()
+        flipped[:, 0] *= -1
+        assert compute_chirality(flipped, sym_pairs, AXIS, model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(1.0)

--- a/tests/qc/test_detector.py
+++ b/tests/qc/test_detector.py
@@ -359,6 +359,58 @@ class TestLabelQCDetector:
         assert len(detector.feature_names) > 0
         assert "max_edge_zscore" in detector.feature_names
         assert "nn_distance" in detector.feature_names
+        # PR-A: the hull feature name must match the issue_map key
+        # ("hull_area_zscore") so the "Unusual pose extent" label can fire.
+        assert "hull_area_zscore" in detector.feature_names
+        assert "hull_area" not in detector.feature_names
+
+    def test_instance_to_array_forces_invisible_as_nan(self, skeleton):
+        """#2753: invisible nodes are NaN'd regardless of the sleap-io default.
+
+        Invisible (visible=False) nodes keep display-only coordinates; QC must
+        never read them. ``_instance_to_array`` passes ``invisible_as_nan=True``
+        explicitly so this holds even if the sleap-io default changes.
+        """
+        pts = np.array(
+            [[100, 100], [100, 120], [100, 150], [80, 115], [120, 115]], dtype=float
+        )
+        inst = Instance.from_numpy(pts, skeleton=skeleton)
+        inst[3]["visible"] = False
+
+        arr = LabelQCDetector()._instance_to_array(inst)
+
+        assert np.all(np.isnan(arr[3]))
+        assert not np.any(np.isnan(arr[[0, 1, 2, 4]]))
+
+    def test_invisible_far_node_does_not_leak_into_geometry(
+        self, simple_labels, skeleton
+    ):
+        """#2753 regression: a far-away invisible node must not inflate geometry.
+
+        A node dragged far away leaks into edge/angle/distance features ONLY
+        when it is visible; when invisible it must be excluded entirely.
+        """
+        detector = LabelQCDetector()
+        detector.fit(simple_labels)
+        i_edge = detector.feature_names.index("max_edge_zscore")
+
+        far = np.array(
+            [[100, 100], [100, 120], [100, 150], [9999, 9999], [120, 115]],
+            dtype=float,
+        )
+        inst_visible = Instance.from_numpy(far, skeleton=skeleton)
+        inst_invisible = Instance.from_numpy(far, skeleton=skeleton)
+        inst_invisible[3]["visible"] = False
+
+        f_visible = detector._extract_features(
+            detector._instance_to_array(inst_visible)
+        )
+        f_invisible = detector._extract_features(
+            detector._instance_to_array(inst_invisible)
+        )
+
+        assert f_visible[i_edge] > 10.0
+        assert f_invisible[i_edge] < 5.0
 
     def test_skeleton_analyzer_properties(self, simple_labels):
         """Test skeleton analyzer extracts properties."""

--- a/tests/qc/test_duplicate_split.py
+++ b/tests/qc/test_duplicate_split.py
@@ -1,0 +1,368 @@
+"""Tests for sleap.qc.features.duplicate_split.
+
+Covers the split-duplicate detector (one animal split across two instances on
+largely disjoint node sets) and the ``duplicate_score`` signal combiner.
+
+The module functions are pure (numpy arrays + a learned-stats dict in, dict /
+float out), so most tests build poses directly as numpy arrays. A couple of
+tests build real ``sleap_io`` instances to exercise the same arrays the
+integration layer would extract.
+"""
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.duplicate_split import (
+    compute_split_duplicate,
+    duplicate_score,
+)
+
+
+# A vertical 6-node chain standing in for a head->tail skeleton, edge ~20 px:
+# 0 head, 1 neck, 2 thorax, 3 abd1, 4 abd2, 5 tail.
+FULL_POSE = np.array(
+    [[100, 100], [100, 120], [100, 140], [100, 160], [100, 180], [100, 200]],
+    dtype=float,
+)
+
+# Learned mean edge lengths keyed by sorted (src, dst) tuples, matching
+# DatasetStats.edge_means. Median is 20.0 -> the scale.
+EDGE_MEANS = {(0, 1): 20.0, (1, 2): 20.0, (2, 3): 20.0, (3, 4): 20.0, (4, 5): 20.0}
+
+# A score this high is unambiguously a split for these tests; well above any
+# sensible operating threshold.
+HIGH = 0.5
+# A score this low means "not a split".
+LOW = 0.1
+
+
+def front_half(pose=FULL_POSE):
+    """Pose with only the front (head-side) nodes visible."""
+    p = pose.copy()
+    p[3:] = np.nan
+    return p
+
+
+def back_half(pose=FULL_POSE):
+    """Pose with only the back (tail-side) nodes visible."""
+    p = pose.copy()
+    p[:3] = np.nan
+    return p
+
+
+def rotate(pose, degrees, about=(100.0, 150.0)):
+    """Rotate a pose about a pivot (preserving NaNs)."""
+    th = np.deg2rad(degrees)
+    rot = np.array([[np.cos(th), -np.sin(th)], [np.sin(th), np.cos(th)]])
+    about = np.asarray(about, dtype=float)
+    return (pose - about) @ rot.T + about
+
+
+class TestComputeSplitDuplicatePositive:
+    """The detector should fire on one animal split across two instances."""
+
+    def test_complementary_head_tail_split_is_high(self):
+        """A = head/front, B = tail/back, disjoint nodes -> high score."""
+        result = compute_split_duplicate(front_half(), back_half(), EDGE_MEANS)
+
+        assert result["split_duplicate_score"] > HIGH
+        assert "split" in result["reason"].lower()
+
+    def test_split_with_one_shared_node_is_high(self):
+        """Halves that meet at a shared node are the clearest split."""
+        a = FULL_POSE.copy()
+        a[4:] = np.nan  # nodes 0,1,2,3
+        b = FULL_POSE.copy()
+        b[:3] = np.nan  # nodes 3,4,5 (node 3 shared, coincident)
+
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] > HIGH
+
+    def test_score_is_in_unit_interval(self):
+        """Score is always a float in [0, 1]."""
+        for a, b in [
+            (front_half(), back_half()),
+            (FULL_POSE, FULL_POSE.copy()),
+            (front_half(), front_half()),
+        ]:
+            score = compute_split_duplicate(a, b, EDGE_MEANS)["split_duplicate_score"]
+            assert isinstance(score, float)
+            assert 0.0 <= score <= 1.0
+
+    def test_uses_bbox_diagonal_fallback_without_edge_means(self):
+        """Without edge_means, the bbox-diagonal scale still yields high."""
+        result = compute_split_duplicate(front_half(), back_half(), None)
+
+        assert result["split_duplicate_score"] > HIGH
+
+    def test_empty_edge_means_falls_back(self):
+        """An empty edge_means dict behaves like None (fallback scale)."""
+        result = compute_split_duplicate(front_half(), back_half(), {})
+
+        assert result["split_duplicate_score"] > HIGH
+
+
+class TestSplitInvariance:
+    """Split detection should be translation/rotation/scale invariant."""
+
+    def test_translation_invariant(self):
+        offset = np.array([500.0, -300.0])
+        base = compute_split_duplicate(front_half(), back_half(), EDGE_MEANS)
+        moved = compute_split_duplicate(
+            front_half(FULL_POSE + offset),
+            back_half(FULL_POSE + offset),
+            EDGE_MEANS,
+        )
+        assert moved["split_duplicate_score"] == pytest.approx(
+            base["split_duplicate_score"], abs=1e-6
+        )
+
+    def test_rotation_invariant(self):
+        base = compute_split_duplicate(front_half(), back_half(), EDGE_MEANS)
+        rotated_pose = rotate(FULL_POSE, 37.0)
+        rot = compute_split_duplicate(
+            front_half(rotated_pose), back_half(rotated_pose), EDGE_MEANS
+        )
+        assert rot["split_duplicate_score"] == pytest.approx(
+            base["split_duplicate_score"], abs=1e-6
+        )
+
+    def test_scale_invariant_with_fallback(self):
+        """3x larger pose with the bbox fallback gives the same score."""
+        base = compute_split_duplicate(front_half(), back_half(), None)
+        big = compute_split_duplicate(
+            front_half(FULL_POSE * 3.0), back_half(FULL_POSE * 3.0), None
+        )
+        assert big["split_duplicate_score"] == pytest.approx(
+            base["split_duplicate_score"], abs=1e-6
+        )
+
+    def test_scale_invariant_with_scaled_edge_means(self):
+        """3x pose with 3x edge stats also matches the 1x score."""
+        base = compute_split_duplicate(front_half(), back_half(), EDGE_MEANS)
+        big_edges = {k: v * 3.0 for k, v in EDGE_MEANS.items()}
+        big = compute_split_duplicate(
+            front_half(FULL_POSE * 3.0), back_half(FULL_POSE * 3.0), big_edges
+        )
+        assert big["split_duplicate_score"] == pytest.approx(
+            base["split_duplicate_score"], abs=1e-6
+        )
+
+
+class TestComputeSplitDuplicateNegative:
+    """The detector must NOT fire on non-splits."""
+
+    def test_identical_copies_are_not_split(self):
+        """Identical copies share all nodes (high co-visibility) -> not split.
+
+        This case is meant to be caught by the IoU / node-overlap signals, not
+        the split signal.
+        """
+        result = compute_split_duplicate(FULL_POSE, FULL_POSE.copy(), EDGE_MEANS)
+
+        assert result["split_duplicate_score"] < LOW
+
+    def test_two_distinct_animals_side_by_side_full_labels(self):
+        """Two fully-labeled distinct animals share node sets -> not split."""
+        b = FULL_POSE.copy()
+        b[:, 0] += 60  # shift right by ~3 edges
+
+        result = compute_split_duplicate(FULL_POSE, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] < LOW
+
+    def test_two_distinct_animals_disjoint_nodes_with_gap(self):
+        """Disjoint node sets but a clear spatial gap -> distinct, not split.
+
+        This is the hardest negative: low co-visibility (so the disjointness
+        precondition passes) but the two point clouds are far apart, which the
+        proximity / coherence checks reject.
+        """
+        a = front_half()  # left animal, front nodes
+        b = FULL_POSE.copy()
+        b[:, 0] += 80
+        b[:3] = np.nan  # right animal, back nodes
+
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] < LOW
+
+    def test_huddling_overlapping_full_animals_low(self):
+        """Two close, fully-labeled (huddling) animals -> not a split.
+
+        High co-visibility is the precondition violation here.
+        """
+        b = FULL_POSE.copy()
+        b[:, 0] += 8  # very close, still both fully labeled
+
+        result = compute_split_duplicate(FULL_POSE, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] < LOW
+
+
+class TestComputeSplitDuplicateDegenerate:
+    """Degenerate inputs must never raise or leak NaN."""
+
+    def test_one_instance_too_few_visible(self):
+        a = FULL_POSE.copy()
+        a[1:] = np.nan  # only one visible node
+        result = compute_split_duplicate(a, back_half(), EDGE_MEANS)
+
+        assert result["split_duplicate_score"] == 0.0
+        assert "too few" in result["reason"].lower()
+
+    def test_each_single_node_too_few_visible(self):
+        a = np.full((6, 2), np.nan)
+        a[0] = [0.0, 0.0]
+        b = np.full((6, 2), np.nan)
+        b[5] = [1.0, 1.0]
+
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] == 0.0
+
+    def test_all_invisible(self):
+        nan_pose = np.full((6, 2), np.nan)
+        result = compute_split_duplicate(nan_pose, nan_pose.copy(), EDGE_MEANS)
+
+        assert result["split_duplicate_score"] == 0.0
+
+    def test_score_never_nan(self):
+        """No combination should produce a NaN score."""
+        cases = [
+            (front_half(), back_half()),
+            (FULL_POSE, FULL_POSE.copy()),
+            (np.full((6, 2), np.nan), back_half()),
+            (front_half(), np.full((6, 2), np.nan)),
+        ]
+        for a, b in cases:
+            score = compute_split_duplicate(a, b, EDGE_MEANS)["split_duplicate_score"]
+            assert np.isfinite(score)
+
+    def test_coincident_points_no_internal_spacing(self):
+        """Instances whose visible nodes are all coincident don't crash.
+
+        Each instance has 2+ visible nodes but zero internal spacing; the
+        coherence factor must degrade gracefully (governed by proximity).
+        """
+        a = np.full((6, 2), np.nan)
+        a[0:2] = [10.0, 10.0]  # two coincident visible nodes
+        b = np.full((6, 2), np.nan)
+        b[3:5] = [10.0, 10.0]  # disjoint node indices, same location
+
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert 0.0 <= result["split_duplicate_score"] <= 1.0
+        assert np.isfinite(result["split_duplicate_score"])
+
+    def test_accepts_list_inputs(self):
+        """Plain nested lists are coerced to arrays without error."""
+        a = front_half().tolist()
+        b = back_half().tolist()
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] > HIGH
+
+
+class TestComputeSplitDuplicateWithSleapIO:
+    """Exercise the same arrays the integration layer extracts from instances."""
+
+    def test_split_from_real_instances(self):
+        """One long-bodied animal split front/back across two instances.
+
+        Uses a 6-node linear (head->tail) skeleton, the shape where the split
+        failure mode actually occurs: instance A labels the front half,
+        instance B the disjoint back half, and together they form one animal.
+        """
+        from sleap_io import Skeleton
+        from sleap_io.model.instance import Instance
+
+        sk = Skeleton(nodes=["n0", "n1", "n2", "n3", "n4", "n5"], name="worm")
+        sk.add_edges(
+            [
+                ("n0", "n1"),
+                ("n1", "n2"),
+                ("n2", "n3"),
+                ("n3", "n4"),
+                ("n4", "n5"),
+            ]
+        )
+
+        inst_a = Instance.from_numpy(front_half(), skeleton=sk)
+        inst_b = Instance.from_numpy(back_half(), skeleton=sk)
+
+        result = compute_split_duplicate(
+            inst_a.numpy(invisible_as_nan=True),
+            inst_b.numpy(invisible_as_nan=True),
+            EDGE_MEANS,
+        )
+        assert result["split_duplicate_score"] > HIGH
+
+    def test_distinct_fly_instances_low(self, skeleton):
+        """Two separate, fully-labeled flies -> not a split."""
+        from sleap_io.model.instance import Instance
+
+        fly_a = np.array(
+            [[100, 100], [100, 115], [100, 130], [85, 110], [115, 110]], dtype=float
+        )
+        fly_b = fly_a.copy()
+        fly_b[:, 0] += 60  # well separated
+
+        inst_a = Instance.from_numpy(fly_a, skeleton=skeleton)
+        inst_b = Instance.from_numpy(fly_b, skeleton=skeleton)
+
+        edge_means = {(0, 1): 15.0, (1, 2): 15.0, (1, 3): 15.0, (1, 4): 15.0}
+
+        result = compute_split_duplicate(
+            inst_a.numpy(invisible_as_nan=True),
+            inst_b.numpy(invisible_as_nan=True),
+            edge_means,
+        )
+        assert result["split_duplicate_score"] < LOW
+
+
+class TestDuplicateScore:
+    """Tests for the duplicate_score signal combiner."""
+
+    def test_identical_via_iou(self):
+        """A strong IoU alone flags a duplicate."""
+        assert duplicate_score(1.0, 0.0, 0.0) == 1.0
+
+    def test_partial_via_node_overlap(self):
+        """A strong node overlap alone flags a duplicate."""
+        assert duplicate_score(0.0, 0.95, 0.0) == pytest.approx(0.95)
+
+    def test_split_via_split_signal(self):
+        """A strong split signal alone flags a duplicate."""
+        assert duplicate_score(0.0, 0.0, 0.85) == pytest.approx(0.85)
+
+    def test_distinct_instances_low(self):
+        """Weak signals across the board -> low combined score."""
+        assert duplicate_score(0.05, 0.1, 0.0) == pytest.approx(0.1)
+        assert duplicate_score(0.0, 0.0, 0.0) == 0.0
+
+    def test_saturating_max(self):
+        """Combined score is the max of the (clamped) signals."""
+        assert duplicate_score(0.3, 0.6, 0.4) == pytest.approx(0.6)
+
+    def test_output_in_unit_interval(self):
+        """Out-of-range inputs are clamped into [0, 1]."""
+        assert duplicate_score(2.0, 5.0, 3.0) == 1.0
+        assert duplicate_score(-1.0, -2.0, -0.5) == 0.0
+
+    def test_nan_and_inf_treated_as_zero(self):
+        """Non-finite signals never inflate or corrupt the result.
+
+        Both NaN and +/-inf are treated as 0 so a garbage/missing signal cannot
+        spuriously flag a duplicate (an inf must not saturate the score).
+        """
+        assert duplicate_score(np.nan, np.nan, np.nan) == 0.0
+        # inf is dropped to 0, so the real 0.7 split signal wins.
+        assert duplicate_score(np.inf, 0.3, 0.7) == pytest.approx(0.7)
+        # All non-finite -> 0, never 1.
+        assert duplicate_score(np.nan, 0.0, np.inf) == 0.0
+
+    def test_returns_float(self):
+        result = duplicate_score(0.4, 0.2, 0.1)
+        assert isinstance(result, float)

--- a/tests/qc/test_frame_level.py
+++ b/tests/qc/test_frame_level.py
@@ -184,6 +184,10 @@ class TestComputeNodeOverlap:
 
         assert len(result["common_nodes"]) == 0
         assert result["overlap_ratio"] == 0.0
+        # Key parity with the normal-path return so callers never KeyError.
+        assert result["mean_distance"] == float("inf")
+        assert result["min_distance"] == float("inf")
+        assert result["max_distance"] == float("inf")
 
 
 class TestDetectDuplicates:

--- a/tests/qc/test_missing_node.py
+++ b/tests/qc/test_missing_node.py
@@ -1,0 +1,341 @@
+"""Tests for sleap.qc.features.missing_node.
+
+These tests cover the Tier-1 (geometry/visibility-only) missing-node detector
+``score_missing_nodes``. The co-visibility matrix it consumes is normally
+learned by :class:`VisibilityModel`; here we both construct matrices by hand
+(for precise control) and fit a real ``VisibilityModel`` (to confirm the two
+interoperate as the integration layer expects).
+"""
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.missing_node import score_missing_nodes
+from sleap.qc.features.visibility import VisibilityModel
+
+
+# A simple 5-node line skeleton reused across tests: 0-1-2-3-4.
+LINE_EDGES = [(0, 1), (1, 2), (2, 3), (3, 4)]
+
+
+def _covis_from_masks(masks: np.ndarray) -> np.ndarray:
+    """Fit a VisibilityModel and return its co-visibility matrix.
+
+    This mirrors exactly what the integration layer does: learn co-visibility on
+    the dataset, then hand the matrix to ``score_missing_nodes``.
+    """
+    model = VisibilityModel()
+    model.fit(np.asarray(masks, dtype=bool))
+    return model.co_visibility_matrix
+
+
+class TestScoreMissingNodesPositive:
+    """The instance is missing a node its peers almost always keep."""
+
+    def test_flags_dropped_covisible_node(self):
+        # All five nodes are essentially always visible together.
+        masks = np.ones((50, 5), dtype=bool)
+        # A tiny bit of noise on node 4 so nothing is a degenerate 100%/0%.
+        masks[:2, 4] = False
+        covis = _covis_from_masks(masks)
+
+        # This instance is missing node 2, which peers keep ~100% of the time.
+        vis = np.array([True, True, False, True, True])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["n_suspicious"] == 1
+        assert result["suspicious_nodes"] == [2]
+        # Expected visibility of node 2 given the others is ~1.0.
+        assert result["missing_node_score"] == pytest.approx(1.0, abs=1e-6)
+
+    def test_flags_multiple_dropped_nodes(self):
+        masks = np.ones((40, 5), dtype=bool)
+        covis = _covis_from_masks(masks)
+
+        # Missing both node 1 and node 3.
+        vis = np.array([True, False, True, False, True])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["n_suspicious"] == 2
+        assert result["suspicious_nodes"] == [1, 3]
+        assert result["missing_node_score"] == pytest.approx(1.0, abs=1e-6)
+
+    def test_hand_built_matrix_positive(self):
+        # Hand-built: node 2 is visible with everything ~95% of the time.
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+
+        vis = np.array([True, True, False, True])
+        result = score_missing_nodes(vis, covis, [(0, 1), (1, 2), (2, 3)])
+
+        assert result["suspicious_nodes"] == [2]
+        assert result["missing_node_score"] == pytest.approx(0.95, abs=1e-6)
+
+
+class TestScoreMissingNodesNegative:
+    """The missing node is one peers usually also lack -> not suspicious."""
+
+    def test_usually_absent_node_not_flagged(self):
+        # Nodes 0,1,2 always visible; nodes 3,4 almost never visible.
+        masks = np.zeros((50, 5), dtype=bool)
+        masks[:, 0:3] = True
+        masks[:2, 3] = True  # 4% visibility for node 3
+        masks[:1, 4] = True  # 2% visibility for node 4
+        covis = _covis_from_masks(masks)
+
+        # Common pattern: 0,1,2 visible, 3,4 missing. Nothing suspicious.
+        vis = np.array([True, True, True, False, False])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["n_suspicious"] == 0
+        assert result["suspicious_nodes"] == []
+        # Score should be the (low) expected visibility of nodes 3/4.
+        assert result["missing_node_score"] < 0.1
+
+    def test_score_below_threshold_not_flagged(self):
+        # Node 2 co-visible only 80% of the time; default threshold is 0.9.
+        n = 4
+        covis = np.full((n, n), 0.8)
+        np.fill_diagonal(covis, 1.0)
+
+        vis = np.array([True, True, False, True])
+        result = score_missing_nodes(vis, covis, [(0, 1), (1, 2), (2, 3)])
+
+        assert result["n_suspicious"] == 0
+        # But the score still reflects the 0.8 expected probability.
+        assert result["missing_node_score"] == pytest.approx(0.8, abs=1e-6)
+
+
+class TestScoreMissingNodesAllVisible:
+    """All nodes visible -> nothing missing -> score 0."""
+
+    def test_all_visible_score_zero(self):
+        masks = np.ones((20, 5), dtype=bool)
+        covis = _covis_from_masks(masks)
+
+        vis = np.array([True, True, True, True, True])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["missing_node_score"] == 0.0
+        assert result["n_suspicious"] == 0
+        assert result["suspicious_nodes"] == []
+
+
+class TestThreshold:
+    """The threshold argument controls flagging."""
+
+    def test_custom_threshold_flags_lower_prob(self):
+        n = 4
+        covis = np.full((n, n), 0.8)
+        np.fill_diagonal(covis, 1.0)
+        vis = np.array([True, True, False, True])
+
+        # Default 0.9 -> not flagged.
+        assert score_missing_nodes(vis, covis, [])["n_suspicious"] == 0
+        # Lower threshold -> flagged.
+        result = score_missing_nodes(vis, covis, [], threshold=0.75)
+        assert result["suspicious_nodes"] == [2]
+
+    def test_threshold_is_inclusive(self):
+        n = 3
+        covis = np.full((n, n), 0.9)
+        np.fill_diagonal(covis, 1.0)
+        vis = np.array([True, False, True])
+
+        # p_expected == threshold exactly should flag (>=).
+        result = score_missing_nodes(vis, covis, [], threshold=0.9)
+        assert result["suspicious_nodes"] == [1]
+
+
+class TestRequireNeighborsVisible:
+    """The optional neighbor-strengthening rule."""
+
+    def test_flagged_when_all_neighbors_visible(self):
+        n = 5
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+
+        # Node 2 missing; its neighbors 1 and 3 are both visible.
+        vis = np.array([True, True, False, True, True])
+        result = score_missing_nodes(
+            vis, covis, LINE_EDGES, require_neighbors_visible=True
+        )
+        assert result["suspicious_nodes"] == [2]
+
+    def test_not_flagged_when_a_neighbor_invisible(self):
+        n = 5
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+
+        # Node 2 missing AND its neighbor 3 also missing -> looks like an
+        # occluded region, not an accidental single drop.
+        vis = np.array([True, True, False, False, True])
+        result = score_missing_nodes(
+            vis, covis, LINE_EDGES, require_neighbors_visible=True
+        )
+        # Node 2 has an invisible neighbor (3) so it is NOT flagged. Node 3's
+        # neighbor 2 is also invisible, so it is not flagged either.
+        assert result["suspicious_nodes"] == []
+        # The score (max expected prob over invisible nodes) is still high --
+        # the strengthening rule only gates *flagging*, not the raw score.
+        assert result["missing_node_score"] == pytest.approx(0.95, abs=1e-6)
+
+    def test_node_with_no_neighbors_not_flagged_under_rule(self):
+        # 4 nodes, but node 3 is isolated (no edges touch it).
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+        edges = [(0, 1), (1, 2)]  # node 3 has no neighbors
+
+        vis = np.array([True, True, True, False])
+        # Without the rule, node 3 is flagged.
+        assert score_missing_nodes(vis, covis, edges)["suspicious_nodes"] == [3]
+        # With the rule, a neighborless node cannot satisfy "all neighbors
+        # visible" and is skipped.
+        result = score_missing_nodes(
+            vis, covis, edges, require_neighbors_visible=True
+        )
+        assert result["suspicious_nodes"] == []
+
+
+class TestDegenerate:
+    """Degenerate / edge inputs must not raise or leak NaN."""
+
+    def test_no_visible_nodes_score_zero(self):
+        n = 4
+        covis = np.full((n, n), 0.95)
+        vis = np.array([False, False, False, False])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        # No visible node to condition on -> no evidence -> score 0.
+        assert result["missing_node_score"] == 0.0
+        assert result["n_suspicious"] == 0
+
+    def test_single_visible_node(self):
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+        vis = np.array([True, False, False, False])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        # Only node 0 visible; nodes 1,2,3 each have p_expected ~0.95.
+        assert result["suspicious_nodes"] == [1, 2, 3]
+        assert result["missing_node_score"] == pytest.approx(0.95, abs=1e-6)
+
+    def test_empty_skeleton(self):
+        vis = np.array([], dtype=bool)
+        covis = np.zeros((0, 0))
+        result = score_missing_nodes(vis, covis, [])
+
+        assert result["missing_node_score"] == 0.0
+        assert result["suspicious_nodes"] == []
+        assert result["n_suspicious"] == 0
+
+    def test_matrix_shape_mismatch_returns_zero(self):
+        # A 5-node mask with a 3x3 matrix is inconsistent; do not crash.
+        vis = np.array([True, True, False, True, True])
+        covis = np.full((3, 3), 0.95)
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["missing_node_score"] == 0.0
+        assert result["n_suspicious"] == 0
+
+    def test_nan_in_covis_column_does_not_leak(self):
+        # A node that was never visible during fitting can yield NaN columns.
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+        # Make every entry predicting node 2's visibility NaN.
+        covis[:, 2] = np.nan
+
+        vis = np.array([True, True, False, True])
+        result = score_missing_nodes(vis, covis, [(0, 1), (1, 2), (2, 3)])
+
+        # No usable evidence for node 2 -> p_expected treated as 0, not NaN.
+        assert np.isfinite(result["missing_node_score"])
+        assert result["missing_node_score"] == 0.0
+        assert result["n_suspicious"] == 0
+
+    def test_score_never_exceeds_one(self):
+        # Even with an out-of-range matrix, the score is clamped to [0, 1].
+        n = 3
+        covis = np.full((n, n), 1.5)  # pathological > 1 probabilities
+        vis = np.array([True, False, True])
+        result = score_missing_nodes(vis, covis, [])
+
+        assert 0.0 <= result["missing_node_score"] <= 1.0
+
+    def test_non_boolean_mask_is_coerced(self):
+        # Integer 0/1 masks (a common alternative encoding) must work.
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+        vis = np.array([1, 1, 0, 1])  # node 2 missing
+        result = score_missing_nodes(vis, covis, [(0, 1), (1, 2), (2, 3)])
+
+        assert result["suspicious_nodes"] == [2]
+
+
+class TestSleapIoIntegration:
+    """Build masks/skeleton from sleap_io and confirm end-to-end behavior."""
+
+    def test_end_to_end_with_sleap_io_instances(self):
+        import sleap_io as sio
+
+        # 4-node skeleton: head - thorax - abdomen - tail (a line).
+        skel = sio.Skeleton(
+            nodes=["head", "thorax", "abdomen", "tail"],
+            edges=[("head", "thorax"), ("thorax", "abdomen"), ("abdomen", "tail")],
+        )
+        name_to_idx = {n.name: i for i, n in enumerate(skel.nodes)}
+        edges = [
+            (name_to_idx[e.source.name], name_to_idx[e.destination.name])
+            for e in skel.edges
+        ]
+        n_nodes = len(skel.nodes)
+
+        # Build a dataset of instances. "tail" is frequently invisible
+        # (systematic), the rest are almost always visible.
+        rng = np.random.default_rng(0)
+        instances: list[sio.Instance] = []
+        masks: list[np.ndarray] = []
+        for _ in range(60):
+            pts = rng.normal(size=(n_nodes, 2)) * 5 + np.array([0, 0])
+            pts = pts.astype(float)
+            # Tail invisible ~70% of the time.
+            if rng.random() < 0.7:
+                pts[3] = np.nan
+            inst = sio.Instance.from_numpy(pts, skeleton=skel)
+            instances.append(inst)
+            masks.append(~np.isnan(pts).any(axis=1))
+
+        masks = np.asarray(masks, dtype=bool)
+        covis = _covis_from_masks(masks)
+
+        # Case 1: an instance missing "tail" -- which is systematically dropped.
+        # Tier-1 should NOT flag it (this is the documented limitation).
+        vis_systematic = np.array([True, True, True, False])
+        res_sys = score_missing_nodes(vis_systematic, covis, edges)
+        assert 3 not in res_sys["suspicious_nodes"]
+        assert res_sys["missing_node_score"] < 0.9
+
+        # Case 2: an instance missing "thorax" -- a node peers almost always
+        # keep. Tier-1 SHOULD flag it as a suspicious outlier drop.
+        vis_outlier = np.array([True, False, True, True])
+        res_out = score_missing_nodes(vis_outlier, covis, edges)
+        assert 1 in res_out["suspicious_nodes"]
+        assert res_out["missing_node_score"] >= 0.9
+
+    def test_covis_from_instances_matches_visibility_model(self):
+        # Sanity: feeding VisibilityModel's own matrix back yields a finite,
+        # in-range score for a typical pattern.
+        masks = np.ones((30, 5), dtype=bool)
+        masks[::3, 4] = False
+        model = VisibilityModel().fit(masks)
+
+        vis = np.array([True, True, False, True, True])
+        result = score_missing_nodes(vis, model.co_visibility_matrix, LINE_EDGES)
+
+        assert 0.0 <= result["missing_node_score"] <= 1.0
+        assert result["suspicious_nodes"] == [2]

--- a/tests/qc/test_missing_node.py
+++ b/tests/qc/test_missing_node.py
@@ -193,9 +193,7 @@ class TestRequireNeighborsVisible:
         assert score_missing_nodes(vis, covis, edges)["suspicious_nodes"] == [3]
         # With the rule, a neighborless node cannot satisfy "all neighbors
         # visible" and is skipped.
-        result = score_missing_nodes(
-            vis, covis, edges, require_neighbors_visible=True
-        )
+        result = score_missing_nodes(vis, covis, edges, require_neighbors_visible=True)
         assert result["suspicious_nodes"] == []
 
 

--- a/tests/qc/test_ordering.py
+++ b/tests/qc/test_ordering.py
@@ -23,9 +23,7 @@ CORRECT_CURVED_TAIL = np.array(
 def _rotate(points: np.ndarray, degrees: float) -> np.ndarray:
     """Rotate points about the origin by ``degrees`` (NaN-safe)."""
     theta = np.deg2rad(degrees)
-    R = np.array(
-        [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
-    )
+    R = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
     return points @ R.T
 
 
@@ -402,9 +400,7 @@ class TestEndToEndWithSleapIO:
 
         skel = self._tail_skeleton()
         # Swap Tail_1 <-> Tail_2 positions (adjacent swap).
-        coords = np.array(
-            [[0, 0], [1, 0.5], [3, 0.9], [2, 0.8], [4, 0.8]], dtype=float
-        )
+        coords = np.array([[0, 0], [1, 0.5], [3, 0.9], [2, 0.8], [4, 0.8]], dtype=float)
         inst = sio.Instance.from_numpy(coords, skeleton=skel)
 
         names = [n.name for n in skel.nodes]

--- a/tests/qc/test_ordering.py
+++ b/tests/qc/test_ordering.py
@@ -1,0 +1,434 @@
+"""Tests for sleap.qc.features.ordering (wrong keypoint order along a chain)."""
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.ordering import (
+    DEFAULT_MAX_TURN_ANGLE,
+    compute_chain_ordering,
+    resolve_chains,
+)
+
+
+# A canonical 5-node tail chain (indices used directly as the chain).
+TAIL_CHAIN = [0, 1, 2, 3, 4]
+
+# A correctly-ordered tail with a gentle 2D arc. Monotone in x with a small
+# bend in y -- a realistic, correctly-labeled (slightly curved) tail.
+CORRECT_CURVED_TAIL = np.array(
+    [[0, 0], [1, 0.5], [2, 0.8], [3, 0.9], [4, 0.8]], dtype=float
+)
+
+
+def _rotate(points: np.ndarray, degrees: float) -> np.ndarray:
+    """Rotate points about the origin by ``degrees`` (NaN-safe)."""
+    theta = np.deg2rad(degrees)
+    R = np.array(
+        [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
+    )
+    return points @ R.T
+
+
+class TestComputeChainOrderingStraight:
+    """A correctly-ordered chain should not be flagged."""
+
+    def test_straight_chain_zero_inversions(self):
+        """A perfectly straight chain -> ~0 turning angle, 0 inversions."""
+        points = np.array([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]], dtype=float)
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] < 1e-6
+
+    def test_gently_curved_chain_not_flagged(self):
+        """A gently curved (correct) tail has small turns, no inversions."""
+        result = compute_chain_ordering(CORRECT_CURVED_TAIL, [TAIL_CHAIN])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        # Largest turn is well under the 60-degree default threshold.
+        assert result["max_turn_angle"] < DEFAULT_MAX_TURN_ANGLE
+
+
+class TestComputeChainOrderingCurled:
+    """Robustness: a correctly-ordered but strongly curled chain is NOT flagged."""
+
+    def test_half_circle_curl_not_flagged(self):
+        """A half-circle (correct order) has gentle per-step turns."""
+        t = np.linspace(0, np.pi, 6)
+        points = np.stack([np.cos(t), np.sin(t)], axis=1) * 5.0
+        chain = list(range(6))
+
+        result = compute_chain_ordering(points, [chain])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] < DEFAULT_MAX_TURN_ANGLE
+
+    def test_strong_curl_three_quarter_circle_not_flagged(self):
+        """A 3/4-circle curl with enough nodes is still correctly ordered."""
+        t = np.linspace(0, 1.5 * np.pi, 8)
+        points = np.stack([np.cos(t), np.sin(t)], axis=1) * 5.0
+        chain = list(range(8))
+
+        result = compute_chain_ordering(points, [chain])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] < DEFAULT_MAX_TURN_ANGLE
+
+
+class TestComputeChainOrderingAdjacentSwap:
+    """An adjacent swap shows up as large turning angles + inversions."""
+
+    def test_adjacent_swap_high_turn_and_inversions(self):
+        """Swapping t1<->t2 (idx 2 & 3 positions) -> sharp reversals."""
+        # Correct straight tail is x = 0,1,2,3,4. Swap the positions held by
+        # node indices 2 and 3 (an adjacent label swap).
+        points = np.array([[0, 0], [1, 0], [3, 0], [2, 0], [4, 0]], dtype=float)
+
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        # Two consecutive interior nodes turn sharply -> high inversion rate.
+        assert result["order_inversion_rate"] > 0.5
+        # A full direction reversal approaches pi radians.
+        assert result["max_turn_angle"] > np.deg2rad(150.0)
+        assert result["worst_chain"] == tuple(TAIL_CHAIN)
+        assert result["worst_node"] in (2, 3)
+
+    def test_adjacent_swap_two_consecutive_large_turns(self):
+        """An adjacent swap produces (at least) two large turning angles."""
+        points = np.array([[0, 0], [1, 0], [3, 0], [2, 0], [4, 0]], dtype=float)
+
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        # 3 interior nodes; an adjacent swap flags 2 of them -> rate ~= 2/3.
+        assert result["order_inversion_rate"] == pytest.approx(2.0 / 3.0)
+
+
+class TestComputeChainOrderingNonAdjacentReversal:
+    """A non-adjacent swap makes segments geometrically cross."""
+
+    def test_t1_t3_reversal_has_intersection(self):
+        """Swapping t1<->t3 (idx 1 & 3) makes a self-crossing chain."""
+        points = CORRECT_CURVED_TAIL.copy()
+        points[[1, 3]] = points[[3, 1]]
+
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        assert result["chain_intersection_count"] > 0
+        # It also produces sharp turns.
+        assert result["order_inversion_rate"] > 0.0
+        assert result["max_turn_angle"] > DEFAULT_MAX_TURN_ANGLE
+
+    def test_correct_chain_has_no_intersection(self):
+        """A correctly ordered curved chain has zero self-crossings."""
+        result = compute_chain_ordering(CORRECT_CURVED_TAIL, [TAIL_CHAIN])
+        assert result["chain_intersection_count"] == 0
+
+
+class TestComputeChainOrderingInvariance:
+    """Turning angle is invariant to translation, rotation, and scale."""
+
+    def test_translation_invariant(self):
+        points = CORRECT_CURVED_TAIL.copy()
+        shifted = points + np.array([100.0, -50.0])
+
+        base = compute_chain_ordering(points, [TAIL_CHAIN])
+        moved = compute_chain_ordering(shifted, [TAIL_CHAIN])
+
+        assert moved["max_turn_angle"] == pytest.approx(base["max_turn_angle"])
+        assert moved["order_inversion_rate"] == base["order_inversion_rate"]
+
+    def test_rotation_invariant(self):
+        points = CORRECT_CURVED_TAIL.copy()
+        rotated = _rotate(points, 73.0)
+
+        base = compute_chain_ordering(points, [TAIL_CHAIN])
+        rot = compute_chain_ordering(rotated, [TAIL_CHAIN])
+
+        assert rot["max_turn_angle"] == pytest.approx(base["max_turn_angle"])
+        assert rot["order_inversion_rate"] == base["order_inversion_rate"]
+
+    def test_scale_invariant(self):
+        points = CORRECT_CURVED_TAIL.copy()
+        scaled = points * 17.0
+
+        base = compute_chain_ordering(points, [TAIL_CHAIN])
+        sc = compute_chain_ordering(scaled, [TAIL_CHAIN])
+
+        assert sc["max_turn_angle"] == pytest.approx(base["max_turn_angle"])
+        assert sc["order_inversion_rate"] == base["order_inversion_rate"]
+
+    def test_swap_detected_under_rotation(self):
+        """An adjacent swap is still flagged after an arbitrary rotation."""
+        swapped = np.array([[0, 0], [1, 0], [3, 0], [2, 0], [4, 0]], dtype=float)
+        rotated = _rotate(swapped, 41.0)
+
+        result = compute_chain_ordering(rotated, [TAIL_CHAIN])
+        assert result["order_inversion_rate"] > 0.5
+        assert result["max_turn_angle"] > np.deg2rad(150.0)
+
+
+class TestComputeChainOrderingThreshold:
+    """The per-chain turning-angle threshold is configurable."""
+
+    def test_lower_threshold_flags_gentle_curve(self):
+        """A very low threshold flags even a gentle (correct) curve."""
+        # CORRECT_CURVED_TAIL has a max turn of ~0.2 rad; threshold below it.
+        result = compute_chain_ordering(
+            CORRECT_CURVED_TAIL, [TAIL_CHAIN], max_turn_angle=0.1
+        )
+        assert result["order_inversion_rate"] > 0.0
+
+    def test_higher_threshold_tolerates_more(self):
+        """A high threshold tolerates a turn that the default would flag."""
+        # A ~90-degree turn at the middle node.
+        points = np.array([[0, 0], [1, 0], [2, 0], [2, 1], [2, 2]], dtype=float)
+
+        default_res = compute_chain_ordering(points, [TAIL_CHAIN])
+        loose_res = compute_chain_ordering(
+            points, [TAIL_CHAIN], max_turn_angle=np.deg2rad(170.0)
+        )
+
+        assert default_res["order_inversion_rate"] > 0.0
+        assert loose_res["order_inversion_rate"] == 0.0
+
+
+class TestComputeChainOrderingDegenerate:
+    """Degenerate inputs must never leak NaN or crash."""
+
+    def test_no_chains_returns_default(self):
+        points = CORRECT_CURVED_TAIL.copy()
+        result = compute_chain_ordering(points, [])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] == 0.0
+        assert result["worst_chain"] == ()
+        assert result["worst_node"] == -1
+
+    def test_chain_too_short(self):
+        """A chain with fewer than 3 nodes has no interior turning angle."""
+        points = np.array([[0, 0], [1, 0]], dtype=float)
+        result = compute_chain_ordering(points, [[0, 1]])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["max_turn_angle"] == 0.0
+        assert result["worst_node"] == -1
+
+    def test_all_invisible_chain(self):
+        """A fully occluded chain yields the default (no evaluable turns)."""
+        points = np.full((5, 2), np.nan)
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] == 0.0
+        assert result["worst_node"] == -1
+        assert not np.isnan(result["max_turn_angle"])
+
+    def test_occluded_interior_node_skipped(self):
+        """An invisible interior node is skipped, not treated as a reversal."""
+        # Straight chain but node idx 2 (interior) is invisible.
+        points = np.array(
+            [[0, 0], [1, 0], [np.nan, np.nan], [3, 0], [4, 0]], dtype=float
+        )
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        # The two interior turns touching the NaN node are skipped; the
+        # remaining geometry is straight, so nothing is flagged and no NaN
+        # leaks through.
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert not np.isnan(result["max_turn_angle"])
+
+    def test_partial_visibility_still_evaluates_visible_turns(self):
+        """With one endpoint occluded, the visible interior turn is evaluated."""
+        # Endpoint idx 0 invisible; interior nodes 1,2,3 form a sharp turn.
+        points = np.array(
+            [[np.nan, np.nan], [0, 0], [1, 0], [1, 1], [1, 2]], dtype=float
+        )
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        # Node 2 turn (idx1->idx2->idx3): straight->up is a 90-degree turn,
+        # which exceeds the 60-degree default and is flagged.
+        assert result["order_inversion_rate"] > 0.0
+        assert not np.isnan(result["max_turn_angle"])
+
+    def test_coincident_nodes_no_crash(self):
+        """Coincident (zero-length segment) nodes produce no NaN / crash."""
+        points = np.array([[0, 0], [0, 0], [0, 0], [3, 0], [4, 0]], dtype=float)
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        assert not np.isnan(result["max_turn_angle"])
+        assert result["order_inversion_rate"] >= 0.0
+
+
+class TestComputeChainOrderingMultipleChains:
+    """Aggregation is the max over chains; worst chain/node are recorded."""
+
+    def test_aggregates_max_over_chains(self):
+        """The worst chain drives the reported metrics."""
+        # Two chains: a clean one (nodes 0-2) and a swapped one (nodes 3-7).
+        points = np.array(
+            [
+                [0, 0],  # 0  clean chain
+                [1, 0],  # 1
+                [2, 0],  # 2
+                [0, 5],  # 3  swapped chain start
+                [1, 5],  # 4
+                [3, 5],  # 5  <- swapped position
+                [2, 5],  # 6  <- swapped position
+                [4, 5],  # 7
+            ],
+            dtype=float,
+        )
+        clean_chain = [0, 1, 2]
+        swapped_chain = [3, 4, 5, 6, 7]
+
+        result = compute_chain_ordering(points, [clean_chain, swapped_chain])
+
+        assert result["order_inversion_rate"] > 0.0
+        # Worst node belongs to the swapped chain.
+        assert result["worst_chain"] == tuple(swapped_chain)
+        assert result["worst_node"] in swapped_chain
+
+
+class TestResolveChains:
+    """resolve_chains maps names to indices, with auto-chain fallback."""
+
+    NODE_NAMES = ["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]
+
+    def test_resolves_user_defined_names(self):
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]],
+            auto_chains=None,
+        )
+        assert chains == [[0, 1, 2, 3, 4]]
+
+    def test_user_defined_takes_priority_over_auto(self):
+        """A user-declared order is ground truth; auto chains are ignored."""
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["Tail_2", "Tail_1", "Tail_0"]],  # user's intended order
+            auto_chains=[[0, 1, 2, 3, 4]],
+        )
+        assert chains == [[3, 2, 1]]
+
+    def test_falls_back_to_auto_chains(self):
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            ordered_chains_by_name=None,
+            auto_chains=[[0, 1, 2, 3, 4]],
+        )
+        assert chains == [[0, 1, 2, 3, 4]]
+
+    def test_empty_when_nothing_provided(self):
+        chains = resolve_chains(self.NODE_NAMES, None, None)
+        assert chains == []
+
+    def test_unknown_names_skipped(self):
+        """Names not in the skeleton are dropped from the resolved chain."""
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["TTI", "NotANode", "Tail_1", "Tail_2", "TailTip"]],
+            auto_chains=None,
+        )
+        assert chains == [[0, 2, 3, 4]]
+
+    def test_too_short_user_chain_falls_back_to_auto(self):
+        """A user chain that resolves to <3 nodes falls back to auto chains."""
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["TTI", "Tail_0"]],  # only 2 nodes
+            auto_chains=[[0, 1, 2, 3, 4]],
+        )
+        assert chains == [[0, 1, 2, 3, 4]]
+
+    def test_multiple_user_chains(self):
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["TTI", "Tail_0", "Tail_1"], ["Tail_1", "Tail_2", "TailTip"]],
+            auto_chains=None,
+        )
+        assert chains == [[0, 1, 2], [2, 3, 4]]
+
+    def test_auto_chains_below_min_length_dropped(self):
+        """Auto chains shorter than 3 nodes are dropped in fallback."""
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            None,
+            auto_chains=[[0, 1], [0, 1, 2, 3, 4]],
+        )
+        assert chains == [[0, 1, 2, 3, 4]]
+
+
+class TestEndToEndWithSleapIO:
+    """Build a real sleap-io skeleton/instance and run the detector end-to-end."""
+
+    def _tail_skeleton(self):
+        import sleap_io as sio
+
+        return sio.Skeleton(
+            nodes=["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"],
+            edges=[
+                ("TTI", "Tail_0"),
+                ("Tail_0", "Tail_1"),
+                ("Tail_1", "Tail_2"),
+                ("Tail_2", "TailTip"),
+            ],
+        )
+
+    def test_correct_instance_not_flagged(self):
+        import sleap_io as sio
+
+        skel = self._tail_skeleton()
+        inst = sio.Instance.from_numpy(CORRECT_CURVED_TAIL, skeleton=skel)
+
+        names = [n.name for n in skel.nodes]
+        chains = resolve_chains(
+            names, [["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]], None
+        )
+        result = compute_chain_ordering(inst.numpy(), chains)
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+
+    def test_swapped_instance_flagged(self):
+        import sleap_io as sio
+
+        skel = self._tail_skeleton()
+        # Swap Tail_1 <-> Tail_2 positions (adjacent swap).
+        coords = np.array(
+            [[0, 0], [1, 0.5], [3, 0.9], [2, 0.8], [4, 0.8]], dtype=float
+        )
+        inst = sio.Instance.from_numpy(coords, skeleton=skel)
+
+        names = [n.name for n in skel.nodes]
+        chains = resolve_chains(
+            names, [["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]], None
+        )
+        result = compute_chain_ordering(inst.numpy(), chains)
+
+        assert result["order_inversion_rate"] > 0.0
+        assert result["max_turn_angle"] > DEFAULT_MAX_TURN_ANGLE
+
+    def test_occluded_instance_no_nan(self):
+        import sleap_io as sio
+
+        skel = self._tail_skeleton()
+        coords = CORRECT_CURVED_TAIL.copy()
+        coords[2] = np.nan  # occlude an interior tail node
+        inst = sio.Instance.from_numpy(coords, skeleton=skel)
+
+        names = [n.name for n in skel.nodes]
+        chains = resolve_chains(
+            names, [["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]], None
+        )
+        result = compute_chain_ordering(inst.numpy(), chains)
+
+        assert not np.isnan(result["max_turn_angle"])
+        assert result["order_inversion_rate"] == 0.0

--- a/tests/qc/test_pose_split.py
+++ b/tests/qc/test_pose_split.py
@@ -1,0 +1,422 @@
+"""Tests for sleap.qc.features.pose_split (chimera detector)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.pose_split import (
+    compute_pose_split,
+    compute_pose_split_fallback,
+)
+
+
+# ---------------------------------------------------------------------------
+# Skeleton / baseline-stat helpers
+# ---------------------------------------------------------------------------
+
+
+def chain_adjacency(n_nodes: int) -> dict[int, list[int]]:
+    """Adjacency for a line graph 0-1-2-...-(n-1)."""
+    adj: dict[int, list[int]] = {i: [] for i in range(n_nodes)}
+    for i in range(n_nodes - 1):
+        adj[i].append(i + 1)
+        adj[i + 1].append(i)
+    return adj
+
+
+def edges_from_adjacency(adj: dict[int, list[int]]) -> list[tuple[int, int]]:
+    """Sorted unique undirected edges from an adjacency dict."""
+    seen = set()
+    for node, nbrs in adj.items():
+        for nb in nbrs:
+            seen.add(tuple(sorted((node, nb))))
+    return sorted(seen)
+
+
+def learn_edge_stats(
+    instances: list[np.ndarray],
+    edges: list[tuple[int, int]],
+    min_std: float = 1e-6,
+) -> tuple[dict[tuple[int, int], float], dict[tuple[int, int], float]]:
+    """Mimic BaselineFeatureExtractor's edge-length stats from clean poses.
+
+    Returns (edge_means, edge_stds) keyed by sorted (i, j) tuples.
+    """
+    lengths: dict[tuple[int, int], list[float]] = {e: [] for e in edges}
+    for pts in instances:
+        for i, j in edges:
+            p1, p2 = pts[i], pts[j]
+            if not (np.isnan(p1).any() or np.isnan(p2).any()):
+                lengths[(i, j)].append(float(np.linalg.norm(p2 - p1)))
+    means = {e: (float(np.mean(v)) if v else 0.0) for e, v in lengths.items()}
+    stds = {
+        e: max(float(np.std(v)) if v else min_std, min_std)
+        for e, v in lengths.items()
+    }
+    return means, stds
+
+
+@pytest.fixture
+def normal_chain_stats():
+    """A 6-node line skeleton with edge stats learned from normal poses.
+
+    Each segment ~10 units long with small jitter.
+    """
+    n_nodes = 6
+    adj = chain_adjacency(n_nodes)
+    edges = edges_from_adjacency(adj)
+
+    rng = np.random.default_rng(0)
+    instances = []
+    base = np.array([[i * 10.0, 0.0] for i in range(n_nodes)])
+    for _ in range(40):
+        instances.append(base + rng.normal(0, 0.4, size=(n_nodes, 2)))
+    means, stds = learn_edge_stats(instances, edges)
+    return adj, edges, means, stds
+
+
+# ---------------------------------------------------------------------------
+# Graph-based path: chimera vs normal vs occluded
+# ---------------------------------------------------------------------------
+
+
+def test_clear_chimera_high_score(normal_chain_stats):
+    """Two tight clusters joined by one very long edge -> high split_score."""
+    adj, _edges, means, stds = normal_chain_stats
+
+    # Cluster A: nodes 0-2 near origin (segments ~10). Cluster B: nodes 3-5 far
+    # away (also internally ~10 apart). The 2->3 edge is the stretched bridge.
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [10.0, 0.0],
+            [20.0, 0.0],
+            [320.0, 0.0],  # huge jump across the bridge edge (2,3)
+            [330.0, 0.0],
+            [340.0, 0.0],
+        ]
+    )
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result["split_score"] > 1.0
+    # Balanced 3/3 split -> ratio 0.5.
+    assert result["split_ratio"] == pytest.approx(0.5)
+    # Gap (~300) is huge relative to intra-cluster spread (~6.7).
+    assert result["gap_ratio"] > 10.0
+
+
+def test_normal_pose_low_score(normal_chain_stats):
+    """A normal in-distribution pose -> ~zero split_score."""
+    adj, _edges, means, stds = normal_chain_stats
+
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    points[2, 1] += 0.5  # tiny perturbation, still normal
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result["split_score"] < 0.5
+    # Gap between the two halves is comparable to their internal spread.
+    assert result["gap_ratio"] < 3.0
+
+
+def test_partially_occluded_normal_pose_low_score(normal_chain_stats):
+    """Occluded single animal (disconnected visible subgraph) -> low score.
+
+    Hiding an interior node breaks the chain into two visible components with
+    *no* bridging edge between them. Removing the largest-z edge then yields
+    more than two components, so we must not flag it.
+    """
+    adj, _edges, means, stds = normal_chain_stats
+
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    points[2] = np.nan  # occlude an interior node -> subgraph splits at 1|3
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result["split_score"] < 0.5
+
+
+def test_occluded_single_node_not_chimera(normal_chain_stats):
+    """One stray displaced node is a single-node error, not a chimera.
+
+    Node 5 is yanked far away. That is an unbalanced 1-vs-5 split, which the
+    balance gate must suppress even though the end edge is stretched.
+    """
+    adj, _edges, means, stds = normal_chain_stats
+
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    points[5] = [500.0, 0.0]  # single stretched leaf
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result["split_ratio"] < 0.2  # 1/6
+    assert result["split_score"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_two_close_overlapping_animals_low_score(normal_chain_stats):
+    """Two animals merged but spatially interleaved/overlapping -> low score.
+
+    When two correctly-merged animals genuinely overlap, the two halves of the
+    skeleton are interleaved in space: the gap between the cluster centroids is
+    small relative to the within-cluster spread, so gap_ratio stays below the
+    floor and the score is ~zero. (A *separated* pair with a stretched bridge is
+    a true chimera and is covered by ``test_clear_chimera_high_score``.)
+    """
+    adj, _edges, means, stds = normal_chain_stats
+
+    # Interleave: nodes alternate around the origin so neither graph-half forms
+    # a spatially distinct cluster. The bridge edge (2,3) is normal length.
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [10.0, 2.0],
+            [20.0, 0.0],
+            [25.0, 2.0],
+            [15.0, -2.0],
+            [5.0, 0.0],
+        ]
+    )
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    # Centroids of the two graph-halves nearly coincide -> tiny gap_ratio.
+    assert result["gap_ratio"] < 2.0
+    assert result["split_score"] < 1.0
+
+
+def test_score_is_nonnegative_and_finite(normal_chain_stats):
+    """split_score is always >= 0 and finite across cases."""
+    adj, _edges, means, stds = normal_chain_stats
+    rng = np.random.default_rng(7)
+    for _ in range(20):
+        pts = rng.normal(0, 50, size=(6, 2))
+        result = compute_pose_split(pts, adj, means, stds)
+        assert result["split_score"] >= 0.0
+        assert np.isfinite(result["split_score"])
+        assert np.isfinite(result["gap_ratio"])
+        assert 0.0 <= result["split_ratio"] <= 0.5
+
+
+# ---------------------------------------------------------------------------
+# Invariance
+# ---------------------------------------------------------------------------
+
+
+def test_translation_rotation_scale_invariance(normal_chain_stats):
+    """split_ratio and gap_ratio are invariant to translation and rotation.
+
+    (Scale invariance holds for gap_ratio/split_ratio; split_score depends on
+    the learned edge z-score which is scale-sensitive by design, so we only
+    assert the ratios are scale-invariant here.)
+    """
+    adj, _edges, means, stds = normal_chain_stats
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [10.0, 0.0],
+            [20.0, 0.0],
+            [320.0, 0.0],
+            [330.0, 0.0],
+            [340.0, 0.0],
+        ]
+    )
+    base = compute_pose_split(points, adj, means, stds)
+
+    # Rotate 37 degrees + translate.
+    theta = np.deg2rad(37.0)
+    rot = np.array(
+        [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
+    )
+    moved = points @ rot.T + np.array([123.4, -56.7])
+    rt = compute_pose_split(moved, adj, means, stds)
+
+    assert rt["split_ratio"] == pytest.approx(base["split_ratio"])
+    assert rt["gap_ratio"] == pytest.approx(base["gap_ratio"], rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Degenerate / guard cases
+# ---------------------------------------------------------------------------
+
+
+def test_too_few_visible_nodes_returns_zero(normal_chain_stats):
+    """Fewer than MIN_VISIBLE_NODES visible -> all-zero result."""
+    adj, _edges, means, stds = normal_chain_stats
+    points = np.full((6, 2), np.nan)
+    points[0] = [0.0, 0.0]
+    points[3] = [100.0, 0.0]  # only 2 visible
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result == {"split_score": 0.0, "split_ratio": 0.0, "gap_ratio": 0.0}
+
+
+def test_no_adjacency_uses_fallback():
+    """adjacency=None routes to the geometry-only fallback for a chimera."""
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [10.0, 0.0],
+            [20.0, 0.0],
+            [320.0, 0.0],
+            [330.0, 0.0],
+            [340.0, 0.0],
+        ]
+    )
+    result = compute_pose_split(points, None, {}, {})
+    assert result["split_score"] > 0.0
+    assert result["split_ratio"] == pytest.approx(0.5)
+    assert result["gap_ratio"] > 10.0
+
+
+def test_empty_adjacency_uses_fallback():
+    """Empty adjacency dict routes to the fallback; uniform line -> ~zero.
+
+    An evenly spaced line is *not* bimodal: 2-means halves it with a large
+    centroid gap but a near-zero silhouette, so the fallback's bimodality gate
+    suppresses it.
+    """
+    points = np.array([[0.0, 0.0], [10.0, 0.0], [20.0, 0.0], [30.0, 0.0]])
+    result = compute_pose_split(points, {}, {}, {})
+    assert result["split_score"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_missing_edge_stats_falls_back_gracefully(normal_chain_stats):
+    """If learned stats lack the visible edges, no crash; defers to fallback."""
+    adj, _edges, _means, _stds = normal_chain_stats
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    # Empty stats -> no edge gets a z-score -> best_edge is None -> fallback.
+    result = compute_pose_split(points, adj, {}, {})
+    assert np.isfinite(result["split_score"])
+    assert result["split_score"] >= 0.0
+
+
+def test_nan_never_leaks(normal_chain_stats):
+    """NaN nodes never produce NaN outputs."""
+    adj, _edges, means, stds = normal_chain_stats
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    points[1] = np.nan
+    points[4] = np.nan
+    result = compute_pose_split(points, adj, means, stds)
+    for v in result.values():
+        assert not np.isnan(v)
+
+
+# ---------------------------------------------------------------------------
+# Fallback (star / short skeleton) path
+# ---------------------------------------------------------------------------
+
+
+def test_star_skeleton_uses_fallback():
+    """A star skeleton (hub + leaves) routes through the fallback.
+
+    Hub node 0 connects to all others. Leaves 1-3 are one tight cluster, leaves
+    4-6 are a far cluster -> the geometry fallback should see two clusters.
+    """
+    n_nodes = 7
+    adj: dict[int, list[int]] = {0: [1, 2, 3, 4, 5, 6]}
+    for k in range(1, n_nodes):
+        adj[k] = [0]
+    edges = edges_from_adjacency(adj)
+
+    # Tight cluster near origin, far cluster near x=300; hub between-ish.
+    points = np.array(
+        [
+            [150.0, 0.0],  # hub
+            [0.0, 0.0],
+            [5.0, 5.0],
+            [-5.0, 5.0],
+            [300.0, 0.0],
+            [305.0, 5.0],
+            [295.0, 5.0],
+        ]
+    )
+    # Provide normal-ish stats so the (non-fallback) z would be modest; we only
+    # care that the star is routed to the fallback.
+    means = {e: 150.0 for e in edges}
+    stds = {e: 30.0 for e in edges}
+
+    result = compute_pose_split(points, adj, means, stds)
+    assert result["split_score"] >= 0.0
+    assert np.isfinite(result["split_score"])
+    # Two well separated leaf groups -> meaningful gap_ratio.
+    assert result["gap_ratio"] > 1.5
+
+
+def test_fallback_clear_bimodal_high():
+    """Fallback fires on two tight, well-separated clusters."""
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [4.0, 0.0],
+            [0.0, 4.0],
+            [200.0, 0.0],
+            [204.0, 0.0],
+            [200.0, 4.0],
+        ]
+    )
+    result = compute_pose_split_fallback(points)
+    assert result["split_score"] > 0.0
+    assert result["split_ratio"] == pytest.approx(0.5)
+    assert result["gap_ratio"] > 5.0
+
+
+def test_fallback_single_blob_low():
+    """Fallback stays low for a single compact blob (no real gap)."""
+    rng = np.random.default_rng(3)
+    points = rng.normal(0, 5, size=(8, 2))
+    result = compute_pose_split_fallback(points)
+    # A diffuse single blob: gap between halves is comparable to spread.
+    assert result["split_score"] < 1.0
+
+
+def test_fallback_too_few_visible_zero():
+    """Fallback returns zeros with too few visible nodes."""
+    points = np.full((6, 2), np.nan)
+    points[0] = [0.0, 0.0]
+    points[1] = [1.0, 1.0]
+    result = compute_pose_split_fallback(points)
+    assert result == {"split_score": 0.0, "split_ratio": 0.0, "gap_ratio": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Integration with sleap_io-built skeleton (smoke test)
+# ---------------------------------------------------------------------------
+
+
+def test_integration_with_sleap_io_skeleton():
+    """End-to-end style: build adjacency/stats like the detector would.
+
+    Uses SkeletonAnalyzer.get_adjacency() and edge-length stats over clean
+    instances, mirroring how the integration layer supplies arguments.
+    """
+    import sleap_io as sio
+
+    from sleap.qc.features.skeleton import SkeletonAnalyzer
+
+    node_names = ["n0", "n1", "n2", "n3", "n4", "n5"]
+    skel = sio.Skeleton(
+        nodes=node_names,
+        edges=[("n0", "n1"), ("n1", "n2"), ("n2", "n3"), ("n3", "n4"), ("n4", "n5")],
+    )
+    analyzer = SkeletonAnalyzer(skel)
+    adj = analyzer.get_adjacency()
+    edges = analyzer.edges
+
+    rng = np.random.default_rng(11)
+    base = np.array([[i * 10.0, 0.0] for i in range(6)])
+    clean = [base + rng.normal(0, 0.4, size=(6, 2)) for _ in range(40)]
+    means, stds = learn_edge_stats(clean, [tuple(sorted(e)) for e in edges])
+
+    # Normal pose -> low.
+    normal_res = compute_pose_split(base.copy(), adj, means, stds)
+    assert normal_res["split_score"] < 0.5
+
+    # Chimera -> high.
+    chimera = base.copy()
+    chimera[3:] += np.array([300.0, 0.0])
+    chimera_res = compute_pose_split(chimera, adj, means, stds)
+    assert chimera_res["split_score"] > normal_res["split_score"]
+    assert chimera_res["split_score"] > 1.0

--- a/tests/qc/test_pose_split.py
+++ b/tests/qc/test_pose_split.py
@@ -51,8 +51,7 @@ def learn_edge_stats(
                 lengths[(i, j)].append(float(np.linalg.norm(p2 - p1)))
     means = {e: (float(np.mean(v)) if v else 0.0) for e, v in lengths.items()}
     stds = {
-        e: max(float(np.std(v)) if v else min_std, min_std)
-        for e, v in lengths.items()
+        e: max(float(np.std(v)) if v else min_std, min_std) for e, v in lengths.items()
     }
     return means, stds
 
@@ -226,9 +225,7 @@ def test_translation_rotation_scale_invariance(normal_chain_stats):
 
     # Rotate 37 degrees + translate.
     theta = np.deg2rad(37.0)
-    rot = np.array(
-        [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
-    )
+    rot = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
     moved = points @ rot.T + np.array([123.4, -56.7])
     rt = compute_pose_split(moved, adj, means, stds)
 


### PR DESCRIPTION
**Stacked on #2759** (base = `fix/qc-invisible-nodes-2753`). Implements the detector work in #2756.

Adds 5 detectors for the common labeling errors, on top of the existing geometry + GMM pipeline.

## Detectors

| | Error | Mechanism | Default |
|---|---|---|---|
| (c) | Whole-instance L/R flip | chirality (signed side vs **midline** body axis) feature + hard-rule; auto-infers L/R pairs from node names | **ON** |
| (d) | Chimera (1 instance, 2 animals) | pose-split / graph-cut feature (log-compressed) → GMM | **ON** |
| (a) | Duplicate / split instances | scale-aware complementary-split signal folded into the frame-level duplicate score | **ON** |
| (b) | Wrong keypoint order along a chain | turning-angle / segment-crossing over auto- **or user-defined `ordered_chains`** + hard-rule | experimental (OFF) |
| (f-T1) | Labelable-but-unlabeled node | co-visibility-prior heuristic via a non-GMM channel | experimental (OFF) |

## Scaffold
- `QCConfig`: per-detector flags + thresholds + user-defined `ordered_chains` (by node name).
- Feature vector **18 → 22** with a **fixed-width invariant** (disabled detectors emit constant defaults).
- `_score_instance`: **raise-only** hard-rule overrides (flip, chain-order) — never lower the GMM score; set a named `top_issue`.
- `QCResults`: `forced_issues` + non-GMM `channel_scores`, merged in `get_flagged` (`final = max(GMM, channel)`).
- Frame-level duplicate detection combines IoU + node-overlap + split-duplicate into one graded score.
- New feature names auto-flow into the existing table / CSV / canvases.

## Tests
**278 `tests/qc` pass** (136 module + 29 integration + prior scaffold); **50 GUI QC widget tests pass**; ruff clean.

## Real-data validation (59k-instance CVAT project)
The detectors fire — flip surfaces genuine external-labeler L/R errors. Validation caught a **body-axis bug** (the skeleton's longest path can end at a *side* node, e.g. `Nose→Haunch_left`), now fixed to use **midline non-symmetric** nodes (`Nose→TTI`): flip false-positives **17.6% → 7.7%**, overall flag rate **59% → 46%**.

⚠️ **Default thresholds still over-flag on real heterogeneous data** (flip 7.7%; the experimental chain-order/missing-node 12–17% — hence default-OFF). Precision is **unvalidated against ground truth**.

## Follow-ups
1. **GUI config setter** — per-detector toggles + threshold sliders, threaded through `QCAnalysisWorker` so users tune/disable per project *(next PR)*.
2. **Calibration** — review flagged samples vs ground truth + tune thresholds (belly-up poses, occluded-axis, coarse-granularity flip FPs) before any detector is considered tuned.
3. Pre-existing baseline over-flagging (multi-video "Isolated node" + visibility-feature noise) tracked separately.
