### PR TITLE
feat(cli): show build commit hash in sleap doctor and startup banner

### DIFF
--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -422,7 +422,17 @@ _DOCTOR_WIDTHS = {
     default=None,
     help="Save output to file. Use '-o auto' for auto-timestamped filename.",
 )
-def doctor(output_json: bool, output_file: Optional[str]) -> None:
+@click.option(
+    "--commit",
+    "show_commit",
+    is_flag=True,
+    default=False,
+    help=(
+        "Resolve and display the SLEAP commit hash for release installs by "
+        "looking up the release tag on GitHub (off by default; needs network)."
+    ),
+)
+def doctor(output_json: bool, output_file: Optional[str], show_commit: bool) -> None:
     """Show system diagnostics for troubleshooting.
 
     Displays detailed information about your system configuration,
@@ -453,10 +463,13 @@ def doctor(output_json: bool, output_file: Optional[str]) -> None:
         get_disk_info,
         get_ffmpeg_info,
         analyze_path,
+        short_sha,
+        resolve_tag_commit,
+        SLEAP_REPO,
     )
 
     if output_json:
-        _doctor_json()
+        _doctor_json(show_commit)
         return
 
     console = Console()
@@ -696,6 +709,21 @@ def doctor(output_json: bool, output_file: Optional[str]) -> None:
                 packages.append(pkg_info)
     all_data["packages"] = packages
 
+    # Optionally resolve the SLEAP commit from its release tag via GitHub. Only
+    # done with --commit (it needs network) and only for release installs that
+    # don't already carry a local commit.
+    resolved_commits = {}
+    if show_commit:
+        sleap_pkg = next((p for p in packages if p.name == "sleap"), None)
+        if sleap_pkg and not sleap_pkg.git_commit:
+            with console.status(
+                f"[{DIM}]Resolving commit from GitHub...[/]", spinner="dots"
+            ):
+                sha = resolve_tag_commit(SLEAP_REPO, sleap_pkg.version)
+            if sha:
+                resolved_commits["sleap"] = sha
+    all_data["resolved_commits"] = resolved_commits
+
     console.print("[Packages]", style=f"bold {SLEAP_BLUE}")
     w = max(len(pkg.name) for pkg in packages) + 1 if packages else 10  # +1 for colon
     for pkg in packages:
@@ -710,14 +738,19 @@ def doctor(output_json: bool, output_file: Optional[str]) -> None:
             f"  [{SLEAP_TEAL}]{(pkg.name + ':'):<{w}}[/] "
             f"[{SLEAP_GREEN}]v{pkg.version}[/] ([{source_color}]{pkg.source}[/])"
         )
-        if pkg.editable and pkg.git_commit:
-            git_info = f"git:{pkg.git_branch or 'HEAD'}@{pkg.git_commit}"
+        if pkg.git_commit:
+            git_info = f"git:{pkg.git_branch or 'HEAD'}@{short_sha(pkg.git_commit)}"
             if pkg.git_dirty:
                 git_info += "*"
             pkg_line += f" [[{SLEAP_PURPLE}]{git_info}[/]]"
+        elif pkg.name in resolved_commits:
+            tag_info = f"github:v{pkg.version}@{short_sha(resolved_commits[pkg.name])}"
+            pkg_line += f" [[{SLEAP_PURPLE}]{tag_info}[/]]"
         console.print(pkg_line)
         if pkg.editable:
             console.print(f"  {'':<{w}} Location: [{SLEAP_CYAN}]{pkg.location}[/]")
+        elif pkg.git_remote:
+            console.print(f"  {'':<{w}} Remote: [{SLEAP_CYAN}]{pkg.git_remote}[/]")
     console.print()
 
     # -------------------------------------------------------------------------
@@ -820,8 +853,13 @@ def doctor(output_json: bool, output_file: Optional[str]) -> None:
     console.print()
 
 
-def _doctor_json() -> None:
-    """Output diagnostics as JSON."""
+def _doctor_json(show_commit: bool = False) -> None:
+    """Output diagnostics as JSON.
+
+    Args:
+        show_commit: If True, resolve the SLEAP commit from its release tag via
+            GitHub for release installs (needs network). See ``doctor --commit``.
+    """
     import dataclasses
     import json
 
@@ -837,6 +875,7 @@ def _doctor_json() -> None:
         get_disk_info,
         get_ffmpeg_info,
         analyze_path,
+        get_sleap_commit,
     )
 
     def to_dict(obj):
@@ -871,6 +910,7 @@ def _doctor_json() -> None:
 
     data = {
         "sleap_version": sleap.__version__,
+        "sleap_commit": get_sleap_commit(resolve_remote=show_commit),
         "platform": {
             "system": platform.system(),
             "release": platform.release(),
@@ -1053,18 +1093,26 @@ def _format_doctor_plain(data: dict) -> str:
     lines.append("")
 
     # Packages
+    from sleap.system_info import short_sha
+
     packages = data.get("packages", [])
+    resolved_commits = data.get("resolved_commits", {})
     lines.append("[Packages]")
     w = max(len(pkg.name) for pkg in packages) + 1 if packages else 10  # +1 for colon
     for pkg in packages:
         pkg_line = f"  {(pkg.name + ':'):<{w}} v{pkg.version} ({pkg.source})"
+        if pkg.git_commit:
+            git_info = f"git:{pkg.git_branch or 'HEAD'}@{short_sha(pkg.git_commit)}"
+            if pkg.git_dirty:
+                git_info += "*"
+            pkg_line += f" [{git_info}]"
+        elif pkg.name in resolved_commits:
+            short = short_sha(resolved_commits[pkg.name])
+            pkg_line += f" [github:v{pkg.version}@{short}]"
         if pkg.editable:
-            if pkg.git_commit:
-                git_info = f"git:{pkg.git_branch or 'HEAD'}@{pkg.git_commit}"
-                if pkg.git_dirty:
-                    git_info += "*"
-                pkg_line += f" [{git_info}]"
             pkg_line += f"\n  {'':<{w}} Location: {pkg.location}"
+        elif pkg.git_remote:
+            pkg_line += f"\n  {'':<{w}} Remote: {pkg.git_remote}"
         lines.append(pkg_line)
     lines.append("")
 

--- a/sleap/system_info.py
+++ b/sleap/system_info.py
@@ -86,6 +86,7 @@ def short_sha(sha: Optional[str]) -> str:
     """
     return sha[:SHORT_SHA_LEN] if sha else ""
 
+
 # ASCII art logo
 SLEAP_ASCII = r"""
  ____  _     _____    _    ____

--- a/sleap/system_info.py
+++ b/sleap/system_info.py
@@ -67,6 +67,25 @@ SLEAP_RED_HEX = "#e74c3c"
 SLEAP_YELLOW_HEX = "#f1c40f"
 DIM = "dim"
 
+# Number of characters to show for shortened git commit SHAs in display.
+SHORT_SHA_LEN = 8
+
+# GitHub repo used to resolve a release tag back to its commit (sleap doctor).
+SLEAP_REPO = "talmolab/sleap"
+
+
+def short_sha(sha: Optional[str]) -> str:
+    """Shorten a git commit SHA for display.
+
+    Args:
+        sha: Full or short commit SHA, or None.
+
+    Returns:
+        The first ``SHORT_SHA_LEN`` characters of ``sha``, or an empty string
+        if ``sha`` is falsy.
+    """
+    return sha[:SHORT_SHA_LEN] if sha else ""
+
 # ASCII art logo
 SLEAP_ASCII = r"""
  ____  _     _____    _    ____
@@ -430,6 +449,11 @@ def _build_version_line() -> Text:
     line.append("SLEAP", style="bold rgb(26,188,156)")
     line.append(f" v{sleap_version}", style="rgb(93,173,226)")
 
+    # Commit hash for editable / git-URL installs (helps pin down the exact build)
+    sleap_commit = get_sleap_commit()
+    if sleap_commit:
+        line.append(f" ({sleap_commit})", style="dim")
+
     # sleap-io (if installed)
     if sleap_io_info["version"]:
         line.append(" | ", style="dim")
@@ -661,8 +685,8 @@ def get_git_info(path: str) -> dict:
 
     info = {}
 
-    # Get commit hash
-    rc, stdout, _ = run_command(["git", "-C", path, "rev-parse", "--short", "HEAD"])
+    # Get commit hash (full SHA; shortened with short_sha() at display time)
+    rc, stdout, _ = run_command(["git", "-C", path, "rev-parse", "HEAD"])
     if rc == 0:
         info["commit"] = stdout
 
@@ -696,6 +720,10 @@ def get_detailed_package_info(name: str) -> Optional[PackageInfoData]:
         is_editable = False
         source = "pip"
         location = ""
+        # Commit info recorded by pip for git-URL installs (vcs_info).
+        vcs_commit: Optional[str] = None
+        vcs_revision: Optional[str] = None
+        vcs_remote: Optional[str] = None
 
         # Check direct_url.json for modern pip installs
         try:
@@ -710,7 +738,12 @@ def get_detailed_package_info(name: str) -> Optional[PackageInfoData]:
                     if url.startswith("file://"):
                         location = url[7:]  # Strip file://
                 elif "vcs_info" in direct_url:
+                    # e.g. pip install git+https://github.com/talmolab/sleap@ref
                     source = "git"
+                    vcs_info = direct_url["vcs_info"]
+                    vcs_commit = vcs_info.get("commit_id")
+                    vcs_revision = vcs_info.get("requested_revision")
+                    vcs_remote = direct_url.get("url") or None
                 elif direct_url.get("url", "").startswith("file://"):
                     source = "local"
         except FileNotFoundError:
@@ -749,7 +782,7 @@ def get_detailed_package_info(name: str) -> Optional[PackageInfoData]:
             editable=is_editable,
         )
 
-        # Get git info for editable installs
+        # Get git info for editable installs (live working tree)
         if is_editable and location:
             git_info = get_git_info(location)
             if git_info:
@@ -758,10 +791,86 @@ def get_detailed_package_info(name: str) -> Optional[PackageInfoData]:
                 pkg_info.git_dirty = git_info.get("dirty", False)
                 pkg_info.git_remote = git_info.get("remote")
 
+        # Git-URL installs (pip install git+...): pip records the exact commit in
+        # direct_url.json, so we get provenance without a working tree or git.
+        if source == "git":
+            pkg_info.git_commit = vcs_commit
+            pkg_info.git_branch = vcs_revision
+            pkg_info.git_remote = vcs_remote
+
         return pkg_info
 
     except importlib.metadata.PackageNotFoundError:
         return None
+
+
+def resolve_tag_commit(repo: str, version: str, timeout: int = 3) -> Optional[str]:
+    """Resolve a release version to its commit SHA via the GitHub REST API.
+
+    Release installs (PyPI/conda) don't record a commit locally, but each release
+    is tagged ``vX.Y.Z``. This looks that tag up on GitHub and returns the commit
+    it points to. It is fully offline-safe: any failure (no network, rate limit,
+    missing tag, unexpected response) returns ``None`` so callers degrade
+    gracefully.
+
+    Args:
+        repo: GitHub "owner/name", e.g. ``"talmolab/sleap"``.
+        version: Package version, e.g. ``"1.6.3"`` (mapped to tag ``"v1.6.3"``).
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The full commit SHA the tag points to, or ``None`` if it could not be
+        resolved.
+    """
+    if not repo or not version:
+        return None
+
+    import urllib.error
+    import urllib.request
+
+    # The /commits/{ref} endpoint dereferences tags (lightweight or annotated).
+    url = f"https://api.github.com/repos/{repo}/commits/v{version}"
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "sleap-doctor",  # GitHub rejects requests without a UA
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+    sha = payload.get("sha") if isinstance(payload, dict) else None
+    return sha or None
+
+
+def get_sleap_commit(resolve_remote: bool = False) -> Optional[str]:
+    """Get the short git commit SHA the installed SLEAP was built from.
+
+    Works without a network for editable installs (live git checkout) and for
+    installs from a git URL (e.g. ``pip install git+https://github.com/talmolab/
+    sleap``), where pip records the commit in ``direct_url.json``.
+
+    Args:
+        resolve_remote: If ``True`` and no commit is available locally (a plain
+            PyPI/conda release install), resolve the release tag to its commit
+            via the GitHub API. Off by default since it requires network access.
+
+    Returns:
+        The shortened commit SHA, or ``None`` if it could not be determined.
+    """
+    info = get_detailed_package_info("sleap")
+    if info and info.git_commit:
+        return short_sha(info.git_commit)
+    if resolve_remote:
+        from sleap.version import __version__
+
+        sha = resolve_tag_commit(SLEAP_REPO, __version__)
+        return short_sha(sha) if sha else None
+    return None
 
 
 def get_uv_config_value(key: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -242,9 +242,7 @@ class TestCLIBasics:
             "sleap.system_info.resolve_tag_commit",
             return_value="e08bdad8353fffcacb9d3012f5a052d37381ca73",
         ):
-            result = runner.invoke(
-                cli, ["doctor", "--commit", "-o", str(output_file)]
-            )
+            result = runner.invoke(cli, ["doctor", "--commit", "-o", str(output_file)])
         assert result.exit_code == 0
         assert "github:v1.6.3@e08bdad8" in output_file.read_text()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,6 +79,8 @@ class TestCLIBasics:
         assert "binaries" in data
         assert "path_entries" in data
         assert "path_conflicts" in data
+        # Commit provenance: present as a key, value may be None for release installs
+        assert "sleap_commit" in data
         # Check platform has new fields
         assert "ram_used" in data["platform"]
         assert "disk_used" in data["platform"]
@@ -153,6 +155,98 @@ class TestCLIBasics:
         assert result.exit_code == 0
         assert "Tip:" in result.output
         assert "sleap doctor -o" in result.output
+
+    def test_doctor_commit_flag_in_help(self):
+        """Verify the --commit flag is documented and off by default."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["doctor", "--help"])
+        assert result.exit_code == 0
+        assert "--commit" in result.output
+
+    def test_doctor_no_commit_flag_skips_github(self):
+        """Without --commit, doctor never reaches out to GitHub."""
+        from unittest.mock import patch
+
+        runner = CliRunner()
+        with patch("sleap.system_info.resolve_tag_commit") as mock_resolve:
+            result = runner.invoke(cli, ["doctor"])
+        assert result.exit_code == 0
+        mock_resolve.assert_not_called()
+
+    def test_doctor_commit_flag_resolves_release(self):
+        """--commit resolves a release install's commit from its tag."""
+        from unittest.mock import patch
+
+        from sleap.system_info import PackageInfoData
+
+        def fake_pkg(name):
+            if name == "sleap":
+                return PackageInfoData(
+                    name="sleap", version="1.6.3", source="pip", editable=False
+                )
+            return None
+
+        runner = CliRunner()
+        with patch(
+            "sleap.system_info.get_detailed_package_info", side_effect=fake_pkg
+        ), patch(
+            "sleap.system_info.resolve_tag_commit",
+            return_value="e08bdad8353fffcacb9d3012f5a052d37381ca73",
+        ) as mock_resolve:
+            result = runner.invoke(cli, ["doctor", "--commit"])
+        assert result.exit_code == 0
+        mock_resolve.assert_called_once()
+        # Shown as resolved-from-tag, distinct from a local git checkout.
+        assert "github:v1.6.3@e08bdad8" in result.output
+
+    def test_doctor_commit_flag_json(self):
+        """--commit --json populates the top-level sleap_commit field."""
+        import json
+        from unittest.mock import patch
+
+        from sleap.system_info import PackageInfoData
+
+        release = PackageInfoData(
+            name="sleap", version="1.6.3", source="pip", editable=False
+        )
+        runner = CliRunner()
+        with patch(
+            "sleap.system_info.get_detailed_package_info", return_value=release
+        ), patch(
+            "sleap.system_info.resolve_tag_commit",
+            return_value="e08bdad8353fffcacb9d3012f5a052d37381ca73",
+        ):
+            result = runner.invoke(cli, ["doctor", "--json", "--commit"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["sleap_commit"] == "e08bdad8"
+
+    def test_doctor_commit_flag_file_output(self, tmp_path):
+        """--commit -o writes the resolved-from-tag commit into the saved file."""
+        from unittest.mock import patch
+
+        from sleap.system_info import PackageInfoData
+
+        def fake_pkg(name):
+            if name == "sleap":
+                return PackageInfoData(
+                    name="sleap", version="1.6.3", source="pip", editable=False
+                )
+            return None
+
+        output_file = tmp_path / "doctor.txt"
+        runner = CliRunner()
+        with patch(
+            "sleap.system_info.get_detailed_package_info", side_effect=fake_pkg
+        ), patch(
+            "sleap.system_info.resolve_tag_commit",
+            return_value="e08bdad8353fffcacb9d3012f5a052d37381ca73",
+        ):
+            result = runner.invoke(
+                cli, ["doctor", "--commit", "-o", str(output_file)]
+            )
+        assert result.exit_code == 0
+        assert "github:v1.6.3@e08bdad8" in output_file.read_text()
 
 
 class TestSleapIoIntegration:

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -487,9 +487,7 @@ class TestCommitInfo:
                 "requested_revision": "main",
             },
         }
-        with patch(
-            "importlib.metadata.distribution", return_value=_FakeDist(payload)
-        ):
+        with patch("importlib.metadata.distribution", return_value=_FakeDist(payload)):
             pkg = get_detailed_package_info("sleap")
         assert pkg.source == "git"
         assert pkg.editable is False
@@ -503,9 +501,7 @@ class TestCommitInfo:
             "url": "https://github.com/talmolab/sleap.git",
             "vcs_info": {"vcs": "git", "commit_id": "abcdef1234567890"},
         }
-        with patch(
-            "importlib.metadata.distribution", return_value=_FakeDist(payload)
-        ):
+        with patch("importlib.metadata.distribution", return_value=_FakeDist(payload)):
             pkg = get_detailed_package_info("sleap")
         assert pkg.git_commit == "abcdef1234567890"
         assert pkg.git_branch is None
@@ -519,16 +515,12 @@ class TestCommitInfo:
                 "commit_id": "e08bdad8353fffcacb9d3012f5a052d37381ca73",
             },
         }
-        with patch(
-            "importlib.metadata.distribution", return_value=_FakeDist(payload)
-        ):
+        with patch("importlib.metadata.distribution", return_value=_FakeDist(payload)):
             assert get_sleap_commit() == "e08bdad8"
 
     def test_get_sleap_commit_release_install(self):
         """A plain release install (no direct_url.json) has no commit info."""
-        with patch(
-            "importlib.metadata.distribution", return_value=_FakeDist(None)
-        ):
+        with patch("importlib.metadata.distribution", return_value=_FakeDist(None)):
             assert get_sleap_commit() is None
 
     def test_build_version_line_includes_commit(self):
@@ -573,9 +565,7 @@ class TestCommitInfo:
         release = PackageInfoData(
             name="sleap", version="1.6.3", source="pip", editable=False
         )
-        with patch(
-            "sleap.system_info.get_detailed_package_info", return_value=release
-        ):
+        with patch("sleap.system_info.get_detailed_package_info", return_value=release):
             # Off by default: no network, no commit.
             assert get_sleap_commit() is None
             # On: resolve via the (mocked) GitHub lookup.
@@ -585,9 +575,7 @@ class TestCommitInfo:
             ):
                 assert get_sleap_commit(resolve_remote=True) == "e08bdad8"
             # On but unresolved (offline / no tag): still None, never "".
-            with patch(
-                "sleap.system_info.resolve_tag_commit", return_value=None
-            ):
+            with patch("sleap.system_info.resolve_tag_commit", return_value=None):
                 assert get_sleap_commit(resolve_remote=True) is None
 
     def test_get_sleap_commit_prefers_local_over_remote(self):
@@ -599,9 +587,7 @@ class TestCommitInfo:
             editable=True,
             git_commit="e08bdad8353fffcacb9d3012f5a052d37381ca73",
         )
-        with patch(
-            "sleap.system_info.get_detailed_package_info", return_value=local
-        ):
+        with patch("sleap.system_info.get_detailed_package_info", return_value=local):
             with patch("sleap.system_info.resolve_tag_commit") as mock_resolve:
                 assert get_sleap_commit(resolve_remote=True) == "e08bdad8"
                 mock_resolve.assert_not_called()

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -1,7 +1,8 @@
 """Tests for the SLEAP system_info module."""
 
+import json
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from rich.console import Console
 
@@ -30,6 +31,11 @@ from sleap.system_info import (
     get_disk_info,
     get_ffmpeg_info,
     analyze_path,
+    # Commit provenance
+    short_sha,
+    get_sleap_commit,
+    resolve_tag_commit,
+    _build_version_line,
 )
 
 
@@ -442,3 +448,160 @@ class TestEdgeCases:
             with patch.dict("sys.modules", {"imageio_ffmpeg": None}):
                 binaries = get_ffmpeg_info()
                 assert isinstance(binaries, list)
+
+
+class _FakeDist:
+    """Minimal importlib.metadata.Distribution stand-in for commit tests."""
+
+    _path = None
+
+    def __init__(self, direct_url_payload, version="1.6.3"):
+        self.version = version
+        self._direct_url_payload = direct_url_payload
+
+    def read_text(self, name):
+        import json
+
+        if name == "direct_url.json" and self._direct_url_payload is not None:
+            return json.dumps(self._direct_url_payload)
+        raise FileNotFoundError(name)
+
+
+class TestCommitInfo:
+    """Tests for git commit provenance in diagnostics and the startup banner."""
+
+    def test_short_sha(self):
+        """Verify short_sha shortens full SHAs and tolerates empty input."""
+        assert short_sha("e08bdad8353fffcacb9d3012f5a052d37381ca73") == "e08bdad8"
+        assert short_sha("abc123") == "abc123"  # already shorter than the limit
+        assert short_sha(None) == ""
+        assert short_sha("") == ""
+
+    def test_git_url_install_captures_commit(self):
+        """pip install git+...@ref: commit/branch/remote come from vcs_info."""
+        payload = {
+            "url": "https://github.com/talmolab/sleap.git",
+            "vcs_info": {
+                "vcs": "git",
+                "commit_id": "e08bdad8353fffcacb9d3012f5a052d37381ca73",
+                "requested_revision": "main",
+            },
+        }
+        with patch(
+            "importlib.metadata.distribution", return_value=_FakeDist(payload)
+        ):
+            pkg = get_detailed_package_info("sleap")
+        assert pkg.source == "git"
+        assert pkg.editable is False
+        assert pkg.git_commit == "e08bdad8353fffcacb9d3012f5a052d37381ca73"
+        assert pkg.git_branch == "main"
+        assert pkg.git_remote == "https://github.com/talmolab/sleap.git"
+
+    def test_git_url_install_without_ref(self):
+        """Git install with no @ref still records the resolved commit."""
+        payload = {
+            "url": "https://github.com/talmolab/sleap.git",
+            "vcs_info": {"vcs": "git", "commit_id": "abcdef1234567890"},
+        }
+        with patch(
+            "importlib.metadata.distribution", return_value=_FakeDist(payload)
+        ):
+            pkg = get_detailed_package_info("sleap")
+        assert pkg.git_commit == "abcdef1234567890"
+        assert pkg.git_branch is None
+
+    def test_get_sleap_commit_with_commit(self):
+        """get_sleap_commit returns the shortened SHA for a git install."""
+        payload = {
+            "url": "https://github.com/talmolab/sleap.git",
+            "vcs_info": {
+                "vcs": "git",
+                "commit_id": "e08bdad8353fffcacb9d3012f5a052d37381ca73",
+            },
+        }
+        with patch(
+            "importlib.metadata.distribution", return_value=_FakeDist(payload)
+        ):
+            assert get_sleap_commit() == "e08bdad8"
+
+    def test_get_sleap_commit_release_install(self):
+        """A plain release install (no direct_url.json) has no commit info."""
+        with patch(
+            "importlib.metadata.distribution", return_value=_FakeDist(None)
+        ):
+            assert get_sleap_commit() is None
+
+    def test_build_version_line_includes_commit(self):
+        """The banner version line shows the commit when one is known."""
+        with patch("sleap.system_info.get_sleap_commit", return_value="e08bdad8"):
+            line = _build_version_line()
+        assert "(e08bdad8)" in line.plain
+
+    def test_build_version_line_omits_commit_when_absent(self):
+        """No commit info -> no empty parens appended to the version line."""
+        with patch("sleap.system_info.get_sleap_commit", return_value=None):
+            line = _build_version_line()
+        assert "()" not in line.plain
+
+    def test_resolve_tag_commit_success(self):
+        """A successful GitHub lookup returns the full commit SHA."""
+        full = "e08bdad8353fffcacb9d3012f5a052d37381ca73"
+        resp = MagicMock()
+        resp.read.return_value = json.dumps({"sha": full}).encode()
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = False
+        with patch("urllib.request.urlopen", return_value=resp):
+            assert resolve_tag_commit("talmolab/sleap", "1.6.3") == full
+
+    def test_resolve_tag_commit_offline_returns_none(self):
+        """Network errors degrade to None rather than raising."""
+        import urllib.error
+
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("offline"),
+        ):
+            assert resolve_tag_commit("talmolab/sleap", "1.6.3") is None
+
+    def test_resolve_tag_commit_empty_inputs(self):
+        """Empty repo/version short-circuits to None (no request made)."""
+        assert resolve_tag_commit("", "1.6.3") is None
+        assert resolve_tag_commit("talmolab/sleap", "") is None
+
+    def test_get_sleap_commit_resolve_remote_for_release(self):
+        """A release install resolves its commit only when resolve_remote=True."""
+        release = PackageInfoData(
+            name="sleap", version="1.6.3", source="pip", editable=False
+        )
+        with patch(
+            "sleap.system_info.get_detailed_package_info", return_value=release
+        ):
+            # Off by default: no network, no commit.
+            assert get_sleap_commit() is None
+            # On: resolve via the (mocked) GitHub lookup.
+            with patch(
+                "sleap.system_info.resolve_tag_commit",
+                return_value="e08bdad8353fffcacb9d3012f5a052d37381ca73",
+            ):
+                assert get_sleap_commit(resolve_remote=True) == "e08bdad8"
+            # On but unresolved (offline / no tag): still None, never "".
+            with patch(
+                "sleap.system_info.resolve_tag_commit", return_value=None
+            ):
+                assert get_sleap_commit(resolve_remote=True) is None
+
+    def test_get_sleap_commit_prefers_local_over_remote(self):
+        """A local commit is used without any network lookup."""
+        local = PackageInfoData(
+            name="sleap",
+            version="1.6.3",
+            source="editable",
+            editable=True,
+            git_commit="e08bdad8353fffcacb9d3012f5a052d37381ca73",
+        )
+        with patch(
+            "sleap.system_info.get_detailed_package_info", return_value=local
+        ):
+            with patch("sleap.system_info.resolve_tag_commit") as mock_resolve:
+                assert get_sleap_commit(resolve_remote=True) == "e08bdad8"
+                mock_resolve.assert_not_called()


### PR DESCRIPTION
## Summary

Makes it easy to see the exact git commit a SLEAP install was built from — in the startup banner and `sleap doctor` — which is especially useful when an install came from GitHub rather than a tagged release.

## What changed

- **Startup banner & `sleap doctor`** now display the commit for installs where it's known locally (no network):
  - **Editable** installs (`pip install -e .`) — from the live git checkout.
  - **Git-URL** installs (`pip install git+https://github.com/talmolab/sleap`) — read from pip's `direct_url.json` `vcs_info`, so no working tree or `git` binary is needed.
- **`sleap doctor --commit`** (off by default) — for plain **PyPI/conda release** installs, resolves the release tag (`vX.Y.Z`) to its commit via the GitHub API. Fully offline-safe: any failure (offline, rate-limited, missing tag) degrades to showing no commit.
- **`sleap doctor --json`** gains a top-level `sleap_commit` field.

## Behavior

| Install type | `sleap doctor` (default) | `sleap doctor --commit` |
|---|---|---|
| editable / `git+…` | commit shown (local) | same (local wins, no network) |
| PyPI / conda release | no commit | resolved from tag via GitHub |

Release install with `--commit`:
```
[Packages]
  sleap:  v1.6.3 (pip) [github:v1.6.3@e08bdad8]
```

## Notes

- The startup banner stays fully local/offline — only `sleap doctor --commit` ever hits the network.
- Tag resolution only helps tagged releases (which already map 1:1 to a commit via the `vX.Y.Z` convention). Untagged dev/nightly wheels would need a build-time commit stamp; left as a future option.

## Test plan

- `tests/test_system_info.py`: `short_sha`, `vcs_info` commit extraction, `get_sleap_commit` (local/remote/offline), `resolve_tag_commit` (success/offline/empty).
- `tests/test_cli.py`: `--commit` in help, no network without the flag, resolves on release install (console / `--json` / `-o`).
- `ruff` clean.

With the help of Claude.
