### PR TITLE
feat(qc): appearance + in-sample prediction detectors (B2) (#2756)

### DIFF
--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -965,6 +965,50 @@ class QCWidget(QtWidgets.QWidget):
         )
         self._add_detector_row(5, self._cb_missing, missing_thr_row)
 
+        # --- Appearance / wrong-object (B2 channel), experimental, default-OFF ---
+        self._cb_appearance = QtWidgets.QCheckBox("Appearance / wrong-object")
+        self._cb_appearance.setChecked(False)
+        self._cb_appearance.setToolTip(
+            "Flag a keypoint placed on visually-wrong pixels (e.g. on bedding "
+            "instead of fur), using a per-node image-appearance model. "
+            "Experimental; off by default."
+        )
+        # No tunable hard threshold in the GUI: appearance is a channel score.
+        appearance_note = QtWidgets.QLabel("(image-based)")
+        appearance_note.setEnabled(False)
+        appearance_note.setToolTip(
+            "Appearance scoring reads image patches around each node; it has no "
+            "hard threshold to tune here."
+        )
+        self._add_detector_row(6, self._cb_appearance, appearance_note)
+
+        # --- In-sample model prediction (B2 channel), experimental, default-OFF ---
+        self._cb_insample = QtWidgets.QCheckBox("In-sample model prediction")
+        self._cb_insample.setChecked(False)
+        self._cb_insample.setToolTip(
+            "Run a trained sleap-nn model on the labeled frames and flag "
+            "unlabeled nodes the model confidently localizes (labelable-but-"
+            "skipped parts).\n"
+            "WARNING: runs full model inference and can be slow on large "
+            "projects. Experimental; off by default."
+        )
+        # Model-path picker: a (display-only) line edit plus a Browse button.
+        self._insample_model_edit = QtWidgets.QLineEdit()
+        self._insample_model_edit.setReadOnly(True)
+        self._insample_model_edit.setPlaceholderText("trained sleap-nn model folder")
+        self._insample_model_edit.setToolTip(
+            "Folder of a trained sleap-nn model (with best.ckpt + "
+            "training_config.yaml) to run in-sample. Empty disables the channel."
+        )
+        self._insample_browse_btn = QtWidgets.QPushButton("Browse...")
+        self._insample_browse_btn.setToolTip(
+            "Choose the trained sleap-nn model folder for in-sample prediction."
+        )
+        insample_picker = self._make_threshold_row(
+            [(self._insample_model_edit, self._insample_browse_btn)]
+        )
+        self._add_detector_row(7, self._cb_insample, insample_picker)
+
         # Disable each detector's tunable widgets when its checkbox is off.
         self._cb_flip.toggled.connect(self._sb_flip_thr.setEnabled)
         self._sb_flip_thr.setEnabled(self._cb_flip.isChecked())
@@ -981,7 +1025,27 @@ class QCWidget(QtWidgets.QWidget):
         self._cb_chain.toggled.connect(_set_chain_enabled)
         _set_chain_enabled(self._cb_chain.isChecked())
 
+        # Disable the in-sample model picker + Browse button when its checkbox
+        # is off (mirrors the other detectors' disable-on-uncheck behavior).
+        def _set_insample_enabled(on: bool):
+            self._insample_model_edit.setEnabled(on)
+            self._insample_browse_btn.setEnabled(on)
+
+        self._cb_insample.toggled.connect(_set_insample_enabled)
+        _set_insample_enabled(self._cb_insample.isChecked())
+        self._insample_browse_btn.clicked.connect(self._on_browse_insample_model)
+
         layout.addWidget(group)
+
+    def _on_browse_insample_model(self):
+        """Open a folder picker and set the in-sample model path line edit."""
+        directory = QtWidgets.QFileDialog.getExistingDirectory(
+            self,
+            "Select trained sleap-nn model folder",
+            self._insample_model_edit.text() or "",
+        )
+        if directory:
+            self._insample_model_edit.setText(directory)
 
     def _make_threshold_row(self, items: list) -> QtWidgets.QWidget:
         """Pack labeled threshold widgets into a single compact row widget.
@@ -1046,6 +1110,9 @@ class QCWidget(QtWidgets.QWidget):
             ordered_chains=self._parse_ordered_chains(),
             use_missing_node_check=self._cb_missing.isChecked(),
             missing_node_prob_threshold=self._sb_missing_thr.value(),
+            use_appearance=self._cb_appearance.isChecked(),
+            use_insample_prediction=self._cb_insample.isChecked(),
+            insample_model_path=self._insample_model_edit.text().strip(),
         )
 
     def _parse_ordered_chains(self) -> list:

--- a/sleap/qc/config.py
+++ b/sleap/qc/config.py
@@ -32,6 +32,27 @@ class QCConfig:
             when the longest chain has >= 4 nodes. Experimental, default-OFF.
         use_missing_node_check: Whether to run the missing-node check (a node a
             instance's peers usually keep is absent). Experimental, default-OFF.
+        use_appearance: Whether to run the appearance-outlier channel (a node
+            placed on visually-wrong pixels, e.g. on bedding instead of fur).
+            Needs decoded image frames; scored outside the GMM as the
+            ``"appearance"`` channel. Experimental, default-OFF.
+        appearance_patch_size: Side length (pixels) of the square image patch
+            cut around each node for the appearance descriptor.
+        appearance_min_samples: Minimum number of patch samples a node needs at
+            fit time before the appearance model has an opinion on it.
+        use_insample_prediction: Whether to run the in-sample model-prediction
+            channel (Tier-2 missing-node): run a trained sleap-nn model on the
+            labeled frames and flag unlabeled nodes the model confidently
+            localizes. Scored outside the GMM as the ``"prediction"`` channel.
+            EXPENSIVE (full model inference). Experimental, default-OFF.
+        insample_model_path: Path to a trained sleap-nn model directory for the
+            in-sample prediction channel. Empty disables the channel (no-op).
+        insample_peak_threshold: Peak-finding confidence threshold passed to the
+            in-sample model inference (lower = more candidate peaks).
+        insample_min_confidence: Confidence at/above which a model prediction at
+            an unlabeled node counts as a disagreement (gates the channel score).
+        insample_device: Torch device for the in-sample inference
+            (``"auto"``/``"cpu"``/``"cuda"``/``"mps"``).
         instance_threshold: Threshold for flagging instances (0-1).
             Higher = fewer flags, lower = more flags.
         frame_threshold: Threshold for frame-level checks.
@@ -69,6 +90,9 @@ class QCConfig:
     use_duplicate_score: bool = True  # (a)
     use_chain_ordering: Literal["auto"] | bool = False  # (b) experimental
     use_missing_node_check: bool = False  # (f, Tier-1) experimental
+    # B2 non-GMM channels (default-OFF / experimental).
+    use_appearance: bool = False  # (e) appearance outlier / wrong-object
+    use_insample_prediction: bool = False  # (f, Tier-2) in-sample model prediction
 
     # Thresholds (validated in v4 investigation)
     instance_threshold: float = 0.7  # Default: balanced
@@ -83,6 +107,16 @@ class QCConfig:
     chain_turn_angle_deg: float = 60.0
     order_inversion_threshold: float = 0.3
     missing_node_prob_threshold: float = 0.9
+
+    # B2 appearance-outlier channel settings.
+    appearance_patch_size: int = 7
+    appearance_min_samples: int = 20
+
+    # B2 in-sample model-prediction channel settings.
+    insample_model_path: str = ""
+    insample_peak_threshold: float = 0.2
+    insample_min_confidence: float = 0.5
+    insample_device: str = "auto"
 
     # User-defined ordered chains (lists of node NAMES) for chain-ordering.
     ordered_chains: list = field(default_factory=list)

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -20,6 +20,8 @@ from sleap.qc.features.chirality import (
 from sleap.qc.features.pose_split import compute_pose_split
 from sleap.qc.features.ordering import compute_chain_ordering, resolve_chains
 from sleap.qc.features.missing_node import score_missing_nodes
+from sleap.qc.features.appearance import fit_appearance, score_appearance
+from sleap.qc.insample_prediction import run_insample_prediction
 from sleap.qc.frame_level import (
     InstanceCountChecker,
     check_negative_frame,
@@ -114,6 +116,10 @@ class LabelQCDetector:
         self._ordering_chains: list[list[int]] = []
         self._adjacency: Optional[dict[int, list[int]]] = None
         self._co_visibility: Optional[np.ndarray] = None
+
+        # B2 appearance-channel fit-time state (set in fit() when
+        # use_appearance is on, consumed in score()). None = no appearance model.
+        self._appearance_model: Optional[dict] = None
 
     def fit(
         self,
@@ -216,6 +222,30 @@ class LabelQCDetector:
                 instances, self._symmetry_pairs, self._axis_nodes
             )
 
+        # B2 appearance channel (experimental, default-OFF): build a per-node
+        # appearance model from the labeled frames. Guarded by use_appearance so
+        # the default path never touches (potentially expensive) video decoding.
+        # Each labeled frame is decoded ONCE; undecodable frames are skipped.
+        if self.config.use_appearance:
+            _report("Fitting feature extractors", 0.18, "Appearance model")
+            appearance_pairs = []
+            for video in labels.videos:
+                for lf in [lf for lf in labels if lf.video == video]:
+                    try:
+                        frame = video[lf.frame_idx]
+                    except Exception:
+                        continue
+                    for inst in lf.user_instances:
+                        appearance_pairs.append(
+                            (frame, inst.numpy(invisible_as_nan=True))
+                        )
+            self._appearance_model = fit_appearance(
+                appearance_pairs,
+                n_nodes=self.skeleton_analyzer.n_nodes,
+                patch_size=self.config.appearance_patch_size,
+                min_samples=self.config.appearance_min_samples,
+            )
+
         # Build feature matrix (use LOO NN distances for training)
         _report("Extracting features", 0.20, f"0/{len(instances)}")
         self.feature_names = self._get_feature_names()  # Set first, needed by extract
@@ -288,6 +318,16 @@ class LabelQCDetector:
             for lf in labeled_frames:
                 frame_idx = lf.frame_idx
 
+                # Decode the frame ONCE per labeled frame for the appearance
+                # channel (experimental). Hoisted out of the instance loop so a
+                # frame is never decoded more than once; undecodable -> None.
+                appearance_frame = None
+                if self.config.use_appearance and self._appearance_model is not None:
+                    try:
+                        appearance_frame = lf.video[frame_idx]
+                    except Exception:
+                        appearance_frame = None
+
                 # Collect instances for this frame
                 frame_instances = []
                 for inst_idx, inst in enumerate(lf.user_instances):
@@ -327,6 +367,21 @@ class LabelQCDetector:
                                 key
                             ] = _mn["missing_node_score"]
 
+                    # Appearance channel (experimental): scored against the
+                    # per-node appearance model using the once-decoded frame.
+                    if (
+                        self.config.use_appearance
+                        and self._appearance_model is not None
+                        and appearance_frame is not None
+                    ):
+                        _ap = score_appearance(
+                            appearance_frame, points, self._appearance_model
+                        )
+                        if _ap["appearance_outlier_score"] > 0:
+                            results.channel_scores.setdefault("appearance", {})[key] = (
+                                _ap["appearance_outlier_score"]
+                            )
+
                     # Progress update (every 500 instances)
                     instance_count += 1
                     if instance_count % 500 == 0:
@@ -340,6 +395,25 @@ class LabelQCDetector:
                     frame_instances, video_id, is_negative=lf.is_negative
                 )
                 results.frame_results[frame_key] = frame_qc
+
+        # In-sample model-prediction channel (experimental, Tier-2 missing-node):
+        # ONE batched inference over ALL labeled frames, run after the per-instance
+        # loop completes. run_insample_prediction self-skips (returns an empty
+        # instance_scores) when the model path is falsy, so guarding only on
+        # use_insample_prediction is safe and avoids real inference by default.
+        if self.config.use_insample_prediction:
+            out = run_insample_prediction(
+                labels,
+                model_path=self.config.insample_model_path or "",
+                peak_threshold=self.config.insample_peak_threshold,
+                min_confidence=self.config.insample_min_confidence,
+                device=self.config.insample_device,
+                progress_callback=progress_callback,
+            )
+            for (v_idx, f_idx, i_idx), s in out["instance_scores"].items():
+                results.channel_scores.setdefault("prediction", {})[
+                    InstanceKey(v_idx, f_idx, i_idx)
+                ] = s
 
         _report("Complete", 1.0, f"{instance_count} instances scored")
         return results

--- a/sleap/qc/features/appearance.py
+++ b/sleap/qc/features/appearance.py
@@ -1,0 +1,412 @@
+"""Appearance-outlier detection: points placed on occluders / the wrong object.
+
+This module implements detector (e): "points placed on occluders / wrong
+object" -- e.g. a keypoint dragged onto white cotton bedding sitting over a dark
+mouse, or onto a cage bar. Unlike the geometry-only detectors, the *geometry*
+of such an error can look perfectly plausible (the point is in a sensible place
+for the pose); what gives it away is the **image content** under the node. We
+therefore build a small per-node appearance model from the labeled data and
+flag nodes whose local image patch does not look like that node usually looks.
+
+How it works
+------------
+At fit time, for every *visible* node of every (clean) labeled instance we cut a
+``patch_size x patch_size`` window centred on the node's ``(x, y)`` in its frame
+and reduce it to a compact **appearance descriptor**: per-channel mean and
+standard deviation of the patch intensities (a length-2 vector for grayscale
+``(H, W, 1)`` frames, length-6 for RGB). Mean captures brightness ("white cotton
+bedding" vs "dark fur"), std captures local texture/contrast. We accumulate
+these descriptors per node and fit a robust Gaussian (median + regularized
+covariance), giving a per-node squared **Mahalanobis** distance. Nodes with
+fewer than ``min_samples`` descriptors are left unmodeled (no opinion).
+
+At score time, for each visible node we cut the same descriptor and compute its
+Mahalanobis distance to that node's learned model, then squash it to ``[0, 1]``
+against a per-node distance scale learned at fit time (so "normal" appearance
+sits near 0 and clear outliers approach 1). The per-instance score is the
+**max** over nodes -- one badly-misplaced node is enough to warrant review.
+
+This is a NON-GMM channel detector (default-OFF / experimental): it produces a
+per-instance ``appearance_outlier_score`` in ``[0, 1]`` that the integration
+layer stores in :attr:`QCResults.channel_scores` under the ``"appearance"``
+channel, exactly like the missing-node detector.
+
+Honest scope / limitations
+---------------------------
+- The descriptor is intentionally tiny (mean + std per channel). It catches
+  gross "this node is on visually-different stuff" errors (bright bedding vs
+  dark fur, a node on the cage floor vs on the animal). It will NOT distinguish
+  two regions that have the same brightness/texture but are semantically
+  different (e.g. two similarly-grey body parts).
+- It learns the *project's own* appearance statistics. If a node is
+  systematically mislabeled onto the same wrong surface across the whole
+  dataset, that wrong surface becomes "normal" and is not flagged.
+- Patches near the image border are clipped to the valid region, so an
+  edge node is described by fewer pixels but is still modeled/scored.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import numpy as np
+
+
+# Minimum number of patch samples required before a node is modeled at all.
+DEFAULT_MIN_SAMPLES = 20
+
+# Floor added to the covariance diagonal (in descriptor units, ~intensity^2)
+# to keep it invertible when a node's patches are nearly constant.
+_COV_REG = 1.0
+
+# Multiple of the learned median Mahalanobis distance that maps to a score of
+# ~0.5 (the half-saturation point of the squashing function). Larger = more
+# permissive (a node must be more anomalous to score high).
+_DIST_SCALE_FACTOR = 3.0
+
+# Floor on the per-node distance scale so a node whose training patches are
+# essentially identical (median distance ~0) does not produce an infinite /
+# hair-trigger score. In Mahalanobis (whitened) units.
+_MIN_DIST_SCALE = 1.0
+
+
+def extract_patch_descriptor(
+    frame: np.ndarray,
+    x: float,
+    y: float,
+    patch_size: int = 7,
+) -> Optional[np.ndarray]:
+    """Cut a patch around ``(x, y)`` and reduce it to an appearance descriptor.
+
+    The descriptor is the per-channel **mean** followed by the per-channel
+    **standard deviation** of the patch intensities. For a grayscale frame
+    ``(H, W, 1)`` (or ``(H, W)``) this is a length-2 vector ``[mean, std]``; for
+    an RGB frame ``(H, W, 3)`` it is length-6 ``[mean_r, mean_g, mean_b, std_r,
+    std_g, std_b]``. Patches that fall partly outside the image are clipped to
+    the valid region (an edge node is described by fewer pixels).
+
+    Args:
+        frame: Decoded image as ``(H, W)``, ``(H, W, 1)`` or ``(H, W, C)``
+            ndarray (typically ``uint8``). Decoding is the caller's job so the
+            heavy video I/O stays out of unit tests.
+        x: Node x-coordinate (column) in pixels. May be fractional; rounded to
+            the nearest pixel for the patch centre.
+        y: Node y-coordinate (row) in pixels.
+        patch_size: Side length (pixels) of the square window. Values < 1 are
+            treated as 1. Defaults to 7.
+
+    Returns:
+        A 1-D ``float64`` descriptor of length ``2 * C``, or ``None`` if the
+        frame is unusable (empty / not 2-D-or-3-D), the coordinate is NaN, or
+        the clipped patch is empty (centre fully outside the image).
+    """
+    if frame is None:
+        return None
+    frame = np.asarray(frame)
+    if frame.ndim == 2:
+        frame = frame[:, :, None]
+    if frame.ndim != 3 or frame.size == 0:
+        return None
+    if not (np.isfinite(x) and np.isfinite(y)):
+        return None
+
+    height, width = frame.shape[0], frame.shape[1]
+    if height == 0 or width == 0:
+        return None
+
+    half = max(int(patch_size), 1) // 2
+    cx = int(round(float(x)))
+    cy = int(round(float(y)))
+
+    # Clip the window to the valid image region so edge nodes still yield a
+    # (smaller) patch instead of an out-of-bounds error.
+    r0 = max(cy - half, 0)
+    r1 = min(cy + half + 1, height)
+    c0 = max(cx - half, 0)
+    c1 = min(cx + half + 1, width)
+    if r1 <= r0 or c1 <= c0:
+        # Centre is fully outside the image -> nothing to describe.
+        return None
+
+    patch = frame[r0:r1, c0:c1, :].astype(np.float64)
+    # Reduce over the spatial axes, keeping per-channel stats.
+    flat = patch.reshape(-1, patch.shape[2])
+    means = flat.mean(axis=0)
+    stds = flat.std(axis=0)
+    return np.concatenate([means, stds]).astype(np.float64)
+
+
+def _patches_to_descriptors(
+    patches: Iterable[np.ndarray], patch_size: int
+) -> list[np.ndarray]:
+    """Reduce already-cut patches to descriptors (helper for tests/integration).
+
+    Each patch is treated as a tiny image and run through the same per-channel
+    mean+std reduction as :func:`extract_patch_descriptor`. ``None`` / empty
+    patches are skipped.
+    """
+    out: list[np.ndarray] = []
+    for patch in patches:
+        if patch is None:
+            continue
+        patch = np.asarray(patch)
+        if patch.ndim == 2:
+            patch = patch[:, :, None]
+        if patch.ndim != 3 or patch.size == 0:
+            continue
+        flat = patch.reshape(-1, patch.shape[2]).astype(np.float64)
+        out.append(
+            np.concatenate([flat.mean(axis=0), flat.std(axis=0)]).astype(np.float64)
+        )
+    return out
+
+
+def _fit_node_model(descriptors: np.ndarray) -> Optional[dict]:
+    """Fit a robust Gaussian + distance scale for one node's descriptors.
+
+    Uses the median as a robust centre and a regularized covariance (with a
+    small diagonal floor) so the squared Mahalanobis distance stays finite even
+    for near-constant patches. The learned ``dist_scale`` is the median
+    training Mahalanobis distance, used later to squash test distances to
+    ``[0, 1]``.
+
+    Args:
+        descriptors: ``(n_samples, n_features)`` array of node descriptors.
+
+    Returns:
+        Per-node model dict, or ``None`` if there are too few samples.
+    """
+    descriptors = np.asarray(descriptors, dtype=np.float64)
+    n_samples, n_features = descriptors.shape
+    if n_samples < 2:
+        return None
+
+    center = np.median(descriptors, axis=0)
+    cov = np.cov(descriptors, rowvar=False)
+    cov = np.atleast_2d(cov)
+    # Regularize: keep the matrix invertible / well-conditioned even when a
+    # feature is (near-)constant across the training patches.
+    cov = cov + _COV_REG * np.eye(n_features)
+    try:
+        inv_cov = np.linalg.inv(cov)
+    except np.linalg.LinAlgError:
+        inv_cov = np.linalg.pinv(cov)
+
+    # Per-node distance scale: typical (median) Mahalanobis distance of the
+    # training descriptors themselves. Floored so identical patches don't give
+    # a hair-trigger score.
+    diffs = descriptors - center
+    d2 = np.einsum("ij,jk,ik->i", diffs, inv_cov, diffs)
+    d2 = np.clip(d2, 0.0, None)
+    train_dist = np.sqrt(d2)
+    dist_scale = float(max(np.median(train_dist), _MIN_DIST_SCALE))
+
+    return {
+        "center": center,
+        "inv_cov": inv_cov,
+        "dist_scale": dist_scale,
+        "n_samples": int(n_samples),
+    }
+
+
+def _mahalanobis_distance(descriptor: np.ndarray, node_model: dict) -> float:
+    """Squared-root Mahalanobis distance of ``descriptor`` to a node model."""
+    diff = np.asarray(descriptor, dtype=np.float64) - node_model["center"]
+    d2 = float(diff @ node_model["inv_cov"] @ diff)
+    if not np.isfinite(d2) or d2 < 0.0:
+        d2 = 0.0
+    return float(np.sqrt(d2))
+
+
+def _squash(distance: float, dist_scale: float) -> float:
+    """Map a non-negative distance to ``[0, 1)`` with a smooth saturation.
+
+    Uses ``d / (d + s)`` where ``s = _DIST_SCALE_FACTOR * dist_scale`` is the
+    half-saturation distance: a node at the typical (training-median) distance
+    scores well below 0.5, while a node many scales away approaches 1.
+    """
+    if not np.isfinite(distance) or distance <= 0.0:
+        return 0.0
+    s = max(_DIST_SCALE_FACTOR * dist_scale, 1e-6)
+    return float(distance / (distance + s))
+
+
+def fit_appearance(
+    frames_and_instances: Iterable[tuple],
+    n_nodes: int,
+    patch_size: int = 7,
+    min_samples: int = DEFAULT_MIN_SAMPLES,
+) -> dict:
+    """Learn a per-node appearance model from labeled instances.
+
+    For each ``(frame, points)`` pair and each *visible* node, cut a
+    ``patch_size x patch_size`` patch at the node's ``(x, y)`` and reduce it to
+    an appearance descriptor (per-channel mean + std). Descriptors are pooled
+    per node and a robust Gaussian is fit per node that has at least
+    ``min_samples`` samples; nodes below that are left unmodeled.
+
+    Decoding is the caller's responsibility: pass already-decoded frame arrays
+    (``(H, W)``, ``(H, W, 1)`` or ``(H, W, C)``) so the heavy video I/O stays
+    out of unit tests. Pairs whose frame is ``None`` (e.g. undecodable) are
+    skipped; NaN / out-of-frame nodes are skipped per node.
+
+    Args:
+        frames_and_instances: Iterable of ``(frame, points)`` tuples, where
+            ``frame`` is a decoded image (or ``None`` to skip) and ``points`` is
+            an ``(n_nodes, 2)`` array with NaN for invisible nodes.
+        n_nodes: Number of skeleton nodes (length of each ``points`` row dim).
+        patch_size: Side length of the square appearance patch. Defaults to 7.
+        min_samples: Minimum patch samples for a node to be modeled. Defaults to
+            :data:`DEFAULT_MIN_SAMPLES` (20).
+
+    Returns:
+        A model dict with:
+
+        - ``"node_models"``: ``dict[int, dict]`` mapping modeled node index to
+          its per-node model (``center``, ``inv_cov``, ``dist_scale``,
+          ``n_samples``). Unmodeled nodes are absent.
+        - ``"node_sample_counts"``: ``dict[int, int]`` mapping every node index
+          seen to how many descriptors were collected (modeled or not). Useful
+          for diagnostics / explaining why a node has no opinion.
+        - ``"n_nodes"``: number of skeleton nodes.
+        - ``"patch_size"``: the patch size used (so scoring can default to it).
+        - ``"min_samples"``: the threshold used.
+        - ``"descriptor_dim"``: descriptor length seen (``2 * C``), or ``None``
+          if no descriptors were collected.
+    """
+    n_nodes = int(n_nodes)
+    patch_size = max(int(patch_size), 1)
+    per_node: list[list[np.ndarray]] = [[] for _ in range(n_nodes)]
+    descriptor_dim: Optional[int] = None
+
+    for pair in frames_and_instances:
+        if pair is None:
+            continue
+        frame, points = pair
+        if frame is None or points is None:
+            continue
+        points = np.asarray(points, dtype=float)
+        if points.ndim != 2 or points.shape[1] < 2:
+            continue
+
+        n = min(points.shape[0], n_nodes)
+        for node_idx in range(n):
+            x, y = points[node_idx, 0], points[node_idx, 1]
+            if not (np.isfinite(x) and np.isfinite(y)):
+                continue
+            desc = extract_patch_descriptor(frame, x, y, patch_size)
+            if desc is None:
+                continue
+            # Descriptor length is fixed by channel count; guard against mixing
+            # grayscale and RGB frames in one fit (keep the first seen shape).
+            if descriptor_dim is None:
+                descriptor_dim = desc.shape[0]
+            elif desc.shape[0] != descriptor_dim:
+                continue
+            per_node[node_idx].append(desc)
+
+    node_models: dict[int, dict] = {}
+    node_sample_counts: dict[int, int] = {}
+    for node_idx in range(n_nodes):
+        samples = per_node[node_idx]
+        node_sample_counts[node_idx] = len(samples)
+        if len(samples) < min_samples:
+            continue
+        model = _fit_node_model(np.asarray(samples, dtype=np.float64))
+        if model is not None:
+            node_models[node_idx] = model
+
+    return {
+        "node_models": node_models,
+        "node_sample_counts": node_sample_counts,
+        "n_nodes": n_nodes,
+        "patch_size": patch_size,
+        "min_samples": int(min_samples),
+        "descriptor_dim": descriptor_dim,
+    }
+
+
+def score_appearance(
+    frame: np.ndarray,
+    points: np.ndarray,
+    model: dict,
+    patch_size: Optional[int] = None,
+) -> dict:
+    """Score an instance for appearance outliers against a fitted model.
+
+    For each *visible* node that the model has an opinion on, cut its patch,
+    compute the Mahalanobis distance of its descriptor to the node's learned
+    model, and squash it to ``[0, 1]``. The per-instance score is the max over
+    scored nodes (one clearly-misplaced node is enough to flag the instance).
+
+    Args:
+        frame: Decoded image (``(H, W)``, ``(H, W, 1)`` or ``(H, W, C)``), or
+            ``None`` if the frame could not be decoded (returns a zero score).
+        points: ``(n_nodes, 2)`` array with NaN for invisible nodes.
+        model: Model dict from :func:`fit_appearance`.
+        patch_size: Patch side length. If ``None``, uses the size stored in the
+            model (the one used at fit time).
+
+    Returns:
+        Dictionary with:
+
+        - ``"appearance_outlier_score"``: ``float`` in ``[0, 1]``. Max squashed
+          Mahalanobis distance over scored nodes (0.0 if none could be scored).
+          High = a node sits on visually-anomalous pixels.
+        - ``"worst_node"``: ``int`` node index of the highest-scoring node, or
+          ``-1`` if no node was scored.
+        - ``"node_scores"``: ``dict[int, float]`` mapping each scored node index
+          to its individual ``[0, 1]`` outlier score.
+    """
+    empty = {
+        "appearance_outlier_score": 0.0,
+        "worst_node": -1,
+        "node_scores": {},
+    }
+    if model is None:
+        return empty
+    node_models = model.get("node_models", {})
+    if not node_models:
+        return empty
+    if frame is None or points is None:
+        return empty
+
+    if patch_size is None:
+        patch_size = model.get("patch_size", 7)
+    patch_size = max(int(patch_size), 1)
+    descriptor_dim = model.get("descriptor_dim")
+
+    points = np.asarray(points, dtype=float)
+    if points.ndim != 2 or points.shape[1] < 2:
+        return empty
+
+    node_scores: dict[int, float] = {}
+    n = points.shape[0]
+    for node_idx, node_model in node_models.items():
+        if node_idx >= n:
+            continue
+        x, y = points[node_idx, 0], points[node_idx, 1]
+        if not (np.isfinite(x) and np.isfinite(y)):
+            continue
+        desc = extract_patch_descriptor(frame, x, y, patch_size)
+        if desc is None:
+            continue
+        # Skip if the channel count (descriptor length) does not match the
+        # model -- scoring an RGB frame against a grayscale model is undefined.
+        if descriptor_dim is not None and desc.shape[0] != descriptor_dim:
+            continue
+        if desc.shape[0] != node_model["center"].shape[0]:
+            continue
+        dist = _mahalanobis_distance(desc, node_model)
+        node_scores[int(node_idx)] = _squash(dist, node_model["dist_scale"])
+
+    if not node_scores:
+        return empty
+
+    worst_node = max(node_scores, key=node_scores.get)
+    score = float(np.clip(node_scores[worst_node], 0.0, 1.0))
+    return {
+        "appearance_outlier_score": score,
+        "worst_node": int(worst_node),
+        "node_scores": node_scores,
+    }

--- a/sleap/qc/insample_prediction.py
+++ b/sleap/qc/insample_prediction.py
@@ -1,0 +1,509 @@
+"""In-sample model prediction: labelable-but-unlabeled points (Tier-2).
+
+This module implements the *model-based* (Tier-2) variant of detector (f),
+"labelable points left unlabeled" -- the maintainer's active-learning idea.
+
+The geometry/visibility-only sibling
+(:mod:`sleap.qc.features.missing_node`) can only catch *outlier* drops: an
+instance missing a node its co-visible peers usually keep. It is blind to
+dataset-wide systematic under-labeling (e.g. nobody ever labels the tail tip),
+because the project's own visibility statistics never expect a node that is
+rarely labeled.
+
+This detector instead runs a *trained model* on the ALREADY-labeled frames
+(in-sample inference). For each node a human left UNLABELED/invisible, it reads
+the model's predicted confidence at the matched predicted instance's node and
+flags the cases where the model *confidently* localizes a part the human left
+blank. That distinguishes:
+
+    * "truly occluded" -- the model is also unsure (low confidence), and
+    * "labelable but skipped" -- the model is confident the part is there.
+
+Design / scope:
+    * **Import-safe.** Importing this module never imports ``torch`` or
+      ``sleap_nn``; those heavy imports happen lazily inside
+      :func:`run_insample_prediction`.
+    * **Graceful.** If ``sleap_nn``/the model is unavailable, or the model's
+      skeleton node-names do not match ``labels.skeletons[0]``, the function
+      logs a reason and returns an empty/zero result instead of crashing.
+    * **Non-GMM channel.** The per-instance ``prediction_disagreement_score`` is
+      surfaced via :attr:`QCResults.channel_scores` (like the missing-node
+      channel), not as a GMM feature. Default-OFF / experimental.
+
+The matching + scoring logic (:func:`match_predictions_to_users` and
+:func:`score_instance_disagreement`) is a pure, model-free core so it can be
+unit-tested with canned predicted instances and without any torch dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import sleap_io as sio
+
+logger = logging.getLogger(__name__)
+
+
+# Default score for an instance with no disagreement (or that could not be
+# evaluated). Surfaced as the channel score; 0.0 means "nothing to flag".
+_NO_DISAGREEMENT = 0.0
+
+
+def _visible_mask(points: np.ndarray) -> np.ndarray:
+    """Boolean ``(n_nodes,)`` mask of nodes with finite (visible) coordinates.
+
+    A node is "visible/labeled" when both of its coordinates are finite. NaN
+    (the convention for invisible/unlabeled nodes) -> ``False``.
+    """
+    points = np.asarray(points, dtype=float)
+    return ~np.isnan(points[:, :2]).any(axis=1)
+
+
+def _instance_centroid(points: np.ndarray) -> np.ndarray:
+    """Mean of the visible node coordinates, or NaNs if none are visible."""
+    points = np.asarray(points, dtype=float)
+    mask = _visible_mask(points)
+    if not mask.any():
+        return np.array([np.nan, np.nan])
+    return np.nanmean(points[mask, :2], axis=0)
+
+
+def _predicted_scores(pred_points: np.ndarray, n_nodes: int) -> np.ndarray:
+    """Extract the per-node confidence column from a predicted-instance array.
+
+    ``sio.PredictedInstance.numpy(scores=True)`` returns an ``(n_nodes, 3)``
+    array of ``(x, y, score)``. This pulls out the score column and pads/truncates
+    defensively to ``n_nodes`` so a malformed prediction can never index out of
+    range against the user skeleton. Missing entries -> ``NaN`` (treated as "no
+    prediction").
+
+    Args:
+        pred_points: ``(n_nodes, 3)`` predicted array of ``(x, y, score)``.
+        n_nodes: Expected node count (from the user skeleton).
+
+    Returns:
+        ``(n_nodes,)`` float array of per-node confidences (``NaN`` where the
+        model produced no usable score).
+    """
+    pred_points = np.asarray(pred_points, dtype=float)
+    scores = np.full(n_nodes, np.nan, dtype=float)
+    if pred_points.ndim != 2 or pred_points.shape[1] < 3:
+        return scores
+    k = min(n_nodes, pred_points.shape[0])
+    scores[:k] = pred_points[:k, 2]
+    return scores
+
+
+def match_predictions_to_users(
+    user_points: list[np.ndarray],
+    pred_points: list[np.ndarray],
+) -> list[Optional[int]]:
+    """Match each USER instance to the nearest PREDICTED instance in a frame.
+
+    Bottom-up (and top-down) models emit predicted instances with no guaranteed
+    correspondence to the user instances in the same frame, so we associate them
+    by spatial proximity: each user instance is paired with the predicted
+    instance whose visible-node centroid is closest (greedy nearest, one
+    predicted instance per user instance, mutually exclusive).
+
+    The matching is symmetric in spirit to "match each predicted instance to the
+    nearest user instance" -- a greedy global nearest-centroid assignment -- but
+    is indexed by user instance so the caller can directly look up the prediction
+    for a given user instance.
+
+    Args:
+        user_points: List of ``(n_nodes, 2)`` user pose arrays (NaN = invisible).
+        pred_points: List of ``(n_nodes, >=2)`` predicted pose arrays. Only the
+            first two columns (x, y) are used for centroid matching.
+
+    Returns:
+        A list parallel to ``user_points``: ``match[i]`` is the index into
+        ``pred_points`` of the predicted instance matched to user instance ``i``,
+        or ``None`` if no prediction could be matched (no predictions in the
+        frame, or no usable centroid).
+    """
+    n_user = len(user_points)
+    matches: list[Optional[int]] = [None] * n_user
+    if n_user == 0 or len(pred_points) == 0:
+        return matches
+
+    user_centroids = [_instance_centroid(p) for p in user_points]
+    pred_centroids = [_instance_centroid(p) for p in pred_points]
+
+    # Build all valid (distance, user_idx, pred_idx) pairs, then assign greedily
+    # from the closest pair outward. This is O(U*P) which is tiny per frame.
+    pairs: list[tuple[float, int, int]] = []
+    for ui, uc in enumerate(user_centroids):
+        if np.isnan(uc).any():
+            continue
+        for pi, pc in enumerate(pred_centroids):
+            if np.isnan(pc).any():
+                continue
+            dist = float(np.hypot(uc[0] - pc[0], uc[1] - pc[1]))
+            pairs.append((dist, ui, pi))
+
+    pairs.sort(key=lambda t: t[0])
+    used_pred: set[int] = set()
+    assigned_user: set[int] = set()
+    for _dist, ui, pi in pairs:
+        if ui in assigned_user or pi in used_pred:
+            continue
+        matches[ui] = pi
+        assigned_user.add(ui)
+        used_pred.add(pi)
+
+    return matches
+
+
+def score_instance_disagreement(
+    user_points: np.ndarray,
+    pred_scores: Optional[np.ndarray],
+    min_confidence: float = 0.5,
+) -> dict:
+    """Score how strongly a model disagrees with a user's *unlabeled* nodes.
+
+    For each node the user left invisible/unlabeled (NaN), look up the matched
+    predicted instance's confidence at that node. A node is a *disagreement* when
+    the model is confident the part is present::
+
+        disagreement at node k  <=>  user node k is invisible
+                                      AND pred_scores[k] >= min_confidence
+
+    The per-instance ``prediction_disagreement_score`` is the maximum predicted
+    confidence over the instance's unlabeled nodes, but only counting nodes whose
+    confidence clears ``min_confidence`` (so it is gated -- a model that is mildly
+    unsure about every blank node yields 0.0). The result is therefore in
+    ``[0, 1]`` and 0.0 when the model never confidently fills a human-left blank.
+
+    Args:
+        user_points: ``(n_nodes, 2)`` user pose array (NaN = invisible/unlabeled).
+        pred_scores: ``(n_nodes,)`` per-node predicted confidence for the matched
+            predicted instance, or ``None`` if the user instance had no matched
+            prediction. ``NaN`` entries mean "model produced no peak there".
+        min_confidence: Confidence at/above which a model prediction at an
+            unlabeled node counts as a disagreement. Defaults to ``0.5``.
+
+    Returns:
+        Dictionary with:
+
+        - ``prediction_disagreement_score``: ``float`` in ``[0, 1]`` (gated max,
+          see above).
+        - ``disagreement_nodes``: ``list[int]`` of flagged node indices
+          (ascending) -- nodes the user left blank that the model localized at
+          ``>= min_confidence``.
+        - ``unlabeled_confidences``: ``dict[int, float]`` mapping every unlabeled
+          node index to the model's confidence there (NaN-confidence nodes
+          omitted). Useful for explanations / per-node records.
+        - ``n_disagreements``: ``int`` count of flagged nodes.
+    """
+    user_points = np.asarray(user_points, dtype=float)
+    n_nodes = user_points.shape[0]
+    invisible = ~_visible_mask(user_points)
+    invisible_idx = np.where(invisible)[0]
+
+    empty = {
+        "prediction_disagreement_score": _NO_DISAGREEMENT,
+        "disagreement_nodes": [],
+        "unlabeled_confidences": {},
+        "n_disagreements": 0,
+    }
+
+    # No unlabeled nodes, or no matched prediction -> nothing to evaluate.
+    if len(invisible_idx) == 0 or pred_scores is None:
+        return empty
+
+    pred_scores = np.asarray(pred_scores, dtype=float)
+    if pred_scores.shape[0] != n_nodes:
+        # Shape mismatch (should not happen given _predicted_scores padding);
+        # be defensive and report nothing rather than mis-index.
+        return empty
+
+    unlabeled_confidences: dict[int, float] = {}
+    disagreement_nodes: list[int] = []
+    confident_values: list[float] = []
+    for k in invisible_idx:
+        conf = pred_scores[k]
+        if not np.isfinite(conf):
+            continue
+        unlabeled_confidences[int(k)] = float(conf)
+        if conf >= min_confidence:
+            disagreement_nodes.append(int(k))
+            confident_values.append(float(conf))
+
+    score = float(np.max(confident_values)) if confident_values else _NO_DISAGREEMENT
+    # Clamp defensively: predicted confidences are nominally in [0, 1] but
+    # refinement could overshoot by a hair.
+    score = float(np.clip(score, 0.0, 1.0))
+
+    return {
+        "prediction_disagreement_score": score,
+        "disagreement_nodes": sorted(disagreement_nodes),
+        "unlabeled_confidences": unlabeled_confidences,
+        "n_disagreements": len(disagreement_nodes),
+    }
+
+
+def _skeleton_node_names(skeleton) -> list[str]:
+    """Best-effort list of node names from a sleap-io skeleton."""
+    nodes = getattr(skeleton, "nodes", None)
+    if nodes is None:
+        return []
+    names: list[str] = []
+    for n in nodes:
+        name = getattr(n, "name", None)
+        names.append(name if isinstance(name, str) else str(n))
+    return names
+
+
+def _video_key(video, video_idx: int) -> str:
+    """Stable, hashable identifier for a video (mirrors LabelQCDetector).
+
+    ``Video.filename`` is a list for image-sequence backends, which is
+    unhashable, so fall back to the video index.
+    """
+    filename = getattr(video, "filename", None)
+    if isinstance(filename, str) and filename:
+        return filename
+    return str(video_idx)
+
+
+def _empty_result(reason: str) -> dict:
+    """Build a no-op result and log why we bailed out."""
+    logger.info("In-sample prediction detector: %s", reason)
+    return {
+        "instance_scores": {},
+        "records": [],
+        "ran": False,
+        "reason": reason,
+    }
+
+
+def run_insample_prediction(
+    labels: "sio.Labels",
+    model_path: str,
+    peak_threshold: float = 0.2,
+    min_confidence: float = 0.5,
+    device: str = "auto",
+    progress_callback=None,
+) -> dict:
+    """Flag labelable-but-unlabeled points via in-sample model prediction.
+
+    Runs a trained ``sleap_nn`` model on the ALREADY-labeled frames of
+    ``labels`` (in-sample), matches each predicted instance to the nearest user
+    instance, and -- for every node the user left invisible -- reads the matched
+    prediction's confidence there. A confident prediction at a blank node is a
+    "disagreement" (the model expects a labeled part the human skipped).
+
+    This is the model-based (Tier-2) variant of detector (f). It is import-safe
+    (no top-level torch/``sleap_nn`` import) and graceful: any failure to load
+    or run the model, or a skeleton node-name mismatch, returns a zero result
+    with ``ran=False`` and a logged ``reason`` rather than raising.
+
+    Args:
+        labels: Labels with user-annotated instances to evaluate (in-sample).
+        model_path: Path to a trained ``sleap_nn`` model directory (containing
+            ``best.ckpt`` + ``training_config.yaml``). If falsy (``None``/empty),
+            the detector no-ops -- callers should not run this stage without a
+            configured model path.
+        peak_threshold: Minimum peak confidence for the model's peak finding.
+            Lower values let the model report weaker peaks (more candidate
+            disagreements). Passed through to inference. Defaults to ``0.2``.
+        min_confidence: Confidence at/above which a model prediction at an
+            unlabeled node counts as a disagreement (gates the per-instance
+            score). Defaults to ``0.5``.
+        device: Torch device for inference (``"auto"``/``"cpu"``/``"cuda"``/
+            ``"mps"``). Defaults to ``"auto"``.
+        progress_callback: Optional callable ``(step, fraction, detail)`` for
+            progress reporting (matches ``LabelQCDetector`` callbacks). May be
+            ``None``.
+
+    Returns:
+        Dictionary with:
+
+        - ``instance_scores``: ``dict[(video_idx, frame_idx, instance_idx),
+          float]`` of per-user-instance ``prediction_disagreement_score`` in
+          ``[0, 1]``. Only instances with a non-zero score are included (so the
+          integration layer can copy them straight into
+          ``QCResults.channel_scores["prediction"]``).
+        - ``records``: ``list[dict]`` of per-node disagreement records, one per
+          ``(video_idx, frame_idx, instance_idx, node_idx)`` where the user left
+          the node blank and the model was confident. Each record has keys
+          ``video_idx, frame_idx, instance_idx, node_idx, node_name,
+          predicted_confidence``.
+        - ``ran``: ``bool`` -- whether inference actually ran.
+        - ``reason``: ``str`` -- why it did not run (empty when ``ran`` is True).
+    """
+
+    def _report(step: str, fraction: float, detail: Optional[str] = None) -> None:
+        if progress_callback is not None:
+            progress_callback(step, fraction, detail)
+
+    if not model_path:
+        return _empty_result("no model path configured; skipping (no-op)")
+
+    if not labels.skeletons:
+        return _empty_result("labels have no skeleton; skipping")
+
+    user_skeleton = labels.skeletons[0]
+    user_node_names = _skeleton_node_names(user_skeleton)
+    n_nodes = len(user_node_names)
+    if n_nodes == 0:
+        return _empty_result("user skeleton has no nodes; skipping")
+
+    # --- Lazy, guarded model load + inference. All torch/sleap_nn touching code
+    # lives below this point so importing this module stays cheap and safe. ---
+    _report("In-sample prediction", 0.0, "Loading model")
+    try:
+        from sleap_nn.predict import run_inference
+    except Exception as e:  # pragma: no cover - environment-dependent
+        return _empty_result(f"sleap_nn unavailable ({e!r}); skipping")
+
+    # ``run_inference`` ALWAYS writes the predicted Labels to disk when
+    # make_labels=True (defaulting to ``./results.predictions.slp``), with no
+    # flag to disable it. We are only after the in-memory predictions, so direct
+    # the output into a throwaway temp dir and remove it afterward to avoid
+    # littering the user's working directory.
+    try:
+        with tempfile.TemporaryDirectory(prefix="sleap_qc_insample_") as tmpdir:
+            out_path = os.path.join(tmpdir, "insample.predictions.slp")
+            predicted_labels = run_inference(
+                input_labels=labels,
+                model_paths=[model_path],
+                only_labeled_frames=True,
+                exclude_user_labeled=False,
+                peak_threshold=peak_threshold,
+                make_labels=True,
+                device=device,
+                output_path=out_path,
+            )
+    except Exception as e:
+        return _empty_result(f"inference failed ({e!r}); skipping")
+
+    if predicted_labels is None or not getattr(predicted_labels, "skeletons", None):
+        return _empty_result("inference returned no predictions; skipping")
+
+    # Node-name match guard: the predicted skeleton must line up with the user
+    # skeleton or the per-node confidence lookup would be meaningless.
+    pred_node_names = _skeleton_node_names(predicted_labels.skeletons[0])
+    if pred_node_names != user_node_names:
+        return _empty_result(
+            "model skeleton node-names do not match labels.skeletons[0] "
+            f"(model={pred_node_names!r} vs labels={user_node_names!r}); skipping"
+        )
+
+    _report("In-sample prediction", 0.5, "Matching predictions")
+
+    # Index predicted frames by (video_idx, frame_idx) so we can align them to
+    # the user frames regardless of frame ordering in the returned Labels.
+    # Map predicted videos back to user-video indices by identifier so a
+    # video_idx is stable across the two Labels objects.
+    user_video_key_to_idx = {_video_key(v, i): i for i, v in enumerate(labels.videos)}
+
+    def _resolve_video_idx(video, fallback_idx: int) -> int:
+        return user_video_key_to_idx.get(_video_key(video, fallback_idx), fallback_idx)
+
+    pred_by_frame: dict[tuple[int, int], list] = {}
+    for pv_idx, pvideo in enumerate(predicted_labels.videos):
+        v_idx = _resolve_video_idx(pvideo, pv_idx)
+        for lf in predicted_labels:
+            if lf.video is not pvideo:
+                continue
+            pred_by_frame.setdefault((v_idx, lf.frame_idx), []).extend(
+                list(lf.instances)
+            )
+
+    instance_scores: dict[tuple[int, int, int], float] = {}
+    records: list[dict] = []
+
+    for video_idx, video in enumerate(labels.videos):
+        labeled_frames = [lf for lf in labels if lf.video == video]
+        for lf in labeled_frames:
+            frame_idx = lf.frame_idx
+            user_instances = list(lf.user_instances)
+            if not user_instances:
+                continue
+
+            user_points = [inst.numpy(invisible_as_nan=True) for inst in user_instances]
+            pred_instances = pred_by_frame.get((video_idx, frame_idx), [])
+            pred_points = [
+                _predicted_scores_array(pi, n_nodes) for pi in pred_instances
+            ]
+
+            matches = match_predictions_to_users(
+                user_points, [pp["xy"] for pp in pred_points]
+            )
+
+            for inst_idx, upts in enumerate(user_points):
+                match_idx = matches[inst_idx]
+                pred_scores = (
+                    pred_points[match_idx]["scores"] if match_idx is not None else None
+                )
+                result = score_instance_disagreement(
+                    upts, pred_scores, min_confidence=min_confidence
+                )
+
+                score = result["prediction_disagreement_score"]
+                if score > 0.0:
+                    instance_scores[(video_idx, frame_idx, inst_idx)] = score
+
+                confs = result["unlabeled_confidences"]
+                for node_idx in result["disagreement_nodes"]:
+                    records.append(
+                        {
+                            "video_idx": video_idx,
+                            "frame_idx": frame_idx,
+                            "instance_idx": inst_idx,
+                            "node_idx": node_idx,
+                            "node_name": user_node_names[node_idx]
+                            if node_idx < len(user_node_names)
+                            else str(node_idx),
+                            "predicted_confidence": confs.get(node_idx, float("nan")),
+                        }
+                    )
+
+    _report(
+        "In-sample prediction",
+        1.0,
+        f"{len(instance_scores)} instances with disagreements",
+    )
+
+    return {
+        "instance_scores": instance_scores,
+        "records": records,
+        "ran": True,
+        "reason": "",
+    }
+
+
+def _predicted_scores_array(pred_instance, n_nodes: int) -> dict:
+    """Extract ``{"xy": (n,2), "scores": (n,)}`` from a predicted instance.
+
+    Uses ``PredictedInstance.numpy(scores=True)`` -> ``(n_nodes, 3)`` of
+    ``(x, y, score)``. Splits out the coordinate columns (for centroid matching)
+    and the score column (for the disagreement lookup). Defensive against odd
+    shapes / instances that don't support ``scores=True``.
+    """
+    try:
+        arr = np.asarray(pred_instance.numpy(scores=True), dtype=float)
+    except TypeError:
+        # Older/odd instance without a scores kwarg: fall back to coords only,
+        # treating confidence as "present but unknown" -> NaN (never flags).
+        arr = np.asarray(pred_instance.numpy(), dtype=float)
+        xy = np.full((n_nodes, 2), np.nan)
+        k = min(n_nodes, arr.shape[0])
+        if arr.ndim == 2 and arr.shape[1] >= 2:
+            xy[:k] = arr[:k, :2]
+        return {"xy": xy, "scores": np.full(n_nodes, np.nan)}
+
+    xy = np.full((n_nodes, 2), np.nan)
+    if arr.ndim == 2 and arr.shape[1] >= 2:
+        k = min(n_nodes, arr.shape[0])
+        xy[:k] = arr[:k, :2]
+    scores = _predicted_scores(arr, n_nodes)
+    return {"xy": xy, "scores": scores}

--- a/sleap/qc/results.py
+++ b/sleap/qc/results.py
@@ -27,7 +27,11 @@ class FrameKey(NamedTuple):
 
 # Human-readable labels for channel-only issues (scored outside the GMM and
 # merged into get_flagged). Keyed by channel name.
-CHANNEL_ISSUE_LABELS = {"missing_node": "Missing labelable node"}
+CHANNEL_ISSUE_LABELS = {
+    "missing_node": "Missing labelable node",
+    "appearance": "Appearance outlier",
+    "prediction": "Model expects a labeled part here",
+}
 
 
 @dataclass

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -1039,6 +1039,109 @@ class TestQCDetectorSettings:
         assert widget._ordered_chains_edit.isEnabled()
 
 
+class TestQCB2DetectorSettings:
+    """Tests for the two B2 channel controls (appearance + in-sample model)."""
+
+    def test_b2_controls_exist_with_defaults(self, qtbot):
+        """The appearance + in-sample controls exist and default OFF."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Appearance / wrong-object checkbox, experimental default-OFF.
+        assert widget._cb_appearance is not None
+        assert widget._cb_appearance.text() == "Appearance / wrong-object"
+        assert not widget._cb_appearance.isChecked()
+
+        # In-sample model prediction checkbox, experimental default-OFF.
+        assert widget._cb_insample is not None
+        assert widget._cb_insample.text() == "In-sample model prediction"
+        assert not widget._cb_insample.isChecked()
+
+        # Model-path picker exists: a placeholder line edit + a Browse button.
+        assert widget._insample_model_edit is not None
+        assert widget._insample_model_edit.text() == ""
+        assert "model" in widget._insample_model_edit.placeholderText().lower()
+        assert widget._insample_browse_btn is not None
+        assert "Browse" in widget._insample_browse_btn.text()
+
+    def test_insample_tooltip_warns_about_slow_inference(self, qtbot):
+        """The in-sample checkbox tooltip warns that it runs full inference."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        tip = widget._cb_insample.toolTip().lower()
+        assert "inference" in tip
+        assert "slow" in tip
+
+    def test_insample_picker_disabled_when_unchecked(self, qtbot):
+        """The model picker + Browse button disable when in-sample is off."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Off by default -> picker + browse disabled.
+        assert not widget._insample_model_edit.isEnabled()
+        assert not widget._insample_browse_btn.isEnabled()
+
+        # Enabling the checkbox enables both.
+        widget._cb_insample.setChecked(True)
+        assert widget._insample_model_edit.isEnabled()
+        assert widget._insample_browse_btn.isEnabled()
+
+        # Disabling again disables both.
+        widget._cb_insample.setChecked(False)
+        assert not widget._insample_model_edit.isEnabled()
+        assert not widget._insample_browse_btn.isEnabled()
+
+    def test_browse_sets_model_path_from_dialog(self, qtbot):
+        """Clicking Browse opens getExistingDirectory and sets the line edit."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        with patch(
+            "sleap.gui.widgets.qc.QtWidgets.QFileDialog.getExistingDirectory",
+            return_value="/path/to/model",
+        ) as mock_dialog:
+            widget._on_browse_insample_model()
+            mock_dialog.assert_called_once()
+        assert widget._insample_model_edit.text() == "/path/to/model"
+
+    def test_browse_cancel_leaves_path_unchanged(self, qtbot):
+        """Cancelling the folder dialog (empty return) leaves the path empty."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        with patch(
+            "sleap.gui.widgets.qc.QtWidgets.QFileDialog.getExistingDirectory",
+            return_value="",
+        ):
+            widget._on_browse_insample_model()
+        assert widget._insample_model_edit.text() == ""
+
+    def test_build_qc_config_b2_defaults(self, qtbot):
+        """_build_qc_config maps the B2 controls; both channels default OFF."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        config = widget._build_qc_config()
+        assert config.use_appearance is False
+        assert config.use_insample_prediction is False
+        assert config.insample_model_path == ""
+
+    def test_build_qc_config_reflects_b2_toggles(self, qtbot):
+        """Toggling the B2 checkboxes + path is reflected in the built config."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        widget._cb_appearance.setChecked(True)
+        widget._cb_insample.setChecked(True)
+        widget._insample_model_edit.setText("  /models/best  ")
+
+        config = widget._build_qc_config()
+        assert config.use_appearance is True
+        assert config.use_insample_prediction is True
+        # Path is stripped of surrounding whitespace.
+        assert config.insample_model_path == "/models/best"
+
+
 class TestQCAnalysisWorkerConfig:
     """Tests for threading the QCConfig into the analysis worker."""
 

--- a/tests/qc/test_appearance.py
+++ b/tests/qc/test_appearance.py
@@ -1,0 +1,373 @@
+"""Tests for sleap.qc.features.appearance.
+
+These tests cover the appearance-outlier detector (e): "points placed on
+occluders / wrong object". The detector learns a per-node image-patch
+descriptor distribution and flags nodes whose local pixels do not match what
+that node usually sits on (e.g. a keypoint dragged onto bright cotton bedding
+over a dark mouse).
+
+Synthetic frames give us precise control over appearance: a node placed on a
+region matching its learned appearance should score ~0, while a node moved onto
+a visually-distinct patch (a bright square on a dark background) should score
+high. Degenerate cases (too few samples, all-NaN, edge patches, undecodable
+frames) must be safe. A final opt-in smoke test exercises the real grayscale
+``train.slp`` end-to-end.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.appearance import (
+    DEFAULT_MIN_SAMPLES,
+    extract_patch_descriptor,
+    fit_appearance,
+    score_appearance,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-frame helpers.
+# ---------------------------------------------------------------------------
+
+H, W = 64, 64
+N_NODES = 3
+
+# Per-node "home" location and intensity (grayscale background is dark = 20).
+# Each node sits on a distinct-but-modest grey level so descriptors differ.
+BG = 20
+NODE_LOCS = [(16, 16), (32, 40), (48, 24)]  # (y, x)
+NODE_GREY = [80, 130, 60]
+BLOB_HALF = 5  # half-size of the painted region around each node
+
+
+def _make_grayscale_frame(jitter: int = 0, seed: int = 0) -> np.ndarray:
+    """Build a (H, W, 1) uint8 frame with a grey blob at each node's home.
+
+    A small amount of additive noise (controlled by ``jitter``) makes the
+    per-node descriptors non-degenerate so a real covariance can be fit.
+    """
+    rng = np.random.default_rng(seed)
+    frame = np.full((H, W, 1), BG, dtype=np.float64)
+    for (y, x), grey in zip(NODE_LOCS, NODE_GREY):
+        frame[
+            y - BLOB_HALF : y + BLOB_HALF + 1,
+            x - BLOB_HALF : x + BLOB_HALF + 1,
+            0,
+        ] = grey
+    if jitter:
+        frame += rng.normal(0.0, jitter, size=frame.shape)
+    return np.clip(frame, 0, 255).astype(np.uint8)
+
+
+def _home_points() -> np.ndarray:
+    """(N_NODES, 2) array placing every node on its home blob (x, y order)."""
+    pts = np.full((N_NODES, 2), np.nan)
+    for i, (y, x) in enumerate(NODE_LOCS):
+        pts[i] = [x, y]
+    return pts
+
+
+def _build_training_set(n_frames: int = 30, seed0: int = 0) -> list[tuple]:
+    """List of (frame, home_points) pairs for fitting."""
+    pairs = []
+    for k in range(n_frames):
+        frame = _make_grayscale_frame(jitter=3, seed=seed0 + k)
+        pairs.append((frame, _home_points()))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# extract_patch_descriptor.
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPatchDescriptor:
+    def test_grayscale_descriptor_length_two(self):
+        frame = _make_grayscale_frame()
+        desc = extract_patch_descriptor(frame, x=16, y=16, patch_size=7)
+        assert desc is not None
+        assert desc.shape == (2,)  # [mean, std]
+        # Centre of node-0 blob -> mean near its grey level, std ~0.
+        assert desc[0] == pytest.approx(NODE_GREY[0], abs=1.0)
+        assert desc[1] == pytest.approx(0.0, abs=1.0)
+
+    def test_rgb_descriptor_length_six(self):
+        frame = np.zeros((32, 32, 3), dtype=np.uint8)
+        frame[:, :, 0] = 200  # red channel high
+        desc = extract_patch_descriptor(frame, x=16, y=16, patch_size=5)
+        assert desc is not None
+        assert desc.shape == (6,)  # [mean_rgb..., std_rgb...]
+        assert desc[0] == pytest.approx(200.0, abs=1.0)
+        assert desc[1] == pytest.approx(0.0, abs=1.0)
+
+    def test_2d_frame_promoted_to_single_channel(self):
+        frame2d = np.full((32, 32), 100, dtype=np.uint8)
+        desc = extract_patch_descriptor(frame2d, x=10, y=10, patch_size=5)
+        assert desc is not None
+        assert desc.shape == (2,)
+        assert desc[0] == pytest.approx(100.0, abs=1e-6)
+
+    def test_bright_patch_distinct_from_dark(self):
+        frame = _make_grayscale_frame()
+        # Background (dark) vs node blob (brighter) -> clearly different means.
+        dark = extract_patch_descriptor(frame, x=2, y=2, patch_size=7)
+        bright = extract_patch_descriptor(frame, x=16, y=16, patch_size=7)
+        assert dark[0] < bright[0]
+
+    def test_edge_patch_is_clipped_not_error(self):
+        frame = _make_grayscale_frame()
+        # Corner node: patch extends off the top-left but should still return.
+        desc = extract_patch_descriptor(frame, x=0, y=0, patch_size=7)
+        assert desc is not None
+        assert desc.shape == (2,)
+        assert np.all(np.isfinite(desc))
+
+    def test_nan_coordinate_returns_none(self):
+        frame = _make_grayscale_frame()
+        assert extract_patch_descriptor(frame, x=np.nan, y=10) is None
+        assert extract_patch_descriptor(frame, x=10, y=np.nan) is None
+
+    def test_centre_fully_outside_returns_none(self):
+        frame = _make_grayscale_frame()
+        assert extract_patch_descriptor(frame, x=1000, y=1000, patch_size=7) is None
+        assert extract_patch_descriptor(frame, x=-50, y=-50, patch_size=7) is None
+
+    def test_none_or_empty_frame_returns_none(self):
+        assert extract_patch_descriptor(None, x=1, y=1) is None
+        assert extract_patch_descriptor(np.zeros((0, 0, 1)), x=0, y=0) is None
+
+
+# ---------------------------------------------------------------------------
+# fit_appearance.
+# ---------------------------------------------------------------------------
+
+
+class TestFitAppearance:
+    def test_models_nodes_with_enough_samples(self):
+        # 30 frames -> 30 samples per node, above the default of 20.
+        pairs = _build_training_set(n_frames=30)
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7)
+
+        assert set(model["node_models"].keys()) == {0, 1, 2}
+        for node_idx in range(N_NODES):
+            assert model["node_sample_counts"][node_idx] == 30
+            nm = model["node_models"][node_idx]
+            assert nm["center"].shape == (2,)
+            assert nm["inv_cov"].shape == (2, 2)
+            assert nm["dist_scale"] > 0
+            assert nm["n_samples"] == 30
+        assert model["descriptor_dim"] == 2
+        assert model["patch_size"] == 7
+        assert model["n_nodes"] == N_NODES
+
+    def test_node_below_min_samples_not_modeled(self):
+        # Only 5 frames -> 5 samples/node, below default 20 -> no models.
+        pairs = _build_training_set(n_frames=5)
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7)
+        assert model["node_models"] == {}
+        for node_idx in range(N_NODES):
+            assert model["node_sample_counts"][node_idx] == 5
+
+    def test_custom_min_samples_threshold(self):
+        pairs = _build_training_set(n_frames=10)
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7, min_samples=5)
+        # 10 >= 5 -> all nodes modeled.
+        assert set(model["node_models"].keys()) == {0, 1, 2}
+
+    def test_invisible_node_contributes_no_samples(self):
+        # Node 1 is NaN in every frame -> never sampled, never modeled.
+        pairs = []
+        for k in range(30):
+            frame = _make_grayscale_frame(jitter=3, seed=k)
+            pts = _home_points()
+            pts[1] = [np.nan, np.nan]
+            pairs.append((frame, pts))
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7)
+        assert model["node_sample_counts"][1] == 0
+        assert 1 not in model["node_models"]
+        assert {0, 2}.issubset(model["node_models"].keys())
+
+    def test_none_frames_skipped(self):
+        pairs = _build_training_set(n_frames=25)
+        pairs.append((None, _home_points()))  # undecodable frame
+        pairs.append(None)  # malformed pair
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7)
+        # The bad entries are ignored; valid frames still produce models.
+        assert set(model["node_models"].keys()) == {0, 1, 2}
+        assert model["node_sample_counts"][0] == 25
+
+    def test_empty_training_set(self):
+        model = fit_appearance([], n_nodes=N_NODES, patch_size=7)
+        assert model["node_models"] == {}
+        assert model["descriptor_dim"] is None
+        assert model["n_nodes"] == N_NODES
+
+    def test_default_min_samples_constant(self):
+        assert DEFAULT_MIN_SAMPLES == 20
+
+
+# ---------------------------------------------------------------------------
+# score_appearance.
+# ---------------------------------------------------------------------------
+
+
+class TestScoreAppearance:
+    def _fit(self, n_frames=30):
+        return fit_appearance(
+            _build_training_set(n_frames=n_frames), n_nodes=N_NODES, patch_size=7
+        )
+
+    def test_matching_appearance_scores_low(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=999)
+        result = score_appearance(frame, _home_points(), model)
+        # All nodes on their learned blobs -> low outlier score.
+        assert result["appearance_outlier_score"] < 0.3
+        assert set(result["node_scores"].keys()) == {0, 1, 2}
+        assert result["worst_node"] in (0, 1, 2)
+
+    def test_node_on_bright_anomaly_scores_high(self):
+        model = self._fit()
+        # Paint a bright square far from any blob and drag node 0 onto it.
+        frame = _make_grayscale_frame(jitter=3, seed=7)
+        frame[4:14, 4:14, 0] = 255  # bright cotton-like patch on dark bg
+        pts = _home_points()
+        pts[0] = [9, 9]  # move node 0 onto the bright square
+
+        result = score_appearance(frame, pts, model)
+        assert result["worst_node"] == 0
+        assert result["node_scores"][0] > 0.7
+        assert result["appearance_outlier_score"] > 0.7
+        # The untouched nodes (1, 2) remain low.
+        assert result["node_scores"][1] < 0.3
+        assert result["node_scores"][2] < 0.3
+
+    def test_score_is_max_over_nodes(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=11)
+        frame[4:14, 4:14, 0] = 255
+        pts = _home_points()
+        pts[2] = [9, 9]  # only node 2 is on the anomaly
+
+        result = score_appearance(frame, pts, model)
+        assert result["worst_node"] == 2
+        assert result["appearance_outlier_score"] == pytest.approx(
+            max(result["node_scores"].values())
+        )
+
+    def test_all_nan_instance_scores_zero(self):
+        model = self._fit()
+        frame = _make_grayscale_frame()
+        pts = np.full((N_NODES, 2), np.nan)
+        result = score_appearance(frame, pts, model)
+        assert result["appearance_outlier_score"] == 0.0
+        assert result["worst_node"] == -1
+        assert result["node_scores"] == {}
+
+    def test_none_frame_scores_zero(self):
+        model = self._fit()
+        result = score_appearance(None, _home_points(), model)
+        assert result["appearance_outlier_score"] == 0.0
+        assert result["worst_node"] == -1
+
+    def test_empty_model_scores_zero(self):
+        # Model with no node models (e.g. too few training samples).
+        empty_model = fit_appearance(
+            _build_training_set(n_frames=3), n_nodes=N_NODES, patch_size=7
+        )
+        assert empty_model["node_models"] == {}
+        result = score_appearance(_make_grayscale_frame(), _home_points(), empty_model)
+        assert result["appearance_outlier_score"] == 0.0
+        assert result["worst_node"] == -1
+
+    def test_none_model_scores_zero(self):
+        result = score_appearance(_make_grayscale_frame(), _home_points(), None)
+        assert result["appearance_outlier_score"] == 0.0
+
+    def test_only_modeled_visible_nodes_scored(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=42)
+        pts = _home_points()
+        pts[1] = [np.nan, np.nan]  # node 1 invisible in this instance
+        result = score_appearance(frame, pts, model)
+        # Node 1 was modeled but is invisible here -> not scored.
+        assert set(result["node_scores"].keys()) == {0, 2}
+
+    def test_edge_node_scored_safely(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=5)
+        pts = _home_points()
+        pts[0] = [0, 0]  # node 0 dragged to the corner (clipped patch)
+        result = score_appearance(frame, pts, model)
+        # Must return a finite score without raising on the clipped patch.
+        assert np.isfinite(result["appearance_outlier_score"])
+        assert 0.0 <= result["appearance_outlier_score"] <= 1.0
+
+    def test_scores_clamped_to_unit_interval(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=3)
+        frame[4:14, 4:14, 0] = 255
+        pts = _home_points()
+        pts[0] = [9, 9]
+        result = score_appearance(frame, pts, model)
+        for s in result["node_scores"].values():
+            assert 0.0 <= s <= 1.0
+        assert 0.0 <= result["appearance_outlier_score"] <= 1.0
+
+    def test_patch_size_defaults_to_model(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=8)
+        # Not passing patch_size should reuse the fit-time size and work.
+        result = score_appearance(frame, _home_points(), model)
+        assert set(result["node_scores"].keys()) == {0, 1, 2}
+
+
+# ---------------------------------------------------------------------------
+# Real-data smoke test (opt-in; needs the local train.slp).
+# ---------------------------------------------------------------------------
+
+REAL_SLP = "/home/talmolab/als2h_0922CVATNN/train.slp"
+
+
+@pytest.mark.skipif(not os.path.exists(REAL_SLP), reason="real train.slp not available")
+def test_real_data_smoke():
+    """End-to-end on real grayscale frames: fit on a subset, score a couple."""
+    import sleap_io as sio
+
+    labels = sio.load_slp(REAL_SLP)
+    n_nodes = len(labels.skeletons[0].nodes)
+
+    # Decode a handful of labeled frames (cap decode cost).
+    pairs = []
+    decoded = []
+    for lf in labels:
+        if not lf.user_instances:
+            continue
+        try:
+            frame = lf.video[lf.frame_idx]
+        except Exception:
+            continue
+        for inst in lf.user_instances:
+            pairs.append((frame, inst.numpy(invisible_as_nan=True)))
+        decoded.append((frame, lf))
+        if len(decoded) >= 5:
+            break
+
+    assert pairs, "expected at least one labeled instance to decode"
+    # Confirm real frames are grayscale (H, W, 1) uint8 as documented.
+    assert decoded[0][0].ndim == 3
+
+    # Lower min_samples so a 5-frame subset can actually model some nodes.
+    model = fit_appearance(pairs, n_nodes=n_nodes, patch_size=7, min_samples=3)
+
+    # Score the instances of the first couple decoded frames.
+    n_scored = 0
+    for frame, lf in decoded[:2]:
+        for inst in lf.user_instances:
+            res = score_appearance(frame, inst.numpy(invisible_as_nan=True), model)
+            assert np.isfinite(res["appearance_outlier_score"])
+            assert 0.0 <= res["appearance_outlier_score"] <= 1.0
+            n_scored += 1
+    assert n_scored > 0

--- a/tests/qc/test_b2_integration.py
+++ b/tests/qc/test_b2_integration.py
@@ -1,0 +1,450 @@
+"""Integration tests for the B2 non-GMM channel wiring in LabelQCDetector.
+
+These cover the two B2 channel modules once they are wired into the detector:
+
+- the appearance-outlier channel (detector (e)): scored against a per-node
+  image-appearance model built at fit time from decoded frames, surfaced via
+  ``QCResults.channel_scores["appearance"]`` and labeled "Appearance outlier",
+- the in-sample model-prediction channel (detector (f), Tier-2): a single
+  batched ``run_insample_prediction`` call run after the per-instance loop,
+  surfaced via ``QCResults.channel_scores["prediction"]`` and labeled "Model
+  expects a labeled part here".
+
+Both are non-GMM channels (default-OFF / experimental), wired exactly like the
+existing missing-node channel. They MUST NOT change the fixed 22-wide feature
+vector (they are channels, not GMM features). Real model inference is never run
+here -- ``run_insample_prediction`` is monkeypatched, and the appearance model
+is exercised either against tiny real decodable frames or via a monkeypatched
+``fit_appearance``/``score_appearance`` to test the wiring in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+import sleap_io as sio
+from sleap_io import LabeledFrame
+from sleap_io.model.instance import Instance
+
+import sleap.qc.detector as detector_mod
+from sleap.qc import LabelQCDetector, QCConfig, QCResults
+from sleap.qc.detector import V3_FEATURE_NAMES
+from sleap.qc.features.baseline import BASELINE_FEATURE_NAMES
+from sleap.qc.results import CHANNEL_ISSUE_LABELS, InstanceKey
+
+
+# ---------------------------------------------------------------------------
+# Skeleton / pose / labels fixtures (mirror the B1 integration helpers)
+# ---------------------------------------------------------------------------
+
+
+def _line_skeleton(n: int = 6) -> sio.Skeleton:
+    """A simple ``n``-node line graph 0-1-...-(n-1)."""
+    names = [f"n{i}" for i in range(n)]
+    skel = sio.Skeleton(names)
+    skel.add_edges([(f"n{i}", f"n{i + 1}") for i in range(n - 1)])
+    return skel
+
+
+def _line_base(n: int = 6, spacing: float = 10.0) -> np.ndarray:
+    return np.array([[i * spacing, 0.0] for i in range(n)], dtype=float)
+
+
+def _labels_from_poses(skeleton: sio.Skeleton, poses: list[np.ndarray]) -> sio.Labels:
+    """Build a single-video Labels with one instance per frame."""
+    video = sio.Video.from_filename("test_video.mp4")
+    labels = sio.Labels()
+    for frame_idx, pts in enumerate(poses):
+        inst = Instance.from_numpy(pts, skeleton=skeleton)
+        labels.append(LabeledFrame(video=video, frame_idx=frame_idx, instances=[inst]))
+    return labels
+
+
+# ---------------------------------------------------------------------------
+# Real decodable frames for the appearance channel
+# ---------------------------------------------------------------------------
+
+
+def _make_image_video(images: list[np.ndarray], tmpdir: str) -> sio.Video:
+    """Write grayscale image frames to PNGs and wrap them in an ImageVideo.
+
+    Decoding ``video[idx]`` returns an ``(H, W, 1)`` uint8 array, exactly the
+    decoded-frame shape the appearance module expects, so this exercises the
+    real ``fit()`` decode path without depending on a video codec.
+    """
+    try:
+        import imageio.v3 as iio
+    except Exception:  # pragma: no cover - older imageio
+        import imageio as iio
+
+    paths = []
+    for i, img in enumerate(images):
+        path = os.path.join(tmpdir, f"frame_{i:04d}.png")
+        iio.imwrite(path, np.asarray(img, dtype=np.uint8))
+        paths.append(path)
+    return sio.Video.from_filename(paths)
+
+
+def _appearance_labels_real_frames(tmpdir: str):
+    """Build a Labels over real decodable frames with one planted outlier.
+
+    A 3-node line skeleton is placed at fixed pixel locations in a dark
+    background. For most frames every node sits on dark pixels; in the final
+    (outlier) frame node 1 is dragged onto a bright square (the "wrong object"),
+    so its appearance descriptor is far from the learned dark-pixel model.
+
+    Returns ``(labels, skeleton, outlier_frame_idx, node_xy)``.
+    """
+    height, width = 40, 60
+    n_frames = 40
+    rng = np.random.default_rng(7)
+
+    # Fixed node pixel locations (kept away from borders so full patches fit).
+    node_xy = np.array([[12.0, 20.0], [30.0, 20.0], [48.0, 20.0]], dtype=float)
+
+    images = []
+    poses = []
+    for _ in range(n_frames):
+        # Dark, low-contrast background under every node.
+        img = rng.integers(0, 25, size=(height, width), dtype=np.uint8)
+        images.append(img)
+        # Tiny jitter so descriptors are not perfectly identical.
+        poses.append(node_xy + rng.normal(0, 0.3, size=node_xy.shape))
+
+    # Outlier frame: paint a bright block under node 1's location.
+    outlier_idx = n_frames
+    out_img = rng.integers(0, 25, size=(height, width), dtype=np.uint8)
+    cx, cy = int(round(node_xy[1, 0])), int(round(node_xy[1, 1]))
+    out_img[cy - 5 : cy + 6, cx - 5 : cx + 6] = 250  # bright "wrong object"
+    images.append(out_img)
+    poses.append(node_xy.copy())
+
+    skel = _line_skeleton(3)
+    video = _make_image_video(images, tmpdir)
+    labels = sio.Labels(videos=[video], skeletons=[skel])
+    for frame_idx, pts in enumerate(poses):
+        inst = Instance.from_numpy(pts, skeleton=skel)
+        labels.append(LabeledFrame(video=video, frame_idx=frame_idx, instances=[inst]))
+    return labels, skel, outlier_idx, node_xy
+
+
+# ---------------------------------------------------------------------------
+# Width invariance: the B2 channels must not change the 22-wide feature vector
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureWidthInvariance:
+    """The B2 channels are channels, not GMM features -> width stays 22."""
+
+    EXPECTED_WIDTH = 22  # 12 baseline + 10 v3.
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            QCConfig(),  # both B2 channels OFF
+            QCConfig(use_appearance=True),
+            QCConfig(use_insample_prediction=True),
+            QCConfig(use_appearance=True, use_insample_prediction=True),
+        ],
+    )
+    def test_feature_vector_stays_22_with_b2_channels(self, config):
+        """fit() + a single _extract_features still yield width-22 vectors.
+
+        Holds with either or both B2 channels toggled on. (use_appearance with
+        the synthetic .mp4 video here decodes nothing, so the appearance model
+        is empty -- which is exactly fine for the width check.)
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(0)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+
+        detector = LabelQCDetector(config)
+        detector.fit(_labels_from_poses(skel, poses))
+
+        assert len(detector.feature_names) == self.EXPECTED_WIDTH
+        assert V3_FEATURE_NAMES == [
+            "max_curvature",
+            "curvature_std",
+            "visibility_pattern_score",
+            "nn_distance",
+            "hull_area_zscore",
+            "hull_compactness",
+            "chirality_wrong_fraction",
+            "pose_split_score",
+            "order_inversion_rate",
+            "chain_intersection_count",
+        ]
+        feats = detector._extract_features(base)
+        assert feats.shape == (self.EXPECTED_WIDTH,)
+        total = len(BASELINE_FEATURE_NAMES) + len(V3_FEATURE_NAMES)
+        assert total == self.EXPECTED_WIDTH
+
+
+# ---------------------------------------------------------------------------
+# Appearance channel
+# ---------------------------------------------------------------------------
+
+
+class TestAppearanceChannelRealFrames:
+    """End-to-end appearance channel against tiny real decodable frames."""
+
+    def test_outlier_populates_appearance_channel_and_surfaces_label(self):
+        """A node dragged onto a bright block is flagged 'Appearance outlier'.
+
+        Exercises the genuine fit-time decode path (``video[frame_idx]``), the
+        per-node appearance model, and the score-time channel population +
+        get_flagged label surfacing -- no mocking of the appearance module.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            labels, _skel, outlier_idx, _xy = _appearance_labels_real_frames(tmpdir)
+
+            # min_samples low enough that 40 frames (40 patches/node) model it.
+            config = QCConfig(use_appearance=True, appearance_min_samples=20)
+            detector = LabelQCDetector(config)
+            detector.fit(labels)
+
+            # The appearance model actually learned at least node 1.
+            assert detector._appearance_model is not None
+            assert 1 in detector._appearance_model["node_models"]
+
+            results = detector.score(labels)
+
+            assert "appearance" in results.channel_scores
+            chan = results.channel_scores["appearance"]
+            out_key = InstanceKey(0, outlier_idx, 0)
+            assert out_key in chan
+            assert chan[out_key] > 0.0
+
+            # The clean training frames sit on dark pixels -> near-zero outlier
+            # score, so they should out-score the planted bright-block frame.
+            assert chan[out_key] > max(
+                (chan.get(InstanceKey(0, i, 0), 0.0) for i in range(40)),
+                default=0.0,
+            )
+
+            # When the appearance channel wins for the outlier, get_flagged
+            # surfaces it with the channel's human-readable label.
+            flagged = detector.score(labels).get_flagged(
+                threshold=min(chan[out_key], 0.99)
+            )
+            by_key = {f.instance_key: f for f in flagged}
+            assert out_key in by_key
+            assert by_key[out_key].top_issue == CHANNEL_ISSUE_LABELS["appearance"]
+
+
+class TestAppearanceChannelWiring:
+    """Appearance channel wiring tested with a monkeypatched module (no I/O)."""
+
+    def test_channel_populated_via_monkeypatched_module(self, monkeypatch):
+        """With canned fit/score values, the appearance channel is populated.
+
+        Monkeypatches ``fit_appearance``/``score_appearance`` as imported into
+        ``sleap.qc.detector`` so the test is independent of any real frame
+        decoding (the synthetic .mp4 video here cannot be decoded). This pins
+        the WIRING: a non-empty model is built, frames are decoded once, and a
+        positive ``appearance_outlier_score`` lands in channel_scores.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(1)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(8)]
+        outlier_idx = len(poses)
+        poses.append(base.copy())
+        labels = _labels_from_poses(skel, poses)
+
+        # Canned model + a frame stub so the decode try/except yields non-None.
+        canned_model = {"node_models": {0: {}}, "patch_size": 7}
+        monkeypatch.setattr(
+            detector_mod, "fit_appearance", lambda *a, **k: canned_model
+        )
+
+        # Make every frame decode to a tiny non-None array.
+        fake_frame = np.zeros((4, 4, 1), dtype=np.uint8)
+        for video in labels.videos:
+            monkeypatch.setattr(
+                type(video), "__getitem__", lambda self, idx: fake_frame, raising=False
+            )
+
+        # Only the outlier frame gets a positive score; the rest score 0.
+        def fake_score(frame, points, model, patch_size=None):
+            is_outlier = bool(np.allclose(np.nan_to_num(points), base))
+            return {
+                "appearance_outlier_score": 0.92 if is_outlier else 0.0,
+                "worst_node": 0 if is_outlier else -1,
+                "node_scores": {0: 0.92} if is_outlier else {},
+            }
+
+        monkeypatch.setattr(detector_mod, "score_appearance", fake_score)
+
+        detector = LabelQCDetector(QCConfig(use_appearance=True))
+        detector.fit(labels)
+        assert detector._appearance_model is canned_model
+
+        results = detector.score(labels)
+        assert "appearance" in results.channel_scores
+        out_key = InstanceKey(0, outlier_idx, 0)
+        assert results.channel_scores["appearance"][out_key] == pytest.approx(0.92)
+        # A zero-scoring frame is never recorded (mirrors missing_node).
+        assert InstanceKey(0, 0, 0) not in results.channel_scores["appearance"]
+
+    def test_appearance_off_by_default_no_model_no_channel(self, monkeypatch):
+        """Default config builds no appearance model and never decodes frames."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(2)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(8)]
+        labels = _labels_from_poses(skel, poses)
+
+        # fit_appearance/score_appearance must never be called with the default.
+        def _boom(*a, **k):  # pragma: no cover - asserts non-invocation
+            raise AssertionError("appearance module called with use_appearance=False")
+
+        monkeypatch.setattr(detector_mod, "fit_appearance", _boom)
+        monkeypatch.setattr(detector_mod, "score_appearance", _boom)
+
+        detector = LabelQCDetector(QCConfig())  # appearance OFF
+        detector.fit(labels)
+        assert detector._appearance_model is None
+
+        results = detector.score(labels)
+        assert "appearance" not in results.channel_scores
+
+
+# ---------------------------------------------------------------------------
+# In-sample model-prediction channel (run_insample_prediction is MOCKED)
+# ---------------------------------------------------------------------------
+
+
+class TestInsamplePredictionChannel:
+    """In-sample prediction channel wiring; never runs real inference."""
+
+    def test_channel_populated_via_monkeypatched_inference(self, monkeypatch):
+        """Canned run_insample_prediction output lands in channel_scores.
+
+        Monkeypatches ``run_insample_prediction`` (as imported into the
+        detector) to return a fixed result, so no torch/sleap_nn or real
+        inference is involved. Pins that the single batched call's
+        ``instance_scores`` are copied into the ``"prediction"`` channel.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(3)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(8)]
+        labels = _labels_from_poses(skel, poses)
+
+        captured = {}
+
+        def fake_run(labels_arg, **kwargs):
+            captured["labels"] = labels_arg
+            captured["kwargs"] = kwargs
+            return {
+                "ran": True,
+                "reason": "",
+                "instance_scores": {(0, 0, 0): 0.9},
+                "records": [],
+            }
+
+        monkeypatch.setattr(detector_mod, "run_insample_prediction", fake_run)
+
+        config = QCConfig(
+            use_insample_prediction=True, insample_model_path="/fake/model"
+        )
+        detector = LabelQCDetector(config)
+        detector.fit(labels)
+        results = detector.score(labels)
+
+        # Called exactly once, in-sample, with the labels + configured params.
+        assert captured["labels"] is labels
+        assert captured["kwargs"]["model_path"] == "/fake/model"
+        assert captured["kwargs"]["peak_threshold"] == config.insample_peak_threshold
+        assert captured["kwargs"]["min_confidence"] == config.insample_min_confidence
+        assert captured["kwargs"]["device"] == config.insample_device
+
+        # The canned score is surfaced under the "prediction" channel.
+        assert "prediction" in results.channel_scores
+        pred_key = InstanceKey(0, 0, 0)
+        assert results.channel_scores["prediction"][pred_key] == pytest.approx(0.9)
+
+    def test_insample_off_by_default_not_called(self, monkeypatch):
+        """Default config never calls run_insample_prediction; no channel.
+
+        This is the key safety guard: with use_insample_prediction=False (the
+        default) the expensive inference path is not even invoked, and behavior
+        is unchanged (no "prediction" channel).
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(5)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(8)]
+        labels = _labels_from_poses(skel, poses)
+
+        called = {"count": 0}
+
+        def fake_run(*a, **k):  # pragma: no cover - asserts non-invocation
+            called["count"] += 1
+            raise AssertionError("run_insample_prediction called with channel OFF")
+
+        monkeypatch.setattr(detector_mod, "run_insample_prediction", fake_run)
+
+        detector = LabelQCDetector(QCConfig())  # in-sample prediction OFF
+        detector.fit(labels)
+        results = detector.score(labels)
+
+        assert called["count"] == 0
+        assert "prediction" not in results.channel_scores
+        # Behavior unchanged: every instance still scored as before.
+        assert len(results.instance_scores) == len(poses)
+
+
+# ---------------------------------------------------------------------------
+# get_flagged label surfacing for the B2 channels
+# ---------------------------------------------------------------------------
+
+
+class TestB2ChannelLabelSurfacing:
+    """A B2-channel-dominant key surfaces via get_flagged with the right label.
+
+    Built on a hand-constructed QCResults (mirrors the B1 missing-node label
+    test) so the channel cleanly out-scores the GMM. On the tiny synthetic
+    datasets used elsewhere the GMM's normalized score saturates near 1.0, which
+    would otherwise mask the channel label in an end-to-end run; the detector
+    population of these channels is covered by the wiring tests above.
+    """
+
+    @pytest.mark.parametrize(
+        "channel",
+        ["appearance", "prediction"],
+    )
+    def test_channel_dominant_key_uses_channel_label(self, channel):
+        results = QCResults(feature_names=["max_edge_zscore"])
+        gmm_key = InstanceKey(0, 0, 0)  # GMM-only
+        chan_only_key = InstanceKey(0, 1, 0)  # channel-only, no GMM score
+        both_key = InstanceKey(0, 2, 0)  # both, channel dominant
+
+        results.instance_scores = {gmm_key: 0.9, both_key: 0.4}
+        results.feature_contributions = {
+            gmm_key: {"max_edge_zscore": 5.0},
+            both_key: {"max_edge_zscore": 1.0},
+        }
+        results.channel_scores = {channel: {chan_only_key: 0.85, both_key: 0.95}}
+
+        flagged = results.get_flagged(threshold=0.7)
+        by_key = {f.instance_key: f for f in flagged}
+
+        # Channel-only key: flagged on the channel, with the channel label, and
+        # absent feature contributions are tolerated (empty dict).
+        assert chan_only_key in by_key
+        assert by_key[chan_only_key].score == pytest.approx(0.85)
+        assert by_key[chan_only_key].top_issue == CHANNEL_ISSUE_LABELS[channel]
+        assert by_key[chan_only_key].feature_contributions == {}
+
+        # Both present, channel wins -> channel label and the higher score.
+        assert by_key[both_key].score == pytest.approx(0.95)
+        assert by_key[both_key].top_issue == CHANNEL_ISSUE_LABELS[channel]
+
+        # GMM-only key keeps its inferred (feature-based) issue.
+        assert by_key[gmm_key].top_issue != CHANNEL_ISSUE_LABELS[channel]

--- a/tests/qc/test_insample_prediction.py
+++ b/tests/qc/test_insample_prediction.py
@@ -1,0 +1,387 @@
+"""Tests for the in-sample prediction detector (Tier-2 detector (f)).
+
+These unit tests exercise the matching + disagreement logic and the graceful
+no-op behavior WITHOUT requiring torch. The model inference call
+(``sleap_nn.predict.run_inference``) is monkeypatched to return canned
+``sio.PredictedInstance`` objects, so the whole pipeline can be tested
+deterministically and cheaply.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap.qc.insample_prediction import (
+    match_predictions_to_users,
+    score_instance_disagreement,
+    run_insample_prediction,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build tiny Labels / predicted instances.
+# ---------------------------------------------------------------------------
+
+NODE_NAMES = ["A", "B", "C", "D"]
+
+
+def _skeleton(names=NODE_NAMES):
+    return sio.Skeleton(list(names))
+
+
+def _user_instance(skeleton, points):
+    """User instance from an (n_nodes, 2) array (NaN -> invisible)."""
+    return sio.Instance.from_numpy(np.asarray(points, dtype=float), skeleton=skeleton)
+
+
+def _pred_instance(skeleton, points, scores, instance_score=0.9):
+    """Predicted instance with per-node scores."""
+    return sio.PredictedInstance.from_numpy(
+        points_data=np.asarray(points, dtype=float),
+        skeleton=skeleton,
+        point_scores=np.asarray(scores, dtype=float),
+        score=instance_score,
+    )
+
+
+def _labels_one_frame(skeleton, user_arrays):
+    """A Labels with a single video + single frame holding user instances."""
+    video = sio.Video.from_filename("fake_video.mp4")
+    insts = [_user_instance(skeleton, a) for a in user_arrays]
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=insts)
+    return sio.Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+
+def _patch_run_inference(monkeypatch, predicted_labels):
+    """Install a fake ``sleap_nn.predict`` module returning canned predictions.
+
+    Avoids importing the real (torch-backed) ``sleap_nn`` entirely.
+    """
+    fake_predict = types.ModuleType("sleap_nn.predict")
+
+    def fake_run_inference(*args, **kwargs):  # noqa: ANN001, ANN002
+        return predicted_labels
+
+    fake_predict.run_inference = fake_run_inference
+
+    fake_pkg = sys.modules.get("sleap_nn")
+    if fake_pkg is None:
+        fake_pkg = types.ModuleType("sleap_nn")
+        monkeypatch.setitem(sys.modules, "sleap_nn", fake_pkg)
+    monkeypatch.setitem(sys.modules, "sleap_nn.predict", fake_predict)
+
+
+# ---------------------------------------------------------------------------
+# Pure logic: match_predictions_to_users
+# ---------------------------------------------------------------------------
+
+
+class TestMatching:
+    def test_no_predictions_returns_all_none(self):
+        user = [np.array([[0.0, 0.0], [1.0, 1.0]])]
+        assert match_predictions_to_users(user, []) == [None]
+
+    def test_no_users_returns_empty(self):
+        pred = [np.array([[0.0, 0.0], [1.0, 1.0]])]
+        assert match_predictions_to_users([], pred) == []
+
+    def test_nearest_centroid_match_two_instances(self):
+        # User 0 near origin, user 1 near (100,100).
+        users = [
+            np.array([[0.0, 0.0], [2.0, 0.0]]),  # centroid (1,0)
+            np.array([[100.0, 100.0], [102.0, 100.0]]),  # centroid (101,100)
+        ]
+        # Predictions deliberately in swapped list order to prove it matches by
+        # geometry, not by index.
+        preds = [
+            np.array([[99.0, 100.0], [103.0, 100.0]]),  # centroid (101,100) -> user1
+            np.array([[1.0, 0.0], [1.0, 0.0]]),  # centroid (1,0) -> user0
+        ]
+        matches = match_predictions_to_users(users, preds)
+        assert matches == [1, 0]
+
+    def test_mutually_exclusive_assignment(self):
+        # Two users but only one prediction: the closer user wins, the other
+        # gets None (one prediction cannot be claimed twice).
+        users = [
+            np.array([[0.0, 0.0]]),  # centroid (0,0), closer
+            np.array([[10.0, 0.0]]),  # centroid (10,0)
+        ]
+        preds = [np.array([[1.0, 0.0]])]  # centroid (1,0)
+        matches = match_predictions_to_users(users, preds)
+        assert matches == [0, None]
+
+    def test_user_with_no_visible_nodes_is_unmatched(self):
+        users = [np.array([[np.nan, np.nan], [np.nan, np.nan]])]
+        preds = [np.array([[0.0, 0.0], [1.0, 1.0]])]
+        assert match_predictions_to_users(users, preds) == [None]
+
+
+# ---------------------------------------------------------------------------
+# Pure logic: score_instance_disagreement
+# ---------------------------------------------------------------------------
+
+
+class TestDisagreementScoring:
+    def test_confident_prediction_at_unlabeled_node_flags(self):
+        # Node 2 unlabeled by user; model confident (0.85) -> disagreement.
+        user = np.array([[0.0, 0.0], [1.0, 1.0], [np.nan, np.nan], [3.0, 3.0]])
+        pred_scores = np.array([0.9, 0.8, 0.85, 0.7])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["n_disagreements"] == 1
+        assert res["disagreement_nodes"] == [2]
+        assert res["prediction_disagreement_score"] == pytest.approx(0.85)
+        assert res["unlabeled_confidences"] == {2: pytest.approx(0.85)}
+
+    def test_occluded_node_with_low_model_confidence_not_flagged(self):
+        # Node 2 unlabeled AND model also unsure (0.1 < min_confidence) ->
+        # "truly occluded", not flagged.
+        user = np.array([[0.0, 0.0], [1.0, 1.0], [np.nan, np.nan], [3.0, 3.0]])
+        pred_scores = np.array([0.9, 0.8, 0.1, 0.7])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["n_disagreements"] == 0
+        assert res["disagreement_nodes"] == []
+        assert res["prediction_disagreement_score"] == 0.0
+        # The unlabeled node's (low) confidence is still recorded for context.
+        assert res["unlabeled_confidences"] == {2: pytest.approx(0.1)}
+
+    def test_score_is_gated_max_over_multiple_unlabeled(self):
+        # Two unlabeled nodes; one low (0.3), one high (0.95). Score = the
+        # high one (gated max), and only it is flagged.
+        user = np.array([[0.0, 0.0], [np.nan, np.nan], [np.nan, np.nan], [3.0, 3.0]])
+        pred_scores = np.array([0.9, 0.3, 0.95, 0.7])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["disagreement_nodes"] == [2]
+        assert res["prediction_disagreement_score"] == pytest.approx(0.95)
+
+    def test_labeled_node_never_flagged_even_if_model_confident(self):
+        # All nodes labeled -> nothing to flag regardless of model confidence.
+        user = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+        pred_scores = np.array([0.99, 0.99, 0.99, 0.99])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["n_disagreements"] == 0
+        assert res["prediction_disagreement_score"] == 0.0
+
+    def test_no_matched_prediction_is_zero(self):
+        user = np.array([[0.0, 0.0], [np.nan, np.nan]])
+        res = score_instance_disagreement(user, None, min_confidence=0.5)
+        assert res["prediction_disagreement_score"] == 0.0
+        assert res["n_disagreements"] == 0
+
+    def test_nan_model_confidence_at_unlabeled_node_ignored(self):
+        # Model produced no peak (NaN score) at the unlabeled node -> not a
+        # disagreement and not recorded.
+        user = np.array([[0.0, 0.0], [np.nan, np.nan]])
+        pred_scores = np.array([0.9, np.nan])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["n_disagreements"] == 0
+        assert res["prediction_disagreement_score"] == 0.0
+        assert res["unlabeled_confidences"] == {}
+
+    def test_min_confidence_threshold_boundary(self):
+        # Exactly at threshold counts (>=).
+        user = np.array([[np.nan, np.nan], [1.0, 1.0]])
+        pred_scores = np.array([0.5, 0.9])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["disagreement_nodes"] == [0]
+        # Just below threshold does not.
+        res2 = score_instance_disagreement(
+            user, np.array([0.49, 0.9]), min_confidence=0.5
+        )
+        assert res2["disagreement_nodes"] == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with a MOCKED predictor (no torch).
+# ---------------------------------------------------------------------------
+
+
+class TestRunInsamplePredictionMocked:
+    def test_confident_unlabeled_node_flagged_end_to_end(self, monkeypatch):
+        skel = _skeleton()
+        # User left node C (idx 2) blank.
+        user_arr = np.array([[0.0, 0.0], [1.0, 0.0], [np.nan, np.nan], [3.0, 0.0]])
+        labels = _labels_one_frame(skel, [user_arr])
+
+        # Model predicts ALL four nodes, confident at the blank node C (0.92).
+        pred = _pred_instance(
+            skel,
+            points=np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+            scores=np.array([0.95, 0.9, 0.92, 0.88]),
+        )
+        pred_video = labels.videos[0]
+        pred_lf = sio.LabeledFrame(video=pred_video, frame_idx=0, instances=[pred])
+        pred_labels = sio.Labels(
+            labeled_frames=[pred_lf], videos=[pred_video], skeletons=[skel]
+        )
+        _patch_run_inference(monkeypatch, pred_labels)
+
+        out = run_insample_prediction(
+            labels, model_path="/fake/model", min_confidence=0.5
+        )
+
+        assert out["ran"] is True
+        key = (0, 0, 0)
+        assert key in out["instance_scores"]
+        assert out["instance_scores"][key] == pytest.approx(0.92)
+        # One per-node record for node C.
+        assert len(out["records"]) == 1
+        rec = out["records"][0]
+        assert rec["node_idx"] == 2
+        assert rec["node_name"] == "C"
+        assert rec["predicted_confidence"] == pytest.approx(0.92)
+        assert (rec["video_idx"], rec["frame_idx"], rec["instance_idx"]) == key
+
+    def test_truly_occluded_node_not_flagged_end_to_end(self, monkeypatch):
+        skel = _skeleton()
+        # User left node C blank.
+        user_arr = np.array([[0.0, 0.0], [1.0, 0.0], [np.nan, np.nan], [3.0, 0.0]])
+        labels = _labels_one_frame(skel, [user_arr])
+
+        # Model is ALSO unsure at node C (0.12) -> truly occluded, no flag.
+        pred = _pred_instance(
+            skel,
+            points=np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+            scores=np.array([0.95, 0.9, 0.12, 0.88]),
+        )
+        pred_video = labels.videos[0]
+        pred_lf = sio.LabeledFrame(video=pred_video, frame_idx=0, instances=[pred])
+        pred_labels = sio.Labels(
+            labeled_frames=[pred_lf], videos=[pred_video], skeletons=[skel]
+        )
+        _patch_run_inference(monkeypatch, pred_labels)
+
+        out = run_insample_prediction(
+            labels, model_path="/fake/model", min_confidence=0.5
+        )
+        assert out["ran"] is True
+        assert out["instance_scores"] == {}
+        assert out["records"] == []
+
+    def test_two_instances_matched_independently(self, monkeypatch):
+        skel = _skeleton()
+        # Instance 0 (near origin) missing node C; instance 1 (far) fully labeled.
+        u0 = np.array([[0.0, 0.0], [1.0, 0.0], [np.nan, np.nan], [3.0, 0.0]])
+        u1 = np.array([[100.0, 0.0], [101.0, 0.0], [102.0, 0.0], [103.0, 0.0]])
+        labels = _labels_one_frame(skel, [u0, u1])
+
+        pred_video = labels.videos[0]
+        # Prediction near origin (matches u0), confident at C.
+        p0 = _pred_instance(
+            skel,
+            points=np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+            scores=np.array([0.95, 0.9, 0.93, 0.88]),
+        )
+        # Prediction near (100,0) (matches u1).
+        p1 = _pred_instance(
+            skel,
+            points=np.array([[100.0, 0.0], [101.0, 0.0], [102.0, 0.0], [103.0, 0.0]]),
+            scores=np.array([0.9, 0.9, 0.9, 0.9]),
+        )
+        pred_lf = sio.LabeledFrame(video=pred_video, frame_idx=0, instances=[p1, p0])
+        pred_labels = sio.Labels(
+            labeled_frames=[pred_lf], videos=[pred_video], skeletons=[skel]
+        )
+        _patch_run_inference(monkeypatch, pred_labels)
+
+        out = run_insample_prediction(labels, model_path="/fake/model")
+        # Only instance 0 has a blank node, and only it should be flagged.
+        assert (0, 0, 0) in out["instance_scores"]
+        assert (0, 0, 1) not in out["instance_scores"]
+        assert out["instance_scores"][(0, 0, 0)] == pytest.approx(0.93)
+
+    def test_node_name_mismatch_is_graceful_noop(self, monkeypatch):
+        skel = _skeleton(["A", "B", "C", "D"])
+        user_arr = np.array([[0.0, 0.0], [1.0, 0.0], [np.nan, np.nan], [3.0, 0.0]])
+        labels = _labels_one_frame(skel, [user_arr])
+
+        # Predicted skeleton has DIFFERENT node names -> must no-op gracefully.
+        wrong_skel = _skeleton(["W", "X", "Y", "Z"])
+        pred = _pred_instance(
+            wrong_skel,
+            points=np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+            scores=np.array([0.95, 0.9, 0.92, 0.88]),
+        )
+        pred_video = labels.videos[0]
+        pred_lf = sio.LabeledFrame(video=pred_video, frame_idx=0, instances=[pred])
+        pred_labels = sio.Labels(
+            labeled_frames=[pred_lf], videos=[pred_video], skeletons=[wrong_skel]
+        )
+        _patch_run_inference(monkeypatch, pred_labels)
+
+        out = run_insample_prediction(labels, model_path="/fake/model")
+        assert out["ran"] is False
+        assert "node-names do not match" in out["reason"]
+        assert out["instance_scores"] == {}
+        assert out["records"] == []
+
+    def test_no_model_path_is_noop(self):
+        skel = _skeleton()
+        labels = _labels_one_frame(skel, [np.zeros((4, 2))])
+        out = run_insample_prediction(labels, model_path="")
+        assert out["ran"] is False
+        assert "no model path" in out["reason"]
+        assert out["instance_scores"] == {}
+
+    def test_no_model_path_none_is_noop(self):
+        skel = _skeleton()
+        labels = _labels_one_frame(skel, [np.zeros((4, 2))])
+        out = run_insample_prediction(labels, model_path=None)
+        assert out["ran"] is False
+        assert out["instance_scores"] == {}
+
+    def test_sleap_nn_unavailable_is_graceful(self, monkeypatch):
+        # Simulate an environment where importing sleap_nn.predict fails.
+        skel = _skeleton()
+        labels = _labels_one_frame(skel, [np.zeros((4, 2))])
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def boom(name, *args, **kwargs):
+            if name == "sleap_nn.predict" or name.startswith("sleap_nn"):
+                raise ImportError("simulated missing sleap_nn")
+            return real_import(name, *args, **kwargs)
+
+        # Remove cached module so the import is re-attempted and fails.
+        monkeypatch.delitem(sys.modules, "sleap_nn.predict", raising=False)
+        monkeypatch.setattr(builtins, "__import__", boom)
+
+        out = run_insample_prediction(labels, model_path="/fake/model")
+        assert out["ran"] is False
+        assert "sleap_nn unavailable" in out["reason"]
+
+    def test_inference_exception_is_graceful(self, monkeypatch):
+        skel = _skeleton()
+        labels = _labels_one_frame(skel, [np.zeros((4, 2))])
+
+        fake_predict = types.ModuleType("sleap_nn.predict")
+
+        def boom_inference(*args, **kwargs):
+            raise RuntimeError("CUDA OOM simulated")
+
+        fake_predict.run_inference = boom_inference
+        fake_pkg = sys.modules.get("sleap_nn") or types.ModuleType("sleap_nn")
+        monkeypatch.setitem(sys.modules, "sleap_nn", fake_pkg)
+        monkeypatch.setitem(sys.modules, "sleap_nn.predict", fake_predict)
+
+        out = run_insample_prediction(labels, model_path="/fake/model")
+        assert out["ran"] is False
+        assert "inference failed" in out["reason"]
+
+    def test_import_is_torch_free(self):
+        # Importing the module must NOT have pulled in torch / sleap_nn.
+        import importlib
+
+        # Fresh import check: the module itself imports neither at top level.
+        mod = importlib.import_module("sleap.qc.insample_prediction")
+        src = mod.__doc__ or ""
+        assert "Import-safe" in src
+        # The function references are present without torch imported by us.
+        assert callable(mod.run_insample_prediction)


### PR DESCRIPTION
**Stacked on #2766** (base = `feat/qc-detector-gui-2756`). Completes the #2756 detector set (all six).

The two input-channel-heavy detectors, both opt-in **non-GMM channels** (default-OFF, like missing-node):

## Detectors
- **(e) Appearance / wrong-object** (`sleap/qc/features/appearance.py`) — a per-node image-patch appearance model; flags keypoints on visually anomalous pixels (e.g. on white bedding over dark fur). Decodes labeled frames via the sleap-io backend → `channel_scores["appearance"]` → "Appearance outlier".
- **(f Tier-2) In-sample model prediction** (`sleap/qc/insample_prediction.py`) — runs a trained sleap-nn model on the labeled frames and flags unlabeled nodes the model confidently localizes (the "labelable but skipped" signal, distinguishing skipped from truly occluded). One batched inference after the per-instance loop → `channel_scores["prediction"]` → "Model expects a labeled part here". **Import-safe** (lazy torch/sleap_nn import) and **self-skips** when no model path is set or the model/skeleton is unavailable.

## Wiring
- `QCConfig`: `use_appearance`/`appearance_patch_size`/`appearance_min_samples`; `use_insample_prediction`/`insample_model_path`/`insample_peak_threshold`/`insample_min_confidence`/`insample_device` — all default-OFF/safe.
- `detector.py`: appearance fitted at `fit()` (decodes frames) + scored in the score loop (frame decoded **once per labeled frame**); in-sample prediction as a single post-loop batched stage. `results.py`: two `CHANNEL_ISSUE_LABELS` entries.
- GUI: two more "Detector Settings" toggles + a **model-folder picker** for f-T2.

## Real-data validation (250-frame CVAT subset)
- **Appearance:** scored all 674 instances; **4 surfaced** as "Appearance outlier" (synthetic white-cotton-on-dark-fur → 0.98).
- **f-T2:** **real Leopard-model inference** (~2 s / 250 frames on CUDA) found **84** candidate skipped-but-labelable nodes.

⚠️ **Calibration caveat:** f-T2 confidences (~0.5–0.65) sit below the default 0.7 threshold, and the over-flagging GMM dominates `top_issue` via the `max(GMM, channel)` merge — so these channel flags need threshold/GMM **calibration** to surface by default. The detectors work; surfacing is the calibration follow-up (same theme as the rest of the detector set).

## Tests
**405 QC + GUI tests pass** (incl. real-frame appearance + mocked-inference f-T2 integration tests, and GUI control tests); ruff `check` + `format` clean. Default config (both OFF) leaves behavior unchanged and runs no inference.
