### PR TITLE
feat(qc): Label QC label-error detectors + GUI + #2753 fix (#2756)

### DIFF
--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -711,20 +711,26 @@ class QCSkeletonTraceCanvas(Canvas):
     chain currently being traced, and the canvas highlights the trace in click
     order with numbered badges so the path is obvious at a glance.
 
-    Where possible the skeleton is drawn using a *real* labeled animal's node
-    coordinates (like SLEAP's skeleton builder shows the actual animal shape):
-    callers pass a representative per-node position via :meth:`set_node_positions`
-    (e.g. the median over a sample of labeled instances), and the canvas
-    centers/scales those raw label coordinates to fill the view. When no labeled
-    coordinates are available the layout falls back to a deterministic, seeded
-    spring layout (or a horizontal line if networkx is missing) so the picture is
-    still stable across redraws. Either way the node positions are normalized
-    into roughly the same ``[-1, 1]`` frame, so the fixed click-pick radius works
-    against both layouts.
+    Where possible the skeleton is drawn over a *real* labeled frame: the owning
+    widget picks one labeled instance with as many nodes present as possible,
+    decodes that frame's image, and hands both the image and the instance's
+    per-node *pixel* coordinates to :meth:`set_skeleton`. The canvas then shows
+    the photo as the background (``imshow``, top-left origin like an image) and
+    overlays the markers/edges/trace badges at their true pixel positions, so the
+    user traces directly on the actual animal (issue #2769 follow-up). The view
+    is zoomable (mouse wheel) and pannable (middle/right drag) so a small animal
+    can be enlarged; double-click resets to the full image.
 
-    Clicking selects the nearest node within a small radius and emits
-    :attr:`node_clicked`; the owning widget owns the chain list and calls
-    :meth:`set_trace` to update the highlighted order.
+    When no frame image is available the canvas falls back to the abstract
+    layout: a representative per-node coordinate (or a deterministic seeded
+    spring layout, or a horizontal line if networkx is missing) normalized into a
+    ``[-1, 1]`` frame on a plain white background. Either way the layout is
+    stable across redraws.
+
+    Clicking with the *left* button selects the nearest node within a pick radius
+    and emits :attr:`node_clicked`; the owning widget owns the chain list and
+    calls :meth:`set_trace` to update the highlighted order. The middle/right
+    buttons pan instead of selecting.
 
     Signals:
         node_clicked: Emitted with the node *name* (str) when the user clicks a
@@ -734,7 +740,7 @@ class QCSkeletonTraceCanvas(Canvas):
 
     node_clicked = QtCore.Signal(str)
 
-    def __init__(self, width: int = 5, height: int = 3, dpi: int = 100):
+    def __init__(self, width: int = 7, height: int = 5, dpi: int = 100):
         """Initialize the canvas.
 
         Args:
@@ -748,32 +754,51 @@ class QCSkeletonTraceCanvas(Canvas):
         super().__init__(self.fig)
 
         self.setSizePolicy(
-            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred
+            QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding
         )
-        self.setMinimumSize(260, 220)
+        # Bigger minimum so the animal is clearly visible; the user explicitly
+        # asked for a larger, zoomable canvas.
+        self.setMinimumSize(480, 380)
 
-        # Node display positions keyed by node name: {name: (x, y)}. These are
-        # the *normalized* coordinates actually drawn/hit-tested (roughly in
-        # [-1, 1]); see :meth:`_compute_layout`.
+        # Node display positions keyed by node name: {name: (x, y)}. In image
+        # mode these are raw *pixel* coordinates; in the abstract fallback they
+        # are *normalized* (roughly [-1, 1]); see :meth:`_compute_layout`.
         self._positions: dict = {}
         self._node_names: list = []
         self._edges: list = []  # list of (src_name, dst_name)
         # Optional representative per-node coordinates from real labeled
         # instances ({name: (x, y)} in raw label/image space). When present
-        # these drive the layout (a real animal shape); when empty the canvas
-        # falls back to the spring/line layout.
+        # these drive the abstract layout (a real animal shape); when empty the
+        # canvas falls back to the spring/line layout.
         self._node_coords: dict = {}
+        # The labeled frame image to show as the canvas background (np.ndarray,
+        # 2D grayscale or HxWx3 RGB), or None to use the abstract white layout.
+        self._background_image = None
+        # The matplotlib AxesImage handle for the background (when shown).
+        self._image_artist = None
         # The chain currently being traced, in click order (node names).
         self._trace: list = []
-        # Click hit-test radius in data coordinates. Both the spring layout and
-        # the real-coordinate layout are normalized to ~[-1, 1], so this fixed
-        # radius works for either.
+        # Click hit-test radius for the abstract layout (data coords). Both the
+        # spring layout and the real-coordinate layout are normalized to
+        # ~[-1, 1], so this fixed radius works for either. In image (pixel) mode
+        # the pick radius is derived from the current view extent instead, so it
+        # keeps working after zooming/panning -- see :meth:`node_at`.
         self._pick_radius = 0.18
 
+        # Pan bookkeeping: the data-space anchor recorded on a middle/right
+        # button press, used to translate the view on drag.
+        self._pan_anchor = None
+
         self.mpl_connect("button_press_event", self._on_click)
+        self.mpl_connect("scroll_event", self._on_scroll)
+        self.mpl_connect("button_press_event", self._on_pan_press)
+        self.mpl_connect("motion_notify_event", self._on_pan_move)
+        self.mpl_connect("button_release_event", self._on_pan_release)
         self.update_plot()
 
-    def set_skeleton(self, node_names: list, edges: list, node_positions=None):
+    def set_skeleton(
+        self, node_names: list, edges: list, node_positions=None, image=None
+    ):
         """Set the skeleton to display and recompute the layout.
 
         Args:
@@ -782,9 +807,18 @@ class QCSkeletonTraceCanvas(Canvas):
             node_positions: Optional dict mapping node name to a representative
                 ``(x, y)`` coordinate from real labeled instances (raw label
                 space). When given (and non-empty), the skeleton is drawn using
-                those coordinates so it looks like the actual animal; otherwise
-                the canvas falls back to the spring/line layout. May also be set
-                separately via :meth:`set_node_positions`.
+                those coordinates. If an ``image`` is also given these are
+                treated as raw *pixel* coordinates and drawn over the image at
+                their true positions; otherwise they are centered/scaled into the
+                abstract ``[-1, 1]`` frame (like the SLEAP skeleton builder).
+                When omitted the canvas falls back to the spring/line layout.
+                May also be set separately via :meth:`set_node_positions`.
+            image: Optional labeled-frame image (``np.ndarray``; 2D grayscale,
+                ``(H, W, 1)`` grayscale, or ``(H, W, 3)`` RGB) to show as the
+                canvas background. When provided together with ``node_positions``
+                the canvas enters *image mode*: the photo is shown with a
+                top-left origin and the skeleton is overlaid at pixel coords.
+                ``None`` keeps the plain abstract layout.
         """
         self._node_names = list(node_names)
         # Keep only edges whose endpoints are present, as name pairs.
@@ -800,10 +834,63 @@ class QCSkeletonTraceCanvas(Canvas):
         else:
             # A new skeleton without coords drops any stale real coordinates.
             self._node_coords = {}
-        self._positions = self._compute_layout()
+        # Image mode requires both an image and at least one real pixel coord;
+        # otherwise we cannot place the skeleton on the photo, so fall back.
+        self._background_image = self._coerce_image(image)
+        if self._background_image is not None and self._node_coords:
+            # Pixel mode: draw nodes at their true image coordinates (no
+            # normalization), so they line up with the animal in the photo.
+            self._positions = {
+                name: (float(x), float(y))
+                for name, (x, y) in self._node_coords.items()
+                if np.isfinite(x) and np.isfinite(y)
+            }
+        else:
+            self._background_image = None
+            self._positions = self._compute_layout()
         # Drop any traced nodes that no longer exist in this skeleton.
         self._trace = [n for n in self._trace if n in valid]
+        # A new skeleton/image is a structural change: start from the full
+        # extent rather than preserving a stale zoom from a previous project.
+        self.axes.set_xlim(0.0, 1.0)
+        self.axes.set_ylim(0.0, 1.0)
+        self._pan_anchor = None
         self.update_plot()
+
+    @staticmethod
+    def _coerce_image(image):
+        """Normalize a frame image into a 2D/RGB array ``imshow`` can render.
+
+        Squeezes a trailing singleton channel (``(H, W, 1)`` grayscale) down to
+        ``(H, W)`` and passes ``(H, W, 3)`` RGB through unchanged. Anything that
+        is not a usable 2D/RGB image (wrong rank, empty, or not array-like)
+        returns ``None`` so the caller falls back to the abstract layout.
+
+        Args:
+            image: Candidate image (``np.ndarray`` or array-like), or ``None``.
+
+        Returns:
+            A 2D ``(H, W)`` or 3D ``(H, W, 3)`` ``np.ndarray``, or ``None``.
+        """
+        if image is None:
+            return None
+        try:
+            arr = np.asarray(image)
+        except Exception:
+            return None
+        if arr.size == 0:
+            return None
+        # Drop a leading singleton (e.g. a (1, H, W, C) single-frame stack).
+        while arr.ndim > 3 and arr.shape[0] == 1:
+            arr = arr[0]
+        if arr.ndim == 3 and arr.shape[-1] == 1:
+            arr = arr[..., 0]
+        if arr.ndim == 2:
+            return arr
+        if arr.ndim == 3 and arr.shape[-1] in (3, 4):
+            # Keep RGB; drop an alpha channel for a stable imshow.
+            return arr[..., :3]
+        return None
 
     def set_node_positions(self, node_positions: dict):
         """Set representative per-node coordinates from real labeled instances.
@@ -823,7 +910,14 @@ class QCSkeletonTraceCanvas(Canvas):
             for name, (x, y) in (node_positions or {}).items()
             if name in valid
         }
+        # Setting positions without an image is an abstract-layout update; drop
+        # any stale background so we do not draw normalized coords over a photo.
+        self._background_image = None
         self._positions = self._compute_layout()
+        # Structural change: reset any zoom/pan to the full extent.
+        self.axes.set_xlim(0.0, 1.0)
+        self.axes.set_ylim(0.0, 1.0)
+        self._pan_anchor = None
         self.update_plot()
 
     def _compute_layout(self) -> dict:
@@ -922,14 +1016,30 @@ class QCSkeletonTraceCanvas(Canvas):
         return list(self._trace)
 
     def update_plot(self):
-        """Redraw the skeleton, edges, and the highlighted trace path."""
+        """Redraw the skeleton, edges, and the highlighted trace path.
+
+        Draws over the labeled-frame photo at true pixel coordinates when an
+        image is set (image mode), otherwise on a plain white background using
+        the normalized abstract layout. Preserves the current zoom/pan view when
+        only the trace changes, so wheel-zooming and then clicking nodes does not
+        snap the view back to the full extent.
+        """
+        image_mode = self._background_image is not None
+        # Remember the current view so a redraw triggered by a trace edit keeps
+        # the user's zoom/pan. We only restore it when the axes already held a
+        # real view (not the initial 0..1 default) and the data is unchanged.
+        prev_xlim = self.axes.get_xlim()
+        prev_ylim = self.axes.get_ylim()
+        had_view = prev_xlim != (0.0, 1.0) or prev_ylim != (0.0, 1.0)
+
         self.axes.clear()
+        self._image_artist = None
         self.axes.set_xticks([])
         self.axes.set_yticks([])
         for spine in self.axes.spines.values():
             spine.set_visible(False)
 
-        if not self._positions:
+        if not self._positions and not image_mode:
             self.axes.text(
                 0.5,
                 0.5,
@@ -944,22 +1054,55 @@ class QCSkeletonTraceCanvas(Canvas):
             self.draw()
             return
 
+        # --- Background image (image mode) ---------------------------------
+        if image_mode:
+            img = self._background_image
+            kwargs = {"origin": "upper", "interpolation": "nearest", "zorder": 0}
+            if img.ndim == 2:
+                kwargs["cmap"] = "gray"
+            self._image_artist = self.axes.imshow(img, **kwargs)
+
+        # In pixel (image) mode markers/labels are sized in pixels relative to
+        # the image, so scale them off the image size; the abstract layout keeps
+        # the original compact styling.
+        if image_mode:
+            h, w = self._background_image.shape[:2]
+            span = float(max(h, w)) or 1.0
+            marker_s = max(80.0, (span * 0.012) ** 2)
+            edge_lw = max(1.2, span / 400.0)
+            trace_lw = max(2.0, span / 250.0)
+            badge_fs = 9
+            label_fs = 8
+            label_dy = 14
+        else:
+            marker_s = 260
+            edge_lw = 1.2
+            trace_lw = 2.5
+            badge_fs = 9
+            label_fs = 8
+            label_dy = 12
+
         # Draw skeleton edges first so nodes sit on top. Skip any edge whose
         # endpoint lacks a position (e.g. a node with no labeled coordinate in
         # the real-animal layout).
+        edge_color = "#e8f0ff" if image_mode else "#ced4da"
         for src, dst in self._edges:
             if src not in self._positions or dst not in self._positions:
                 continue
             x0, y0 = self._positions[src]
             x1, y1 = self._positions[dst]
-            self.axes.plot([x0, x1], [y0, y1], color="#ced4da", linewidth=1.2, zorder=1)
+            self.axes.plot(
+                [x0, x1], [y0, y1], color=edge_color, linewidth=edge_lw, zorder=1
+            )
 
         # Draw the trace path (in click order) as a highlighted poly-line.
         drawable_trace = [n for n in self._trace if n in self._positions]
         if len(drawable_trace) >= 2:
             tx = [self._positions[n][0] for n in drawable_trace]
             ty = [self._positions[n][1] for n in drawable_trace]
-            self.axes.plot(tx, ty, color="#007bff", linewidth=2.5, zorder=2, alpha=0.9)
+            self.axes.plot(
+                tx, ty, color="#007bff", linewidth=trace_lw, zorder=2, alpha=0.9
+            )
 
         # Map node -> 1-based position in the trace (for numbered badges).
         trace_order = {name: i + 1 for i, name in enumerate(self._trace)}
@@ -970,7 +1113,7 @@ class QCSkeletonTraceCanvas(Canvas):
             self.axes.scatter(
                 [x],
                 [y],
-                s=260,
+                s=marker_s,
                 facecolor="#007bff" if in_trace else "#e9ecef",
                 edgecolor="#0056b3" if in_trace else "#adb5bd",
                 linewidths=1.5,
@@ -984,7 +1127,7 @@ class QCSkeletonTraceCanvas(Canvas):
                     str(trace_order[name]),
                     ha="center",
                     va="center",
-                    fontsize=9,
+                    fontsize=badge_fs,
                     fontweight="bold",
                     color="white",
                     zorder=4,
@@ -992,39 +1135,92 @@ class QCSkeletonTraceCanvas(Canvas):
             self.axes.annotate(
                 name,
                 xy=(x, y),
-                xytext=(0, 12),
+                xytext=(0, label_dy),
                 textcoords="offset points",
                 ha="center",
                 va="bottom",
-                fontsize=8,
-                color="#212529" if in_trace else "#495057",
+                fontsize=label_fs,
+                color=(
+                    "#f1f3f5" if image_mode else ("#212529" if in_trace else "#495057")
+                ),
                 zorder=4,
+                bbox=(
+                    dict(boxstyle="round,pad=0.15", fc="#212529aa", ec="none")
+                    if image_mode
+                    else None
+                ),
             )
 
-        # Pad the limits so labels are not clipped. Use ``adjustable="box"`` so
-        # the equal-aspect constraint resizes the axes box rather than silently
-        # overriding the explicit limits set here (which would emit a warning).
-        xs = [p[0] for p in self._positions.values()]
-        ys = [p[1] for p in self._positions.values()]
-        pad = 0.35
-        self.axes.set_aspect("equal", adjustable="box")
-        self.axes.set_xlim(min(xs) - pad, max(xs) + pad)
-        self.axes.set_ylim(min(ys) - pad, max(ys) + pad)
+        if image_mode:
+            self.axes.set_aspect("equal", adjustable="box")
+            h, w = self._background_image.shape[:2]
+            if had_view:
+                # Preserve the user's zoom/pan across a trace-only redraw.
+                self.axes.set_xlim(prev_xlim)
+                self.axes.set_ylim(prev_ylim)
+            else:
+                # Full image extent; y inverted so (0,0) is top-left like a photo.
+                self.axes.set_xlim(-0.5, w - 0.5)
+                self.axes.set_ylim(h - 0.5, -0.5)
+        else:
+            # Pad the limits so labels are not clipped. Use ``adjustable="box"``
+            # so the equal-aspect constraint resizes the axes box rather than
+            # silently overriding the explicit limits (which would warn).
+            xs = [p[0] for p in self._positions.values()]
+            ys = [p[1] for p in self._positions.values()]
+            pad = 0.35
+            self.axes.set_aspect("equal", adjustable="box")
+            self.axes.set_xlim(min(xs) - pad, max(xs) + pad)
+            self.axes.set_ylim(min(ys) - pad, max(ys) + pad)
 
         self.draw()
 
+    def reset_view(self):
+        """Reset the view to the full image (or layout) extent and redraw."""
+        # Forget any zoom/pan, then let update_plot recompute the full extent.
+        self.axes.set_xlim(0.0, 1.0)
+        self.axes.set_ylim(0.0, 1.0)
+        self.update_plot()
+
+    def _current_pick_radius(self) -> float:
+        """Pick radius in *data* units for the currently active layout.
+
+        The abstract layout is normalized to ``~[-1, 1]`` so a fixed radius
+        works. In image (pixel) mode the data units are image pixels and the
+        view changes with zoom, so the radius is taken as a fraction of the
+        current visible width -- this keeps the clickable target a roughly
+        constant on-screen size after zooming and panning.
+
+        Returns:
+            The hit-test radius in the active data coordinate space.
+        """
+        if self._background_image is None:
+            return self._pick_radius
+        x0, x1 = self.axes.get_xlim()
+        view_w = abs(x1 - x0)
+        if not np.isfinite(view_w) or view_w <= 0:
+            # No real view yet: fall back to a fraction of the image width.
+            view_w = float(self._background_image.shape[1]) or 1.0
+        # ~6% of the visible width; clamp so it never collapses to nothing.
+        return max(view_w * 0.06, 1.0)
+
     def node_at(self, x: float, y: float) -> Optional[str]:
         """Return the node name nearest to ``(x, y)`` within the pick radius.
+
+        Works in whichever coordinate space is currently active: normalized
+        units for the abstract layout, image pixels for the photo overlay. In
+        pixel mode the radius scales with the current view (see
+        :meth:`_current_pick_radius`) so picking keeps working after zoom/pan.
 
         Args:
             x: X position in data coordinates.
             y: Y position in data coordinates.
 
         Returns:
-            The nearest node name within :attr:`_pick_radius`, or None.
+            The nearest node name within the active pick radius, or None.
         """
         best_name = None
-        best_dist = self._pick_radius
+        best_dist = self._current_pick_radius()
         for name, (nx_, ny_) in self._positions.items():
             dist = ((nx_ - x) ** 2 + (ny_ - y) ** 2) ** 0.5
             if dist <= best_dist:
@@ -1033,14 +1229,96 @@ class QCSkeletonTraceCanvas(Canvas):
         return best_name
 
     def _on_click(self, event):
-        """Emit :attr:`node_clicked` for the node nearest the click, if any."""
+        """Handle a left click: select the nearest node, or reset on dbl-click.
+
+        Left-button single clicks emit :attr:`node_clicked` for the nearest node
+        (the tracing interaction). A left-button double-click resets the view to
+        the full extent. Middle/right buttons are reserved for panning and are
+        ignored here.
+        """
         if event.inaxes != self.axes:
+            return
+        # Only the left button drives selection; middle/right pan instead.
+        if event.button not in (1, None):
+            return
+        if getattr(event, "dblclick", False):
+            self.reset_view()
             return
         if event.xdata is None or event.ydata is None:
             return
         name = self.node_at(event.xdata, event.ydata)
         if name is not None:
             self.node_clicked.emit(name)
+
+    def _on_scroll(self, event):
+        """Zoom the view in/out around the cursor on a mouse-wheel scroll.
+
+        Scales the current x/y limits about ``(event.xdata, event.ydata)`` so the
+        point under the cursor stays put: scrolling up zooms in, down zooms out.
+        """
+        if event.inaxes != self.axes:
+            return
+        if event.xdata is None or event.ydata is None:
+            return
+        # Up zooms in (shrink the view), down zooms out (grow it).
+        scale = 0.8 if event.button == "up" else 1.25
+        x0, x1 = self.axes.get_xlim()
+        y0, y1 = self.axes.get_ylim()
+        cx, cy = event.xdata, event.ydata
+        # Keep the cursor anchored: scale each side's distance from the cursor.
+        self.axes.set_xlim(cx + (x0 - cx) * scale, cx + (x1 - cx) * scale)
+        self.axes.set_ylim(cy + (y0 - cy) * scale, cy + (y1 - cy) * scale)
+        self.draw()
+
+    def _on_pan_press(self, event):
+        """Record the pan anchor when a non-left button is pressed in the axes.
+
+        The anchor is the press location in *display pixels* together with the
+        axes limits at press time; tracking pixels (rather than data coords)
+        avoids feedback when the limits move out from under the cursor mid-drag.
+        """
+        if event.inaxes != self.axes:
+            return
+        # Middle (2) or right (3) button starts a pan; left is for selection.
+        if event.button in (2, 3):
+            x0, x1 = self.axes.get_xlim()
+            y0, y1 = self.axes.get_ylim()
+            bbox = self.axes.get_window_extent()
+            # Data units per display pixel, frozen at press time so the mapping
+            # cannot drift as the limits move during the drag.
+            self._pan_anchor = (
+                event.x,
+                event.y,
+                x0,
+                x1,
+                y0,
+                y1,
+                (x1 - x0) / bbox.width if bbox.width else 0.0,
+                (y1 - y0) / bbox.height if bbox.height else 0.0,
+            )
+
+    def _on_pan_move(self, event):
+        """Translate the view to follow the cursor while panning.
+
+        Converts the pixel movement since the press into a data-space shift
+        using the frozen press-time pixel scale, then offsets the press-time
+        limits by that shift so the grabbed point stays under the cursor.
+        """
+        if self._pan_anchor is None:
+            return
+        if event.x is None or event.y is None:
+            return
+        px, py, x0, x1, y0, y1, sx, sy = self._pan_anchor
+        shift_x = (event.x - px) * sx
+        shift_y = (event.y - py) * sy
+        self.axes.set_xlim(x0 - shift_x, x1 - shift_x)
+        self.axes.set_ylim(y0 - shift_y, y1 - shift_y)
+        self.draw()
+
+    def _on_pan_release(self, event):
+        """End the current pan gesture."""
+        if event.button in (2, 3):
+            self._pan_anchor = None
 
 
 class QCFlagTableModel(QtCore.QAbstractTableModel):
@@ -1331,7 +1609,10 @@ class QCChainTraceDialog(QtWidgets.QDialog):
         # Non-modal would let the underlying project change under the editor;
         # a modal dialog keeps the chain state edit self-contained.
         self.setModal(True)
-        self.setMinimumSize(420, 460)
+        # Larger so the real labeled frame is clearly visible for tracing
+        # (issue #2769 follow-up).
+        self.setMinimumSize(640, 680)
+        self.resize(820, 820)
 
         layout = QtWidgets.QVBoxLayout(self)
         layout.setContentsMargins(10, 10, 10, 10)
@@ -1993,12 +2274,33 @@ class QCWidget(QtWidgets.QWidget):
         outer.addWidget(heading)
 
         # --- Interactive skeleton canvas: click nodes in order to trace. ---
-        self._skeleton_canvas = QCSkeletonTraceCanvas(width=5, height=2.6)
+        # Bigger + zoomable so the real labeled animal is clearly visible
+        # (issue #2769 follow-up: trace on the actual frame photo).
+        self._skeleton_canvas = QCSkeletonTraceCanvas(width=7, height=5)
         self._skeleton_canvas.setToolTip(
-            "Click nodes in order to trace a chain. Numbered blue nodes show the "
-            "current order; click 'Add chain' to save it."
+            "Click nodes in order to trace a chain. The numbered blue nodes show "
+            "the current order; click 'Add chain' to save it.\n"
+            "Scroll to zoom, drag with the middle/right mouse button to pan, "
+            "and double-click to reset the view."
         )
-        outer.addWidget(self._skeleton_canvas)
+        outer.addWidget(self._skeleton_canvas, stretch=1)
+
+        # A small view-control row: a hint plus an explicit Reset view button
+        # (double-click also resets).
+        view_row = QtWidgets.QHBoxLayout()
+        view_row.setSpacing(4)
+        view_hint = QtWidgets.QLabel(
+            "Scroll to zoom · middle/right-drag to pan · double-click to reset"
+        )
+        view_hint.setStyleSheet("color:#6c757d;")
+        view_row.addWidget(view_hint)
+        view_row.addStretch()
+        self._reset_view_btn = QtWidgets.QToolButton()
+        self._reset_view_btn.setText("Reset view")
+        self._reset_view_btn.setToolTip("Reset zoom/pan to show the whole frame.")
+        self._reset_view_btn.clicked.connect(self._skeleton_canvas.reset_view)
+        view_row.addWidget(self._reset_view_btn)
+        outer.addLayout(view_row)
 
         # --- Current trace readout (ordered chips) + actions. ---
         trace_row = QtWidgets.QHBoxLayout()
@@ -2278,15 +2580,21 @@ class QCWidget(QtWidgets.QWidget):
 
         Reads the first skeleton from the loaded labels (if any) and hands its
         nodes/edges to the :class:`QCSkeletonTraceCanvas` so the user can trace
-        on the real skeleton. Also computes a representative per-node position
-        from the labeled instances (:meth:`_representative_node_positions`) so
-        the canvas can draw the actual animal shape rather than an abstract
-        spring layout (issue #2769 follow-up). Clears the canvas when no skeleton
-        is available.
+        on the real skeleton. It then picks one real labeled instance with as
+        many nodes present as possible and decodes that frame's image
+        (:meth:`_best_labeled_instance_image`), so the canvas can show the actual
+        photo with the skeleton overlaid at true pixel coordinates -- the user
+        traces on the real animal (issue #2769 follow-up). When no image can be
+        decoded (e.g. the video file is missing) it falls back to a centered,
+        abstract layout from a representative instance
+        (:meth:`_representative_node_positions`). Clears the canvas when no
+        skeleton is available.
 
         Uses ``labels.skeletons`` (a list) rather than the ``labels.skeleton``
         convenience property, since the latter *raises* when there are zero or
-        multiple skeletons. Any backend hiccup falls back to an empty canvas.
+        multiple skeletons. Nothing here may throw: any backend hiccup degrades
+        to a less rich view (image -> abstract -> spring -> empty) so the dialog
+        always opens.
         """
         node_names: list = []
         edges: list = []
@@ -2304,10 +2612,99 @@ class QCWidget(QtWidgets.QWidget):
                 ]
         except Exception:
             node_names, edges, skeleton = [], [], None
+
+        # Prefer the real labeled frame: one instance's pixel coords + the photo.
+        pixel_positions, image = self._best_labeled_instance_image(skeleton, node_names)
+        if image is not None and pixel_positions:
+            self._skeleton_canvas.set_skeleton(
+                node_names, edges, node_positions=pixel_positions, image=image
+            )
+            return
+
+        # No usable image: draw an abstract animal shape from a representative
+        # instance (centered/scaled), falling back to the spring layout inside
+        # the canvas when even that is unavailable.
         node_positions = self._representative_node_positions(skeleton, node_names)
         self._skeleton_canvas.set_skeleton(
-            node_names, edges, node_positions=node_positions
+            node_names, edges, node_positions=node_positions, image=None
         )
+
+    def _best_labeled_instance_image(self, skeleton, node_names: list):
+        """Pick the best-labeled instance and decode its frame image.
+
+        Scans every labeled frame for *user* instances that share ``skeleton``
+        and counts how many nodes are present (finite/visible). The instance with
+        the most present nodes wins (preferring one with *all* nodes present;
+        ties break to the first found), since a fully-labeled animal makes the
+        clearest tracing target. That instance's frame image is decoded via
+        ``labeled_frame.image`` (which works for embedded ``pkg.slp`` frames).
+
+        The whole scan is wrapped defensively: a missing video, an undecodable
+        frame, or any backend error returns ``(positions, None)`` (or ``({},
+        None)``) so the caller falls back to the abstract layout and the dialog
+        still opens.
+
+        Args:
+            skeleton: The skeleton whose ``node_names`` order aligns with each
+                instance's ``numpy()`` rows, or ``None``.
+            node_names: The skeleton node names (used as result keys).
+
+        Returns:
+            A ``(positions, image)`` tuple. ``positions`` maps node name to the
+            chosen instance's ``(x, y)`` *pixel* coordinate (present nodes only);
+            ``image`` is the decoded frame as an ``np.ndarray`` or ``None``.
+        """
+        labels = self._labels
+        if labels is None or skeleton is None or not node_names:
+            return {}, None
+
+        n_nodes = len(node_names)
+        best_lf = None
+        best_pts = None
+        best_count = -1
+        try:
+            frames = getattr(labels, "labeled_frames", None)
+            if frames is None:
+                frames = labels  # iterate the Labels object directly
+            for lf in frames:
+                for inst in getattr(lf, "user_instances", []):
+                    # Only instances sharing this skeleton align row-for-row.
+                    if getattr(inst, "skeleton", None) is not skeleton:
+                        continue
+                    pts = np.asarray(inst.numpy(invisible_as_nan=True), dtype=float)
+                    if pts.shape != (n_nodes, 2):
+                        continue
+                    present = int(np.isfinite(pts).all(axis=1).sum())
+                    if present > best_count:
+                        best_count = present
+                        best_pts = pts
+                        best_lf = lf
+                        # A fully-present instance is ideal; stop early.
+                        if present == n_nodes:
+                            raise StopIteration
+        except StopIteration:
+            pass
+        except Exception:
+            return {}, None
+
+        if best_lf is None or best_pts is None or best_count <= 0:
+            return {}, None
+
+        positions = {
+            name: (float(best_pts[i, 0]), float(best_pts[i, 1]))
+            for i, name in enumerate(node_names)
+            if np.isfinite(best_pts[i, 0]) and np.isfinite(best_pts[i, 1])
+        }
+
+        # Decode the frame image; any failure (missing video, bad backend) falls
+        # back to an image-less (abstract) overlay.
+        image = None
+        try:
+            image = np.asarray(best_lf.image)
+        except Exception:
+            image = None
+
+        return positions, image
 
     def _representative_node_positions(
         self, skeleton, node_names: list, max_instances: int = 200

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -224,6 +224,14 @@ class CollapsibleGroupBox(QtWidgets.QGroupBox):
         outer.addWidget(self.content)
 
         self.setCheckable(True)
+        # Hide the native check-box indicator so the header shows ONLY the ▶/▼
+        # disclosure arrow, not a check box. A checkable QGroupBox otherwise
+        # draws a native checkbox next to the title (very visible on macOS)
+        # (issue #2769 follow-up). The box stays checkable -- isChecked()/
+        # setChecked()/toggled and click-to-expand keep working -- and styling
+        # the indicator to zero size moves rendering onto the stylesheet engine
+        # so the checkbox is gone on every platform.
+        self.setStyleSheet("QGroupBox::indicator { width: 0px; height: 0px; }")
         # A pointing-hand cursor reinforces that the whole header is clickable,
         # like a disclosure summary.
         self.setCursor(QtCore.Qt.PointingHandCursor)

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -1208,7 +1208,20 @@ class QCWidget(QtWidgets.QWidget):
 
     def _setup_ui(self):
         """Set up the widget UI."""
-        layout = QtWidgets.QVBoxLayout(self)
+        # The whole panel lives in a scroll area so a tall panel (charts +
+        # table + details) scrolls within the dock instead of forcing the dock
+        # and window to grow without bound (issue #2769, item 4 follow-up).
+        outer = QtWidgets.QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        self._scroll = QtWidgets.QScrollArea()
+        self._scroll.setWidgetResizable(True)
+        self._scroll.setFrameShape(QtWidgets.QFrame.NoFrame)
+        self._scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+        outer.addWidget(self._scroll)
+
+        container = QtWidgets.QWidget()
+        self._scroll.setWidget(container)
+        layout = QtWidgets.QVBoxLayout(container)
         layout.setContentsMargins(8, 8, 8, 8)
         layout.setSpacing(6)
 
@@ -1308,9 +1321,12 @@ class QCWidget(QtWidgets.QWidget):
 
         self._viz_tabs = QtWidgets.QTabWidget()
         self._viz_tabs.setMinimumHeight(180)
-        # Let the tabs shrink when space is limited but not expand unboundedly
+        # Lock the charts height so the matplotlib canvases can't keep expanding
+        # the panel without bound (issue #2769, item 4 follow-up); the
+        # panel-level scroll area handles any overflow below.
+        self._viz_tabs.setMaximumHeight(300)
         self._viz_tabs.setSizePolicy(
-            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Maximum
         )
 
         # Score distribution tab

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -35,6 +35,209 @@ if TYPE_CHECKING:
     from sleap.qc.results import QCResults, QCFlag
 
 
+# Plain-language, biologist-friendly help for each detector. Each entry is
+# (short title, body) and is shown when the user clicks the "?" help button next
+# to a detector in the Detector Settings panel (issue #2769, item 3). The text
+# deliberately avoids math/statistics jargon and describes what the detector
+# catches and what the mistake looks like on a real animal.
+DETECTOR_HELP = {
+    "flip": (
+        "Whole-instance L/R flip",
+        "Flags an animal whose left and right body parts look swapped — for "
+        "example, the left and right ears traced on the wrong sides, so the "
+        "whole pose is mirror-flipped.\n\n"
+        "Use this when you suspect a labeler clicked the left/right parts the "
+        "wrong way around.",
+    ),
+    "chimera": (
+        "Chimera (pose split)",
+        "Flags one animal whose body parts actually belong to two different "
+        "animals — like a single skeleton that jumps from one mouse's head to "
+        "another mouse's tail.\n\n"
+        "This often happens when two animals are close together and the labels "
+        "get mixed up between them.",
+    ),
+    "duplicate": (
+        "Duplicate / split",
+        "Flags two labels that sit almost on top of each other — usually the "
+        "same animal accidentally traced twice, or one animal split into two "
+        "overlapping copies.\n\n"
+        "Review these to delete the extra copy and keep a single clean label.",
+    ),
+    "chain": (
+        "Wrong chain order",
+        "Flags a body part traced out of order along a connected chain, such as "
+        "a tail. Imagine the tail tip placed before the tail base, so the chain "
+        "doubles back on itself instead of running smoothly from base to tip.\n\n"
+        "Helpful for catching tail or limb points clicked in the wrong sequence.",
+    ),
+    "missing": (
+        "Missing labelable node",
+        "Flags an animal that is missing a body part its neighbors usually "
+        "have. For example, most mice in your project have a visible nose, but "
+        "this one is missing its nose label even though the nose looks "
+        "visible.\n\n"
+        "Use this to find parts that were skipped or forgotten during labeling.",
+    ),
+    "appearance": (
+        "Appearance / wrong-object",
+        "Flags a body part placed on the wrong-looking spot in the image — for "
+        "example, a paw point that landed on the bedding or cage floor instead "
+        "of on the animal's fur.\n\n"
+        "It looks at the actual pixels around each point, so it catches points "
+        "dragged off the animal.",
+    ),
+    "insample": (
+        "In-sample model prediction",
+        "Runs a trained pose model on your already-labeled frames and points "
+        "out body parts the model is confident about but that you left "
+        "unlabeled — likely parts that were visible but skipped.\n\n"
+        "Note: this runs full model inference, so it can be slow on large "
+        "projects.",
+    ),
+}
+
+
+# Plain-language sentence templates for the primary issue on a flagged
+# instance, keyed by the raw ``QCFlag.top_issue`` string (issue #2769, item 7).
+# Used to rewrite the Selected Instance / Statistics panels in friendly terms
+# instead of raw feature names. Keys cover the forced hard-rule labels, the
+# per-channel labels, and the inferred issue labels from QCResults; anything not
+# listed falls back to a cleaned-up version of the raw label.
+ISSUE_FRIENDLY = {
+    # Forced hard-rule issues.
+    "Whole-instance L/R flip": "left/right sides look swapped",
+    "Wrong keypoint order along chain": "body parts traced out of order",
+    # Per-channel issues.
+    "Missing labelable node": "a body part looks missing",
+    "Appearance outlier": "a point sits on the wrong-looking spot",
+    "Model expects a labeled part here": "a visible part looks unlabeled",
+    # Inferred (structural / GMM) issues.
+    "Unusual edge length": "two parts are an unusual distance apart",
+    "Unusual proportions": "the body proportions look off",
+    "Unusual joint angle": "a joint bends at an unusual angle",
+    "Unusual pose structure": "the overall pose looks unusual",
+    "Unusual node spacing": "the spacing between parts looks off",
+    "Unusual scale": "the animal looks an unusual size",
+    "Isolated node": "one part sits far from the rest",
+    "Inconsistent spacing": "the spacing between parts is inconsistent",
+    "Likely L/R swap": "left/right sides may be swapped",
+    "Unusual visibility": "an unusual set of parts is visible",
+    "Isolated invisible node": "a part is hidden where you'd expect it shown",
+    "Unusual visibility pattern": "which parts are visible looks unusual",
+    "Unusual pose shape": "the pose shape looks unusual",
+    "Unusual curvature": "the body curves in an unusual way",
+    "Unusual pose extent": "the pose spreads out unusually",
+    "Unknown": "something looks unusual",
+}
+
+
+# Placeholder shown in the Selected Instance panel before a row is chosen.
+SELECT_INSTANCE_PLACEHOLDER = "Click a row in the table to review why it was flagged."
+
+
+def _friendly_issue(top_issue: str) -> str:
+    """Map a raw ``QCFlag.top_issue`` to a short plain-language phrase.
+
+    Args:
+        top_issue: The raw issue label from a QCFlag (e.g.
+            ``"Whole-instance L/R flip"`` or ``"Unusual joint angle"``).
+
+    Returns:
+        A lowercase clause suitable for dropping into a sentence such as
+        "Flagged: <clause> (confidence ...)". Unknown labels fall back to a
+        cleaned-up, lowercased version of the raw text.
+    """
+    if top_issue in ISSUE_FRIENDLY:
+        return ISSUE_FRIENDLY[top_issue]
+    # Fallback: strip any "High " prefix and the underscores from raw feature
+    # names so even unmapped issues read reasonably.
+    cleaned = top_issue
+    if cleaned.startswith("High "):
+        cleaned = cleaned[len("High ") :]
+    cleaned = cleaned.replace("_", " ").strip()
+    return cleaned.lower() if cleaned else "something looks unusual"
+
+
+class CheckableFilterMenu(QtWidgets.QMenu):
+    """A QMenu that stays open while the user toggles its checkable items.
+
+    Used for the multi-select issue-type filter on the flagged-instances list
+    (issue #2769, item 5 / feature request #2758): a plain QMenu closes after
+    every click, which is tedious when ticking several issue types in a row.
+    Here a click on a *checkable* action toggles it in place and keeps the menu
+    open; non-checkable actions (e.g. "Select all") behave normally.
+    """
+
+    def mouseReleaseEvent(self, event):
+        action = self.activeAction()
+        if action is not None and action.isEnabled() and action.isCheckable():
+            # Toggle in place and keep the menu open for more selections.
+            action.trigger()
+            return
+        super().mouseReleaseEvent(event)
+
+
+class CollapsibleGroupBox(QtWidgets.QGroupBox):
+    """A checkable group box whose contents collapse when unchecked.
+
+    Acts as a lightweight collapsible section: the check state of the group box
+    header doubles as an expand/collapse toggle, hiding the body so the panel
+    actually shrinks for a cleaner first-time view (issue #2769, item 4).
+
+    All body widgets live inside a single inner :attr:`content` frame; callers
+    add their layout to ``content`` (e.g. ``QVBoxLayout(group.content)``).
+    Collapsing toggles only the *visibility* of ``content`` -- never its
+    *enabled* state -- so per-widget enabled/disabled logic inside the body
+    keeps working even while collapsed. (A plain checkable QGroupBox would
+    instead disable every descendant when unchecked, which would clobber that
+    logic.)
+
+    Args:
+        title: The header text.
+        collapsed: If True, start collapsed (unchecked) with the body hidden.
+        parent: Parent widget.
+    """
+
+    def __init__(
+        self,
+        title: str = "",
+        collapsed: bool = False,
+        parent: Optional[QtWidgets.QWidget] = None,
+    ):
+        super().__init__(title, parent)
+
+        # Single body frame holding everything the caller adds.
+        self.content = QtWidgets.QWidget(self)
+        outer = QtWidgets.QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.addWidget(self.content)
+
+        self.setCheckable(True)
+        self.setChecked(not collapsed)
+        # Re-apply collapse state whenever the header is toggled.
+        self.toggled.connect(self._on_toggled)
+        self._on_toggled(self.isChecked())
+
+    def _on_toggled(self, checked: bool):
+        """Show/hide the body to match the header check state."""
+        self.content.setVisible(checked)
+        # A checkable QGroupBox disables its direct children when unchecked;
+        # undo that on the body frame so the body's own enabled-state logic is
+        # preserved (collapse is visibility-only here).
+        self.content.setEnabled(True)
+        # Let the layout reclaim/release the space.
+        self.updateGeometry()
+
+    def apply_collapsed_state(self):
+        """Apply the current check state to body visibility.
+
+        Kept for callers that add children after construction; toggling is
+        already handled on construction and on every header click.
+        """
+        self._on_toggled(self.isChecked())
+
+
 class QCScoreCanvas(Canvas):
     """Matplotlib canvas for displaying QC score distribution.
 
@@ -462,14 +665,263 @@ class QCFeatureCanvas(Canvas):
         self.draw()
 
 
+class QCSkeletonTraceCanvas(Canvas):
+    """Matplotlib canvas that draws a skeleton and traces an ordered chain.
+
+    This is the interactive heart of the chain-order "skeleton tracing" UX
+    (issue #2769, item 2). Instead of typing node names, the user *clicks*
+    nodes in order on a rendered skeleton; each click appends that node to the
+    chain currently being traced, and the canvas highlights the trace in click
+    order with numbered badges so the path is obvious at a glance.
+
+    The skeleton is laid out with a deterministic spring layout (seeded) over
+    the skeleton's nodes/edges so the picture is stable across redraws. Clicking
+    selects the nearest node within a small radius and emits
+    :attr:`node_clicked`; the owning widget owns the chain list and calls
+    :meth:`set_trace` to update the highlighted order.
+
+    Signals:
+        node_clicked: Emitted with the node *name* (str) when the user clicks a
+            node. The owning widget decides whether to append/toggle it in the
+            chain being traced.
+    """
+
+    node_clicked = QtCore.Signal(str)
+
+    def __init__(self, width: int = 5, height: int = 3, dpi: int = 100):
+        """Initialize the canvas.
+
+        Args:
+            width: Figure width in inches.
+            height: Figure height in inches.
+            dpi: Dots per inch for the figure.
+        """
+        self.fig = Figure(figsize=(width, height), dpi=dpi, constrained_layout=True)
+        self.axes = self.fig.add_subplot(111)
+
+        super().__init__(self.fig)
+
+        self.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred
+        )
+        self.setMinimumSize(260, 220)
+
+        # Node display positions keyed by node name: {name: (x, y)}.
+        self._positions: dict = {}
+        self._node_names: list = []
+        self._edges: list = []  # list of (src_name, dst_name)
+        # The chain currently being traced, in click order (node names).
+        self._trace: list = []
+        # Click hit-test radius in data coordinates (spring layout is ~[-1, 1]).
+        self._pick_radius = 0.18
+
+        self.mpl_connect("button_press_event", self._on_click)
+        self.update_plot()
+
+    def set_skeleton(self, node_names: list, edges: list):
+        """Set the skeleton to display and recompute the layout.
+
+        Args:
+            node_names: Ordered list of node-name strings.
+            edges: List of ``(source_name, destination_name)`` tuples.
+        """
+        self._node_names = list(node_names)
+        # Keep only edges whose endpoints are present, as name pairs.
+        valid = set(self._node_names)
+        self._edges = [(s, d) for (s, d) in edges if s in valid and d in valid]
+        self._positions = self._compute_layout()
+        # Drop any traced nodes that no longer exist in this skeleton.
+        self._trace = [n for n in self._trace if n in valid]
+        self.update_plot()
+
+    def _compute_layout(self) -> dict:
+        """Compute a deterministic node layout for the current skeleton.
+
+        Uses a seeded spring layout so the drawing is stable across redraws.
+        Falls back to a simple horizontal line if networkx is unavailable.
+
+        Returns:
+            Dict mapping node name to an ``(x, y)`` position.
+        """
+        if not self._node_names:
+            return {}
+        try:
+            import networkx as nx
+
+            graph = nx.Graph()
+            graph.add_nodes_from(self._node_names)
+            graph.add_edges_from(self._edges)
+            # Seed keeps the picture stable so users build muscle memory.
+            pos = nx.spring_layout(graph, seed=42)
+            return {name: (float(p[0]), float(p[1])) for name, p in pos.items()}
+        except Exception:
+            # Fallback: lay nodes out on a horizontal line in node order.
+            n = len(self._node_names)
+            if n == 1:
+                return {self._node_names[0]: (0.0, 0.0)}
+            return {
+                name: (-1.0 + 2.0 * i / (n - 1), 0.0)
+                for i, name in enumerate(self._node_names)
+            }
+
+    def set_trace(self, trace: list):
+        """Set the chain-in-progress (node names, in click order) and redraw.
+
+        Args:
+            trace: Ordered list of node names currently in the trace.
+        """
+        self._trace = [n for n in trace if n in self._positions]
+        self.update_plot()
+
+    @property
+    def trace(self) -> list:
+        """The current chain-in-progress as an ordered list of node names."""
+        return list(self._trace)
+
+    def update_plot(self):
+        """Redraw the skeleton, edges, and the highlighted trace path."""
+        self.axes.clear()
+        self.axes.set_xticks([])
+        self.axes.set_yticks([])
+        for spine in self.axes.spines.values():
+            spine.set_visible(False)
+
+        if not self._positions:
+            self.axes.text(
+                0.5,
+                0.5,
+                "No skeleton available.\nLoad a project with a skeleton to trace "
+                "a chain,\nor type the chain below.",
+                ha="center",
+                va="center",
+                transform=self.axes.transAxes,
+                fontsize=9,
+                color="gray",
+            )
+            self.draw()
+            return
+
+        # Draw skeleton edges first so nodes sit on top.
+        for src, dst in self._edges:
+            x0, y0 = self._positions[src]
+            x1, y1 = self._positions[dst]
+            self.axes.plot([x0, x1], [y0, y1], color="#ced4da", linewidth=1.2, zorder=1)
+
+        # Draw the trace path (in click order) as a highlighted poly-line.
+        if len(self._trace) >= 2:
+            tx = [self._positions[n][0] for n in self._trace]
+            ty = [self._positions[n][1] for n in self._trace]
+            self.axes.plot(tx, ty, color="#007bff", linewidth=2.5, zorder=2, alpha=0.9)
+
+        # Map node -> 1-based position in the trace (for numbered badges).
+        trace_order = {name: i + 1 for i, name in enumerate(self._trace)}
+
+        # Draw nodes.
+        for name, (x, y) in self._positions.items():
+            in_trace = name in trace_order
+            self.axes.scatter(
+                [x],
+                [y],
+                s=260,
+                facecolor="#007bff" if in_trace else "#e9ecef",
+                edgecolor="#0056b3" if in_trace else "#adb5bd",
+                linewidths=1.5,
+                zorder=3,
+            )
+            # Numbered badge for traced nodes; small name label for all.
+            if in_trace:
+                self.axes.text(
+                    x,
+                    y,
+                    str(trace_order[name]),
+                    ha="center",
+                    va="center",
+                    fontsize=9,
+                    fontweight="bold",
+                    color="white",
+                    zorder=4,
+                )
+            self.axes.annotate(
+                name,
+                xy=(x, y),
+                xytext=(0, 12),
+                textcoords="offset points",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+                color="#212529" if in_trace else "#495057",
+                zorder=4,
+            )
+
+        # Pad the limits so labels are not clipped.
+        xs = [p[0] for p in self._positions.values()]
+        ys = [p[1] for p in self._positions.values()]
+        pad = 0.35
+        self.axes.set_xlim(min(xs) - pad, max(xs) + pad)
+        self.axes.set_ylim(min(ys) - pad, max(ys) + pad)
+        self.axes.set_aspect("equal", adjustable="datalim")
+
+        self.draw()
+
+    def node_at(self, x: float, y: float) -> Optional[str]:
+        """Return the node name nearest to ``(x, y)`` within the pick radius.
+
+        Args:
+            x: X position in data coordinates.
+            y: Y position in data coordinates.
+
+        Returns:
+            The nearest node name within :attr:`_pick_radius`, or None.
+        """
+        best_name = None
+        best_dist = self._pick_radius
+        for name, (nx_, ny_) in self._positions.items():
+            dist = ((nx_ - x) ** 2 + (ny_ - y) ** 2) ** 0.5
+            if dist <= best_dist:
+                best_dist = dist
+                best_name = name
+        return best_name
+
+    def _on_click(self, event):
+        """Emit :attr:`node_clicked` for the node nearest the click, if any."""
+        if event.inaxes != self.axes:
+            return
+        if event.xdata is None or event.ydata is None:
+            return
+        name = self.node_at(event.xdata, event.ydata)
+        if name is not None:
+            self.node_clicked.emit(name)
+
+
 class QCFlagTableModel(QtCore.QAbstractTableModel):
-    """Table model for QC flagged instances."""
+    """Table model for QC flagged instances.
 
-    COLUMNS = ["Frame", "Instance", "Score", "Confidence", "Issue"]
+    The trailing "Reviewed" column (issue #2769, item 6) is a user-toggled
+    checkbox so reviewers can mark and see which flagged instances they have
+    already looked at. The reviewed state is *not* stored on the row: it lives
+    in a shared set of instance keys owned by the widget, so it survives
+    threshold re-filters and issue-type filtering (which rebuild the row list).
+    """
 
-    def __init__(self, parent=None):
+    # "Reviewed" is appended last so the existing data/sort column indices
+    # (Frame=0 ... Issue=4) are unchanged.
+    COLUMNS = ["Frame", "Instance", "Score", "Confidence", "Issue", "Reviewed"]
+    REVIEWED_COL = 5
+
+    def __init__(self, parent=None, reviewed_keys: Optional[set] = None):
+        """Initialize the model.
+
+        Args:
+            parent: Parent QObject.
+            reviewed_keys: Optional shared set of ``instance_key`` tuples that
+                have been marked reviewed. The model reads/writes this set for
+                the Reviewed column so the state is keyed by instance identity
+                (video, frame, instance) rather than row index. If None, a new
+                empty set is created.
+        """
         super().__init__(parent)
         self._items: List["QCFlag"] = []
+        self._reviewed_keys: set = reviewed_keys if reviewed_keys is not None else set()
 
     @property
     def items(self) -> List["QCFlag"]:
@@ -483,6 +935,40 @@ class QCFlagTableModel(QtCore.QAbstractTableModel):
         self._items = value
         self.endResetModel()
 
+    @property
+    def reviewed_keys(self) -> set:
+        """Set of instance keys marked reviewed (shared with the widget)."""
+        return self._reviewed_keys
+
+    def is_reviewed(self, item: "QCFlag") -> bool:
+        """Return True if the given flag's instance is marked reviewed."""
+        return item.instance_key in self._reviewed_keys
+
+    def set_reviewed(self, item: "QCFlag", reviewed: bool):
+        """Mark a flag's instance reviewed/unreviewed and repaint its row.
+
+        Args:
+            item: The flag whose instance reviewed-state to set.
+            reviewed: Target reviewed state.
+        """
+        key = item.instance_key
+        changed = (key in self._reviewed_keys) != bool(reviewed)
+        if reviewed:
+            self._reviewed_keys.add(key)
+        else:
+            self._reviewed_keys.discard(key)
+        if changed and item in self._items:
+            row = self._items.index(item)
+            top = self.index(row, 0)
+            bottom = self.index(row, self.columnCount() - 1)
+            self.dataChanged.emit(top, bottom)
+
+    def reviewed_count(self) -> int:
+        """Number of *currently shown* rows whose instance is reviewed."""
+        return sum(
+            1 for item in self._items if item.instance_key in self._reviewed_keys
+        )
+
     def rowCount(self, parent=None) -> int:
         return len(self._items)
 
@@ -493,6 +979,13 @@ class QCFlagTableModel(QtCore.QAbstractTableModel):
         if role == QtCore.Qt.DisplayRole and orientation == QtCore.Qt.Horizontal:
             return self.COLUMNS[section]
         return None
+
+    def flags(self, index):
+        base = super().flags(index)
+        if index.isValid() and index.column() == self.REVIEWED_COL:
+            # Reviewed is a user-checkable column.
+            return base | QtCore.Qt.ItemIsUserCheckable
+        return base
 
     def data(self, index, role=QtCore.Qt.DisplayRole):
         if not index.isValid() or index.row() >= len(self._items):
@@ -512,6 +1005,19 @@ class QCFlagTableModel(QtCore.QAbstractTableModel):
                 return item.confidence.title()
             elif col == 4:  # Issue
                 return item.top_issue.replace("_", " ").title()
+            # Reviewed column shows a checkbox (via CheckStateRole), no text.
+
+        elif role == QtCore.Qt.CheckStateRole:
+            if col == self.REVIEWED_COL:
+                return (
+                    QtCore.Qt.Checked
+                    if item.instance_key in self._reviewed_keys
+                    else QtCore.Qt.Unchecked
+                )
+
+        elif role == QtCore.Qt.TextAlignmentRole:
+            if col == self.REVIEWED_COL:
+                return int(QtCore.Qt.AlignCenter)
 
         elif role == QtCore.Qt.ForegroundRole:
             if col == 2:  # Score column
@@ -528,6 +1034,21 @@ class QCFlagTableModel(QtCore.QAbstractTableModel):
                     return QtGui.QBrush(QtGui.QColor(108, 117, 125))
 
         return None
+
+    def setData(self, index, value, role=QtCore.Qt.EditRole):
+        """Toggle reviewed-state when the user clicks the Reviewed checkbox."""
+        if (
+            index.isValid()
+            and index.column() == self.REVIEWED_COL
+            and role == QtCore.Qt.CheckStateRole
+            and index.row() < len(self._items)
+        ):
+            item = self._items[index.row()]
+            # value may arrive as a Qt.CheckState enum or its int form.
+            reviewed = QtCore.Qt.CheckState(value) == QtCore.Qt.Checked
+            self.set_reviewed(item, reviewed)
+            return True
+        return False
 
     def sort(self, column: int, order: QtCore.Qt.SortOrder = QtCore.Qt.AscendingOrder):
         """Sort the model by the given column.
@@ -552,6 +1073,8 @@ class QCFlagTableModel(QtCore.QAbstractTableModel):
             key = lambda x: conf_order.get(x.confidence, -1)
         elif column == 4:  # Issue (alphabetical)
             key = lambda x: x.top_issue
+        elif column == self.REVIEWED_COL:  # Reviewed (unreviewed first ascending)
+            key = lambda x: x.instance_key in self._reviewed_keys
         else:
             key = lambda x: 0
 
@@ -656,6 +1179,30 @@ class QCWidget(QtWidgets.QWidget):
         self._worker: Optional[QCAnalysisWorker] = None
         self._last_export_dir: Optional[str] = None  # Persist export directory
 
+        # All flagged instances at the current threshold, before the issue-type
+        # filter is applied (item 5). The table shows a filtered subset of this.
+        self._all_flagged: List["QCFlag"] = []
+        # Raw ``top_issue`` strings the user has chosen to SHOW in the table.
+        # None means "no filter yet" -> show everything (item 5).
+        self._visible_issue_types: Optional[set] = None
+        # Checkable filter actions by raw issue, and every issue type seen so
+        # far (so a re-filter can tell genuinely new types from de-selected
+        # ones and default the new ones to shown).
+        self._issue_filter_actions: dict = {}
+        self._issue_filter_seen: set = set()
+        # Session-scoped reviewed-state, keyed by the instance's identity tuple
+        # (video, frame, instance) so it survives threshold/issue re-filters
+        # (item 6). Shared by reference with the table model.
+        self._reviewed_keys: set = set()
+
+        # Ordered chains the user has traced on the skeleton (item 2): each
+        # entry is a list of node names in order. These feed QCConfig together
+        # with any chains typed into the advanced free-text fallback.
+        self._traced_chains: List[List[str]] = []
+        # The chain currently being traced by clicking nodes (node names, in
+        # click order); committed to ``_traced_chains`` via "Add chain".
+        self._trace_in_progress: List[str] = []
+
         self._setup_ui()
         self._connect_signals()
 
@@ -679,12 +1226,19 @@ class QCWidget(QtWidgets.QWidget):
         title_layout.addWidget(self._run_button)
         layout.addLayout(title_layout)
 
-        # Progress bar with status and cancel button (hidden by default)
-        progress_layout = QtWidgets.QHBoxLayout()
+        # Progress area (hidden by default). The status TEXT gets its own line
+        # ABOVE the progress bar so neither is squeezed (issue #2769, item 1).
+        progress_box = QtWidgets.QVBoxLayout()
+        progress_box.setSpacing(2)
+
+        # Status text on its own line.
         self._progress_label = QtWidgets.QLabel("")
         self._progress_label.setVisible(False)
-        progress_layout.addWidget(self._progress_label)
+        self._progress_label.setWordWrap(True)
+        progress_box.addWidget(self._progress_label)
 
+        # Progress bar + Cancel button share the second line.
+        progress_layout = QtWidgets.QHBoxLayout()
         self._progress_bar = QtWidgets.QProgressBar()
         self._progress_bar.setVisible(False)
         self._progress_bar.setTextVisible(True)
@@ -697,7 +1251,8 @@ class QCWidget(QtWidgets.QWidget):
         self._cancel_button.setToolTip("Cancel the running analysis")
         progress_layout.addWidget(self._cancel_button)
 
-        layout.addLayout(progress_layout)
+        progress_box.addLayout(progress_layout)
+        layout.addLayout(progress_box)
 
         # Timer for spinner animation during analysis
         self._spinner_timer = QtCore.QTimer(self)
@@ -739,7 +1294,18 @@ class QCWidget(QtWidgets.QWidget):
         # === Detector settings ===
         self._setup_detector_settings(layout)
 
-        # === Tabbed visualization area ===
+        # === Tabbed visualization area (collapsible) ===
+        # Wrap the charts in a collapsible section so users can hide the heavy
+        # plots for a cleaner panel (issue #2769, item 4). Expanded by default
+        # since the charts are the main view.
+        self._charts_group = CollapsibleGroupBox("Charts", collapsed=False)
+        self._charts_group.setToolTip(
+            "Score, issue-breakdown and feature charts.\n"
+            "Uncheck the header to collapse this section."
+        )
+        charts_layout = QtWidgets.QVBoxLayout(self._charts_group.content)
+        charts_layout.setContentsMargins(6, 4, 6, 6)
+
         self._viz_tabs = QtWidgets.QTabWidget()
         self._viz_tabs.setMinimumHeight(180)
         # Let the tabs shrink when space is limited but not expand unboundedly
@@ -759,14 +1325,54 @@ class QCWidget(QtWidgets.QWidget):
         self._feature_canvas = QCFeatureCanvas(width=6, height=2.2)
         self._viz_tabs.addTab(self._feature_canvas, "Features")
 
-        layout.addWidget(self._viz_tabs)
+        charts_layout.addWidget(self._viz_tabs)
+        layout.addWidget(self._charts_group)
 
         # === Flagged instances table ===
         table_group = QtWidgets.QGroupBox("Flagged Instances")
         table_layout = QtWidgets.QVBoxLayout(table_group)
         table_layout.setContentsMargins(4, 4, 4, 4)
 
-        self._table_model = QCFlagTableModel()
+        # --- Toolbar row above the table: issue-type filter + reviewed count ---
+        # Item 5: a checkable dropdown to include/exclude flagged instances by
+        # issue type. Item 6: a running "X / Y reviewed" counter.
+        toolbar = QtWidgets.QHBoxLayout()
+        toolbar.setContentsMargins(0, 0, 0, 0)
+        toolbar.setSpacing(6)
+
+        toolbar.addWidget(QtWidgets.QLabel("Show:"))
+
+        # Multi-select issue-type filter as a QMenu of checkboxes on a button.
+        self._issue_filter_button = QtWidgets.QToolButton()
+        self._issue_filter_button.setText("Issue types: all")
+        self._issue_filter_button.setPopupMode(QtWidgets.QToolButton.InstantPopup)
+        self._issue_filter_button.setToolButtonStyle(QtCore.Qt.ToolButtonTextOnly)
+        self._issue_filter_button.setToolTip(
+            "Filter the flagged list by issue type.\n"
+            "Tick the issue types you want to see; the table updates live."
+        )
+        # Stays open while the user ticks multiple issue types (item 5).
+        self._issue_filter_menu = CheckableFilterMenu(self._issue_filter_button)
+        self._issue_filter_button.setMenu(self._issue_filter_menu)
+        # Disabled until results exist (nothing to filter yet).
+        self._issue_filter_button.setEnabled(False)
+        toolbar.addWidget(self._issue_filter_button)
+
+        toolbar.addStretch()
+
+        # Running reviewed counter ("12 / 45 reviewed"), item 6.
+        self._reviewed_count_label = QtWidgets.QLabel("0 / 0 reviewed")
+        self._reviewed_count_label.setToolTip(
+            "How many of the flagged instances shown you have marked reviewed.\n"
+            "Tick the Reviewed box (or just navigate to a row) to mark one."
+        )
+        toolbar.addWidget(self._reviewed_count_label)
+
+        table_layout.addLayout(toolbar)
+
+        # Share the reviewed-keys set by reference so the model's Reviewed
+        # column reflects session-scoped, identity-keyed state (item 6).
+        self._table_model = QCFlagTableModel(reviewed_keys=self._reviewed_keys)
         self._table_view = QtWidgets.QTableView()
         self._table_view.setModel(self._table_model)
         self._table_view.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
@@ -775,34 +1381,47 @@ class QCWidget(QtWidgets.QWidget):
         self._table_view.setSortingEnabled(True)
         self._table_view.setMinimumHeight(120)
 
-        # Set column widths
+        # Column widths: stretch the Issue column, keep the trailing Reviewed
+        # checkbox column compact (so it does not grab the leftover width).
         header = self._table_view.horizontalHeader()
-        header.setStretchLastSection(True)
+        header.setStretchLastSection(False)
         header.setSectionResizeMode(QtWidgets.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(4, QtWidgets.QHeaderView.Stretch)  # Issue
+        header.setSectionResizeMode(
+            QCFlagTableModel.REVIEWED_COL, QtWidgets.QHeaderView.ResizeToContents
+        )
 
         table_layout.addWidget(self._table_view)
         layout.addWidget(table_group, stretch=1)
 
         # === Bottom panel: selected instance info and statistics ===
+        # Both are collapsible (issue #2769, item 4) but expanded by default,
+        # since their plain-language summaries (item 7) are useful to everyone.
         bottom_layout = QtWidgets.QHBoxLayout()
 
         # Selected instance details
-        details_group = QtWidgets.QGroupBox("Selected Instance")
-        details_layout = QtWidgets.QVBoxLayout(details_group)
+        self._details_group = CollapsibleGroupBox("Selected Instance", collapsed=False)
+        self._details_group.setToolTip(
+            "Why the selected instance was flagged.\n"
+            "Uncheck the header to collapse this section."
+        )
+        details_layout = QtWidgets.QVBoxLayout(self._details_group.content)
         details_layout.setContentsMargins(6, 6, 6, 6)
 
-        self._details_label = QtWidgets.QLabel(
-            "Click a row in the table to select an instance"
-        )
+        self._details_label = QtWidgets.QLabel(SELECT_INSTANCE_PLACEHOLDER)
         self._details_label.setWordWrap(True)
         self._details_label.setMinimumHeight(70)
         details_layout.addWidget(self._details_label)
 
-        bottom_layout.addWidget(details_group)
+        bottom_layout.addWidget(self._details_group)
 
         # Statistics panel
-        stats_group = QtWidgets.QGroupBox("Statistics")
-        stats_layout = QtWidgets.QVBoxLayout(stats_group)
+        self._stats_group = CollapsibleGroupBox("Statistics", collapsed=False)
+        self._stats_group.setToolTip(
+            "Summary of how many instances were flagged.\n"
+            "Uncheck the header to collapse this section."
+        )
+        stats_layout = QtWidgets.QVBoxLayout(self._stats_group.content)
         stats_layout.setContentsMargins(6, 6, 6, 6)
 
         self._stats_label = QtWidgets.QLabel("No analysis run yet")
@@ -810,7 +1429,7 @@ class QCWidget(QtWidgets.QWidget):
         self._stats_label.setMinimumHeight(70)
         stats_layout.addWidget(self._stats_label)
 
-        bottom_layout.addWidget(stats_group)
+        bottom_layout.addWidget(self._stats_group)
 
         layout.addLayout(bottom_layout)
 
@@ -821,24 +1440,27 @@ class QCWidget(QtWidgets.QWidget):
         enable/disable and tune each detector for the current project. The
         resulting controls are read by :meth:`_build_qc_config`.
 
+        The group is an advanced panel, so it starts COLLAPSED to keep the
+        first-time view clean (issue #2769, item 4); each detector row carries a
+        plain-language "?" help button (item 3).
+
         Args:
             layout: The parent layout to append the group box to.
         """
-        # Checkable group acts as an expand/collapse header; default expanded.
-        group = QtWidgets.QGroupBox("Detector Settings")
-        group.setCheckable(True)
-        group.setChecked(True)
+        # Collapsible header; advanced panel starts collapsed for a clean view.
+        group = CollapsibleGroupBox("Detector Settings", collapsed=True)
         group.setToolTip(
             "Enable/disable and tune individual QC detectors for this project.\n"
-            "Uncheck the header to collapse this panel."
+            "Click the header to expand; uncheck it to collapse again."
         )
         self._detector_settings_group = group
 
-        grid = QtWidgets.QGridLayout(group)
+        grid = QtWidgets.QGridLayout(group.content)
         grid.setContentsMargins(8, 4, 8, 8)
         grid.setHorizontalSpacing(8)
         grid.setVerticalSpacing(4)
-        # Column 2 (the threshold area) takes any extra width.
+        # Column 2 (the threshold area) takes any extra width. Column 3 holds
+        # the per-detector "?" help buttons at the far right.
         grid.setColumnStretch(2, 1)
         self._detector_settings_grid = grid
 
@@ -860,7 +1482,7 @@ class QCWidget(QtWidgets.QWidget):
         flip_thr_row = self._make_threshold_row(
             [(QtWidgets.QLabel("flip frac ≥"), self._sb_flip_thr)]
         )
-        self._add_detector_row(0, self._cb_flip, flip_thr_row)
+        self._add_detector_row(0, self._cb_flip, flip_thr_row, help_key="flip")
 
         # --- Chimera / pose split, reliable, default-ON (no user threshold) ---
         self._cb_chimera = QtWidgets.QCheckBox("Chimera (pose split)")
@@ -873,7 +1495,7 @@ class QCWidget(QtWidgets.QWidget):
         chimera_note = QtWidgets.QLabel("(no threshold)")
         chimera_note.setEnabled(False)
         chimera_note.setToolTip("Chimera detection has no hard threshold to set.")
-        self._add_detector_row(1, self._cb_chimera, chimera_note)
+        self._add_detector_row(1, self._cb_chimera, chimera_note, help_key="chimera")
 
         # --- Duplicate / split, reliable, default-ON ---
         self._cb_duplicate = QtWidgets.QCheckBox("Duplicate / split")
@@ -893,7 +1515,7 @@ class QCWidget(QtWidgets.QWidget):
         dup_thr_row = self._make_threshold_row(
             [(QtWidgets.QLabel("score ≥"), self._sb_dup_thr)]
         )
-        self._add_detector_row(2, self._cb_duplicate, dup_thr_row)
+        self._add_detector_row(2, self._cb_duplicate, dup_thr_row, help_key="duplicate")
 
         # --- Wrong chain order, experimental, default-OFF ---
         self._cb_chain = QtWidgets.QCheckBox("Wrong chain order")
@@ -924,26 +1546,14 @@ class QCWidget(QtWidgets.QWidget):
                 (QtWidgets.QLabel("inv frac ≥"), self._sb_order_thr),
             ]
         )
-        self._add_detector_row(3, self._cb_chain, chain_thr_row)
+        self._add_detector_row(3, self._cb_chain, chain_thr_row, help_key="chain")
 
-        # Optional user-defined ordered chains for the chain-order detector.
-        self._ordered_chains_edit = QtWidgets.QPlainTextEdit()
-        self._ordered_chains_edit.setPlaceholderText(
-            "One chain per line, node names comma-separated, "
-            "e.g. TTI, Tail_0, Tail_1, Tail_2, TailTip"
-        )
-        self._ordered_chains_edit.setToolTip(
-            "Optional ground-truth ordered node chains for the chain-order "
-            "detector (one chain per line, node names comma-separated).\n"
-            "Leave empty to fall back to auto-detected skeleton chains."
-        )
-        # Keep it compact (about two lines tall).
-        fm = self._ordered_chains_edit.fontMetrics()
-        self._ordered_chains_edit.setMaximumHeight(fm.height() * 3 + 8)
-        chains_label = QtWidgets.QLabel("Ordered chains:")
-        chains_label.setToolTip(self._ordered_chains_edit.toolTip())
-        grid.addWidget(chains_label, 4, 1)
-        grid.addWidget(self._ordered_chains_edit, 4, 2)
+        # Skeleton-tracing UX for defining ordered chains (issue #2769, item 2):
+        # a click-to-trace skeleton plus an ordered chip list, instead of forcing
+        # users to type node names. The advanced free-text box is kept inside it
+        # as a fallback. Spans the full grid width.
+        self._chain_trace_panel = self._build_chain_trace_panel()
+        grid.addWidget(self._chain_trace_panel, 4, 0, 1, 4)
 
         # --- Missing labelable node, experimental, default-OFF ---
         self._cb_missing = QtWidgets.QCheckBox("Missing labelable node")
@@ -963,7 +1573,7 @@ class QCWidget(QtWidgets.QWidget):
         missing_thr_row = self._make_threshold_row(
             [(QtWidgets.QLabel("prob ≥"), self._sb_missing_thr)]
         )
-        self._add_detector_row(5, self._cb_missing, missing_thr_row)
+        self._add_detector_row(5, self._cb_missing, missing_thr_row, help_key="missing")
 
         # --- Appearance / wrong-object (B2 channel), experimental, default-OFF ---
         self._cb_appearance = QtWidgets.QCheckBox("Appearance / wrong-object")
@@ -980,7 +1590,9 @@ class QCWidget(QtWidgets.QWidget):
             "Appearance scoring reads image patches around each node; it has no "
             "hard threshold to tune here."
         )
-        self._add_detector_row(6, self._cb_appearance, appearance_note)
+        self._add_detector_row(
+            6, self._cb_appearance, appearance_note, help_key="appearance"
+        )
 
         # --- In-sample model prediction (B2 channel), experimental, default-OFF ---
         self._cb_insample = QtWidgets.QCheckBox("In-sample model prediction")
@@ -1007,7 +1619,9 @@ class QCWidget(QtWidgets.QWidget):
         insample_picker = self._make_threshold_row(
             [(self._insample_model_edit, self._insample_browse_btn)]
         )
-        self._add_detector_row(7, self._cb_insample, insample_picker)
+        self._add_detector_row(
+            7, self._cb_insample, insample_picker, help_key="insample"
+        )
 
         # Disable each detector's tunable widgets when its checkbox is off.
         self._cb_flip.toggled.connect(self._sb_flip_thr.setEnabled)
@@ -1020,7 +1634,9 @@ class QCWidget(QtWidgets.QWidget):
         def _set_chain_enabled(on: bool):
             self._sb_chain_angle.setEnabled(on)
             self._sb_order_thr.setEnabled(on)
-            self._ordered_chains_edit.setEnabled(on)
+            # The whole skeleton-trace panel (canvas, chip list, saved chains and
+            # the advanced free-text fallback) follows the chain checkbox.
+            self._chain_trace_panel.setEnabled(on)
 
         self._cb_chain.toggled.connect(_set_chain_enabled)
         _set_chain_enabled(self._cb_chain.isChecked())
@@ -1035,7 +1651,299 @@ class QCWidget(QtWidgets.QWidget):
         _set_insample_enabled(self._cb_insample.isChecked())
         self._insample_browse_btn.clicked.connect(self._on_browse_insample_model)
 
+        # Apply the (collapsed) start state now that all children exist so the
+        # panel actually starts hidden for a clean first-time view.
+        group.apply_collapsed_state()
+
         layout.addWidget(group)
+
+    def _build_chain_trace_panel(self) -> QtWidgets.QWidget:
+        """Build the skeleton-tracing UI for defining ordered chains.
+
+        Lets the user define an ordered chain by *clicking nodes in order* on a
+        rendered skeleton (issue #2769, item 2) instead of typing node names.
+        The panel contains:
+
+        * a :class:`QCSkeletonTraceCanvas` (click nodes to build a chain),
+        * a live ordered-chip readout of the chain being traced plus
+          Add / Undo / Clear controls,
+        * a list of saved chains with up/down reorder and remove, and
+        * an advanced, collapsible free-text fallback (the original typed-chain
+          box) for power users / projects with no skeleton.
+
+        Both the traced chains and the free-text box feed
+        :meth:`_build_qc_config` via :meth:`_collect_ordered_chains`.
+
+        Returns:
+            The assembled panel widget.
+        """
+        panel = QtWidgets.QWidget()
+        outer = QtWidgets.QVBoxLayout(panel)
+        outer.setContentsMargins(0, 4, 0, 0)
+        outer.setSpacing(4)
+
+        heading = QtWidgets.QLabel(
+            "<b>Ordered chains</b> — trace a chain by clicking nodes in order "
+            "(e.g. tail base → tail tip):"
+        )
+        heading.setWordWrap(True)
+        heading.setToolTip(
+            "Define the ground-truth order of a connected chain of nodes (like a "
+            "tail or a limb) so the detector can spot points clicked out of "
+            "sequence. Click nodes on the skeleton in the order they should run."
+        )
+        outer.addWidget(heading)
+
+        # --- Interactive skeleton canvas: click nodes in order to trace. ---
+        self._skeleton_canvas = QCSkeletonTraceCanvas(width=5, height=2.6)
+        self._skeleton_canvas.setToolTip(
+            "Click nodes in order to trace a chain. Numbered blue nodes show the "
+            "current order; click 'Add chain' to save it."
+        )
+        outer.addWidget(self._skeleton_canvas)
+
+        # --- Current trace readout (ordered chips) + actions. ---
+        trace_row = QtWidgets.QHBoxLayout()
+        trace_row.setSpacing(4)
+        trace_row.addWidget(QtWidgets.QLabel("Tracing:"))
+
+        self._trace_chips_label = QtWidgets.QLabel("(click nodes to start)")
+        self._trace_chips_label.setWordWrap(True)
+        self._trace_chips_label.setTextFormat(QtCore.Qt.RichText)
+        self._trace_chips_label.setToolTip(
+            "The chain you are currently tracing, in click order."
+        )
+        trace_row.addWidget(self._trace_chips_label, stretch=1)
+
+        self._trace_undo_btn = QtWidgets.QToolButton()
+        self._trace_undo_btn.setText("Undo")
+        self._trace_undo_btn.setToolTip("Remove the last node from the trace.")
+        self._trace_undo_btn.clicked.connect(self._on_trace_undo)
+        trace_row.addWidget(self._trace_undo_btn)
+
+        self._trace_clear_btn = QtWidgets.QToolButton()
+        self._trace_clear_btn.setText("Clear")
+        self._trace_clear_btn.setToolTip("Clear the current trace and start over.")
+        self._trace_clear_btn.clicked.connect(self._on_trace_clear)
+        trace_row.addWidget(self._trace_clear_btn)
+
+        self._trace_add_btn = QtWidgets.QToolButton()
+        self._trace_add_btn.setText("Add chain")
+        self._trace_add_btn.setToolTip(
+            "Save the traced chain to the list of ordered chains below."
+        )
+        self._trace_add_btn.clicked.connect(self._on_trace_add_chain)
+        trace_row.addWidget(self._trace_add_btn)
+
+        outer.addLayout(trace_row)
+
+        # --- Saved chains list with up/down reorder + remove. ---
+        saved_row = QtWidgets.QHBoxLayout()
+        saved_row.setSpacing(4)
+
+        self._chains_list = QtWidgets.QListWidget()
+        self._chains_list.setToolTip(
+            "Ordered chains used by the chain-order detector. Select one to "
+            "reorder or remove it."
+        )
+        self._chains_list.setMaximumHeight(78)
+        self._chains_list.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        saved_row.addWidget(self._chains_list, stretch=1)
+
+        # Vertical button strip for the saved-chains list.
+        chain_btns = QtWidgets.QVBoxLayout()
+        chain_btns.setSpacing(2)
+        self._chain_up_btn = QtWidgets.QToolButton()
+        self._chain_up_btn.setArrowType(QtCore.Qt.UpArrow)
+        self._chain_up_btn.setToolTip("Move the selected chain up.")
+        self._chain_up_btn.clicked.connect(lambda: self._move_selected_chain(-1))
+        chain_btns.addWidget(self._chain_up_btn)
+
+        self._chain_down_btn = QtWidgets.QToolButton()
+        self._chain_down_btn.setArrowType(QtCore.Qt.DownArrow)
+        self._chain_down_btn.setToolTip("Move the selected chain down.")
+        self._chain_down_btn.clicked.connect(lambda: self._move_selected_chain(1))
+        chain_btns.addWidget(self._chain_down_btn)
+
+        self._chain_remove_btn = QtWidgets.QToolButton()
+        self._chain_remove_btn.setText("✕")
+        self._chain_remove_btn.setToolTip("Remove the selected chain.")
+        self._chain_remove_btn.clicked.connect(self._on_remove_selected_chain)
+        chain_btns.addWidget(self._chain_remove_btn)
+        chain_btns.addStretch()
+        saved_row.addLayout(chain_btns)
+
+        outer.addLayout(saved_row)
+
+        # --- Advanced free-text fallback (the original typed-chain box). ---
+        # Kept for power users and projects without a skeleton; collapsed by
+        # default so the trace UI is the primary path.
+        advanced = CollapsibleGroupBox("Advanced: type chains as text", collapsed=True)
+        advanced.setToolTip(
+            "Fallback for typing ordered chains by hand (one chain per line, "
+            "node names comma-separated). Useful when no skeleton is loaded or "
+            "for pasting chains. Combined with any chains traced above."
+        )
+        adv_layout = QtWidgets.QVBoxLayout(advanced.content)
+        adv_layout.setContentsMargins(6, 4, 6, 6)
+
+        self._ordered_chains_edit = QtWidgets.QPlainTextEdit()
+        self._ordered_chains_edit.setPlaceholderText(
+            "One chain per line, node names comma-separated, "
+            "e.g. TTI, Tail_0, Tail_1, Tail_2, TailTip"
+        )
+        self._ordered_chains_edit.setToolTip(
+            "Optional ground-truth ordered node chains for the chain-order "
+            "detector (one chain per line, node names comma-separated).\n"
+            "Combined with any chains traced on the skeleton above. Leave both "
+            "empty to fall back to auto-detected skeleton chains."
+        )
+        # Keep it compact (about three lines tall).
+        fm = self._ordered_chains_edit.fontMetrics()
+        self._ordered_chains_edit.setMaximumHeight(fm.height() * 3 + 8)
+        adv_layout.addWidget(self._ordered_chains_edit)
+        advanced.apply_collapsed_state()
+        outer.addWidget(advanced)
+
+        # Wire the canvas click -> append to the trace.
+        self._skeleton_canvas.node_clicked.connect(self._on_trace_node_clicked)
+
+        # Initialize the readout/buttons for an empty trace.
+        self._refresh_trace_readout()
+        self._refresh_chains_list()
+
+        return panel
+
+    def _on_trace_node_clicked(self, name: str):
+        """Append a clicked node to the chain currently being traced.
+
+        Consecutive duplicate clicks on the same node are ignored so a double
+        click does not insert a degenerate zero-length segment.
+
+        Args:
+            name: The node name that was clicked on the skeleton canvas.
+        """
+        if self._trace_in_progress and self._trace_in_progress[-1] == name:
+            return
+        self._trace_in_progress.append(name)
+        self._refresh_trace_readout()
+
+    def _on_trace_undo(self):
+        """Remove the last node from the chain being traced."""
+        if self._trace_in_progress:
+            self._trace_in_progress.pop()
+            self._refresh_trace_readout()
+
+    def _on_trace_clear(self):
+        """Clear the chain currently being traced."""
+        if self._trace_in_progress:
+            self._trace_in_progress = []
+            self._refresh_trace_readout()
+
+    def _on_trace_add_chain(self):
+        """Commit the traced chain (>= 2 nodes) to the saved-chains list."""
+        chain = list(self._trace_in_progress)
+        if len(chain) < 2:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Trace a chain first",
+                "Click at least two nodes on the skeleton (in order) before "
+                "adding a chain.",
+            )
+            return
+        self._traced_chains.append(chain)
+        self._trace_in_progress = []
+        self._refresh_trace_readout()
+        self._refresh_chains_list()
+
+    def _refresh_trace_readout(self):
+        """Sync the trace chips, canvas highlight, and trace-action buttons."""
+        chain = self._trace_in_progress
+        # Mirror the trace onto the canvas highlight.
+        if hasattr(self, "_skeleton_canvas"):
+            self._skeleton_canvas.set_trace(chain)
+
+        if chain:
+            chips = "  →  ".join(
+                f"<span style='background:#e7f1ff; color:#0056b3; "
+                f"padding:1px 5px; border-radius:6px;'>{i + 1}. {name}</span>"
+                for i, name in enumerate(chain)
+            )
+            self._trace_chips_label.setText(chips)
+        else:
+            self._trace_chips_label.setText(
+                "<span style='color:#6c757d;'>(click nodes to start)</span>"
+            )
+
+        has_any = bool(chain)
+        self._trace_undo_btn.setEnabled(has_any)
+        self._trace_clear_btn.setEnabled(has_any)
+        # Need at least two nodes to make a meaningful chain.
+        self._trace_add_btn.setEnabled(len(chain) >= 2)
+
+    def _refresh_chains_list(self):
+        """Repopulate the saved-chains list from ``_traced_chains``."""
+        self._chains_list.clear()
+        for chain in self._traced_chains:
+            self._chains_list.addItem(" → ".join(chain))
+        has_rows = self._chains_list.count() > 0
+        self._chain_up_btn.setEnabled(has_rows)
+        self._chain_down_btn.setEnabled(has_rows)
+        self._chain_remove_btn.setEnabled(has_rows)
+
+    def _move_selected_chain(self, delta: int):
+        """Move the selected saved chain up or down by one.
+
+        Args:
+            delta: -1 to move up, +1 to move down.
+        """
+        row = self._chains_list.currentRow()
+        if row < 0:
+            return
+        new_row = row + delta
+        if not (0 <= new_row < len(self._traced_chains)):
+            return
+        self._traced_chains[row], self._traced_chains[new_row] = (
+            self._traced_chains[new_row],
+            self._traced_chains[row],
+        )
+        self._refresh_chains_list()
+        self._chains_list.setCurrentRow(new_row)
+
+    def _on_remove_selected_chain(self):
+        """Remove the currently selected saved chain."""
+        row = self._chains_list.currentRow()
+        if 0 <= row < len(self._traced_chains):
+            del self._traced_chains[row]
+            self._refresh_chains_list()
+
+    def _update_skeleton_trace(self):
+        """Push the current project's skeleton into the trace canvas.
+
+        Reads the first skeleton from the loaded labels (if any) and hands its
+        nodes/edges to the :class:`QCSkeletonTraceCanvas` so the user can trace
+        on the real skeleton. Clears the canvas when no skeleton is available.
+
+        Uses ``labels.skeletons`` (a list) rather than the ``labels.skeleton``
+        convenience property, since the latter *raises* when there are zero or
+        multiple skeletons. Any backend hiccup falls back to an empty canvas.
+        """
+        node_names: list = []
+        edges: list = []
+        labels = self._labels
+        try:
+            skeletons = (
+                getattr(labels, "skeletons", None) if labels is not None else None
+            )
+            skeleton = skeletons[0] if skeletons else None
+            if skeleton is not None:
+                node_names = list(skeleton.node_names)
+                edges = [
+                    (edge.source.name, edge.destination.name) for edge in skeleton.edges
+                ]
+        except Exception:
+            node_names, edges = [], []
+        self._skeleton_canvas.set_skeleton(node_names, edges)
 
     def _on_browse_insample_model(self):
         """Open a folder picker and set the in-sample model path line edit."""
@@ -1071,20 +1979,66 @@ class QCWidget(QtWidgets.QWidget):
         grid_row: int,
         checkbox: QtWidgets.QCheckBox,
         threshold_widget: QtWidgets.QWidget,
+        help_key: Optional[str] = None,
     ):
-        """Add a [enable checkbox | name | threshold] row to the settings grid.
+        """Add a [enable checkbox | name | threshold | "?"] row to the grid.
 
         The checkbox carries its own label text, so it spans the enable and
-        name columns; the threshold widget sits in the trailing column.
+        name columns; the threshold widget sits in the trailing column, and an
+        optional plain-language "?" help button sits at the far right.
 
         Args:
             grid_row: Row index in the settings grid.
             checkbox: The enable checkbox (its text is the detector name).
             threshold_widget: Widget holding the detector's threshold control(s).
+            help_key: Key into :data:`DETECTOR_HELP` for the "?" help button. If
+                None, no help button is added for this row.
         """
         grid = self._detector_settings_grid
         grid.addWidget(checkbox, grid_row, 0, 1, 2)
         grid.addWidget(threshold_widget, grid_row, 2)
+        if help_key is not None:
+            grid.addWidget(self._make_help_button(help_key), grid_row, 3)
+
+    def _make_help_button(self, help_key: str) -> QtWidgets.QToolButton:
+        """Create a small "?" button that explains a detector in plain language.
+
+        Args:
+            help_key: Key into :data:`DETECTOR_HELP`.
+
+        Returns:
+            A compact tool button that pops up the detector's explanation
+            (issue #2769, item 3).
+        """
+        button = QtWidgets.QToolButton()
+        button.setText("?")
+        button.setAutoRaise(True)
+        button.setFocusPolicy(QtCore.Qt.NoFocus)
+        button.setCursor(QtCore.Qt.PointingHandCursor)
+        # Keep it small and square so it does not bloat the row.
+        button.setFixedSize(20, 20)
+        title = DETECTOR_HELP.get(help_key, ("", ""))[0]
+        button.setToolTip(f"What does '{title}' catch?")
+        button.setAccessibleName(f"Help for {title}")
+        button.clicked.connect(lambda: self._show_detector_help(help_key))
+        return button
+
+    def _show_detector_help(self, help_key: str):
+        """Show a plain-language explanation of a detector in a popup.
+
+        Args:
+            help_key: Key into :data:`DETECTOR_HELP`.
+        """
+        title, body = DETECTOR_HELP.get(
+            help_key, ("Detector", "No description available.")
+        )
+        box = QtWidgets.QMessageBox(self)
+        box.setIcon(QtWidgets.QMessageBox.Information)
+        box.setWindowTitle(f"{title} — what it catches")
+        box.setText(f"<b>{title}</b>")
+        box.setInformativeText(body)
+        box.setStandardButtons(QtWidgets.QMessageBox.Ok)
+        box.exec_()
 
     def _build_qc_config(self) -> "QCConfig":
         """Build a QCConfig from the current detector-settings controls.
@@ -1107,7 +2061,7 @@ class QCWidget(QtWidgets.QWidget):
             use_chain_ordering=self._cb_chain.isChecked(),
             chain_turn_angle_deg=float(self._sb_chain_angle.value()),
             order_inversion_threshold=self._sb_order_thr.value(),
-            ordered_chains=self._parse_ordered_chains(),
+            ordered_chains=self._collect_ordered_chains(),
             use_missing_node_check=self._cb_missing.isChecked(),
             missing_node_prob_threshold=self._sb_missing_thr.value(),
             use_appearance=self._cb_appearance.isChecked(),
@@ -1133,6 +2087,27 @@ class QCWidget(QtWidgets.QWidget):
                 chains.append(names)
         return chains
 
+    def _collect_ordered_chains(self) -> list:
+        """Combine skeleton-traced chains with the advanced free-text chains.
+
+        The chains the user traced by clicking on the skeleton (item 2) come
+        first, followed by any chains typed into the advanced free-text box.
+        Exact duplicate chains are dropped so tracing and then typing the same
+        chain does not double it up.
+
+        Returns:
+            A list of node-name lists for ``QCConfig.ordered_chains``.
+        """
+        chains: list = []
+        seen: set = set()
+        for chain in list(self._traced_chains) + self._parse_ordered_chains():
+            key = tuple(chain)
+            if key in seen:
+                continue
+            seen.add(key)
+            chains.append(list(chain))
+        return chains
+
     def _connect_signals(self):
         """Connect UI signals."""
         self._run_button.clicked.connect(self._on_run_analysis)
@@ -1143,6 +2118,9 @@ class QCWidget(QtWidgets.QWidget):
             self._on_selection_changed
         )
         self._table_view.doubleClicked.connect(self._on_row_double_clicked)
+        # Keep the "X / Y reviewed" counter in sync whenever a Reviewed
+        # checkbox is toggled in the model (item 6).
+        self._table_model.dataChanged.connect(self._update_reviewed_count)
 
     def _update_spinner(self):
         """Update the spinner animation character."""
@@ -1176,12 +2154,26 @@ class QCWidget(QtWidgets.QWidget):
         self._results = None
         self._selected_flag = None
 
+        # Reset the per-results filter/reviewed bookkeeping for a fresh project.
+        self._all_flagged = []
+        self._visible_issue_types = None
+        self._reviewed_keys.clear()
+
+        # Reset the chain being traced (a new project may have a new skeleton);
+        # saved chains are kept so the user does not lose deliberate work.
+        self._trace_in_progress = []
+
         # Update UI
         self._score_canvas.set_scores(np.array([]))
         self._breakdown_canvas.set_issue_counts({})
         self._table_model.items = []
+        self._rebuild_issue_filter_menu([])
+        self._update_reviewed_count()
         self._update_statistics()
-        self._details_label.setText("Click a row in the table to select an instance")
+        self._details_label.setText(SELECT_INSTANCE_PLACEHOLDER)
+        # Refresh the skeleton-trace canvas with this project's skeleton.
+        self._update_skeleton_trace()
+        self._refresh_trace_readout()
 
     def _on_run_analysis(self):
         """Run QC analysis on current labels."""
@@ -1296,17 +2288,32 @@ class QCWidget(QtWidgets.QWidget):
         self._update_statistics()
 
     def _update_flagged_display(self):
-        """Update the flagged instances table and breakdown chart."""
+        """Update the flagged instances table and breakdown chart.
+
+        Re-filters the full flagged list at the current threshold, rebuilds the
+        issue-type filter menu to match the categories now present (item 5),
+        then pushes only the user-selected issue types into the table. The
+        breakdown chart keeps showing the FULL set so the distribution stays
+        complete regardless of which types are toggled in the table.
+        """
         if self._results is None:
             return
 
         threshold = self._threshold_slider.value() / 100.0
         flagged = self._results.get_flagged(threshold=threshold)
+        self._all_flagged = flagged
 
-        # Update table
-        self._table_model.items = flagged
+        # Rebuild the issue-type filter to match the categories now present,
+        # preserving the user's current show/hide choices where possible.
+        # de-dup while keeping first-seen (score-descending) order.
+        present_types = list(dict.fromkeys(f.top_issue for f in flagged))
+        self._rebuild_issue_filter_menu(present_types)
 
-        # Update breakdown chart
+        # Push only the selected issue types into the table (item 5).
+        self._apply_issue_filter()
+
+        # Update breakdown chart from the FULL flagged set (not the filtered
+        # view) so the distribution is always complete.
         issue_counts = {}
         for flag in flagged:
             issue = flag.top_issue.replace("_", " ").title()
@@ -1321,10 +2328,149 @@ class QCWidget(QtWidgets.QWidget):
             self._results.feature_names,
         )
 
+    def _rebuild_issue_filter_menu(self, present_types: List[str]):
+        """Rebuild the issue-type filter menu for the categories present.
+
+        Builds one checkable action per raw ``top_issue`` value currently in the
+        flagged set, labeled with its plain-language category name. The user's
+        previous show/hide choices are preserved for types that still exist;
+        newly appeared types default to shown (item 5).
+
+        Args:
+            present_types: Raw ``top_issue`` strings present in the flagged set,
+                in display order.
+        """
+        menu = self._issue_filter_menu
+        menu.clear()
+        self._issue_filter_actions = {}
+
+        if not present_types:
+            self._visible_issue_types = None
+            self._issue_filter_button.setEnabled(False)
+            self._update_issue_filter_button_text()
+            return
+
+        # Carry over previous selections; default new types to shown.
+        prev = self._visible_issue_types
+        if prev is None:
+            selected = set(present_types)
+        else:
+            selected = {t for t in present_types if t in prev}
+            # Any brand-new type (not seen when prev was captured) starts shown.
+            known = set(prev) | self._issue_filter_seen
+            selected |= {t for t in present_types if t not in known}
+        self._visible_issue_types = selected
+        self._issue_filter_seen = set(present_types)
+
+        # Convenience "All" / "None" actions at the top.
+        all_action = menu.addAction("Select all")
+        all_action.triggered.connect(lambda: self._set_all_issue_types(True))
+        none_action = menu.addAction("Select none")
+        none_action.triggered.connect(lambda: self._set_all_issue_types(False))
+        menu.addSeparator()
+
+        for raw in present_types:
+            label = self._issue_category_label(raw)
+            action = menu.addAction(label)
+            action.setCheckable(True)
+            action.setChecked(raw in selected)
+            # Bind the raw key for this action.
+            action.toggled.connect(
+                lambda checked, key=raw: self._on_issue_type_toggled(key, checked)
+            )
+            self._issue_filter_actions[raw] = action
+
+        self._issue_filter_button.setEnabled(True)
+        self._update_issue_filter_button_text()
+
+    def _issue_category_label(self, raw_issue: str) -> str:
+        """Plain-language menu label for a raw ``top_issue`` category.
+
+        Title-cases the raw label the same way the table's Issue column does so
+        the filter entries read identically to the rows they hide/show.
+
+        Args:
+            raw_issue: The raw ``top_issue`` string.
+
+        Returns:
+            A human-friendly category label.
+        """
+        return raw_issue.replace("_", " ").title()
+
+    def _on_issue_type_toggled(self, raw_issue: str, checked: bool):
+        """Handle a single issue-type checkbox toggle in the filter menu."""
+        if self._visible_issue_types is None:
+            self._visible_issue_types = set()
+        if checked:
+            self._visible_issue_types.add(raw_issue)
+        else:
+            self._visible_issue_types.discard(raw_issue)
+        self._update_issue_filter_button_text()
+        self._apply_issue_filter()
+
+    def _set_all_issue_types(self, checked: bool):
+        """Check or uncheck every issue-type entry at once."""
+        actions = getattr(self, "_issue_filter_actions", {})
+        if checked:
+            self._visible_issue_types = set(actions.keys())
+        else:
+            self._visible_issue_types = set()
+        # Reflect in the checkboxes without re-triggering per-item handlers.
+        for raw, action in actions.items():
+            action.blockSignals(True)
+            action.setChecked(raw in self._visible_issue_types)
+            action.blockSignals(False)
+        self._update_issue_filter_button_text()
+        self._apply_issue_filter()
+
+    def _update_issue_filter_button_text(self):
+        """Update the filter button caption to reflect the active selection."""
+        actions = getattr(self, "_issue_filter_actions", {})
+        total = len(actions)
+        if total == 0:
+            self._issue_filter_button.setText("Issue types: all")
+            return
+        selected = self._visible_issue_types or set()
+        n_sel = sum(1 for raw in actions if raw in selected)
+        if n_sel == total:
+            self._issue_filter_button.setText("Issue types: all")
+        elif n_sel == 0:
+            self._issue_filter_button.setText("Issue types: none")
+        else:
+            self._issue_filter_button.setText(f"Issue types: {n_sel} of {total}")
+
+    def _filtered_flagged(self) -> List["QCFlag"]:
+        """Return the flagged list restricted to the selected issue types."""
+        if self._visible_issue_types is None:
+            return list(self._all_flagged)
+        return [
+            f for f in self._all_flagged if f.top_issue in self._visible_issue_types
+        ]
+
+    def _apply_issue_filter(self):
+        """Push the issue-type-filtered flagged subset into the table model."""
+        self._table_model.items = self._filtered_flagged()
+        self._update_reviewed_count()
+
+    def _update_reviewed_count(self, *args):
+        """Refresh the "X / Y reviewed" counter for the rows currently shown.
+
+        Args:
+            *args: Ignored; lets this slot accept ``dataChanged`` signal args.
+        """
+        total = self._table_model.rowCount()
+        reviewed = self._table_model.reviewed_count()
+        self._reviewed_count_label.setText(f"{reviewed} / {total} reviewed")
+
     def _update_statistics(self):
-        """Update the statistics panel."""
+        """Update the statistics panel in plain language.
+
+        Summarizes the analysis as a short sentence ("45 of 1,200 instances
+        flagged (3.8%). Most common issue: ...") instead of bare numbers
+        (issue #2769, item 7).
+        """
         if self._labels is None:
-            self._stats_label.setText("No labels loaded")
+            self._stats_label.setText("No labels loaded yet.")
             return
 
         n_instances = sum(len(lf.user_instances) for lf in self._labels)
@@ -1332,38 +2478,48 @@ class QCWidget(QtWidgets.QWidget):
 
         if self._results is None:
             self._stats_label.setText(
-                f"<b>Ready to analyze:</b><br/>"
-                f"• {n_instances} instances<br/>"
-                f"• {n_frames} frames"
+                f"Ready to analyze {n_instances:,} instances "
+                f"across {n_frames:,} frames.<br/>"
+                f"Click <b>Run Analysis</b> to find labeling issues."
             )
             return
 
         threshold = self._threshold_slider.value() / 100.0
-        scores = np.array(list(self._results.instance_scores.values()))
         flagged = self._results.get_flagged(threshold=threshold)
         n_flagged = len(flagged)
         pct_flagged = (n_flagged / n_instances * 100) if n_instances > 0 else 0
 
-        # Score statistics
-        mean_score = np.mean(scores) if len(scores) > 0 else 0
-        median_score = np.median(scores) if len(scores) > 0 else 0
-        max_score = np.max(scores) if len(scores) > 0 else 0
+        # Nothing flagged at the current sensitivity: reassure the user.
+        if n_flagged == 0:
+            self._stats_label.setText(
+                f"No issues flagged out of {n_instances:,} instances "
+                f"at this sensitivity.<br/>"
+                f"Drag the Sensitivity slider toward <b>More</b> to flag "
+                f"borderline cases."
+            )
+            return
 
-        # Count by confidence
+        # Most common issue, in the same friendly wording as the table column.
+        issue_counts = {}
+        for flag in flagged:
+            label = flag.top_issue.replace("_", " ").title()
+            issue_counts[label] = issue_counts.get(label, 0) + 1
+        top_label, top_count = max(issue_counts.items(), key=lambda kv: kv[1])
+
+        # High-confidence count gives a sense of how many are clear-cut.
         high_conf = sum(1 for f in flagged if f.confidence == "high")
-        med_conf = sum(1 for f in flagged if f.confidence == "medium")
 
-        # Frame-level issues
-        frame_issues = self._results.get_frame_issues()
-        n_frame_issues = len(frame_issues)
-
-        self._stats_label.setText(
-            f"<b>Flagged:</b> {n_flagged} / {n_instances} ({pct_flagged:.1f}%)<br/>"
-            f"<b>By confidence:</b> {high_conf} high, {med_conf} medium<br/>"
-            f"<b>Frame issues:</b> {n_frame_issues}<br/>"
-            f"<b>Scores:</b> mean={mean_score:.2f}, "
-            f"median={median_score:.2f}, max={max_score:.2f}"
+        lines = [
+            f"<b>{n_flagged:,} of {n_instances:,}</b> instances flagged "
+            f"({pct_flagged:.1f}%).",
+            f"Most common issue: <b>{top_label}</b> ({top_count}).",
+        ]
+        if high_conf:
+            lines.append(f"{high_conf:,} are high-confidence.")
+        lines.append(
+            "<span style='color:#6c757d;'>Click a row to review each one.</span>"
         )
+        self._stats_label.setText("<br/>".join(lines))
 
     def _on_selection_changed(self, selected, deselected):
         """Handle selection change in table."""
@@ -1374,6 +2530,11 @@ class QCWidget(QtWidgets.QWidget):
                 self._selected_flag = self._table_model.items[row]
                 self._update_selected_details()
 
+                # Auto-mark reviewed on navigate: selecting a row jumps the user
+                # to that instance, so count it as "looked at" (item 6). The
+                # model emits dataChanged, refreshing the running counter.
+                self._table_model.set_reviewed(self._selected_flag, True)
+
                 # Navigate to the instance
                 self.navigate_to_instance.emit(
                     self._selected_flag.video_idx,
@@ -1382,9 +2543,7 @@ class QCWidget(QtWidgets.QWidget):
                 )
         else:
             self._selected_flag = None
-            self._details_label.setText(
-                "Click a row in the table to select an instance"
-            )
+            self._details_label.setText(SELECT_INSTANCE_PLACEHOLDER)
 
     def _on_row_double_clicked(self, index):
         """Handle double-click on table row."""
@@ -1398,30 +2557,27 @@ class QCWidget(QtWidgets.QWidget):
             )
 
     def _update_selected_details(self):
-        """Update the selected instance details panel."""
+        """Update the selected instance details panel in plain language.
+
+        Maps the flag's primary issue + score onto a friendly sentence telling
+        the user *why* the instance was flagged and where to find it, instead of
+        showing raw feature names (issue #2769, item 7).
+        """
         if self._selected_flag is None:
-            self._details_label.setText(
-                "Click a row in the table to select an instance"
-            )
+            self._details_label.setText(SELECT_INSTANCE_PLACEHOLDER)
             return
 
         flag = self._selected_flag
 
-        # Get top contributing features
-        contributions = flag.feature_contributions
-        top_features = sorted(contributions.items(), key=lambda x: x[1], reverse=True)[
-            :3
-        ]
-        features_text = "<br/>".join(
-            f"  • {name.replace('_', ' ')}: {value:.3f}" for name, value in top_features
-        )
+        reason = _friendly_issue(flag.top_issue)
+        # Capitalize the first letter of the reason for a readable sentence.
+        reason_sentence = reason[:1].upper() + reason[1:] if reason else reason
 
         self._details_label.setText(
-            f"<b>Frame:</b> {flag.frame_idx} | "
-            f"<b>Instance:</b> {flag.instance_idx}<br/>"
-            f"<b>Score:</b> {flag.score:.3f} ({flag.confidence} confidence)<br/>"
-            f"<b>Primary Issue:</b> {flag.top_issue.replace('_', ' ').title()}<br/>"
-            f"<b>Top Features:</b><br/>{features_text}"
+            f"<b>Flagged:</b> {reason_sentence} "
+            f"(confidence {flag.score:.2f}).<br/>"
+            f"Frame {flag.frame_idx}, instance {flag.instance_idx}.<br/>"
+            f"<span style='color:#6c757d;'>Double-click the row to jump there.</span>"
         )
 
     @property

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -965,6 +965,50 @@ class QCWidget(QtWidgets.QWidget):
         )
         self._add_detector_row(5, self._cb_missing, missing_thr_row)
 
+        # --- Appearance / wrong-object (B2 channel), experimental, default-OFF ---
+        self._cb_appearance = QtWidgets.QCheckBox("Appearance / wrong-object")
+        self._cb_appearance.setChecked(False)
+        self._cb_appearance.setToolTip(
+            "Flag a keypoint placed on visually-wrong pixels (e.g. on bedding "
+            "instead of fur), using a per-node image-appearance model. "
+            "Experimental; off by default."
+        )
+        # No tunable hard threshold in the GUI: appearance is a channel score.
+        appearance_note = QtWidgets.QLabel("(image-based)")
+        appearance_note.setEnabled(False)
+        appearance_note.setToolTip(
+            "Appearance scoring reads image patches around each node; it has no "
+            "hard threshold to tune here."
+        )
+        self._add_detector_row(6, self._cb_appearance, appearance_note)
+
+        # --- In-sample model prediction (B2 channel), experimental, default-OFF ---
+        self._cb_insample = QtWidgets.QCheckBox("In-sample model prediction")
+        self._cb_insample.setChecked(False)
+        self._cb_insample.setToolTip(
+            "Run a trained sleap-nn model on the labeled frames and flag "
+            "unlabeled nodes the model confidently localizes (labelable-but-"
+            "skipped parts).\n"
+            "WARNING: runs full model inference and can be slow on large "
+            "projects. Experimental; off by default."
+        )
+        # Model-path picker: a (display-only) line edit plus a Browse button.
+        self._insample_model_edit = QtWidgets.QLineEdit()
+        self._insample_model_edit.setReadOnly(True)
+        self._insample_model_edit.setPlaceholderText("trained sleap-nn model folder")
+        self._insample_model_edit.setToolTip(
+            "Folder of a trained sleap-nn model (with best.ckpt + "
+            "training_config.yaml) to run in-sample. Empty disables the channel."
+        )
+        self._insample_browse_btn = QtWidgets.QPushButton("Browse...")
+        self._insample_browse_btn.setToolTip(
+            "Choose the trained sleap-nn model folder for in-sample prediction."
+        )
+        insample_picker = self._make_threshold_row(
+            [(self._insample_model_edit, self._insample_browse_btn)]
+        )
+        self._add_detector_row(7, self._cb_insample, insample_picker)
+
         # Disable each detector's tunable widgets when its checkbox is off.
         self._cb_flip.toggled.connect(self._sb_flip_thr.setEnabled)
         self._sb_flip_thr.setEnabled(self._cb_flip.isChecked())
@@ -981,7 +1025,27 @@ class QCWidget(QtWidgets.QWidget):
         self._cb_chain.toggled.connect(_set_chain_enabled)
         _set_chain_enabled(self._cb_chain.isChecked())
 
+        # Disable the in-sample model picker + Browse button when its checkbox
+        # is off (mirrors the other detectors' disable-on-uncheck behavior).
+        def _set_insample_enabled(on: bool):
+            self._insample_model_edit.setEnabled(on)
+            self._insample_browse_btn.setEnabled(on)
+
+        self._cb_insample.toggled.connect(_set_insample_enabled)
+        _set_insample_enabled(self._cb_insample.isChecked())
+        self._insample_browse_btn.clicked.connect(self._on_browse_insample_model)
+
         layout.addWidget(group)
+
+    def _on_browse_insample_model(self):
+        """Open a folder picker and set the in-sample model path line edit."""
+        directory = QtWidgets.QFileDialog.getExistingDirectory(
+            self,
+            "Select trained sleap-nn model folder",
+            self._insample_model_edit.text() or "",
+        )
+        if directory:
+            self._insample_model_edit.setText(directory)
 
     def _make_threshold_row(self, items: list) -> QtWidgets.QWidget:
         """Pack labeled threshold widgets into a single compact row widget.
@@ -1046,6 +1110,9 @@ class QCWidget(QtWidgets.QWidget):
             ordered_chains=self._parse_ordered_chains(),
             use_missing_node_check=self._cb_missing.isChecked(),
             missing_node_prob_threshold=self._sb_missing_thr.value(),
+            use_appearance=self._cb_appearance.isChecked(),
+            use_insample_prediction=self._cb_insample.isChecked(),
+            insample_model_path=self._insample_model_edit.text().strip(),
         )
 
     def _parse_ordered_chains(self) -> list:

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -31,6 +31,7 @@ from matplotlib.figure import Figure
 
 if TYPE_CHECKING:
     import sleap_io as sio
+    from sleap.qc.config import QCConfig
     from sleap.qc.results import QCResults, QCFlag
 
 
@@ -561,6 +562,11 @@ class QCFlagTableModel(QtCore.QAbstractTableModel):
 class QCAnalysisWorker(QThread):
     """Worker thread for running QC analysis in background.
 
+    Args:
+        labels: A sleap_io.Labels object to analyze.
+        config: Optional QCConfig controlling which detectors run and their
+            thresholds. If None, the detector falls back to QCConfig() defaults.
+
     Signals:
         progress: Emitted with (step_name, progress_pct, detail) during analysis.
         finished: Emitted with QCResults when analysis completes.
@@ -571,9 +577,10 @@ class QCAnalysisWorker(QThread):
     finished = QSignal(object)  # QCResults
     error = QSignal(str)
 
-    def __init__(self, labels, parent=None):
+    def __init__(self, labels, config=None, parent=None):
         super().__init__(parent)
         self._labels = labels
+        self._config = config
         self._results = None
         self._cancelled = False
 
@@ -593,9 +600,10 @@ class QCAnalysisWorker(QThread):
                 progress_pct = int(progress_fraction * 100)
                 self.progress.emit(step_name, progress_pct, detail or "")
 
-            # Create detector
+            # Create detector (config may be None; LabelQCDetector falls back
+            # to QCConfig() defaults in that case).
             self.progress.emit("Initializing...", 0, "")
-            detector = LabelQCDetector()
+            detector = LabelQCDetector(self._config)
 
             # Fit model with progress callback
             detector.fit(self._labels, progress_callback=progress_callback)
@@ -728,6 +736,9 @@ class QCWidget(QtWidgets.QWidget):
 
         layout.addLayout(threshold_layout)
 
+        # === Detector settings ===
+        self._setup_detector_settings(layout)
+
         # === Tabbed visualization area ===
         self._viz_tabs = QtWidgets.QTabWidget()
         self._viz_tabs.setMinimumHeight(180)
@@ -802,6 +813,258 @@ class QCWidget(QtWidgets.QWidget):
         bottom_layout.addWidget(stats_group)
 
         layout.addLayout(bottom_layout)
+
+    def _setup_detector_settings(self, layout: QtWidgets.QVBoxLayout):
+        """Build the collapsible "Detector Settings" group.
+
+        Exposes the per-detector QCConfig toggles and thresholds so users can
+        enable/disable and tune each detector for the current project. The
+        resulting controls are read by :meth:`_build_qc_config`.
+
+        Args:
+            layout: The parent layout to append the group box to.
+        """
+        # Checkable group acts as an expand/collapse header; default expanded.
+        group = QtWidgets.QGroupBox("Detector Settings")
+        group.setCheckable(True)
+        group.setChecked(True)
+        group.setToolTip(
+            "Enable/disable and tune individual QC detectors for this project.\n"
+            "Uncheck the header to collapse this panel."
+        )
+        self._detector_settings_group = group
+
+        grid = QtWidgets.QGridLayout(group)
+        grid.setContentsMargins(8, 4, 8, 8)
+        grid.setHorizontalSpacing(8)
+        grid.setVerticalSpacing(4)
+        # Column 2 (the threshold area) takes any extra width.
+        grid.setColumnStretch(2, 1)
+        self._detector_settings_grid = grid
+
+        # --- Whole-instance L/R flip (chirality), reliable, default-ON ---
+        self._cb_flip = QtWidgets.QCheckBox("Whole-instance L/R flip")
+        self._cb_flip.setChecked(True)
+        self._cb_flip.setToolTip(
+            "Flag instances whose left/right keypoints look mirror-flipped "
+            "(chirality). Reliable detector; on by default."
+        )
+        self._sb_flip_thr = QtWidgets.QDoubleSpinBox()
+        self._sb_flip_thr.setRange(0.0, 1.0)
+        self._sb_flip_thr.setSingleStep(0.05)
+        self._sb_flip_thr.setValue(0.5)
+        self._sb_flip_thr.setToolTip(
+            "Fraction of symmetric pairs that must look flipped before the "
+            "whole instance is force-flagged (chirality_flip_threshold)."
+        )
+        flip_thr_row = self._make_threshold_row(
+            [(QtWidgets.QLabel("flip frac ≥"), self._sb_flip_thr)]
+        )
+        self._add_detector_row(0, self._cb_flip, flip_thr_row)
+
+        # --- Chimera / pose split, reliable, default-ON (no user threshold) ---
+        self._cb_chimera = QtWidgets.QCheckBox("Chimera (pose split)")
+        self._cb_chimera.setChecked(True)
+        self._cb_chimera.setToolTip(
+            "Flag a single instance whose pose spans two animals (a chimera).\n"
+            "Relies on the learned GMM, so it has no hard threshold to tune."
+        )
+        # No tunable threshold: chimera has no hard rule, the GMM decides.
+        chimera_note = QtWidgets.QLabel("(no threshold)")
+        chimera_note.setEnabled(False)
+        chimera_note.setToolTip("Chimera detection has no hard threshold to set.")
+        self._add_detector_row(1, self._cb_chimera, chimera_note)
+
+        # --- Duplicate / split, reliable, default-ON ---
+        self._cb_duplicate = QtWidgets.QCheckBox("Duplicate / split")
+        self._cb_duplicate.setChecked(True)
+        self._cb_duplicate.setToolTip(
+            "Fold the split-duplicate signal into frame-level duplicate "
+            "detection. Reliable detector; on by default."
+        )
+        self._sb_dup_thr = QtWidgets.QDoubleSpinBox()
+        self._sb_dup_thr.setRange(0.0, 1.0)
+        self._sb_dup_thr.setSingleStep(0.05)
+        self._sb_dup_thr.setValue(0.5)
+        self._sb_dup_thr.setToolTip(
+            "Combined duplicate score at/above which a pair of instances is "
+            "flagged as a duplicate (duplicate_score_threshold)."
+        )
+        dup_thr_row = self._make_threshold_row(
+            [(QtWidgets.QLabel("score ≥"), self._sb_dup_thr)]
+        )
+        self._add_detector_row(2, self._cb_duplicate, dup_thr_row)
+
+        # --- Wrong chain order, experimental, default-OFF ---
+        self._cb_chain = QtWidgets.QCheckBox("Wrong chain order")
+        self._cb_chain.setChecked(False)
+        self._cb_chain.setToolTip(
+            "Flag instances whose keypoints run out of order along an ordered "
+            "chain (e.g. a tail). Experimental; off by default."
+        )
+        self._sb_chain_angle = QtWidgets.QSpinBox()
+        self._sb_chain_angle.setRange(10, 150)
+        self._sb_chain_angle.setSuffix("°")
+        self._sb_chain_angle.setValue(60)
+        self._sb_chain_angle.setToolTip(
+            "Per-node turning angle (degrees) above which a chain node counts "
+            "as an ordering inversion (chain_turn_angle_deg)."
+        )
+        self._sb_order_thr = QtWidgets.QDoubleSpinBox()
+        self._sb_order_thr.setRange(0.0, 1.0)
+        self._sb_order_thr.setSingleStep(0.05)
+        self._sb_order_thr.setValue(0.3)
+        self._sb_order_thr.setToolTip(
+            "Fraction of chain nodes that must be inverted before the instance "
+            "is force-flagged (order_inversion_threshold)."
+        )
+        chain_thr_row = self._make_threshold_row(
+            [
+                (QtWidgets.QLabel("turn ≥"), self._sb_chain_angle),
+                (QtWidgets.QLabel("inv frac ≥"), self._sb_order_thr),
+            ]
+        )
+        self._add_detector_row(3, self._cb_chain, chain_thr_row)
+
+        # Optional user-defined ordered chains for the chain-order detector.
+        self._ordered_chains_edit = QtWidgets.QPlainTextEdit()
+        self._ordered_chains_edit.setPlaceholderText(
+            "One chain per line, node names comma-separated, "
+            "e.g. TTI, Tail_0, Tail_1, Tail_2, TailTip"
+        )
+        self._ordered_chains_edit.setToolTip(
+            "Optional ground-truth ordered node chains for the chain-order "
+            "detector (one chain per line, node names comma-separated).\n"
+            "Leave empty to fall back to auto-detected skeleton chains."
+        )
+        # Keep it compact (about two lines tall).
+        fm = self._ordered_chains_edit.fontMetrics()
+        self._ordered_chains_edit.setMaximumHeight(fm.height() * 3 + 8)
+        chains_label = QtWidgets.QLabel("Ordered chains:")
+        chains_label.setToolTip(self._ordered_chains_edit.toolTip())
+        grid.addWidget(chains_label, 4, 1)
+        grid.addWidget(self._ordered_chains_edit, 4, 2)
+
+        # --- Missing labelable node, experimental, default-OFF ---
+        self._cb_missing = QtWidgets.QCheckBox("Missing labelable node")
+        self._cb_missing.setChecked(False)
+        self._cb_missing.setToolTip(
+            "Flag an instance that is missing a node its peers usually keep. "
+            "Experimental; off by default."
+        )
+        self._sb_missing_thr = QtWidgets.QDoubleSpinBox()
+        self._sb_missing_thr.setRange(0.0, 1.0)
+        self._sb_missing_thr.setSingleStep(0.05)
+        self._sb_missing_thr.setValue(0.9)
+        self._sb_missing_thr.setToolTip(
+            "Minimum expected-visibility probability for an absent node to be "
+            "flagged as suspicious (missing_node_prob_threshold)."
+        )
+        missing_thr_row = self._make_threshold_row(
+            [(QtWidgets.QLabel("prob ≥"), self._sb_missing_thr)]
+        )
+        self._add_detector_row(5, self._cb_missing, missing_thr_row)
+
+        # Disable each detector's tunable widgets when its checkbox is off.
+        self._cb_flip.toggled.connect(self._sb_flip_thr.setEnabled)
+        self._sb_flip_thr.setEnabled(self._cb_flip.isChecked())
+        self._cb_duplicate.toggled.connect(self._sb_dup_thr.setEnabled)
+        self._sb_dup_thr.setEnabled(self._cb_duplicate.isChecked())
+        self._cb_missing.toggled.connect(self._sb_missing_thr.setEnabled)
+        self._sb_missing_thr.setEnabled(self._cb_missing.isChecked())
+
+        def _set_chain_enabled(on: bool):
+            self._sb_chain_angle.setEnabled(on)
+            self._sb_order_thr.setEnabled(on)
+            self._ordered_chains_edit.setEnabled(on)
+
+        self._cb_chain.toggled.connect(_set_chain_enabled)
+        _set_chain_enabled(self._cb_chain.isChecked())
+
+        layout.addWidget(group)
+
+    def _make_threshold_row(self, items: list) -> QtWidgets.QWidget:
+        """Pack labeled threshold widgets into a single compact row widget.
+
+        Args:
+            items: List of (label_widget, control_widget) pairs.
+
+        Returns:
+            A container widget laying the pairs out left-to-right.
+        """
+        container = QtWidgets.QWidget()
+        row = QtWidgets.QHBoxLayout(container)
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(4)
+        for label, control in items:
+            row.addWidget(label)
+            row.addWidget(control)
+        row.addStretch()
+        return container
+
+    def _add_detector_row(
+        self,
+        grid_row: int,
+        checkbox: QtWidgets.QCheckBox,
+        threshold_widget: QtWidgets.QWidget,
+    ):
+        """Add a [enable checkbox | name | threshold] row to the settings grid.
+
+        The checkbox carries its own label text, so it spans the enable and
+        name columns; the threshold widget sits in the trailing column.
+
+        Args:
+            grid_row: Row index in the settings grid.
+            checkbox: The enable checkbox (its text is the detector name).
+            threshold_widget: Widget holding the detector's threshold control(s).
+        """
+        grid = self._detector_settings_grid
+        grid.addWidget(checkbox, grid_row, 0, 1, 2)
+        grid.addWidget(threshold_widget, grid_row, 2)
+
+    def _build_qc_config(self) -> "QCConfig":
+        """Build a QCConfig from the current detector-settings controls.
+
+        Reads every per-detector control and maps it onto the corresponding
+        QCConfig field. All fields not exposed in the GUI are left at their
+        QCConfig defaults.
+
+        Returns:
+            A QCConfig reflecting the current control states.
+        """
+        from sleap.qc.config import QCConfig
+
+        return QCConfig(
+            use_chirality=self._cb_flip.isChecked(),
+            chirality_flip_threshold=self._sb_flip_thr.value(),
+            use_split_detection=self._cb_chimera.isChecked(),
+            use_duplicate_score=self._cb_duplicate.isChecked(),
+            duplicate_score_threshold=self._sb_dup_thr.value(),
+            use_chain_ordering=self._cb_chain.isChecked(),
+            chain_turn_angle_deg=float(self._sb_chain_angle.value()),
+            order_inversion_threshold=self._sb_order_thr.value(),
+            ordered_chains=self._parse_ordered_chains(),
+            use_missing_node_check=self._cb_missing.isChecked(),
+            missing_node_prob_threshold=self._sb_missing_thr.value(),
+        )
+
+    def _parse_ordered_chains(self) -> list:
+        """Parse the ordered-chains text box into a list of node-name lists.
+
+        Each non-empty line becomes one chain; node names are split on commas
+        and stripped, with empty names dropped. Empty text yields ``[]``.
+
+        Returns:
+            A list of lists of node-name strings.
+        """
+        text = self._ordered_chains_edit.toPlainText()
+        chains = []
+        for line in text.splitlines():
+            names = [name.strip() for name in line.split(",")]
+            names = [name for name in names if name]
+            if names:
+                chains.append(names)
+        return chains
 
     def _connect_signals(self):
         """Connect UI signals."""
@@ -888,8 +1151,10 @@ class QCWidget(QtWidgets.QWidget):
         self._spinner_idx = 0
         self._spinner_timer.start()
 
-        # Create and start worker thread
-        self._worker = QCAnalysisWorker(self._labels)
+        # Create and start worker thread with the per-detector config from the
+        # Detector Settings controls.
+        config = self._build_qc_config()
+        self._worker = QCAnalysisWorker(self._labels, config=config)
         self._worker.progress.connect(self._on_analysis_progress)
         self._worker.finished.connect(self._on_analysis_finished)
         self._worker.error.connect(self._on_analysis_error)

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -1153,15 +1153,17 @@ class QCSkeletonTraceCanvas(Canvas):
 
         if image_mode:
             self.axes.set_aspect("equal", adjustable="box")
-            h, w = self._background_image.shape[:2]
             if had_view:
                 # Preserve the user's zoom/pan across a trace-only redraw.
                 self.axes.set_xlim(prev_xlim)
                 self.axes.set_ylim(prev_ylim)
             else:
-                # Full image extent; y inverted so (0,0) is top-left like a photo.
-                self.axes.set_xlim(-0.5, w - 0.5)
-                self.axes.set_ylim(h - 0.5, -0.5)
+                # Default view: fit the instance (node bounding box + a margin)
+                # rather than the whole frame, so the animal is large and easy to
+                # trace (issue #2769 follow-up). y inverted -> top-left origin.
+                xlim, ylim = self._instance_fit_limits()
+                self.axes.set_xlim(xlim)
+                self.axes.set_ylim(ylim)
         else:
             # Pad the limits so labels are not clipped. Use ``adjustable="box"``
             # so the equal-aspect constraint resizes the axes box rather than
@@ -1175,9 +1177,43 @@ class QCSkeletonTraceCanvas(Canvas):
 
         self.draw()
 
+    def _instance_fit_limits(self):
+        """Default image-mode view limits: fit the instance plus a margin.
+
+        Returns ``(xlim, ylim)`` in pixel coordinates (``ylim`` inverted for a
+        top-left origin) framing the instance's node bounding box plus a margin
+        and clamped to the image, so the animal fills the canvas instead of
+        sitting tiny inside the full frame (issue #2769 follow-up). Falls back to
+        the full image extent when there are no finite node positions.
+        """
+        h, w = self._background_image.shape[:2]
+        full = ((-0.5, w - 0.5), (h - 0.5, -0.5))
+        pts = [
+            p
+            for p in self._positions.values()
+            if np.isfinite(p[0]) and np.isfinite(p[1])
+        ]
+        if not pts:
+            return full
+        xs = [p[0] for p in pts]
+        ys = [p[1] for p in pts]
+        xmin, xmax, ymin, ymax = min(xs), max(xs), min(ys), max(ys)
+        # Margin: a quarter of the larger bbox side, with a floor so a tiny or
+        # single-node box still gets a sensible window.
+        span = max(xmax - xmin, ymax - ymin)
+        margin = max(span * 0.25, 0.05 * max(w, h), 10.0)
+        x0 = max(xmin - margin, -0.5)
+        x1 = min(xmax + margin, w - 0.5)
+        y0 = max(ymin - margin, -0.5)
+        y1 = min(ymax + margin, h - 0.5)
+        if x1 <= x0 or y1 <= y0:
+            return full
+        return (x0, x1), (y1, y0)  # ylim inverted -> top-left origin
+
     def reset_view(self):
-        """Reset the view to the full image (or layout) extent and redraw."""
-        # Forget any zoom/pan, then let update_plot recompute the full extent.
+        """Reset to the default view (fit the instance, or the layout extent)."""
+        # Forget any zoom/pan, then let update_plot recompute the default view:
+        # instance-fit in image mode, full layout extent otherwise.
         self.axes.set_xlim(0.0, 1.0)
         self.axes.set_ylim(0.0, 1.0)
         self.update_plot()

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -179,11 +179,14 @@ class CheckableFilterMenu(QtWidgets.QMenu):
 
 
 class CollapsibleGroupBox(QtWidgets.QGroupBox):
-    """A checkable group box whose contents collapse when unchecked.
+    """A checkable group box that collapses its body like an HTML ``<details>``.
 
-    Acts as a lightweight collapsible section: the check state of the group box
+    Acts as a lightweight disclosure section: the check state of the group box
     header doubles as an expand/collapse toggle, hiding the body so the panel
-    actually shrinks for a cleaner first-time view (issue #2769, item 4).
+    actually shrinks for a cleaner first-time view (issue #2769, item 4). The
+    header reads like a GitHub ``<details>``/``<summary>`` disclosure -- a
+    ``▶`` arrow when collapsed and a ``▼`` arrow when expanded prefix the title
+    so the click-to-expand affordance is obvious (issue #2769 follow-up).
 
     All body widgets live inside a single inner :attr:`content` frame; callers
     add their layout to ``content`` (e.g. ``QVBoxLayout(group.content)``).
@@ -194,10 +197,14 @@ class CollapsibleGroupBox(QtWidgets.QGroupBox):
     logic.)
 
     Args:
-        title: The header text.
+        title: The header text (shown after the disclosure arrow).
         collapsed: If True, start collapsed (unchecked) with the body hidden.
         parent: Parent widget.
     """
+
+    # Disclosure arrows shown before the title, mirroring an HTML ``<details>``.
+    _ARROW_EXPANDED = "▼"  # ▼
+    _ARROW_COLLAPSED = "▶"  # ▶
 
     def __init__(
         self,
@@ -205,6 +212,9 @@ class CollapsibleGroupBox(QtWidgets.QGroupBox):
         collapsed: bool = False,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
+        # Keep the caller's title separate from the arrow prefix so toggling can
+        # rebuild the displayed title without losing the original text.
+        self._base_title = title
         super().__init__(title, parent)
 
         # Single body frame holding everything the caller adds.
@@ -214,20 +224,39 @@ class CollapsibleGroupBox(QtWidgets.QGroupBox):
         outer.addWidget(self.content)
 
         self.setCheckable(True)
+        # A pointing-hand cursor reinforces that the whole header is clickable,
+        # like a disclosure summary.
+        self.setCursor(QtCore.Qt.PointingHandCursor)
         self.setChecked(not collapsed)
         # Re-apply collapse state whenever the header is toggled.
         self.toggled.connect(self._on_toggled)
         self._on_toggled(self.isChecked())
 
     def _on_toggled(self, checked: bool):
-        """Show/hide the body to match the header check state."""
+        """Show/hide the body and update the disclosure arrow to match state."""
         self.content.setVisible(checked)
         # A checkable QGroupBox disables its direct children when unchecked;
         # undo that on the body frame so the body's own enabled-state logic is
         # preserved (collapse is visibility-only here).
         self.content.setEnabled(True)
+        self._update_title_arrow(checked)
         # Let the layout reclaim/release the space.
         self.updateGeometry()
+
+    def _update_title_arrow(self, expanded: bool):
+        """Prefix the title with a ▶/▼ disclosure arrow for the given state."""
+        arrow = self._ARROW_EXPANDED if expanded else self._ARROW_COLLAPSED
+        # ``setTitle`` triggers no signal, so this is safe inside ``_on_toggled``.
+        super().setTitle(f"{arrow}  {self._base_title}" if self._base_title else arrow)
+
+    def setTitle(self, title: str):  # noqa: N802 (Qt override)
+        """Set the header text, keeping the leading disclosure arrow in sync."""
+        self._base_title = title
+        self._update_title_arrow(self.isChecked())
+
+    def title(self) -> str:  # noqa: N802 (Qt override)
+        """Return the caller-supplied title without the disclosure arrow."""
+        return self._base_title
 
     def apply_collapsed_state(self):
         """Apply the current check state to body visibility.
@@ -674,9 +703,18 @@ class QCSkeletonTraceCanvas(Canvas):
     chain currently being traced, and the canvas highlights the trace in click
     order with numbered badges so the path is obvious at a glance.
 
-    The skeleton is laid out with a deterministic spring layout (seeded) over
-    the skeleton's nodes/edges so the picture is stable across redraws. Clicking
-    selects the nearest node within a small radius and emits
+    Where possible the skeleton is drawn using a *real* labeled animal's node
+    coordinates (like SLEAP's skeleton builder shows the actual animal shape):
+    callers pass a representative per-node position via :meth:`set_node_positions`
+    (e.g. the median over a sample of labeled instances), and the canvas
+    centers/scales those raw label coordinates to fill the view. When no labeled
+    coordinates are available the layout falls back to a deterministic, seeded
+    spring layout (or a horizontal line if networkx is missing) so the picture is
+    still stable across redraws. Either way the node positions are normalized
+    into roughly the same ``[-1, 1]`` frame, so the fixed click-pick radius works
+    against both layouts.
+
+    Clicking selects the nearest node within a small radius and emits
     :attr:`node_clicked`; the owning widget owns the chain list and calls
     :meth:`set_trace` to update the highlighted order.
 
@@ -706,45 +744,101 @@ class QCSkeletonTraceCanvas(Canvas):
         )
         self.setMinimumSize(260, 220)
 
-        # Node display positions keyed by node name: {name: (x, y)}.
+        # Node display positions keyed by node name: {name: (x, y)}. These are
+        # the *normalized* coordinates actually drawn/hit-tested (roughly in
+        # [-1, 1]); see :meth:`_compute_layout`.
         self._positions: dict = {}
         self._node_names: list = []
         self._edges: list = []  # list of (src_name, dst_name)
+        # Optional representative per-node coordinates from real labeled
+        # instances ({name: (x, y)} in raw label/image space). When present
+        # these drive the layout (a real animal shape); when empty the canvas
+        # falls back to the spring/line layout.
+        self._node_coords: dict = {}
         # The chain currently being traced, in click order (node names).
         self._trace: list = []
-        # Click hit-test radius in data coordinates (spring layout is ~[-1, 1]).
+        # Click hit-test radius in data coordinates. Both the spring layout and
+        # the real-coordinate layout are normalized to ~[-1, 1], so this fixed
+        # radius works for either.
         self._pick_radius = 0.18
 
         self.mpl_connect("button_press_event", self._on_click)
         self.update_plot()
 
-    def set_skeleton(self, node_names: list, edges: list):
+    def set_skeleton(self, node_names: list, edges: list, node_positions=None):
         """Set the skeleton to display and recompute the layout.
 
         Args:
             node_names: Ordered list of node-name strings.
             edges: List of ``(source_name, destination_name)`` tuples.
+            node_positions: Optional dict mapping node name to a representative
+                ``(x, y)`` coordinate from real labeled instances (raw label
+                space). When given (and non-empty), the skeleton is drawn using
+                those coordinates so it looks like the actual animal; otherwise
+                the canvas falls back to the spring/line layout. May also be set
+                separately via :meth:`set_node_positions`.
         """
         self._node_names = list(node_names)
         # Keep only edges whose endpoints are present, as name pairs.
         valid = set(self._node_names)
         self._edges = [(s, d) for (s, d) in edges if s in valid and d in valid]
+        if node_positions is not None:
+            # Keep only coords for nodes that exist in this skeleton.
+            self._node_coords = {
+                name: (float(x), float(y))
+                for name, (x, y) in node_positions.items()
+                if name in valid
+            }
+        else:
+            # A new skeleton without coords drops any stale real coordinates.
+            self._node_coords = {}
         self._positions = self._compute_layout()
         # Drop any traced nodes that no longer exist in this skeleton.
         self._trace = [n for n in self._trace if n in valid]
         self.update_plot()
 
-    def _compute_layout(self) -> dict:
-        """Compute a deterministic node layout for the current skeleton.
+    def set_node_positions(self, node_positions: dict):
+        """Set representative per-node coordinates from real labeled instances.
 
-        Uses a seeded spring layout so the drawing is stable across redraws.
-        Falls back to a simple horizontal line if networkx is unavailable.
+        Drives the layout so the skeleton is drawn in the actual animal's shape
+        (like the SLEAP skeleton builder) rather than an abstract spring layout.
+        Coordinates are given in raw label/image space and are centered/scaled to
+        fill the canvas; only nodes present in the current skeleton are kept. An
+        empty dict reverts to the spring/line fallback.
+
+        Args:
+            node_positions: Dict mapping node name to an ``(x, y)`` coordinate.
+        """
+        valid = set(self._node_names)
+        self._node_coords = {
+            name: (float(x), float(y))
+            for name, (x, y) in (node_positions or {}).items()
+            if name in valid
+        }
+        self._positions = self._compute_layout()
+        self.update_plot()
+
+    def _compute_layout(self) -> dict:
+        """Compute a node layout for the current skeleton.
+
+        Prefers a *real* animal layout built from labeled coordinates
+        (:attr:`_node_coords`) so the skeleton looks like the actual animal.
+        When no labeled coordinates are available it falls back to a seeded
+        spring layout (stable across redraws), or a horizontal line if networkx
+        is unavailable. All layouts are normalized to roughly ``[-1, 1]`` so the
+        fixed click-pick radius works regardless of which one is used.
 
         Returns:
-            Dict mapping node name to an ``(x, y)`` position.
+            Dict mapping node name to an ``(x, y)`` position in the normalized
+            display frame.
         """
         if not self._node_names:
             return {}
+        # Prefer real labeled coordinates when we have at least two nodes with
+        # finite positions (a single point gives no scale to normalize against).
+        real = self._layout_from_coords()
+        if real is not None:
+            return real
         try:
             import networkx as nx
 
@@ -763,6 +857,47 @@ class QCSkeletonTraceCanvas(Canvas):
                 name: (-1.0 + 2.0 * i / (n - 1), 0.0)
                 for i, name in enumerate(self._node_names)
             }
+
+    def _layout_from_coords(self):
+        """Build a normalized layout from real labeled node coordinates.
+
+        Centers the labeled coordinates on their centroid and scales them
+        uniformly (preserving the animal's aspect ratio) so the largest extent
+        fills the ``[-1, 1]`` display frame. The image-space y-axis (which grows
+        downward) is flipped so the animal is drawn the right way up. Nodes with
+        no labeled coordinate are skipped entirely (no marker is drawn for them).
+
+        Returns:
+            A dict mapping node name to a normalized ``(x, y)`` position, or
+            ``None`` when fewer than two nodes have finite labeled coordinates
+            (in which case the caller falls back to the spring/line layout).
+        """
+        coords = self._node_coords
+        if not coords:
+            return None
+        names = [
+            name
+            for name in self._node_names
+            if name in coords
+            and np.isfinite(coords[name][0])
+            and np.isfinite(coords[name][1])
+        ]
+        if len(names) < 2:
+            return None
+
+        pts = np.array([coords[name] for name in names], dtype=float)
+        center = pts.mean(axis=0)
+        centered = pts - center
+        # Uniform scale by the largest half-extent keeps the aspect ratio and
+        # maps the widest axis into [-1, 1].
+        half_extent = float(np.max(np.abs(centered))) if centered.size else 0.0
+        scale = 1.0 / half_extent if half_extent > 0 else 1.0
+        normalized = centered * scale
+        # Flip y so image coordinates (y down) draw the animal upright.
+        return {
+            name: (float(normalized[i, 0]), float(-normalized[i, 1]))
+            for i, name in enumerate(names)
+        }
 
     def set_trace(self, trace: list):
         """Set the chain-in-progress (node names, in click order) and redraw.
@@ -801,16 +936,21 @@ class QCSkeletonTraceCanvas(Canvas):
             self.draw()
             return
 
-        # Draw skeleton edges first so nodes sit on top.
+        # Draw skeleton edges first so nodes sit on top. Skip any edge whose
+        # endpoint lacks a position (e.g. a node with no labeled coordinate in
+        # the real-animal layout).
         for src, dst in self._edges:
+            if src not in self._positions or dst not in self._positions:
+                continue
             x0, y0 = self._positions[src]
             x1, y1 = self._positions[dst]
             self.axes.plot([x0, x1], [y0, y1], color="#ced4da", linewidth=1.2, zorder=1)
 
         # Draw the trace path (in click order) as a highlighted poly-line.
-        if len(self._trace) >= 2:
-            tx = [self._positions[n][0] for n in self._trace]
-            ty = [self._positions[n][1] for n in self._trace]
+        drawable_trace = [n for n in self._trace if n in self._positions]
+        if len(drawable_trace) >= 2:
+            tx = [self._positions[n][0] for n in drawable_trace]
+            ty = [self._positions[n][1] for n in drawable_trace]
             self.axes.plot(tx, ty, color="#007bff", linewidth=2.5, zorder=2, alpha=0.9)
 
         # Map node -> 1-based position in the trace (for numbered badges).
@@ -853,13 +993,15 @@ class QCSkeletonTraceCanvas(Canvas):
                 zorder=4,
             )
 
-        # Pad the limits so labels are not clipped.
+        # Pad the limits so labels are not clipped. Use ``adjustable="box"`` so
+        # the equal-aspect constraint resizes the axes box rather than silently
+        # overriding the explicit limits set here (which would emit a warning).
         xs = [p[0] for p in self._positions.values()]
         ys = [p[1] for p in self._positions.values()]
         pad = 0.35
+        self.axes.set_aspect("equal", adjustable="box")
         self.axes.set_xlim(min(xs) - pad, max(xs) + pad)
         self.axes.set_ylim(min(ys) - pad, max(ys) + pad)
-        self.axes.set_aspect("equal", adjustable="datalim")
 
         self.draw()
 
@@ -1151,6 +1293,56 @@ class QCAnalysisWorker(QThread):
             self.error.emit(str(e))
 
 
+class QCChainTraceDialog(QtWidgets.QDialog):
+    """Pop-up dialog that hosts the ordered-chain skeleton-tracing UI.
+
+    The full chain editor (a :class:`QCSkeletonTraceCanvas`, the "Tracing:" chip
+    readout with Undo/Clear/Add-chain, the saved-chains list, and the advanced
+    "type chains as text" box) used to be embedded directly in the Detector
+    Settings panel, which felt cramped. It now lives in this dialog instead
+    (issue #2769 follow-up); the Detector Settings row just has a
+    "Configure chains..." button that opens it.
+
+    The dialog does *not* own any chain state: it simply re-parents and shows the
+    owning :class:`QCWidget`'s live ``_chain_trace_panel``. Tracing therefore
+    edits the widget's ``_traced_chains`` / free-text box directly, so the chains
+    are already written back through :meth:`QCWidget._collect_ordered_chains`
+    when the dialog closes -- no explicit accept/apply step is needed. Closing
+    via the Close button (or the window chrome) simply hides the dialog; the
+    panel is kept alive and reused the next time it is opened.
+
+    Args:
+        parent: The owning :class:`QCWidget`.
+        panel: The chain-trace panel widget to host (built by
+            :meth:`QCWidget._build_chain_trace_panel`).
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget, panel: QtWidgets.QWidget):
+        super().__init__(parent)
+        self.setWindowTitle("Configure ordered chains")
+        # Non-modal would let the underlying project change under the editor;
+        # a modal dialog keeps the chain state edit self-contained.
+        self.setModal(True)
+        self.setMinimumSize(420, 460)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(6)
+
+        # Host the live panel; it stays visible while owned by the dialog.
+        self._panel = panel
+        panel.setParent(self)
+        panel.setVisible(True)
+        layout.addWidget(panel, stretch=1)
+
+        # A single Close button: chains are written back live, so this just
+        # dismisses the editor.
+        buttons = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Close)
+        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(self.accept)
+        layout.addWidget(buttons)
+
+
 class QCWidget(QtWidgets.QWidget):
     """Widget for label quality control analysis with visualizations.
 
@@ -1194,6 +1386,9 @@ class QCWidget(QtWidgets.QWidget):
         # (video, frame, instance) so it survives threshold/issue re-filters
         # (item 6). Shared by reference with the table model.
         self._reviewed_keys: set = set()
+        # Guards against stacking multiple deferred "Hide reviewed" re-filters
+        # when several rows are marked reviewed in quick succession (Group C).
+        self._hide_reviewed_refilter_pending: bool = False
 
         # Ordered chains the user has traced on the skeleton (item 2): each
         # entry is a list of node names in order. These feed QCConfig together
@@ -1373,6 +1568,20 @@ class QCWidget(QtWidgets.QWidget):
         # Disabled until results exist (nothing to filter yet).
         self._issue_filter_button.setEnabled(False)
         toolbar.addWidget(self._issue_filter_button)
+
+        # "Hide reviewed" filter (Group C / feedback on #2769): show only the
+        # not-yet-reviewed flagged instances, AND-combined with the issue-type
+        # filter above. Sits next to the issue-type button so both live filters
+        # read together. Disabled until results exist (nothing to hide yet).
+        self._hide_reviewed_check = QtWidgets.QCheckBox("Hide reviewed")
+        self._hide_reviewed_check.setChecked(False)
+        self._hide_reviewed_check.setEnabled(False)
+        self._hide_reviewed_check.setToolTip(
+            "Show only instances you have NOT marked reviewed.\n"
+            "Combined (AND) with the issue-type filter; the table updates live "
+            "as you tick rows reviewed."
+        )
+        toolbar.addWidget(self._hide_reviewed_check)
 
         toolbar.addStretch()
 
@@ -1566,10 +1775,44 @@ class QCWidget(QtWidgets.QWidget):
 
         # Skeleton-tracing UX for defining ordered chains (issue #2769, item 2):
         # a click-to-trace skeleton plus an ordered chip list, instead of forcing
-        # users to type node names. The advanced free-text box is kept inside it
-        # as a fallback. Spans the full grid width.
+        # users to type node names. The full tracing UI lives in a *pop-up*
+        # dialog (issue #2769 follow-up: the inline panel felt too cramped), so
+        # the grid row only carries a "Configure chains..." button and a short
+        # summary of the current chains. The panel is built eagerly (so its
+        # controls exist for callers/tests) but is hosted in the dialog on
+        # demand rather than embedded here.
         self._chain_trace_panel = self._build_chain_trace_panel()
-        grid.addWidget(self._chain_trace_panel, 4, 0, 1, 4)
+        # Hold a Qt parent so the (currently hidden) panel stays alive between
+        # dialog openings; it is reparented into the dialog when opened.
+        self._chain_trace_panel.setParent(self)
+        self._chain_trace_panel.setVisible(False)
+        self._chain_trace_dialog: Optional["QCChainTraceDialog"] = None
+
+        chain_config_row = QtWidgets.QHBoxLayout()
+        chain_config_row.setContentsMargins(0, 0, 0, 0)
+        chain_config_row.setSpacing(6)
+        self._chain_config_btn = QtWidgets.QPushButton("Configure chains...")
+        self._chain_config_btn.setToolTip(
+            "Open the chain editor to trace ordered chains on the skeleton "
+            "(e.g. tail base → tail tip) used by the chain-order detector."
+        )
+        self._chain_config_btn.clicked.connect(self._open_chain_trace_dialog)
+        chain_config_row.addWidget(self._chain_config_btn)
+
+        self._chain_summary_label = QtWidgets.QLabel("No chains")
+        self._chain_summary_label.setWordWrap(True)
+        self._chain_summary_label.setStyleSheet("color:#6c757d;")
+        self._chain_summary_label.setToolTip(
+            "The ordered chains currently configured for the chain-order "
+            "detector. Click 'Configure chains...' to edit them."
+        )
+        chain_config_row.addWidget(self._chain_summary_label, stretch=1)
+
+        chain_config_container = QtWidgets.QWidget()
+        chain_config_container.setLayout(chain_config_row)
+        self._chain_config_container = chain_config_container
+        grid.addWidget(chain_config_container, 4, 0, 1, 4)
+        self._refresh_chain_summary()
 
         # --- Missing labelable node, experimental, default-OFF ---
         self._cb_missing = QtWidgets.QCheckBox("Missing labelable node")
@@ -1650,8 +1893,11 @@ class QCWidget(QtWidgets.QWidget):
         def _set_chain_enabled(on: bool):
             self._sb_chain_angle.setEnabled(on)
             self._sb_order_thr.setEnabled(on)
-            # The whole skeleton-trace panel (canvas, chip list, saved chains and
-            # the advanced free-text fallback) follows the chain checkbox.
+            # The "Configure chains..." button + summary (the inline entry point)
+            # and the trace panel hosted in the pop-up dialog all follow the
+            # chain checkbox.
+            self._chain_config_btn.setEnabled(on)
+            self._chain_summary_label.setEnabled(on)
             self._chain_trace_panel.setEnabled(on)
 
         self._cb_chain.toggled.connect(_set_chain_enabled)
@@ -1666,6 +1912,30 @@ class QCWidget(QtWidgets.QWidget):
         self._cb_insample.toggled.connect(_set_insample_enabled)
         _set_insample_enabled(self._cb_insample.isChecked())
         self._insample_browse_btn.clicked.connect(self._on_browse_insample_model)
+
+        # --- Restore-defaults footer row, spanning the full grid width. ---
+        # A thin separator above a right-aligned "Restore defaults" button that
+        # resets every control back to QCConfig() defaults (issue #2769
+        # follow-up, "restore to default setting").
+        separator = QtWidgets.QFrame()
+        separator.setFrameShape(QtWidgets.QFrame.HLine)
+        separator.setFrameShadow(QtWidgets.QFrame.Sunken)
+        grid.addWidget(separator, 8, 0, 1, 4)
+
+        restore_row = QtWidgets.QHBoxLayout()
+        restore_row.setContentsMargins(0, 0, 0, 0)
+        restore_row.addStretch()
+        self._restore_defaults_btn = QtWidgets.QPushButton("Restore defaults")
+        self._restore_defaults_btn.setToolTip(
+            "Reset every detector setting on this panel (enable toggles, "
+            "thresholds, ordered chains and the in-sample model path) back to "
+            "the shipped defaults."
+        )
+        self._restore_defaults_btn.clicked.connect(self._on_restore_detector_defaults)
+        restore_row.addWidget(self._restore_defaults_btn)
+        restore_container = QtWidgets.QWidget()
+        restore_container.setLayout(restore_row)
+        grid.addWidget(restore_container, 9, 0, 1, 4)
 
         # Apply the (collapsed) start state now that all children exist so the
         # panel actually starts hidden for a clean first-time view.
@@ -1687,7 +1957,10 @@ class QCWidget(QtWidgets.QWidget):
         * an advanced, collapsible free-text fallback (the original typed-chain
           box) for power users / projects with no skeleton.
 
-        Both the traced chains and the free-text box feed
+        The panel is hosted inside the :class:`QCChainTraceDialog` pop-up rather
+        than embedded in the Detector Settings grid (issue #2769 follow-up), but
+        it still reads/writes the same widget state (``_traced_chains`` and the
+        free-text box), so both the traced chains and the free-text box feed
         :meth:`_build_qc_config` via :meth:`_collect_ordered_chains`.
 
         Returns:
@@ -1699,8 +1972,9 @@ class QCWidget(QtWidgets.QWidget):
         outer.setSpacing(4)
 
         heading = QtWidgets.QLabel(
-            "<b>Ordered chains</b> — trace a chain by clicking nodes in order "
-            "(e.g. tail base → tail tip):"
+            "Trace a chain by clicking nodes on the skeleton in order "
+            "(e.g. tail base → tail tip), then click <b>Add chain</b>. "
+            "Repeat to add more chains."
         )
         heading.setWordWrap(True)
         heading.setToolTip(
@@ -1830,6 +2104,59 @@ class QCWidget(QtWidgets.QWidget):
 
         return panel
 
+    def _open_chain_trace_dialog(self):
+        """Open the pop-up chain editor hosting the full tracing UI.
+
+        Lazily creates a :class:`QCChainTraceDialog`, hands it the live
+        :attr:`_chain_trace_panel` (so editing operates directly on the widget's
+        chain state), shows it modally, and refreshes the inline summary on
+        close (issue #2769 follow-up: the embedded panel was too cramped).
+        """
+        if self._chain_trace_dialog is None:
+            self._chain_trace_dialog = QCChainTraceDialog(self, self._chain_trace_panel)
+        dialog = self._chain_trace_dialog
+        # Make sure the trace readout/canvas reflect the current state each time.
+        self._refresh_trace_readout()
+        self._refresh_chains_list()
+        dialog.exec_()
+        # Editing happened in-place on the shared panel; refresh the summary.
+        self._refresh_chain_summary()
+
+    def _chain_summary_text(self) -> str:
+        """Plain-language summary of the configured ordered chains.
+
+        Combines the traced chains with any advanced free-text chains (the same
+        set :meth:`_collect_ordered_chains` feeds into the config) into a short
+        caption like ``"2 chains: TTI→…→TailTip, Head→Neck"``. Returns
+        ``"No chains"`` when nothing is configured.
+
+        Returns:
+            A short caption describing the current chains.
+        """
+        chains = self._collect_ordered_chains()
+        if not chains:
+            return "No chains"
+
+        def _abbrev(chain: list) -> str:
+            # Show endpoints (with an ellipsis between) so long tail chains stay
+            # compact: e.g. ["TTI","Tail_0","TailTip"] -> "TTI→…→TailTip".
+            if len(chain) <= 2:
+                return "→".join(chain)
+            return f"{chain[0]}→…→{chain[-1]}"
+
+        # Cap how many chains we spell out so the label can't run away.
+        shown = [_abbrev(chain) for chain in chains[:3]]
+        summary = ", ".join(shown)
+        if len(chains) > 3:
+            summary += f", +{len(chains) - 3} more"
+        n = len(chains)
+        return f"{n} chain{'s' if n != 1 else ''}: {summary}"
+
+    def _refresh_chain_summary(self):
+        """Update the inline chain summary label from the current chains."""
+        if hasattr(self, "_chain_summary_label"):
+            self._chain_summary_label.setText(self._chain_summary_text())
+
     def _on_trace_node_clicked(self, name: str):
         """Append a clicked node to the chain currently being traced.
 
@@ -1898,7 +2225,11 @@ class QCWidget(QtWidgets.QWidget):
         self._trace_add_btn.setEnabled(len(chain) >= 2)
 
     def _refresh_chains_list(self):
-        """Repopulate the saved-chains list from ``_traced_chains``."""
+        """Repopulate the saved-chains list from ``_traced_chains``.
+
+        Also refreshes the inline summary label, since every saved-chains change
+        (add / remove / reorder / restore) flows through here.
+        """
         self._chains_list.clear()
         for chain in self._traced_chains:
             self._chains_list.addItem(" → ".join(chain))
@@ -1906,6 +2237,7 @@ class QCWidget(QtWidgets.QWidget):
         self._chain_up_btn.setEnabled(has_rows)
         self._chain_down_btn.setEnabled(has_rows)
         self._chain_remove_btn.setEnabled(has_rows)
+        self._refresh_chain_summary()
 
     def _move_selected_chain(self, delta: int):
         """Move the selected saved chain up or down by one.
@@ -1938,7 +2270,11 @@ class QCWidget(QtWidgets.QWidget):
 
         Reads the first skeleton from the loaded labels (if any) and hands its
         nodes/edges to the :class:`QCSkeletonTraceCanvas` so the user can trace
-        on the real skeleton. Clears the canvas when no skeleton is available.
+        on the real skeleton. Also computes a representative per-node position
+        from the labeled instances (:meth:`_representative_node_positions`) so
+        the canvas can draw the actual animal shape rather than an abstract
+        spring layout (issue #2769 follow-up). Clears the canvas when no skeleton
+        is available.
 
         Uses ``labels.skeletons`` (a list) rather than the ``labels.skeleton``
         convenience property, since the latter *raises* when there are zero or
@@ -1947,6 +2283,7 @@ class QCWidget(QtWidgets.QWidget):
         node_names: list = []
         edges: list = []
         labels = self._labels
+        skeleton = None
         try:
             skeletons = (
                 getattr(labels, "skeletons", None) if labels is not None else None
@@ -1958,8 +2295,85 @@ class QCWidget(QtWidgets.QWidget):
                     (edge.source.name, edge.destination.name) for edge in skeleton.edges
                 ]
         except Exception:
-            node_names, edges = [], []
-        self._skeleton_canvas.set_skeleton(node_names, edges)
+            node_names, edges, skeleton = [], [], None
+        node_positions = self._representative_node_positions(skeleton, node_names)
+        self._skeleton_canvas.set_skeleton(
+            node_names, edges, node_positions=node_positions
+        )
+
+    def _representative_node_positions(
+        self, skeleton, node_names: list, max_instances: int = 200
+    ) -> dict:
+        """Median per-node coordinate over a sample of labeled instances.
+
+        For each skeleton node, takes the median ``(x, y)`` over up to
+        ``max_instances`` labeled (user) instances in which that node is
+        visible, in the raw label coordinate frame. The medians give a stable,
+        outlier-resistant "representative animal" the trace canvas can draw in
+        the real animal's shape. Each instance is recentered on its own centroid
+        first so animals labeled in very different parts of the frame still
+        average into a coherent shape rather than smearing across the image.
+
+        Args:
+            skeleton: The skeleton whose ``node_names`` order aligns with each
+                instance's ``numpy()`` rows, or ``None``.
+            node_names: The skeleton node names (used as the result keys).
+            max_instances: Cap on how many labeled instances to sample.
+
+        Returns:
+            Dict mapping node name to ``(x, y)``, restricted to nodes seen
+            visible in at least one sampled instance. Empty when there is no
+            usable labeled data (the canvas then falls back to a spring layout).
+        """
+        labels = self._labels
+        if labels is None or skeleton is None or not node_names:
+            return {}
+
+        n_nodes = len(node_names)
+        # Collect centered point arrays, one (n_nodes, 2) row-block per instance.
+        stacks: list = []
+        try:
+            for lf in labels:
+                for inst in lf.user_instances:
+                    # Only instances sharing this skeleton align row-for-row.
+                    if getattr(inst, "skeleton", None) is not skeleton:
+                        continue
+                    pts = np.asarray(inst.numpy(invisible_as_nan=True), dtype=float)
+                    if pts.shape != (n_nodes, 2):
+                        continue
+                    visible = np.isfinite(pts).all(axis=1)
+                    if not visible.any():
+                        continue
+                    # Recenter on this instance's visible centroid so instances
+                    # in different frame regions overlay coherently.
+                    centroid = np.nanmean(pts[visible], axis=0)
+                    stacks.append(pts - centroid)
+                    if len(stacks) >= max_instances:
+                        raise StopIteration
+        except StopIteration:
+            pass
+        except Exception:
+            return {}
+
+        if not stacks:
+            return {}
+
+        # Shape: (n_instances, n_nodes, 2); median over instances, ignoring NaNs.
+        arr = np.stack(stacks, axis=0)
+        with np.errstate(all="ignore"):
+            # Suppress the all-NaN-slice warning for never-visible nodes.
+            import warnings
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", category=RuntimeWarning)
+                medians = np.nanmedian(arr, axis=0)  # (n_nodes, 2)
+
+        positions: dict = {}
+        for i, name in enumerate(node_names):
+            x, y = medians[i]
+            if np.isfinite(x) and np.isfinite(y):
+                positions[name] = (float(x), float(y))
+        return positions
 
     def _on_browse_insample_model(self):
         """Open a folder picker and set the in-sample model path line edit."""
@@ -2085,6 +2499,84 @@ class QCWidget(QtWidgets.QWidget):
             insample_model_path=self._insample_model_edit.text().strip(),
         )
 
+    @staticmethod
+    def _config_flag(value, default: bool) -> bool:
+        """Resolve a QCConfig toggle (which may be ``"auto"``) to a checkbox bool.
+
+        Several QCConfig toggles accept a literal ``"auto"`` sentinel as well as
+        a plain ``bool`` (e.g. ``use_chirality``/``use_chain_ordering``). The
+        Detector Settings checkboxes are plain on/off, so map a real bool
+        straight through and fall back to the detector's documented GUI default
+        for ``"auto"`` (or any other non-bool) value.
+
+        Args:
+            value: The QCConfig field value (``bool`` or ``"auto"``).
+            default: The checkbox state to use when ``value`` is not a bool.
+
+        Returns:
+            The boolean checkbox state to apply.
+        """
+        return value if isinstance(value, bool) else default
+
+    def _apply_config_to_widgets(self, config: "QCConfig"):
+        """Push a QCConfig's values back into the Detector Settings controls.
+
+        Inverse of :meth:`_build_qc_config`: every per-detector control that
+        feeds the config is set from the matching field, so the panel can be
+        reset to a known configuration (e.g. the "Restore defaults" button feeds
+        a fresh ``QCConfig()``). Toggles that accept ``"auto"`` fall back to the
+        detector's documented GUI default via :meth:`_config_flag`.
+
+        Args:
+            config: The configuration to display in the controls.
+        """
+        # Enable checkboxes (map "auto" sentinels to the documented GUI default:
+        # reliable detectors ON, experimental detectors OFF).
+        self._cb_flip.setChecked(self._config_flag(config.use_chirality, True))
+        self._cb_chimera.setChecked(self._config_flag(config.use_split_detection, True))
+        self._cb_duplicate.setChecked(
+            self._config_flag(config.use_duplicate_score, True)
+        )
+        self._cb_chain.setChecked(self._config_flag(config.use_chain_ordering, False))
+        self._cb_missing.setChecked(
+            self._config_flag(config.use_missing_node_check, False)
+        )
+        self._cb_appearance.setChecked(self._config_flag(config.use_appearance, False))
+        self._cb_insample.setChecked(
+            self._config_flag(config.use_insample_prediction, False)
+        )
+
+        # Per-detector thresholds.
+        self._sb_flip_thr.setValue(config.chirality_flip_threshold)
+        self._sb_dup_thr.setValue(config.duplicate_score_threshold)
+        self._sb_chain_angle.setValue(int(config.chain_turn_angle_deg))
+        self._sb_order_thr.setValue(config.order_inversion_threshold)
+        self._sb_missing_thr.setValue(config.missing_node_prob_threshold)
+
+        # In-sample model path.
+        self._insample_model_edit.setText(config.insample_model_path or "")
+
+        # Ordered chains: drop the free-text box and any half-finished trace,
+        # then load the config's chains as the saved-chains list.
+        self._ordered_chains_edit.setPlainText("")
+        self._trace_in_progress = []
+        self._traced_chains = [list(chain) for chain in (config.ordered_chains or [])]
+        self._refresh_trace_readout()
+        self._refresh_chains_list()
+
+    def _on_restore_detector_defaults(self):
+        """Reset every Detector Settings control back to ``QCConfig()`` defaults.
+
+        Builds a fresh :class:`~sleap.qc.config.QCConfig` and pushes its values
+        into the controls via :meth:`_apply_config_to_widgets`, so enable
+        checkboxes, thresholds, ordered chains, the in-sample model path and the
+        appearance/missing/prediction toggles all return to the shipped defaults
+        (issue #2769 follow-up, "restore to default setting").
+        """
+        from sleap.qc.config import QCConfig
+
+        self._apply_config_to_widgets(QCConfig())
+
     def _parse_ordered_chains(self) -> list:
         """Parse the ordered-chains text box into a list of node-name lists.
 
@@ -2135,8 +2627,11 @@ class QCWidget(QtWidgets.QWidget):
         )
         self._table_view.doubleClicked.connect(self._on_row_double_clicked)
         # Keep the "X / Y reviewed" counter in sync whenever a Reviewed
-        # checkbox is toggled in the model (item 6).
-        self._table_model.dataChanged.connect(self._update_reviewed_count)
+        # checkbox is toggled in the model (item 6), and -- when "Hide reviewed"
+        # is active -- drop the now-reviewed row from the view live (Group C).
+        self._table_model.dataChanged.connect(self._on_reviewed_changed)
+        # Re-apply the filters whenever the "Hide reviewed" toggle changes.
+        self._hide_reviewed_check.toggled.connect(self._on_hide_reviewed_toggled)
 
     def _update_spinner(self):
         """Update the spinner animation character."""
@@ -2174,6 +2669,13 @@ class QCWidget(QtWidgets.QWidget):
         self._all_flagged = []
         self._visible_issue_types = None
         self._reviewed_keys.clear()
+        # Reset the "Hide reviewed" filter; block its toggled signal so this
+        # reset does not trigger a stray re-filter mid-reset (Group C).
+        self._hide_reviewed_refilter_pending = False
+        self._hide_reviewed_check.blockSignals(True)
+        self._hide_reviewed_check.setChecked(False)
+        self._hide_reviewed_check.setEnabled(False)
+        self._hide_reviewed_check.blockSignals(False)
 
         # Reset the chain being traced (a new project may have a new skeleton);
         # saved chains are kept so the user does not lose deliberate work.
@@ -2319,6 +2821,11 @@ class QCWidget(QtWidgets.QWidget):
         flagged = self._results.get_flagged(threshold=threshold)
         self._all_flagged = flagged
 
+        # The "Hide reviewed" filter is usable as soon as anything is flagged
+        # (Group C); gate it on the full flagged set rather than the issue-type
+        # categories so it works even with a single issue type.
+        self._hide_reviewed_check.setEnabled(bool(flagged))
+
         # Rebuild the issue-type filter to match the categories now present,
         # preserving the user's current show/hide choices where possible.
         # de-dup while keeping first-seen (score-descending) order.
@@ -2456,12 +2963,21 @@ class QCWidget(QtWidgets.QWidget):
             self._issue_filter_button.setText(f"Issue types: {n_sel} of {total}")
 
     def _filtered_flagged(self) -> List["QCFlag"]:
-        """Return the flagged list restricted to the selected issue types."""
+        """Return the flagged list under the active filters.
+
+        Applies the issue-type filter and the "Hide reviewed" filter together
+        (logical AND): when both are active a row must match a selected issue
+        type *and* not be in :attr:`_reviewed_keys` to be shown (Group C).
+        """
         if self._visible_issue_types is None:
-            return list(self._all_flagged)
-        return [
-            f for f in self._all_flagged if f.top_issue in self._visible_issue_types
-        ]
+            flagged = list(self._all_flagged)
+        else:
+            flagged = [
+                f for f in self._all_flagged if f.top_issue in self._visible_issue_types
+            ]
+        if self._hide_reviewed_check.isChecked():
+            flagged = [f for f in flagged if f.instance_key not in self._reviewed_keys]
+        return flagged
 
     def _apply_issue_filter(self):
         """Push the issue-type-filtered flagged subset into the table model."""
@@ -2477,6 +2993,46 @@ class QCWidget(QtWidgets.QWidget):
         total = self._table_model.rowCount()
         reviewed = self._table_model.reviewed_count()
         self._reviewed_count_label.setText(f"{reviewed} / {total} reviewed")
+
+    def _on_reviewed_changed(self, *args):
+        """React to a Reviewed-state change in the model (Group C, item 6).
+
+        Always refreshes the running "X / Y reviewed" counter. When the "Hide
+        reviewed" filter is active, also re-applies the filters so a row just
+        ticked reviewed drops out of the not-reviewed view live. The re-filter is
+        *deferred* to the next event-loop turn because the ``dataChanged`` that
+        triggers this slot is emitted from inside the model's own ``setData`` (or
+        the selection-driven auto-mark); resetting the model's rows synchronously
+        at that point would yank the data out from under the in-flight edit.
+
+        Args:
+            *args: Ignored; lets this slot accept ``dataChanged`` signal args.
+        """
+        self._update_reviewed_count()
+        if (
+            self._hide_reviewed_check.isChecked()
+            and not self._hide_reviewed_refilter_pending
+        ):
+            self._hide_reviewed_refilter_pending = True
+            QtCore.QTimer.singleShot(0, self._apply_hide_reviewed_refilter)
+
+    def _apply_hide_reviewed_refilter(self):
+        """Deferred re-filter after a reviewed change while hiding reviewed rows.
+
+        Runs on the next event-loop turn (scheduled by :meth:`_on_reviewed_changed`)
+        so the model reset happens cleanly after the originating edit returns.
+        """
+        self._hide_reviewed_refilter_pending = False
+        if self._hide_reviewed_check.isChecked():
+            self._apply_issue_filter()
+
+    def _on_hide_reviewed_toggled(self, checked: bool):
+        """Re-apply the filters when the "Hide reviewed" toggle changes (Group C).
+
+        Args:
+            checked: New checkbox state (True hides reviewed rows).
+        """
+        self._apply_issue_filter()
 
     def _update_statistics(self):
         """Update the statistics panel in plain language.

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -1817,7 +1817,10 @@ class QCWidget(QtWidgets.QWidget):
         self._threshold_label.setMinimumWidth(40)
         self._threshold_label.setAlignment(QtCore.Qt.AlignCenter)
         self._threshold_label.setStyleSheet(
-            "font-weight: bold; background: #f8f9fa; "
+            # Explicit dark text: without it the label inherits the palette text
+            # color, which is white on a dark Linux theme -> white-on-light and
+            # unreadable (issue #2769 follow-up).
+            "color: #212529; font-weight: bold; background: #f8f9fa; "
             "padding: 2px 6px; border-radius: 3px;"
         )
         threshold_layout.addWidget(self._threshold_label)
@@ -2227,6 +2230,9 @@ class QCWidget(QtWidgets.QWidget):
 
         self._cb_chain.toggled.connect(_set_chain_enabled)
         _set_chain_enabled(self._cb_chain.isChecked())
+        # Warn (only on a real user click, not programmatic restore/init) if the
+        # detector is turned on with no chains defined -- it would do nothing.
+        self._cb_chain.clicked.connect(self._on_chain_checked)
 
         # Disable the in-sample model picker + Browse button when its checkbox
         # is off (mirrors the other detectors' disable-on-uncheck behavior).
@@ -2449,6 +2455,32 @@ class QCWidget(QtWidgets.QWidget):
         self._refresh_chains_list()
 
         return panel
+
+    def _on_chain_checked(self, checked: bool):
+        """Prompt to define a chain when chain-order is enabled with none set.
+
+        The "Wrong chain order" detector does nothing without at least one
+        ordered chain, so when the user ticks it on with none configured, offer
+        to open the chain editor right away (issue #2769 follow-up). Connected to
+        ``clicked`` (not ``toggled``) so it never fires on programmatic changes
+        like Restore defaults or initial setup.
+
+        Args:
+            checked: The checkbox's new state from the ``clicked`` signal.
+        """
+        if not checked or self._collect_ordered_chains():
+            return
+        resp = QtWidgets.QMessageBox.question(
+            self,
+            "No chains defined",
+            "The 'Wrong chain order' detector needs at least one ordered chain "
+            "to check, but none are defined yet.\n\n"
+            "Open the chain editor to trace one now?",
+            QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+            QtWidgets.QMessageBox.Yes,
+        )
+        if resp == QtWidgets.QMessageBox.Yes:
+            self._open_chain_trace_dialog()
 
     def _open_chain_trace_dialog(self):
         """Open the pop-up chain editor hosting the full tracing UI.

--- a/sleap/qc/config.py
+++ b/sleap/qc/config.py
@@ -32,6 +32,27 @@ class QCConfig:
             when the longest chain has >= 4 nodes. Experimental, default-OFF.
         use_missing_node_check: Whether to run the missing-node check (a node a
             instance's peers usually keep is absent). Experimental, default-OFF.
+        use_appearance: Whether to run the appearance-outlier channel (a node
+            placed on visually-wrong pixels, e.g. on bedding instead of fur).
+            Needs decoded image frames; scored outside the GMM as the
+            ``"appearance"`` channel. Experimental, default-OFF.
+        appearance_patch_size: Side length (pixels) of the square image patch
+            cut around each node for the appearance descriptor.
+        appearance_min_samples: Minimum number of patch samples a node needs at
+            fit time before the appearance model has an opinion on it.
+        use_insample_prediction: Whether to run the in-sample model-prediction
+            channel (Tier-2 missing-node): run a trained sleap-nn model on the
+            labeled frames and flag unlabeled nodes the model confidently
+            localizes. Scored outside the GMM as the ``"prediction"`` channel.
+            EXPENSIVE (full model inference). Experimental, default-OFF.
+        insample_model_path: Path to a trained sleap-nn model directory for the
+            in-sample prediction channel. Empty disables the channel (no-op).
+        insample_peak_threshold: Peak-finding confidence threshold passed to the
+            in-sample model inference (lower = more candidate peaks).
+        insample_min_confidence: Confidence at/above which a model prediction at
+            an unlabeled node counts as a disagreement (gates the channel score).
+        insample_device: Torch device for the in-sample inference
+            (``"auto"``/``"cpu"``/``"cuda"``/``"mps"``).
         instance_threshold: Threshold for flagging instances (0-1).
             Higher = fewer flags, lower = more flags.
         frame_threshold: Threshold for frame-level checks.
@@ -69,6 +90,9 @@ class QCConfig:
     use_duplicate_score: bool = True  # (a)
     use_chain_ordering: Literal["auto"] | bool = False  # (b) experimental
     use_missing_node_check: bool = False  # (f, Tier-1) experimental
+    # B2 non-GMM channels (default-OFF / experimental).
+    use_appearance: bool = False  # (e) appearance outlier / wrong-object
+    use_insample_prediction: bool = False  # (f, Tier-2) in-sample model prediction
 
     # Thresholds (validated in v4 investigation)
     instance_threshold: float = 0.7  # Default: balanced
@@ -83,6 +107,16 @@ class QCConfig:
     chain_turn_angle_deg: float = 60.0
     order_inversion_threshold: float = 0.3
     missing_node_prob_threshold: float = 0.9
+
+    # B2 appearance-outlier channel settings.
+    appearance_patch_size: int = 7
+    appearance_min_samples: int = 20
+
+    # B2 in-sample model-prediction channel settings.
+    insample_model_path: str = ""
+    insample_peak_threshold: float = 0.2
+    insample_min_confidence: float = 0.5
+    insample_device: str = "auto"
 
     # User-defined ordered chains (lists of node NAMES) for chain-ordering.
     ordered_chains: list = field(default_factory=list)

--- a/sleap/qc/config.py
+++ b/sleap/qc/config.py
@@ -48,7 +48,8 @@ class QCConfig:
     gmm_min_samples: int = 50
     gmm_percentile_threshold: float = 5.0
 
-    # Calibration
+    # Calibration (reserved: NOT consumed anywhere yet — no auto-calibration is
+    # implemented. Flagging uses the fixed instance_threshold / GUI slider value.)
     auto_calibrate: bool = True
     calibration_percentile: float = 95.0
 

--- a/sleap/qc/config.py
+++ b/sleap/qc/config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 
@@ -17,11 +17,39 @@ class QCConfig:
         use_symmetry: Whether to compute symmetry features.
             If "auto", enables when skeleton has symmetry pairs defined.
         use_anatomical: Whether to compute anatomical features (signed angles).
+        use_chirality: Whether to compute the whole-instance left/right
+            mirror-flip (chirality) feature. If "auto", enables when the
+            skeleton has symmetry pairs (defined or inferred by name). Reliable
+            detector, default-ON.
+        use_split_detection: Whether to compute the pose-split (chimera) feature
+            that flags a single instance spanning two animals. Reliable
+            detector, default-ON.
+        use_duplicate_score: Whether to fold the complementary split-duplicate
+            signal into frame-level duplicate detection. Reliable detector,
+            default-ON.
+        use_chain_ordering: Whether to compute the keypoint chain-ordering
+            feature (wrong order along an ordered chain). If "auto", enables
+            when the longest chain has >= 4 nodes. Experimental, default-OFF.
+        use_missing_node_check: Whether to run the missing-node check (a node a
+            instance's peers usually keep is absent). Experimental, default-OFF.
         instance_threshold: Threshold for flagging instances (0-1).
             Higher = fewer flags, lower = more flags.
         frame_threshold: Threshold for frame-level checks.
         duplicate_iou_threshold: IOU threshold for duplicate detection.
         duplicate_node_overlap_ratio: Node overlap ratio for partial duplicates.
+        chirality_flip_threshold: ``chirality_wrong_fraction`` at/above which an
+            instance is force-flagged as a whole-instance L/R flip.
+        duplicate_score_threshold: Combined duplicate-score at/above which a
+            pair is flagged as a duplicate at the frame level.
+        chain_turn_angle_deg: Per-interior-node turning angle (degrees) above
+            which a chain node counts as an ordering inversion.
+        order_inversion_threshold: ``order_inversion_rate`` at/above which an
+            instance is force-flagged as having wrong keypoint order.
+        missing_node_prob_threshold: Minimum expected-visibility probability for
+            a missing node to be flagged as suspicious.
+        ordered_chains: User-defined ordered chains as lists of node *names*
+            (ground truth ordering for the chain-ordering detector). Empty =
+            fall back to auto-detected skeleton chains.
         gmm_n_components: Number of GMM components.
         gmm_min_samples: Minimum samples required for GMM fitting.
             Below this, falls back to z-score thresholding.
@@ -35,6 +63,12 @@ class QCConfig:
     use_curvature: Literal["auto"] | bool = "auto"
     use_symmetry: Literal["auto"] | bool = "auto"
     use_anatomical: bool = False
+    # New detectors: reliable ones default-ON, experimental ones default-OFF.
+    use_chirality: Literal["auto"] | bool = "auto"  # (c)
+    use_split_detection: bool = True  # (d)
+    use_duplicate_score: bool = True  # (a)
+    use_chain_ordering: Literal["auto"] | bool = False  # (b) experimental
+    use_missing_node_check: bool = False  # (f, Tier-1) experimental
 
     # Thresholds (validated in v4 investigation)
     instance_threshold: float = 0.7  # Default: balanced
@@ -42,6 +76,16 @@ class QCConfig:
     duplicate_iou_threshold: float = 0.5
     duplicate_node_overlap_ratio: float = 0.8
     duplicate_node_distance_threshold: float = 10.0
+
+    # New-detector thresholds.
+    chirality_flip_threshold: float = 0.5
+    duplicate_score_threshold: float = 0.5
+    chain_turn_angle_deg: float = 60.0
+    order_inversion_threshold: float = 0.3
+    missing_node_prob_threshold: float = 0.9
+
+    # User-defined ordered chains (lists of node NAMES) for chain-ordering.
+    ordered_chains: list = field(default_factory=list)
 
     # GMM settings
     gmm_n_components: int = 5
@@ -66,3 +110,17 @@ class QCConfig:
             return self.use_symmetry
         # Auto mode: enable if skeleton has symmetry pairs
         return has_symmetry
+
+    def should_use_chirality(self, has_symmetry: bool) -> bool:
+        """Determine if the chirality (L/R mirror-flip) feature should be used."""
+        if isinstance(self.use_chirality, bool):
+            return self.use_chirality
+        # Auto mode: enable if skeleton has symmetry pairs (defined or inferred).
+        return has_symmetry
+
+    def should_use_chain_ordering(self, max_chain_length: int) -> bool:
+        """Determine if the chain-ordering feature should be used."""
+        if isinstance(self.use_chain_ordering, bool):
+            return self.use_chain_ordering
+        # Auto mode: enable for chains >= 4 nodes (need an interior turning angle).
+        return max_chain_length >= 4

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -33,7 +33,7 @@ V3_FEATURE_NAMES = [
     "curvature_std",
     "visibility_pattern_score",
     "nn_distance",
-    "hull_area",
+    "hull_area_zscore",
     "hull_compactness",
 ]
 
@@ -284,12 +284,21 @@ class LabelQCDetector:
         return instances
 
     def _instance_to_array(self, instance: "sio.Instance") -> np.ndarray:
-        """Convert instance to (n_nodes, 2) array.
+        """Convert instance to (n_nodes, 2) array with invisible points as NaN.
 
-        Uses Instance.numpy() which returns invisible points as NaN by default.
-        Feature extractors handle NaN values by skipping them in computations.
+        Explicitly passes ``invisible_as_nan=True`` instead of relying on the
+        sleap-io default. Invisible (``visible=False``) nodes must never
+        contribute their stored coordinates to QC geometry features: those
+        coordinates are display-only placeholders (the GUI has to draw an
+        invisible node *somewhere*), and older sleap-io versions defaulted to
+        returning them, which leaked far-off invisible-node coordinates into
+        the edge/angle/distance/hull statistics (see #2753).
+
+        Feature extractors treat NaN as "missing" and skip those nodes, while
+        the downstream visibility mask (``~np.isnan(...)``) still records that
+        the node is invisible, so the visibility-pattern features keep working.
         """
-        return instance.numpy()
+        return instance.numpy(invisible_as_nan=True)
 
     @staticmethod
     def _video_id(video: "sio.Video", video_idx: int) -> str:

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -16,6 +16,7 @@ from sleap.qc.features.chirality import (
     fit_chirality,
     compute_chirality,
     infer_symmetry_pairs_by_name,
+    order_midline_by_pca,
 )
 from sleap.qc.features.pose_split import compute_pose_split
 from sleap.qc.features.ordering import compute_chain_ordering, resolve_chains
@@ -113,6 +114,7 @@ class LabelQCDetector:
         self._chirality_model: Optional[dict] = None
         self._symmetry_pairs: list[tuple[int, int]] = []
         self._axis_nodes: Optional[tuple[int, int]] = None
+        self._midline_nodes: list[int] = []
         self._ordering_chains: list[list[int]] = []
         self._adjacency: Optional[dict[int, list[int]]] = None
         self._co_visibility: Optional[np.ndarray] = None
@@ -199,15 +201,23 @@ class LabelQCDetector:
         self._symmetry_pairs = list(sa.symmetry_pairs) or infer_symmetry_pairs_by_name(
             sa.node_names
         )
-        # Body axis for chirality must run along MIDLINE (non-symmetric) nodes.
-        # The skeleton's longest graph path can end at a side node (e.g. a
-        # Haunch_left leaf), which biases the axis to one side and makes the
-        # signed-side chirality meaningless (-> false whole-instance-flip flags).
-        # Restrict the spine to non-symmetric nodes for the axis.
+        # Chirality measures each symmetric pair against the LOCAL tangent of the
+        # body midline near that pair, so the midline must be the full ORDERED
+        # set of non-symmetric nodes (nose -> tail). Two failure modes to avoid:
+        #   * a single STRAIGHT axis (nose->tail chord) misjudges the side of a
+        #     pair whenever the animal curls, producing false L/R-flip flags;
+        #   * ``sa.spine`` (the skeleton's longest graph path) drops midline
+        #     nodes that hang off a hub on a star topology (e.g. Neck/Trunk),
+        #     and can even end at a side leaf, biasing the axis to one side.
+        # So take ALL non-symmetric nodes and order them by their mean PCA
+        # projection, which recovers nose->tail robustly across topologies.
         _sym_idxs = {i for pair in self._symmetry_pairs for i in pair}
-        _midline = [i for i in sa.spine if i not in _sym_idxs]
-        if len(_midline) >= 2:
-            self._axis_nodes = (_midline[0], _midline[-1])
+        _midline_unordered = [i for i in range(sa.n_nodes) if i not in _sym_idxs]
+        self._midline_nodes = order_midline_by_pca(instances, _midline_unordered)
+        # Two-node anchor fallback for instances where < 2 midline nodes are
+        # visible (compute_chirality then uses these, else a PCA axis).
+        if len(self._midline_nodes) >= 2:
+            self._axis_nodes = (self._midline_nodes[0], self._midline_nodes[-1])
         elif len(sa.spine) >= 2:
             self._axis_nodes = (sa.spine[0], sa.spine[-1])
         else:
@@ -219,7 +229,10 @@ class LabelQCDetector:
         self._co_visibility = self.visibility_model.co_visibility_matrix
         if self.config.should_use_chirality(len(self._symmetry_pairs) >= 1):
             self._chirality_model = fit_chirality(
-                instances, self._symmetry_pairs, self._axis_nodes
+                instances,
+                self._symmetry_pairs,
+                self._midline_nodes,
+                axis_node_indices=self._axis_nodes,
             )
 
         # B2 appearance channel (experimental, default-OFF): build a per-node
@@ -545,8 +558,9 @@ class LabelQCDetector:
                 compute_chirality(
                     points,
                     self._symmetry_pairs,
-                    self._axis_nodes,
+                    self._midline_nodes,
                     self._chirality_model,
+                    axis_node_indices=self._axis_nodes,
                 )["chirality_wrong_fraction"]
             )
         else:

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -12,6 +12,14 @@ from sleap.qc.features.skeleton import SkeletonAnalyzer
 from sleap.qc.features.structural import compute_curvature, compute_convex_hull
 from sleap.qc.features.visibility import VisibilityModel
 from sleap.qc.features.reference import NearestNeighborScorer, normalize_pose
+from sleap.qc.features.chirality import (
+    fit_chirality,
+    compute_chirality,
+    infer_symmetry_pairs_by_name,
+)
+from sleap.qc.features.pose_split import compute_pose_split
+from sleap.qc.features.ordering import compute_chain_ordering, resolve_chains
+from sleap.qc.features.missing_node import score_missing_nodes
 from sleap.qc.frame_level import (
     InstanceCountChecker,
     check_negative_frame,
@@ -27,7 +35,13 @@ if TYPE_CHECKING:
 ProgressCallback = Callable[[str, float, Optional[str]], None]
 
 
-# Additional feature names for v3 features
+# Additional feature names for v3 features.
+#
+# IMPORTANT: the order here is load-bearing. ``_extract_features`` appends the
+# per-instance feature values in exactly this order, and ``_score_instance``
+# maps contributions back to names positionally. Any change here MUST be
+# mirrored by the append order in ``_extract_features`` or fit/score widths and
+# the contribution mapping will diverge.
 V3_FEATURE_NAMES = [
     "max_curvature",
     "curvature_std",
@@ -35,6 +49,11 @@ V3_FEATURE_NAMES = [
     "nn_distance",
     "hull_area_zscore",
     "hull_compactness",
+    # B1 detectors (appended after hull_compactness, in this exact order):
+    "chirality_wrong_fraction",  # (c) whole-instance L/R flip
+    "pose_split_score",  # (d) chimera / pose-split (log1p-compressed)
+    "order_inversion_rate",  # (b) chain ordering
+    "chain_intersection_count",  # (b) chain ordering
 ]
 
 
@@ -85,6 +104,16 @@ class LabelQCDetector:
 
         # Cache for computed statistics
         self._hull_stats: Optional[dict] = None
+
+        # B1 detector fit-time state (set in fit(), consumed in _extract_features
+        # and score()). Initialized empty so _extract_features is safe even if
+        # called before fit() sets them.
+        self._chirality_model: Optional[dict] = None
+        self._symmetry_pairs: list[tuple[int, int]] = []
+        self._axis_nodes: Optional[tuple[int, int]] = None
+        self._ordering_chains: list[list[int]] = []
+        self._adjacency: Optional[dict[int, list[int]]] = None
+        self._co_visibility: Optional[np.ndarray] = None
 
     def fit(
         self,
@@ -156,6 +185,36 @@ class LabelQCDetector:
             "mean": np.mean(hull_areas) if hull_areas else 1.0,
             "std": np.std(hull_areas) if hull_areas else 1.0,
         }
+
+        # B1 fit-time setup. These MUST exist before _extract_all_features runs,
+        # since _extract_features reads them while building the feature matrix.
+        _report("Fitting feature extractors", 0.16, "B1 detectors")
+        sa = self.skeleton_analyzer
+        self._symmetry_pairs = list(sa.symmetry_pairs) or infer_symmetry_pairs_by_name(
+            sa.node_names
+        )
+        # Body axis for chirality must run along MIDLINE (non-symmetric) nodes.
+        # The skeleton's longest graph path can end at a side node (e.g. a
+        # Haunch_left leaf), which biases the axis to one side and makes the
+        # signed-side chirality meaningless (-> false whole-instance-flip flags).
+        # Restrict the spine to non-symmetric nodes for the axis.
+        _sym_idxs = {i for pair in self._symmetry_pairs for i in pair}
+        _midline = [i for i in sa.spine if i not in _sym_idxs]
+        if len(_midline) >= 2:
+            self._axis_nodes = (_midline[0], _midline[-1])
+        elif len(sa.spine) >= 2:
+            self._axis_nodes = (sa.spine[0], sa.spine[-1])
+        else:
+            self._axis_nodes = None
+        self._adjacency = sa.get_adjacency()
+        self._ordering_chains = resolve_chains(
+            sa.node_names, self.config.ordered_chains or None, sa.get_curvature_chains()
+        )
+        self._co_visibility = self.visibility_model.co_visibility_matrix
+        if self.config.should_use_chirality(len(self._symmetry_pairs) >= 1):
+            self._chirality_model = fit_chirality(
+                instances, self._symmetry_pairs, self._axis_nodes
+            )
 
         # Build feature matrix (use LOO NN distances for training)
         _report("Extracting features", 0.20, f"0/{len(instances)}")
@@ -240,8 +299,33 @@ class LabelQCDetector:
                     features = self._extract_features(points)
                     score, contributions = self._score_instance(features)
 
+                    # Pop the forced-issue marker before contributions are
+                    # stored, so feature_contributions stays pure floats.
+                    forced_issue = contributions.pop("_forced_top_issue", None)
+
                     results.instance_scores[key] = score
                     results.feature_contributions[key] = contributions
+
+                    if forced_issue is not None:
+                        results.forced_issues[key] = forced_issue
+
+                    # Missing-node channel (experimental): scored separately from
+                    # the GMM and merged in QCResults.get_flagged.
+                    if (
+                        self.config.use_missing_node_check
+                        and self._co_visibility is not None
+                    ):
+                        _vmask = ~np.isnan(points).any(axis=1)
+                        _mn = score_missing_nodes(
+                            _vmask,
+                            self._co_visibility,
+                            self.skeleton_analyzer.edges,
+                            threshold=self.config.missing_node_prob_threshold,
+                        )
+                        if _mn["missing_node_score"] > 0:
+                            results.channel_scores.setdefault("missing_node", {})[
+                                key
+                            ] = _mn["missing_node_score"]
 
                     # Progress update (every 500 instances)
                     instance_count += 1
@@ -376,6 +460,55 @@ class LabelQCDetector:
         )
         v3_features.extend([hull_area_z, hull["compactness"]])
 
+        # --- B1 detectors. Each block ALWAYS appends a fixed number of values
+        # (emitting 0.0 defaults when its flag is off), so the feature-vector
+        # width is identical at fit and score time. The append order MUST match
+        # V3_FEATURE_NAMES exactly. ---
+
+        # (c) chirality / whole-instance L/R flip
+        if self._chirality_model is not None:
+            v3_features.append(
+                compute_chirality(
+                    points,
+                    self._symmetry_pairs,
+                    self._axis_nodes,
+                    self._chirality_model,
+                )["chirality_wrong_fraction"]
+            )
+        else:
+            v3_features.append(0.0)
+
+        # (d) chimera / pose-split — log1p to tame the unbounded dynamic range
+        # before the GMM
+        if self.config.use_split_detection:
+            _ps = compute_pose_split(
+                points,
+                self._adjacency,
+                self.baseline_extractor.stats.edge_means,
+                self.baseline_extractor.stats.edge_stds,
+            )["split_score"]
+            v3_features.append(float(np.log1p(max(_ps, 0.0))))
+        else:
+            v3_features.append(0.0)
+
+        # (b) chain ordering (experimental)
+        if (
+            self.config.should_use_chain_ordering(
+                self.skeleton_analyzer.max_chain_length
+            )
+            and self._ordering_chains
+        ):
+            _ord = compute_chain_ordering(
+                points,
+                self._ordering_chains,
+                max_turn_angle=np.deg2rad(self.config.chain_turn_angle_deg),
+            )
+            v3_features.extend(
+                [_ord["order_inversion_rate"], float(_ord["chain_intersection_count"])]
+            )
+        else:
+            v3_features.extend([0.0, 0.0])
+
         return np.concatenate([baseline, np.array(v3_features)])
 
     def _extract_all_features(
@@ -505,12 +638,42 @@ class LabelQCDetector:
             scores = self.zscore_detector.score_batch(features_clean.reshape(1, -1))
             score = scores[0] if len(scores) > 0 else 0.0
 
-        # Build contributions dict
+        score = float(score) if np.isfinite(score) else 0.0
+
+        # Build contributions dict (raw feature values keyed by name).
         contributions = {}
         for i, name in enumerate(self.feature_names):
             contributions[name] = float(features[i]) if i < len(features) else 0.0
 
-        return float(score) if np.isfinite(score) else 0.0, contributions
+        # Raise-only hard-rule overrides. These never lower the GMM score; they
+        # only force it up (and record a human-readable issue) when an
+        # unambiguous structural error is present. The chimera (d) detector gets
+        # NO hard rule for now — it relies on its GMM feature
+        # (pose_split_score), which is why there is no clause for it here.
+        forced = None
+        if (
+            self._chirality_model is not None
+            and contributions.get("chirality_wrong_fraction", 0.0)
+            >= self.config.chirality_flip_threshold
+        ):
+            forced = (
+                max(0.9, contributions["chirality_wrong_fraction"]),
+                "Whole-instance L/R flip",
+            )
+        elif self.config.should_use_chain_ordering(
+            self.skeleton_analyzer.max_chain_length
+        ) and (
+            contributions.get("chain_intersection_count", 0.0) >= 1
+            or contributions.get("order_inversion_rate", 0.0)
+            >= self.config.order_inversion_threshold
+        ):
+            forced = (0.9, "Wrong keypoint order along chain")
+
+        if forced is not None:
+            score = max(score, forced[0])
+            contributions["_forced_top_issue"] = forced[1]
+
+        return score, contributions
 
     def _check_frame(
         self,
@@ -534,15 +697,34 @@ class LabelQCDetector:
 
         # Duplicate detection
         if len(instances) >= 2:
-            duplicates = detect_duplicates(
-                instances,
-                iou_threshold=self.config.duplicate_iou_threshold,
-                node_distance_threshold=self.config.duplicate_node_distance_threshold,
-                node_overlap_ratio=self.config.duplicate_node_overlap_ratio,
-            )
+            if self.config.use_duplicate_score:
+                duplicates = detect_duplicates(
+                    instances,
+                    iou_threshold=self.config.duplicate_iou_threshold,
+                    node_distance_threshold=(
+                        self.config.duplicate_node_distance_threshold
+                    ),
+                    node_overlap_ratio=self.config.duplicate_node_overlap_ratio,
+                    edge_means=self.baseline_extractor.stats.edge_means,
+                    duplicate_score_threshold=self.config.duplicate_score_threshold,
+                )
+            else:
+                # Keep current behavior: IOU + node-overlap only. An
+                # unreachable score threshold (> the clamped [0, 1] max) keeps
+                # the always-computed split-duplicate signal from ever firing.
+                duplicates = detect_duplicates(
+                    instances,
+                    iou_threshold=self.config.duplicate_iou_threshold,
+                    node_distance_threshold=(
+                        self.config.duplicate_node_distance_threshold
+                    ),
+                    node_overlap_ratio=self.config.duplicate_node_overlap_ratio,
+                    duplicate_score_threshold=float("inf"),
+                )
             for dup in duplicates:
                 frame_qc.duplicate_pairs.append((dup["index_a"], dup["index_b"]))
                 frame_qc.duplicate_reasons.append(dup["reason"])
+                frame_qc.duplicate_scores.append(dup.get("duplicate_score", 1.0))
 
         return frame_qc
 

--- a/sleap/qc/detector.py
+++ b/sleap/qc/detector.py
@@ -20,6 +20,8 @@ from sleap.qc.features.chirality import (
 from sleap.qc.features.pose_split import compute_pose_split
 from sleap.qc.features.ordering import compute_chain_ordering, resolve_chains
 from sleap.qc.features.missing_node import score_missing_nodes
+from sleap.qc.features.appearance import fit_appearance, score_appearance
+from sleap.qc.insample_prediction import run_insample_prediction
 from sleap.qc.frame_level import (
     InstanceCountChecker,
     check_negative_frame,
@@ -114,6 +116,10 @@ class LabelQCDetector:
         self._ordering_chains: list[list[int]] = []
         self._adjacency: Optional[dict[int, list[int]]] = None
         self._co_visibility: Optional[np.ndarray] = None
+
+        # B2 appearance-channel fit-time state (set in fit() when
+        # use_appearance is on, consumed in score()). None = no appearance model.
+        self._appearance_model: Optional[dict] = None
 
     def fit(
         self,
@@ -216,6 +222,30 @@ class LabelQCDetector:
                 instances, self._symmetry_pairs, self._axis_nodes
             )
 
+        # B2 appearance channel (experimental, default-OFF): build a per-node
+        # appearance model from the labeled frames. Guarded by use_appearance so
+        # the default path never touches (potentially expensive) video decoding.
+        # Each labeled frame is decoded ONCE; undecodable frames are skipped.
+        if self.config.use_appearance:
+            _report("Fitting feature extractors", 0.18, "Appearance model")
+            appearance_pairs = []
+            for video in labels.videos:
+                for lf in [lf for lf in labels if lf.video == video]:
+                    try:
+                        frame = video[lf.frame_idx]
+                    except Exception:
+                        continue
+                    for inst in lf.user_instances:
+                        appearance_pairs.append(
+                            (frame, inst.numpy(invisible_as_nan=True))
+                        )
+            self._appearance_model = fit_appearance(
+                appearance_pairs,
+                n_nodes=self.skeleton_analyzer.n_nodes,
+                patch_size=self.config.appearance_patch_size,
+                min_samples=self.config.appearance_min_samples,
+            )
+
         # Build feature matrix (use LOO NN distances for training)
         _report("Extracting features", 0.20, f"0/{len(instances)}")
         self.feature_names = self._get_feature_names()  # Set first, needed by extract
@@ -288,6 +318,16 @@ class LabelQCDetector:
             for lf in labeled_frames:
                 frame_idx = lf.frame_idx
 
+                # Decode the frame ONCE per labeled frame for the appearance
+                # channel (experimental). Hoisted out of the instance loop so a
+                # frame is never decoded more than once; undecodable -> None.
+                appearance_frame = None
+                if self.config.use_appearance and self._appearance_model is not None:
+                    try:
+                        appearance_frame = lf.video[frame_idx]
+                    except Exception:
+                        appearance_frame = None
+
                 # Collect instances for this frame
                 frame_instances = []
                 for inst_idx, inst in enumerate(lf.user_instances):
@@ -327,6 +367,21 @@ class LabelQCDetector:
                                 key
                             ] = _mn["missing_node_score"]
 
+                    # Appearance channel (experimental): scored against the
+                    # per-node appearance model using the once-decoded frame.
+                    if (
+                        self.config.use_appearance
+                        and self._appearance_model is not None
+                        and appearance_frame is not None
+                    ):
+                        _ap = score_appearance(
+                            appearance_frame, points, self._appearance_model
+                        )
+                        if _ap["appearance_outlier_score"] > 0:
+                            results.channel_scores.setdefault("appearance", {})[key] = (
+                                _ap["appearance_outlier_score"]
+                            )
+
                     # Progress update (every 500 instances)
                     instance_count += 1
                     if instance_count % 500 == 0:
@@ -340,6 +395,25 @@ class LabelQCDetector:
                     frame_instances, video_id, is_negative=lf.is_negative
                 )
                 results.frame_results[frame_key] = frame_qc
+
+        # In-sample model-prediction channel (experimental, Tier-2 missing-node):
+        # ONE batched inference over ALL labeled frames, run after the per-instance
+        # loop completes. run_insample_prediction self-skips (returns an empty
+        # instance_scores) when the model path is falsy, so guarding only on
+        # use_insample_prediction is safe and avoids real inference by default.
+        if self.config.use_insample_prediction:
+            out = run_insample_prediction(
+                labels,
+                model_path=self.config.insample_model_path or "",
+                peak_threshold=self.config.insample_peak_threshold,
+                min_confidence=self.config.insample_min_confidence,
+                device=self.config.insample_device,
+                progress_callback=progress_callback,
+            )
+            for (v_idx, f_idx, i_idx), s in out["instance_scores"].items():
+                results.channel_scores.setdefault("prediction", {})[
+                    InstanceKey(v_idx, f_idx, i_idx)
+                ] = s
 
         _report("Complete", 1.0, f"{instance_count} instances scored")
         return results

--- a/sleap/qc/features/appearance.py
+++ b/sleap/qc/features/appearance.py
@@ -1,0 +1,412 @@
+"""Appearance-outlier detection: points placed on occluders / the wrong object.
+
+This module implements detector (e): "points placed on occluders / wrong
+object" -- e.g. a keypoint dragged onto white cotton bedding sitting over a dark
+mouse, or onto a cage bar. Unlike the geometry-only detectors, the *geometry*
+of such an error can look perfectly plausible (the point is in a sensible place
+for the pose); what gives it away is the **image content** under the node. We
+therefore build a small per-node appearance model from the labeled data and
+flag nodes whose local image patch does not look like that node usually looks.
+
+How it works
+------------
+At fit time, for every *visible* node of every (clean) labeled instance we cut a
+``patch_size x patch_size`` window centred on the node's ``(x, y)`` in its frame
+and reduce it to a compact **appearance descriptor**: per-channel mean and
+standard deviation of the patch intensities (a length-2 vector for grayscale
+``(H, W, 1)`` frames, length-6 for RGB). Mean captures brightness ("white cotton
+bedding" vs "dark fur"), std captures local texture/contrast. We accumulate
+these descriptors per node and fit a robust Gaussian (median + regularized
+covariance), giving a per-node squared **Mahalanobis** distance. Nodes with
+fewer than ``min_samples`` descriptors are left unmodeled (no opinion).
+
+At score time, for each visible node we cut the same descriptor and compute its
+Mahalanobis distance to that node's learned model, then squash it to ``[0, 1]``
+against a per-node distance scale learned at fit time (so "normal" appearance
+sits near 0 and clear outliers approach 1). The per-instance score is the
+**max** over nodes -- one badly-misplaced node is enough to warrant review.
+
+This is a NON-GMM channel detector (default-OFF / experimental): it produces a
+per-instance ``appearance_outlier_score`` in ``[0, 1]`` that the integration
+layer stores in :attr:`QCResults.channel_scores` under the ``"appearance"``
+channel, exactly like the missing-node detector.
+
+Honest scope / limitations
+---------------------------
+- The descriptor is intentionally tiny (mean + std per channel). It catches
+  gross "this node is on visually-different stuff" errors (bright bedding vs
+  dark fur, a node on the cage floor vs on the animal). It will NOT distinguish
+  two regions that have the same brightness/texture but are semantically
+  different (e.g. two similarly-grey body parts).
+- It learns the *project's own* appearance statistics. If a node is
+  systematically mislabeled onto the same wrong surface across the whole
+  dataset, that wrong surface becomes "normal" and is not flagged.
+- Patches near the image border are clipped to the valid region, so an
+  edge node is described by fewer pixels but is still modeled/scored.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+import numpy as np
+
+
+# Minimum number of patch samples required before a node is modeled at all.
+DEFAULT_MIN_SAMPLES = 20
+
+# Floor added to the covariance diagonal (in descriptor units, ~intensity^2)
+# to keep it invertible when a node's patches are nearly constant.
+_COV_REG = 1.0
+
+# Multiple of the learned median Mahalanobis distance that maps to a score of
+# ~0.5 (the half-saturation point of the squashing function). Larger = more
+# permissive (a node must be more anomalous to score high).
+_DIST_SCALE_FACTOR = 3.0
+
+# Floor on the per-node distance scale so a node whose training patches are
+# essentially identical (median distance ~0) does not produce an infinite /
+# hair-trigger score. In Mahalanobis (whitened) units.
+_MIN_DIST_SCALE = 1.0
+
+
+def extract_patch_descriptor(
+    frame: np.ndarray,
+    x: float,
+    y: float,
+    patch_size: int = 7,
+) -> Optional[np.ndarray]:
+    """Cut a patch around ``(x, y)`` and reduce it to an appearance descriptor.
+
+    The descriptor is the per-channel **mean** followed by the per-channel
+    **standard deviation** of the patch intensities. For a grayscale frame
+    ``(H, W, 1)`` (or ``(H, W)``) this is a length-2 vector ``[mean, std]``; for
+    an RGB frame ``(H, W, 3)`` it is length-6 ``[mean_r, mean_g, mean_b, std_r,
+    std_g, std_b]``. Patches that fall partly outside the image are clipped to
+    the valid region (an edge node is described by fewer pixels).
+
+    Args:
+        frame: Decoded image as ``(H, W)``, ``(H, W, 1)`` or ``(H, W, C)``
+            ndarray (typically ``uint8``). Decoding is the caller's job so the
+            heavy video I/O stays out of unit tests.
+        x: Node x-coordinate (column) in pixels. May be fractional; rounded to
+            the nearest pixel for the patch centre.
+        y: Node y-coordinate (row) in pixels.
+        patch_size: Side length (pixels) of the square window. Values < 1 are
+            treated as 1. Defaults to 7.
+
+    Returns:
+        A 1-D ``float64`` descriptor of length ``2 * C``, or ``None`` if the
+        frame is unusable (empty / not 2-D-or-3-D), the coordinate is NaN, or
+        the clipped patch is empty (centre fully outside the image).
+    """
+    if frame is None:
+        return None
+    frame = np.asarray(frame)
+    if frame.ndim == 2:
+        frame = frame[:, :, None]
+    if frame.ndim != 3 or frame.size == 0:
+        return None
+    if not (np.isfinite(x) and np.isfinite(y)):
+        return None
+
+    height, width = frame.shape[0], frame.shape[1]
+    if height == 0 or width == 0:
+        return None
+
+    half = max(int(patch_size), 1) // 2
+    cx = int(round(float(x)))
+    cy = int(round(float(y)))
+
+    # Clip the window to the valid image region so edge nodes still yield a
+    # (smaller) patch instead of an out-of-bounds error.
+    r0 = max(cy - half, 0)
+    r1 = min(cy + half + 1, height)
+    c0 = max(cx - half, 0)
+    c1 = min(cx + half + 1, width)
+    if r1 <= r0 or c1 <= c0:
+        # Centre is fully outside the image -> nothing to describe.
+        return None
+
+    patch = frame[r0:r1, c0:c1, :].astype(np.float64)
+    # Reduce over the spatial axes, keeping per-channel stats.
+    flat = patch.reshape(-1, patch.shape[2])
+    means = flat.mean(axis=0)
+    stds = flat.std(axis=0)
+    return np.concatenate([means, stds]).astype(np.float64)
+
+
+def _patches_to_descriptors(
+    patches: Iterable[np.ndarray], patch_size: int
+) -> list[np.ndarray]:
+    """Reduce already-cut patches to descriptors (helper for tests/integration).
+
+    Each patch is treated as a tiny image and run through the same per-channel
+    mean+std reduction as :func:`extract_patch_descriptor`. ``None`` / empty
+    patches are skipped.
+    """
+    out: list[np.ndarray] = []
+    for patch in patches:
+        if patch is None:
+            continue
+        patch = np.asarray(patch)
+        if patch.ndim == 2:
+            patch = patch[:, :, None]
+        if patch.ndim != 3 or patch.size == 0:
+            continue
+        flat = patch.reshape(-1, patch.shape[2]).astype(np.float64)
+        out.append(
+            np.concatenate([flat.mean(axis=0), flat.std(axis=0)]).astype(np.float64)
+        )
+    return out
+
+
+def _fit_node_model(descriptors: np.ndarray) -> Optional[dict]:
+    """Fit a robust Gaussian + distance scale for one node's descriptors.
+
+    Uses the median as a robust centre and a regularized covariance (with a
+    small diagonal floor) so the squared Mahalanobis distance stays finite even
+    for near-constant patches. The learned ``dist_scale`` is the median
+    training Mahalanobis distance, used later to squash test distances to
+    ``[0, 1]``.
+
+    Args:
+        descriptors: ``(n_samples, n_features)`` array of node descriptors.
+
+    Returns:
+        Per-node model dict, or ``None`` if there are too few samples.
+    """
+    descriptors = np.asarray(descriptors, dtype=np.float64)
+    n_samples, n_features = descriptors.shape
+    if n_samples < 2:
+        return None
+
+    center = np.median(descriptors, axis=0)
+    cov = np.cov(descriptors, rowvar=False)
+    cov = np.atleast_2d(cov)
+    # Regularize: keep the matrix invertible / well-conditioned even when a
+    # feature is (near-)constant across the training patches.
+    cov = cov + _COV_REG * np.eye(n_features)
+    try:
+        inv_cov = np.linalg.inv(cov)
+    except np.linalg.LinAlgError:
+        inv_cov = np.linalg.pinv(cov)
+
+    # Per-node distance scale: typical (median) Mahalanobis distance of the
+    # training descriptors themselves. Floored so identical patches don't give
+    # a hair-trigger score.
+    diffs = descriptors - center
+    d2 = np.einsum("ij,jk,ik->i", diffs, inv_cov, diffs)
+    d2 = np.clip(d2, 0.0, None)
+    train_dist = np.sqrt(d2)
+    dist_scale = float(max(np.median(train_dist), _MIN_DIST_SCALE))
+
+    return {
+        "center": center,
+        "inv_cov": inv_cov,
+        "dist_scale": dist_scale,
+        "n_samples": int(n_samples),
+    }
+
+
+def _mahalanobis_distance(descriptor: np.ndarray, node_model: dict) -> float:
+    """Squared-root Mahalanobis distance of ``descriptor`` to a node model."""
+    diff = np.asarray(descriptor, dtype=np.float64) - node_model["center"]
+    d2 = float(diff @ node_model["inv_cov"] @ diff)
+    if not np.isfinite(d2) or d2 < 0.0:
+        d2 = 0.0
+    return float(np.sqrt(d2))
+
+
+def _squash(distance: float, dist_scale: float) -> float:
+    """Map a non-negative distance to ``[0, 1)`` with a smooth saturation.
+
+    Uses ``d / (d + s)`` where ``s = _DIST_SCALE_FACTOR * dist_scale`` is the
+    half-saturation distance: a node at the typical (training-median) distance
+    scores well below 0.5, while a node many scales away approaches 1.
+    """
+    if not np.isfinite(distance) or distance <= 0.0:
+        return 0.0
+    s = max(_DIST_SCALE_FACTOR * dist_scale, 1e-6)
+    return float(distance / (distance + s))
+
+
+def fit_appearance(
+    frames_and_instances: Iterable[tuple],
+    n_nodes: int,
+    patch_size: int = 7,
+    min_samples: int = DEFAULT_MIN_SAMPLES,
+) -> dict:
+    """Learn a per-node appearance model from labeled instances.
+
+    For each ``(frame, points)`` pair and each *visible* node, cut a
+    ``patch_size x patch_size`` patch at the node's ``(x, y)`` and reduce it to
+    an appearance descriptor (per-channel mean + std). Descriptors are pooled
+    per node and a robust Gaussian is fit per node that has at least
+    ``min_samples`` samples; nodes below that are left unmodeled.
+
+    Decoding is the caller's responsibility: pass already-decoded frame arrays
+    (``(H, W)``, ``(H, W, 1)`` or ``(H, W, C)``) so the heavy video I/O stays
+    out of unit tests. Pairs whose frame is ``None`` (e.g. undecodable) are
+    skipped; NaN / out-of-frame nodes are skipped per node.
+
+    Args:
+        frames_and_instances: Iterable of ``(frame, points)`` tuples, where
+            ``frame`` is a decoded image (or ``None`` to skip) and ``points`` is
+            an ``(n_nodes, 2)`` array with NaN for invisible nodes.
+        n_nodes: Number of skeleton nodes (length of each ``points`` row dim).
+        patch_size: Side length of the square appearance patch. Defaults to 7.
+        min_samples: Minimum patch samples for a node to be modeled. Defaults to
+            :data:`DEFAULT_MIN_SAMPLES` (20).
+
+    Returns:
+        A model dict with:
+
+        - ``"node_models"``: ``dict[int, dict]`` mapping modeled node index to
+          its per-node model (``center``, ``inv_cov``, ``dist_scale``,
+          ``n_samples``). Unmodeled nodes are absent.
+        - ``"node_sample_counts"``: ``dict[int, int]`` mapping every node index
+          seen to how many descriptors were collected (modeled or not). Useful
+          for diagnostics / explaining why a node has no opinion.
+        - ``"n_nodes"``: number of skeleton nodes.
+        - ``"patch_size"``: the patch size used (so scoring can default to it).
+        - ``"min_samples"``: the threshold used.
+        - ``"descriptor_dim"``: descriptor length seen (``2 * C``), or ``None``
+          if no descriptors were collected.
+    """
+    n_nodes = int(n_nodes)
+    patch_size = max(int(patch_size), 1)
+    per_node: list[list[np.ndarray]] = [[] for _ in range(n_nodes)]
+    descriptor_dim: Optional[int] = None
+
+    for pair in frames_and_instances:
+        if pair is None:
+            continue
+        frame, points = pair
+        if frame is None or points is None:
+            continue
+        points = np.asarray(points, dtype=float)
+        if points.ndim != 2 or points.shape[1] < 2:
+            continue
+
+        n = min(points.shape[0], n_nodes)
+        for node_idx in range(n):
+            x, y = points[node_idx, 0], points[node_idx, 1]
+            if not (np.isfinite(x) and np.isfinite(y)):
+                continue
+            desc = extract_patch_descriptor(frame, x, y, patch_size)
+            if desc is None:
+                continue
+            # Descriptor length is fixed by channel count; guard against mixing
+            # grayscale and RGB frames in one fit (keep the first seen shape).
+            if descriptor_dim is None:
+                descriptor_dim = desc.shape[0]
+            elif desc.shape[0] != descriptor_dim:
+                continue
+            per_node[node_idx].append(desc)
+
+    node_models: dict[int, dict] = {}
+    node_sample_counts: dict[int, int] = {}
+    for node_idx in range(n_nodes):
+        samples = per_node[node_idx]
+        node_sample_counts[node_idx] = len(samples)
+        if len(samples) < min_samples:
+            continue
+        model = _fit_node_model(np.asarray(samples, dtype=np.float64))
+        if model is not None:
+            node_models[node_idx] = model
+
+    return {
+        "node_models": node_models,
+        "node_sample_counts": node_sample_counts,
+        "n_nodes": n_nodes,
+        "patch_size": patch_size,
+        "min_samples": int(min_samples),
+        "descriptor_dim": descriptor_dim,
+    }
+
+
+def score_appearance(
+    frame: np.ndarray,
+    points: np.ndarray,
+    model: dict,
+    patch_size: Optional[int] = None,
+) -> dict:
+    """Score an instance for appearance outliers against a fitted model.
+
+    For each *visible* node that the model has an opinion on, cut its patch,
+    compute the Mahalanobis distance of its descriptor to the node's learned
+    model, and squash it to ``[0, 1]``. The per-instance score is the max over
+    scored nodes (one clearly-misplaced node is enough to flag the instance).
+
+    Args:
+        frame: Decoded image (``(H, W)``, ``(H, W, 1)`` or ``(H, W, C)``), or
+            ``None`` if the frame could not be decoded (returns a zero score).
+        points: ``(n_nodes, 2)`` array with NaN for invisible nodes.
+        model: Model dict from :func:`fit_appearance`.
+        patch_size: Patch side length. If ``None``, uses the size stored in the
+            model (the one used at fit time).
+
+    Returns:
+        Dictionary with:
+
+        - ``"appearance_outlier_score"``: ``float`` in ``[0, 1]``. Max squashed
+          Mahalanobis distance over scored nodes (0.0 if none could be scored).
+          High = a node sits on visually-anomalous pixels.
+        - ``"worst_node"``: ``int`` node index of the highest-scoring node, or
+          ``-1`` if no node was scored.
+        - ``"node_scores"``: ``dict[int, float]`` mapping each scored node index
+          to its individual ``[0, 1]`` outlier score.
+    """
+    empty = {
+        "appearance_outlier_score": 0.0,
+        "worst_node": -1,
+        "node_scores": {},
+    }
+    if model is None:
+        return empty
+    node_models = model.get("node_models", {})
+    if not node_models:
+        return empty
+    if frame is None or points is None:
+        return empty
+
+    if patch_size is None:
+        patch_size = model.get("patch_size", 7)
+    patch_size = max(int(patch_size), 1)
+    descriptor_dim = model.get("descriptor_dim")
+
+    points = np.asarray(points, dtype=float)
+    if points.ndim != 2 or points.shape[1] < 2:
+        return empty
+
+    node_scores: dict[int, float] = {}
+    n = points.shape[0]
+    for node_idx, node_model in node_models.items():
+        if node_idx >= n:
+            continue
+        x, y = points[node_idx, 0], points[node_idx, 1]
+        if not (np.isfinite(x) and np.isfinite(y)):
+            continue
+        desc = extract_patch_descriptor(frame, x, y, patch_size)
+        if desc is None:
+            continue
+        # Skip if the channel count (descriptor length) does not match the
+        # model -- scoring an RGB frame against a grayscale model is undefined.
+        if descriptor_dim is not None and desc.shape[0] != descriptor_dim:
+            continue
+        if desc.shape[0] != node_model["center"].shape[0]:
+            continue
+        dist = _mahalanobis_distance(desc, node_model)
+        node_scores[int(node_idx)] = _squash(dist, node_model["dist_scale"])
+
+    if not node_scores:
+        return empty
+
+    worst_node = max(node_scores, key=node_scores.get)
+    score = float(np.clip(node_scores[worst_node], 0.0, 1.0))
+    return {
+        "appearance_outlier_score": score,
+        "worst_node": int(worst_node),
+        "node_scores": node_scores,
+    }

--- a/sleap/qc/features/chirality.py
+++ b/sleap/qc/features/chirality.py
@@ -21,10 +21,25 @@ invariant to translation, uniform scaling, and rotation of the whole instance
 (it only flips under reflection), which is exactly the property needed to
 isolate mirror flips from ordinary pose variation.
 
-The body axis is derived from two midline / non-symmetric anchor nodes (e.g.
-spine endpoints) passed as ``axis_node_indices=(i, j)``; if those anchors are
-missing for a given instance it falls back to the first principal component of
-the visible non-symmetric points.
+**Local (spine-relative) axis.** A single *straight* body axis (e.g. the chord
+from nose to tail-base) misjudges the side of a pair whenever the animal curls:
+a curled-but-correctly-labeled instance then trips the detector. To stay robust
+to body curvature, each symmetric pair is measured against the *local* tangent
+of the body midline near that pair. The midline is supplied as an **ordered**
+list of non-symmetric node indices (nose -> tail), forming a polyline; for each
+pair the pair midpoint is projected onto the nearest midline segment and that
+segment's tangent is used as the local axis in the cross product. With a
+single-segment (two-node) midline this reduces *exactly* to the straight-axis
+sign, so the two-node ``axis_node_indices`` form remains a special case.
+
+The midline polyline is resolved per instance in this order:
+
+1. the visible nodes of ``midline_node_indices`` (the ordered midline), if at
+   least two are visible;
+2. otherwise the two ``axis_node_indices`` anchors, if both are visible
+   (a degenerate single-segment midline);
+3. otherwise the first principal component of the visible non-symmetric points
+   (PCA fallback), as a single-segment midline through their centroid.
 """
 
 from __future__ import annotations
@@ -122,28 +137,145 @@ def _pca_axis(
     return origin, axis_vec
 
 
-def _resolve_axis(
+def _midline_polyline(
     points: np.ndarray,
-    axis_node_indices: Optional[tuple[int, int]],
-    exclude_indices: set[int],
-) -> Optional[tuple[np.ndarray, np.ndarray]]:
-    """Resolve the body axis for a single instance.
-
-    Prefers the two explicit anchor nodes; falls back to PCA of the visible
-    non-symmetric points if the anchors are unavailable or degenerate.
+    midline_node_indices: Optional[list[int]],
+    min_nodes: int = 2,
+) -> Optional[np.ndarray]:
+    """Ordered polyline of the visible midline nodes.
 
     Args:
         points: ``(n_nodes, 2)`` array of coordinates (NaN for invisible).
-        axis_node_indices: Optional ``(i, j)`` anchor node indices defining the
-            axis as ``points[j] - points[i]``.
+        midline_node_indices: Ordered (nose -> tail) non-symmetric node indices
+            forming the body midline.
+        min_nodes: Minimum number of visible midline nodes required to form a
+            usable polyline.
+
+    Returns:
+        An ``(m, 2)`` array of the visible midline points in order (``m >=
+        min_nodes``), or ``None`` if too few midline nodes are visible.
+    """
+    if not midline_node_indices:
+        return None
+    n_nodes = points.shape[0]
+    poly = [
+        points[i]
+        for i in midline_node_indices
+        if 0 <= i < n_nodes and not np.isnan(points[i]).any()
+    ]
+    if len(poly) < min_nodes:
+        return None
+    return np.asarray(poly, dtype=float)
+
+
+def _project_point_to_polyline(
+    point: np.ndarray, polyline: np.ndarray, min_norm: float = 1e-6
+) -> Optional[tuple[np.ndarray, np.ndarray]]:
+    """Project ``point`` onto the nearest segment of ``polyline``.
+
+    Args:
+        point: Length-2 query point (the symmetric-pair midpoint).
+        polyline: ``(m, 2)`` ordered midline points (``m >= 2``).
+        min_norm: Minimum segment length to consider non-degenerate.
+
+    Returns:
+        Tuple of ``(foot, unit_tangent)`` for the nearest segment, where
+        ``foot`` is the (clamped) foot of the perpendicular and ``unit_tangent``
+        is the segment direction oriented nose -> tail, or ``None`` if every
+        segment is degenerate.
+    """
+    best_d2 = np.inf
+    best_foot: Optional[np.ndarray] = None
+    best_tan: Optional[np.ndarray] = None
+    for k in range(len(polyline) - 1):
+        a = polyline[k]
+        b = polyline[k + 1]
+        ab = b - a
+        seg_len2 = float(ab @ ab)
+        if seg_len2 < min_norm * min_norm:
+            continue
+        # Clamp the projection parameter to the segment so the foot stays on it.
+        t = float((point - a) @ ab) / seg_len2
+        t = max(0.0, min(1.0, t))
+        foot = a + t * ab
+        d2 = float((point - foot) @ (point - foot))
+        if d2 < best_d2:
+            best_d2 = d2
+            best_foot = foot
+            best_tan = ab / np.sqrt(seg_len2)
+    if best_tan is None:
+        return None
+    return best_foot, best_tan
+
+
+def _signed_side_local(
+    left_point: np.ndarray,
+    right_point: np.ndarray,
+    polyline: np.ndarray,
+) -> Optional[float]:
+    """Signed side of the left member relative to the local midline tangent.
+
+    Projects the pair *midpoint* onto the nearest midline segment and uses that
+    segment's tangent as the local body axis, returning
+    ``sign(cross(tangent, left_point - foot))``. With a single-segment polyline
+    this is identical to the straight-axis ``sign(cross(axis, left - origin))``.
+
+    Args:
+        left_point: Length-2 coordinate of the pair's left member.
+        right_point: Length-2 coordinate of the pair's right member.
+        polyline: ``(m, 2)`` ordered midline points (``m >= 2``).
+
+    Returns:
+        ``+1.0`` (left of the local tangent), ``-1.0`` (right), ``0.0`` (on the
+        tangent), or ``None`` if either member is invisible or no usable segment
+        exists.
+    """
+    left_point = np.asarray(left_point, dtype=float)
+    right_point = np.asarray(right_point, dtype=float)
+    if np.isnan(left_point).any() or np.isnan(right_point).any():
+        return None
+    midpoint = 0.5 * (left_point + right_point)
+    projected = _project_point_to_polyline(midpoint, polyline)
+    if projected is None:
+        return None
+    foot, tangent = projected
+    rel = left_point - foot
+    cross = float(tangent[0] * rel[1] - tangent[1] * rel[0])
+    return float(np.sign(cross))
+
+
+def _resolve_midline(
+    points: np.ndarray,
+    midline_node_indices: Optional[list[int]],
+    axis_node_indices: Optional[tuple[int, int]],
+    exclude_indices: set[int],
+) -> Optional[np.ndarray]:
+    """Resolve the midline polyline for a single instance.
+
+    Resolution order: the ordered ``midline_node_indices`` (if >= 2 visible),
+    then the two ``axis_node_indices`` anchors (a single-segment midline), then
+    a PCA single-segment midline over the visible non-symmetric points.
+
+    Args:
+        points: ``(n_nodes, 2)`` array of coordinates (NaN for invisible).
+        midline_node_indices: Ordered (nose -> tail) non-symmetric midline node
+            indices.
+        axis_node_indices: Optional ``(i, j)`` anchor node indices, used as a
+            two-node midline fallback.
         exclude_indices: Symmetric-pair node indices to exclude from PCA.
 
     Returns:
-        Tuple of ``(axis_origin, unit_axis_vec)``, or ``None`` if no usable axis
-        could be derived.
+        An ``(m, 2)`` ordered midline polyline (``m >= 2``), or ``None`` if no
+        usable midline could be derived.
     """
+    # 1. Full ordered midline polyline.
+    poly = _midline_polyline(points, midline_node_indices)
+    if poly is not None:
+        return poly
+
     n_nodes = points.shape[0]
 
+    # 2. Two explicit anchor nodes as a single-segment midline.
     if axis_node_indices is not None:
         i, j = axis_node_indices
         if (
@@ -153,74 +285,63 @@ def _resolve_axis(
             and not np.isnan(points[i]).any()
             and not np.isnan(points[j]).any()
         ):
-            origin = points[i].astype(float)
-            axis_vec = _normalize_axis(points[j] - points[i])
-            if axis_vec is not None:
-                return origin, axis_vec
+            seg = np.stack([points[i], points[j]]).astype(float)
+            if float(np.linalg.norm(seg[1] - seg[0])) >= 1e-6:
+                return seg
 
-    # Fall back to PCA of visible non-symmetric points.
-    return _pca_axis(points, exclude_indices=exclude_indices)
-
-
-def _signed_side(
-    point: np.ndarray, origin: np.ndarray, axis_vec: np.ndarray
-) -> Optional[float]:
-    """Signed side of ``point`` relative to the oriented body axis.
-
-    Computes ``sign(cross(axis_vec, point - origin))``, i.e. which side of the
-    directed axis the point lies on (+1 = left of the axis direction, -1 =
-    right, 0 = on the axis).
-
-    Args:
-        point: Length-2 coordinate of the node.
-        origin: Length-2 axis origin.
-        axis_vec: Length-2 (unit) axis direction.
-
-    Returns:
-        ``+1.0``, ``-1.0``, ``0.0``, or ``None`` if ``point`` is invisible.
-    """
-    point = np.asarray(point, dtype=float)
-    if np.isnan(point).any():
+    # 3. PCA single-segment midline through the non-symmetric centroid.
+    pca = _pca_axis(points, exclude_indices=exclude_indices)
+    if pca is None:
         return None
-    rel = point - origin
-    cross = float(axis_vec[0] * rel[1] - axis_vec[1] * rel[0])
-    return float(np.sign(cross))
+    origin, axis_vec = pca
+    return np.stack([origin, origin + axis_vec]).astype(float)
 
 
 def fit_chirality(
     instances: list[np.ndarray],
     symmetry_pairs: list[tuple[int, int]],
+    midline_node_indices: Optional[list[int]] = None,
     axis_node_indices: Optional[tuple[int, int]] = None,
 ) -> dict:
     """Learn the canonical signed side per symmetric pair from training poses.
 
     For each symmetric pair ``(left, right)`` and each training instance where
-    the pair is co-visible and the body axis is resolvable, the signed side of
-    the *left* member relative to the axis is computed. The canonical side is
-    the majority sign across instances (sign of the mean of the per-instance
-    signs).
+    the pair is co-visible and the body midline is resolvable, the signed side
+    of the *left* member relative to the **local** midline tangent is computed.
+    The canonical side is the majority sign across instances (sign of the mean
+    of the per-instance signs).
 
     Args:
         instances: List of ``(n_nodes, 2)`` pose arrays. NaN marks invisible
             nodes. Should be clean / canonical labels (e.g. user-labeled).
         symmetry_pairs: List of ``(left_idx, right_idx)`` symmetric node pairs.
-        axis_node_indices: Optional ``(i, j)`` anchor node indices defining the
-            body axis. If ``None`` (or unavailable for an instance), a PCA axis
-            over the visible non-symmetric points is used.
+        midline_node_indices: Ordered (nose -> tail) list of non-symmetric
+            midline node indices defining the body midline polyline. When at
+            least two of them are visible for an instance, the local tangent of
+            the nearest midline segment is used as that pair's axis. If ``None``
+            or too few are visible, the resolution falls back to
+            ``axis_node_indices`` then to a PCA axis.
+        axis_node_indices: Optional ``(i, j)`` two-node anchor used as a
+            single-segment midline fallback when ``midline_node_indices`` is
+            unavailable for an instance. Passing only this (with
+            ``midline_node_indices=None``) reproduces the original straight-axis
+            behavior exactly.
 
     Returns:
         A model dict with:
 
         - ``"canonical_side"``: ``dict[tuple[int, int], float]`` mapping each
           symmetric pair to its learned canonical side (``+1.0`` or ``-1.0``).
-          Pairs that were never observed with a resolvable axis are omitted.
+          Pairs that were never observed with a resolvable midline are omitted.
         - ``"pair_support"``: ``dict[tuple[int, int], int]`` mapping each pair to
           the number of training instances that contributed to its estimate.
         - ``"symmetry_pairs"``: the (normalized) list of pairs used.
+        - ``"midline_node_indices"``: the ordered midline indices supplied.
         - ``"axis_node_indices"``: the anchor indices supplied at fit time.
         - ``"n_instances"``: number of training instances seen.
     """
     pairs = [tuple(p) for p in symmetry_pairs]
+    midline = list(midline_node_indices) if midline_node_indices else None
     exclude_indices = {idx for pair in pairs for idx in pair}
 
     # Accumulate signed sides of the left member per pair across instances.
@@ -229,10 +350,9 @@ def fit_chirality(
 
     for points in instances:
         points = np.asarray(points, dtype=float)
-        axis = _resolve_axis(points, axis_node_indices, exclude_indices)
-        if axis is None:
+        polyline = _resolve_midline(points, midline, axis_node_indices, exclude_indices)
+        if polyline is None:
             continue
-        origin, axis_vec = axis
 
         for left_idx, right_idx in pairs:
             # Require BOTH members visible so the side reflects a genuine,
@@ -245,7 +365,7 @@ def fit_chirality(
             ):
                 continue
 
-            side = _signed_side(points[left_idx], origin, axis_vec)
+            side = _signed_side_local(points[left_idx], points[right_idx], polyline)
             if side is None or side == 0.0:
                 # On the axis: ambiguous, contributes no chirality information.
                 continue
@@ -268,6 +388,7 @@ def fit_chirality(
         "canonical_side": canonical_side,
         "pair_support": pair_support,
         "symmetry_pairs": pairs,
+        "midline_node_indices": midline,
         "axis_node_indices": axis_node_indices,
         "n_instances": len(instances),
     }
@@ -276,23 +397,29 @@ def fit_chirality(
 def compute_chirality(
     points: np.ndarray,
     symmetry_pairs: list[tuple[int, int]],
-    axis_node_indices: Optional[tuple[int, int]],
+    midline_node_indices: Optional[list[int]],
     model: dict,
+    axis_node_indices: Optional[tuple[int, int]] = None,
     min_pairs: int = 2,
 ) -> dict[str, float]:
     """Score a single instance for a left/right mirror flip.
 
     For each co-visible symmetric pair with a learned canonical side, the signed
-    side of the *left* member relative to the body axis is compared to the
-    learned canonical side. The returned ``chirality_wrong_fraction`` is the
-    fraction of such pairs whose observed side disagrees with the canonical one.
+    side of the *left* member relative to the **local** midline tangent is
+    compared to the learned canonical side. The returned
+    ``chirality_wrong_fraction`` is the fraction of such pairs whose observed
+    side disagrees with the canonical one.
 
     Args:
         points: ``(n_nodes, 2)`` array of coordinates (NaN for invisible).
         symmetry_pairs: List of ``(left_idx, right_idx)`` symmetric node pairs.
-        axis_node_indices: Optional ``(i, j)`` anchor node indices for the body
-            axis. If ``None`` (or unavailable), a PCA axis is used.
+        midline_node_indices: Ordered (nose -> tail) non-symmetric midline node
+            indices for the body midline polyline. If ``None`` or too few are
+            visible, the resolution falls back to ``axis_node_indices`` then to
+            a PCA axis. Must match what was passed to :func:`fit_chirality`.
         model: Model dict returned by :func:`fit_chirality`.
+        axis_node_indices: Optional ``(i, j)`` two-node anchor used as a
+            single-segment midline fallback (see :func:`fit_chirality`).
         min_pairs: Minimum number of scorable co-visible pairs required for a
             meaningful score. Below this, ``chirality_wrong_fraction`` is 0.0.
 
@@ -307,12 +434,12 @@ def compute_chirality(
     canonical_side: dict[tuple[int, int], float] = model.get("canonical_side", {})
 
     pairs = [tuple(p) for p in symmetry_pairs]
+    midline = list(midline_node_indices) if midline_node_indices else None
     exclude_indices = {idx for pair in pairs for idx in pair}
 
-    axis = _resolve_axis(points, axis_node_indices, exclude_indices)
-    if axis is None:
+    polyline = _resolve_midline(points, midline, axis_node_indices, exclude_indices)
+    if polyline is None:
         return {"chirality_wrong_fraction": 0.0, "n_pairs": 0}
-    origin, axis_vec = axis
 
     n_pairs = 0
     n_wrong = 0
@@ -329,7 +456,7 @@ def compute_chirality(
         ):
             continue
 
-        side = _signed_side(points[left_idx], origin, axis_vec)
+        side = _signed_side_local(points[left_idx], points[right_idx], polyline)
         if side is None or side == 0.0:
             # On the axis: ambiguous, do not count for or against a flip.
             continue
@@ -345,6 +472,68 @@ def compute_chirality(
         "chirality_wrong_fraction": float(n_wrong) / float(n_pairs),
         "n_pairs": n_pairs,
     }
+
+
+def order_midline_by_pca(
+    instances: list[np.ndarray],
+    midline_node_indices: list[int],
+    min_points: int = 2,
+) -> list[int]:
+    """Order midline node indices nose -> tail by their mean PCA projection.
+
+    The body midline polyline needs its nodes in anatomical order, but a
+    skeleton's graph topology does not always provide it (a star-topology
+    skeleton, for example, attaches several midline nodes to a single hub with
+    no path between them). This orders the supplied midline nodes by the average
+    of their projections onto the first principal component of the non-symmetric
+    points, which recovers the nose -> tail ordering robustly across topologies.
+
+    The PCA axis has an arbitrary sign; the returned order is therefore unique
+    only up to reversal. Reversing the midline does not change the local-tangent
+    *line* (only its orientation), and the signed-side cross product flips sign
+    consistently for every pair, so the learned canonical sides absorb the
+    choice. The orientation is fixed deterministically (first node gets the
+    smaller mean projection) purely for reproducibility.
+
+    Args:
+        instances: List of ``(n_nodes, 2)`` pose arrays used to estimate the
+            axis (e.g. the training instances).
+        midline_node_indices: Unordered midline (non-symmetric) node indices.
+        min_points: Minimum non-symmetric points needed in an instance for it to
+            contribute to the projection estimate.
+
+    Returns:
+        The midline node indices ordered by mean PCA projection. If no instance
+        yields a usable axis, the input order is returned unchanged.
+    """
+    midline = [int(i) for i in midline_node_indices]
+    if len(midline) < 2:
+        return midline
+
+    exclude_indices: set[int] = set()  # PCA over all non-NaN points of the body
+    proj_sums = {i: 0.0 for i in midline}
+    proj_counts = {i: 0 for i in midline}
+
+    for points in instances:
+        points = np.asarray(points, dtype=float)
+        pca = _pca_axis(points, exclude_indices=exclude_indices, min_points=min_points)
+        if pca is None:
+            continue
+        origin, axis_vec = pca
+        for i in midline:
+            if 0 <= i < points.shape[0] and not np.isnan(points[i]).any():
+                proj_sums[i] += float((points[i] - origin) @ axis_vec)
+                proj_counts[i] += 1
+
+    # Nodes that were never visible keep a neutral 0.0 projection and sort
+    # stably among themselves (Python's sort is stable on ties).
+    if all(c == 0 for c in proj_counts.values()):
+        return midline
+
+    def _mean_proj(i: int) -> float:
+        return proj_sums[i] / proj_counts[i] if proj_counts[i] else 0.0
+
+    return sorted(midline, key=_mean_proj)
 
 
 def _split_lr_token(name: str) -> Optional[tuple[str, str, bool]]:

--- a/sleap/qc/features/chirality.py
+++ b/sleap/qc/features/chirality.py
@@ -1,0 +1,441 @@
+"""Chirality (left/right mirror flip) features.
+
+A whole-instance left/right mirror flip is invariant to every distance- and
+unsigned-angle-based feature (edge lengths, joint angles, pairwise distances,
+convex hull, ...), so it is invisible to those detectors. Detecting it requires
+a *signed* statistic that encodes which side of the body axis each landmark
+falls on, i.e. the chirality of the pose.
+
+This module learns, per symmetric landmark pair, the canonical (majority) side
+of the body axis on which the "left" member of the pair sits, then scores a new
+instance by the fraction of co-visible symmetric pairs whose observed side
+disagrees with that learned canonical side:
+
+- a clean pose scores ``~0``,
+- a whole-instance mirror flip scores ``~1`` (every pair disagrees),
+- a partial / subset swap scores an intermediate value.
+
+The signed side of a point ``p`` relative to the body axis is the sign of the
+2D cross product of the axis vector with ``(p - axis_origin)``. This is
+invariant to translation, uniform scaling, and rotation of the whole instance
+(it only flips under reflection), which is exactly the property needed to
+isolate mirror flips from ordinary pose variation.
+
+The body axis is derived from two midline / non-symmetric anchor nodes (e.g.
+spine endpoints) passed as ``axis_node_indices=(i, j)``; if those anchors are
+missing for a given instance it falls back to the first principal component of
+the visible non-symmetric points.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+import numpy as np
+
+
+# Recognized left/right suffix and prefix tokens for name-based inference.
+# Each entry maps a "left" token to its "right" counterpart. Matching is
+# case-insensitive on the token, but the surrounding stem must match exactly so
+# that ``Ear_L``/``Ear_R`` pair up while ``Ear_L``/``Eye_R`` do not.
+_LR_SUFFIX_TOKENS: list[tuple[str, str]] = [
+    ("left", "right"),
+    ("l", "r"),
+]
+
+# Separators allowed between a stem and an L/R token, e.g. "Ear_L", "Ear-L",
+# "Ear.L", "EarL", "Ear L".
+_LR_SEPARATORS = r"[ _\-.]?"
+
+
+def _normalize_axis(
+    axis_vec: np.ndarray, min_norm: float = 1e-6
+) -> Optional[np.ndarray]:
+    """Return a unit axis vector, or ``None`` if it is degenerate.
+
+    Args:
+        axis_vec: A length-2 vector describing the body axis direction.
+        min_norm: Minimum norm below which the axis is considered degenerate.
+
+    Returns:
+        The unit-normalized axis vector, or ``None`` if its norm is below
+        ``min_norm`` or it contains NaN.
+    """
+    axis_vec = np.asarray(axis_vec, dtype=float)
+    if axis_vec.shape != (2,) or np.isnan(axis_vec).any():
+        return None
+    norm = float(np.linalg.norm(axis_vec))
+    if norm < min_norm:
+        return None
+    return axis_vec / norm
+
+
+def _pca_axis(
+    points: np.ndarray,
+    exclude_indices: set[int],
+    min_points: int = 2,
+    min_norm: float = 1e-6,
+) -> Optional[tuple[np.ndarray, np.ndarray]]:
+    """Estimate a body axis from the visible non-symmetric points via PCA.
+
+    Uses the first principal component (direction of maximum variance) of the
+    visible points that are *not* part of any symmetric pair as the body-axis
+    direction, anchored at their centroid.
+
+    Args:
+        points: ``(n_nodes, 2)`` array of coordinates (NaN for invisible).
+        exclude_indices: Node indices to exclude (members of symmetric pairs).
+        min_points: Minimum number of distinct visible points required.
+        min_norm: Minimum spread below which the axis is considered degenerate.
+
+    Returns:
+        Tuple of ``(axis_origin, unit_axis_vec)``, or ``None`` if a meaningful
+        axis cannot be estimated.
+    """
+    n_nodes = points.shape[0]
+    keep = [
+        i
+        for i in range(n_nodes)
+        if i not in exclude_indices and not np.isnan(points[i]).any()
+    ]
+    if len(keep) < min_points:
+        return None
+
+    pts = points[keep]
+    origin = pts.mean(axis=0)
+    centered = pts - origin
+
+    # Spread guard: all points effectively coincident -> no direction.
+    if float(np.max(np.abs(centered))) < min_norm:
+        return None
+
+    # First principal component via SVD (robust for 2 points too).
+    try:
+        _, _, vh = np.linalg.svd(centered, full_matrices=False)
+    except np.linalg.LinAlgError:
+        return None
+
+    axis_vec = _normalize_axis(vh[0], min_norm=min_norm)
+    if axis_vec is None:
+        return None
+    return origin, axis_vec
+
+
+def _resolve_axis(
+    points: np.ndarray,
+    axis_node_indices: Optional[tuple[int, int]],
+    exclude_indices: set[int],
+) -> Optional[tuple[np.ndarray, np.ndarray]]:
+    """Resolve the body axis for a single instance.
+
+    Prefers the two explicit anchor nodes; falls back to PCA of the visible
+    non-symmetric points if the anchors are unavailable or degenerate.
+
+    Args:
+        points: ``(n_nodes, 2)`` array of coordinates (NaN for invisible).
+        axis_node_indices: Optional ``(i, j)`` anchor node indices defining the
+            axis as ``points[j] - points[i]``.
+        exclude_indices: Symmetric-pair node indices to exclude from PCA.
+
+    Returns:
+        Tuple of ``(axis_origin, unit_axis_vec)``, or ``None`` if no usable axis
+        could be derived.
+    """
+    n_nodes = points.shape[0]
+
+    if axis_node_indices is not None:
+        i, j = axis_node_indices
+        if (
+            0 <= i < n_nodes
+            and 0 <= j < n_nodes
+            and i != j
+            and not np.isnan(points[i]).any()
+            and not np.isnan(points[j]).any()
+        ):
+            origin = points[i].astype(float)
+            axis_vec = _normalize_axis(points[j] - points[i])
+            if axis_vec is not None:
+                return origin, axis_vec
+
+    # Fall back to PCA of visible non-symmetric points.
+    return _pca_axis(points, exclude_indices=exclude_indices)
+
+
+def _signed_side(
+    point: np.ndarray, origin: np.ndarray, axis_vec: np.ndarray
+) -> Optional[float]:
+    """Signed side of ``point`` relative to the oriented body axis.
+
+    Computes ``sign(cross(axis_vec, point - origin))``, i.e. which side of the
+    directed axis the point lies on (+1 = left of the axis direction, -1 =
+    right, 0 = on the axis).
+
+    Args:
+        point: Length-2 coordinate of the node.
+        origin: Length-2 axis origin.
+        axis_vec: Length-2 (unit) axis direction.
+
+    Returns:
+        ``+1.0``, ``-1.0``, ``0.0``, or ``None`` if ``point`` is invisible.
+    """
+    point = np.asarray(point, dtype=float)
+    if np.isnan(point).any():
+        return None
+    rel = point - origin
+    cross = float(axis_vec[0] * rel[1] - axis_vec[1] * rel[0])
+    return float(np.sign(cross))
+
+
+def fit_chirality(
+    instances: list[np.ndarray],
+    symmetry_pairs: list[tuple[int, int]],
+    axis_node_indices: Optional[tuple[int, int]] = None,
+) -> dict:
+    """Learn the canonical signed side per symmetric pair from training poses.
+
+    For each symmetric pair ``(left, right)`` and each training instance where
+    the pair is co-visible and the body axis is resolvable, the signed side of
+    the *left* member relative to the axis is computed. The canonical side is
+    the majority sign across instances (sign of the mean of the per-instance
+    signs).
+
+    Args:
+        instances: List of ``(n_nodes, 2)`` pose arrays. NaN marks invisible
+            nodes. Should be clean / canonical labels (e.g. user-labeled).
+        symmetry_pairs: List of ``(left_idx, right_idx)`` symmetric node pairs.
+        axis_node_indices: Optional ``(i, j)`` anchor node indices defining the
+            body axis. If ``None`` (or unavailable for an instance), a PCA axis
+            over the visible non-symmetric points is used.
+
+    Returns:
+        A model dict with:
+
+        - ``"canonical_side"``: ``dict[tuple[int, int], float]`` mapping each
+          symmetric pair to its learned canonical side (``+1.0`` or ``-1.0``).
+          Pairs that were never observed with a resolvable axis are omitted.
+        - ``"pair_support"``: ``dict[tuple[int, int], int]`` mapping each pair to
+          the number of training instances that contributed to its estimate.
+        - ``"symmetry_pairs"``: the (normalized) list of pairs used.
+        - ``"axis_node_indices"``: the anchor indices supplied at fit time.
+        - ``"n_instances"``: number of training instances seen.
+    """
+    pairs = [tuple(p) for p in symmetry_pairs]
+    exclude_indices = {idx for pair in pairs for idx in pair}
+
+    # Accumulate signed sides of the left member per pair across instances.
+    side_sums: dict[tuple[int, int], float] = {p: 0.0 for p in pairs}
+    side_counts: dict[tuple[int, int], int] = {p: 0 for p in pairs}
+
+    for points in instances:
+        points = np.asarray(points, dtype=float)
+        axis = _resolve_axis(points, axis_node_indices, exclude_indices)
+        if axis is None:
+            continue
+        origin, axis_vec = axis
+
+        for left_idx, right_idx in pairs:
+            # Require BOTH members visible so the side reflects a genuine,
+            # co-visible pair rather than a lone node.
+            if (
+                left_idx >= points.shape[0]
+                or right_idx >= points.shape[0]
+                or np.isnan(points[left_idx]).any()
+                or np.isnan(points[right_idx]).any()
+            ):
+                continue
+
+            side = _signed_side(points[left_idx], origin, axis_vec)
+            if side is None or side == 0.0:
+                # On the axis: ambiguous, contributes no chirality information.
+                continue
+
+            side_sums[(left_idx, right_idx)] += side
+            side_counts[(left_idx, right_idx)] += 1
+
+    canonical_side: dict[tuple[int, int], float] = {}
+    pair_support: dict[tuple[int, int], int] = {}
+    for pair in pairs:
+        count = side_counts[pair]
+        if count == 0:
+            continue
+        mean_side = side_sums[pair] / count
+        # Sign of the mean = majority side. Break exact ties toward +1.
+        canonical_side[pair] = 1.0 if mean_side >= 0.0 else -1.0
+        pair_support[pair] = count
+
+    return {
+        "canonical_side": canonical_side,
+        "pair_support": pair_support,
+        "symmetry_pairs": pairs,
+        "axis_node_indices": axis_node_indices,
+        "n_instances": len(instances),
+    }
+
+
+def compute_chirality(
+    points: np.ndarray,
+    symmetry_pairs: list[tuple[int, int]],
+    axis_node_indices: Optional[tuple[int, int]],
+    model: dict,
+    min_pairs: int = 2,
+) -> dict[str, float]:
+    """Score a single instance for a left/right mirror flip.
+
+    For each co-visible symmetric pair with a learned canonical side, the signed
+    side of the *left* member relative to the body axis is compared to the
+    learned canonical side. The returned ``chirality_wrong_fraction`` is the
+    fraction of such pairs whose observed side disagrees with the canonical one.
+
+    Args:
+        points: ``(n_nodes, 2)`` array of coordinates (NaN for invisible).
+        symmetry_pairs: List of ``(left_idx, right_idx)`` symmetric node pairs.
+        axis_node_indices: Optional ``(i, j)`` anchor node indices for the body
+            axis. If ``None`` (or unavailable), a PCA axis is used.
+        model: Model dict returned by :func:`fit_chirality`.
+        min_pairs: Minimum number of scorable co-visible pairs required for a
+            meaningful score. Below this, ``chirality_wrong_fraction`` is 0.0.
+
+    Returns:
+        Dictionary with:
+
+        - ``"chirality_wrong_fraction"``: float in ``[0, 1]`` (0 = consistent
+          with the canonical chirality, 1 = fully flipped).
+        - ``"n_pairs"``: number of co-visible pairs that were actually scored.
+    """
+    points = np.asarray(points, dtype=float)
+    canonical_side: dict[tuple[int, int], float] = model.get("canonical_side", {})
+
+    pairs = [tuple(p) for p in symmetry_pairs]
+    exclude_indices = {idx for pair in pairs for idx in pair}
+
+    axis = _resolve_axis(points, axis_node_indices, exclude_indices)
+    if axis is None:
+        return {"chirality_wrong_fraction": 0.0, "n_pairs": 0}
+    origin, axis_vec = axis
+
+    n_pairs = 0
+    n_wrong = 0
+    for left_idx, right_idx in pairs:
+        canonical = canonical_side.get((left_idx, right_idx))
+        if canonical is None:
+            # No learned canonical side for this pair -> cannot judge.
+            continue
+        if (
+            left_idx >= points.shape[0]
+            or right_idx >= points.shape[0]
+            or np.isnan(points[left_idx]).any()
+            or np.isnan(points[right_idx]).any()
+        ):
+            continue
+
+        side = _signed_side(points[left_idx], origin, axis_vec)
+        if side is None or side == 0.0:
+            # On the axis: ambiguous, do not count for or against a flip.
+            continue
+
+        n_pairs += 1
+        if side != canonical:
+            n_wrong += 1
+
+    if n_pairs < min_pairs:
+        return {"chirality_wrong_fraction": 0.0, "n_pairs": n_pairs}
+
+    return {
+        "chirality_wrong_fraction": float(n_wrong) / float(n_pairs),
+        "n_pairs": n_pairs,
+    }
+
+
+def _split_lr_token(name: str) -> Optional[tuple[str, str, bool]]:
+    """Split a node name into ``(stem, canonical_side, is_left)`` if it carries
+    a recognized left/right token.
+
+    Recognizes both suffix forms (``Ear_L``, ``ear_left``, ``EarLeft``) and
+    prefix forms (``L_Ear``, ``left_ear``). The stem is the remaining text with
+    the separator stripped; ``canonical_side`` is ``"left"`` or ``"right"``.
+
+    Args:
+        name: The node name.
+
+    Returns:
+        ``(stem, side, is_left)`` where ``side`` is ``"left"`` or ``"right"`` and
+        ``is_left`` is ``True`` for left tokens, or ``None`` if no L/R token is
+        found.
+    """
+    for left_tok, right_tok in _LR_SUFFIX_TOKENS:
+        for tok, is_left, side in (
+            (left_tok, True, "left"),
+            (right_tok, False, "right"),
+        ):
+            # Suffix form: <stem><sep><tok>, e.g. "Ear_L", "EarLeft".
+            suffix_re = re.compile(
+                rf"^(?P<stem>.+?){_LR_SEPARATORS}{tok}$", re.IGNORECASE
+            )
+            m = suffix_re.match(name)
+            if m is not None:
+                stem = m.group("stem")
+                if stem:
+                    return f"S:{stem.lower()}", side, is_left
+
+            # Prefix form: <tok><sep><stem>, e.g. "L_Ear", "left_ear".
+            prefix_re = re.compile(
+                rf"^{tok}{_LR_SEPARATORS}(?P<stem>.+)$", re.IGNORECASE
+            )
+            m = prefix_re.match(name)
+            if m is not None:
+                stem = m.group("stem")
+                if stem:
+                    return f"P:{stem.lower()}", side, is_left
+
+    return None
+
+
+def infer_symmetry_pairs_by_name(
+    node_names: list[str],
+) -> list[tuple[int, int]]:
+    """Infer left/right symmetric pairs from node-name suffixes/prefixes.
+
+    Used when a skeleton has no symmetries defined (e.g. CVAT-style imports), so
+    that mirror-flip detection still works. Pairs nodes whose names share a stem
+    but differ by a left/right token, e.g. ``Ear_L``/``Ear_R``,
+    ``Shoulder_left``/``Shoulder_right``, ``Haunch_left``/``Haunch_right``,
+    ``L_Eye``/``R_Eye``.
+
+    The single-letter ``_L``/``_R`` form is only honored when a matching stem
+    exists on the other side, which avoids spuriously treating e.g. a lone
+    ``tail`` ending in no token as symmetric.
+
+    Args:
+        node_names: Ordered list of node names (index = node index).
+
+    Returns:
+        List of ``(left_idx, right_idx)`` index pairs, ordered by left index.
+        Each node appears in at most one pair.
+    """
+    # Map (orientation:stem) -> {"left": idx, "right": idx}.
+    groups: dict[str, dict[str, int]] = {}
+
+    for idx, name in enumerate(node_names):
+        parsed = _split_lr_token(name)
+        if parsed is None:
+            continue
+        key, side, _is_left = parsed
+        bucket = groups.setdefault(key, {})
+        # First occurrence wins for a given side (deterministic, stable order).
+        bucket.setdefault(side, idx)
+
+    pairs: list[tuple[int, int]] = []
+    used: set[int] = set()
+    for bucket in groups.values():
+        if "left" in bucket and "right" in bucket:
+            left_idx = bucket["left"]
+            right_idx = bucket["right"]
+            if left_idx in used or right_idx in used or left_idx == right_idx:
+                continue
+            pairs.append((left_idx, right_idx))
+            used.add(left_idx)
+            used.add(right_idx)
+
+    pairs.sort(key=lambda p: p[0])
+    return pairs

--- a/sleap/qc/features/duplicate_split.py
+++ b/sleap/qc/features/duplicate_split.py
@@ -1,0 +1,360 @@
+"""Split/duplicate instance features for frame-level QC.
+
+This module provides pure helpers used by ``sleap.qc.frame_level`` to
+strengthen duplicate-instance detection. The existing IoU and co-visible
+node-overlap signals catch *near-identical overlapping copies* (one animal
+labeled twice on the same nodes), but they miss the complementary
+**split** case: a single animal split across two instances that each label a
+*largely disjoint* set of nodes (e.g. instance A labels head/front, instance
+B labels tail/back). Together the two "halves" form one coherent animal.
+
+The functions here are deliberately scale-normalized (by the median edge
+length learned from the dataset, or the bounding-box diagonal of the larger
+instance as a fallback) so a single threshold works across recordings, and
+they NaN-guard every coordinate so absent/invisible nodes never leak into a
+score.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+# --- Tunable constants -------------------------------------------------------
+# These are interpreted in units of the pose scale (typical edge length), so
+# they are resolution-independent.
+
+# Two instances are considered to label "largely disjoint" node sets once the
+# disjointness ratio (see ``_disjointness``) climbs from this floor toward
+# ``_DISJOINT_FULL``. A disjointness of 0.5 means the two visible-node sets are
+# identical (no split); 1.0 means perfectly complementary.
+_DISJOINT_MIN = 0.55
+_DISJOINT_FULL = 0.85
+
+# Nearest visible node of A to nearest visible node of B, in scale units. Split
+# halves of one animal meet at the body, so the gap is tiny; two separate
+# animals leave a clear gap. The proximity score decays linearly to 0 at this
+# many scale units.
+_GAP_TOL = 2.5
+
+# Inter-instance gap measured relative to the instances' OWN internal node
+# spacing (coherence / "nested rather than side-by-side"). When one animal is
+# split, the two halves abut like a normal skeleton edge, so the join is about
+# one internal spacing; two animals side by side are several spacings apart.
+# Scores 1.0 at <= _COHERENCE_OK internal spacings, decaying to 0 at
+# _COHERENCE_MAX. This is scale-free and does not need edge_means.
+_COHERENCE_OK = 1.5
+_COHERENCE_MAX = 3.0
+
+# Minimum number of visible nodes required (per instance and in the union) to
+# attempt a split judgement at all.
+_MIN_VISIBLE = 2
+
+
+def _visible_mask(points: np.ndarray) -> np.ndarray:
+    """Boolean mask of nodes with finite (visible) coordinates."""
+    return ~np.isnan(points).any(axis=1)
+
+
+def _bbox_diagonal(points: np.ndarray) -> float:
+    """Bounding-box diagonal of the visible nodes (0.0 if < 2 visible)."""
+    visible = points[_visible_mask(points)]
+    if len(visible) < 2:
+        return 0.0
+    span = visible.max(axis=0) - visible.min(axis=0)
+    return float(np.linalg.norm(span))
+
+
+def _median_edge_length(edge_means: Optional[dict]) -> float:
+    """Median of learned edge lengths, or 0.0 if unavailable.
+
+    Args:
+        edge_means: Mapping of edge ``(src, dst)`` tuples to mean edge length,
+            as produced by :class:`~sleap.qc.features.baseline.DatasetStats`.
+            May be ``None`` or empty.
+
+    Returns:
+        Median of the positive edge lengths, else ``0.0``.
+    """
+    if not edge_means:
+        return 0.0
+    values = np.array([v for v in edge_means.values() if np.isfinite(v) and v > 0])
+    if values.size == 0:
+        return 0.0
+    return float(np.median(values))
+
+
+def _resolve_scale(
+    points_a: np.ndarray,
+    points_b: np.ndarray,
+    edge_means: Optional[dict],
+) -> float:
+    """Pick a positive length scale to normalize distances.
+
+    Prefers the dataset-wide median edge length (translation/rotation/scale
+    invariant and stable across instances); falls back to the bounding-box
+    diagonal of the *larger* instance when no edge stats are available.
+
+    Returns:
+        A strictly positive scale (defaults to ``1.0`` if nothing is usable).
+    """
+    scale = _median_edge_length(edge_means)
+    if scale > 1e-8:
+        return scale
+
+    # Fallback: bbox diagonal of the larger (more spatially extended) instance.
+    diag = max(_bbox_diagonal(points_a), _bbox_diagonal(points_b))
+    return diag if diag > 1e-8 else 1.0
+
+
+def _disjointness(visible_a: np.ndarray, visible_b: np.ndarray) -> float:
+    """Fraction of the visible-node union that is NOT shared.
+
+    Defined as ``|A ∪ B| / (|A| + |B|)``:
+
+    - ``0.5`` when the two instances label exactly the same nodes (full
+      overlap; the identical/duplicate case).
+    - ``1.0`` when the two instances label completely disjoint node sets (the
+      complementary split case).
+
+    Returns ``0.0`` when neither instance has visible nodes.
+    """
+    n_a = int(visible_a.sum())
+    n_b = int(visible_b.sum())
+    if n_a == 0 or n_b == 0:
+        return 0.0
+    n_union = int((visible_a | visible_b).sum())
+    return n_union / (n_a + n_b)
+
+
+def _nearest_node_distance(
+    points_a: np.ndarray,
+    points_b: np.ndarray,
+    visible_a: np.ndarray,
+    visible_b: np.ndarray,
+) -> float:
+    """Minimum distance between any visible node of A and any of B.
+
+    This is the inter-instance proximity used to tell a contiguous split
+    (halves touching at the body) from two separated animals. Returns
+    ``inf`` if either instance has no visible nodes.
+    """
+    pts_a = points_a[visible_a]
+    pts_b = points_b[visible_b]
+    if len(pts_a) == 0 or len(pts_b) == 0:
+        return float("inf")
+    # Pairwise distances between the two (small) visible point sets.
+    diffs = pts_a[:, None, :] - pts_b[None, :, :]
+    dists = np.linalg.norm(diffs, axis=2)
+    return float(dists.min())
+
+
+def _internal_spacing(points: np.ndarray, visible: np.ndarray) -> float:
+    """Typical spacing between adjacent visible nodes of one instance.
+
+    Estimated as the median nearest-neighbor distance among the instance's own
+    visible nodes. Used as a scale-free reference: a split animal's two halves
+    abut at roughly one such spacing, while two side-by-side animals are
+    several spacings apart.
+
+    Returns ``nan`` if fewer than two nodes are visible.
+    """
+    pts = points[visible]
+    if len(pts) < 2:
+        return float("nan")
+    diffs = pts[:, None, :] - pts[None, :, :]
+    dists = np.linalg.norm(diffs, axis=2)
+    np.fill_diagonal(dists, np.inf)
+    return float(np.median(dists.min(axis=1)))
+
+
+def _linear_score(value: float, lo: float, hi: float) -> float:
+    """Linearly ramp ``value`` from 0 at ``lo`` to 1 at ``hi`` (clamped).
+
+    Works for both increasing (``lo < hi``) and decreasing (``lo > hi``)
+    ramps.
+    """
+    if hi == lo:
+        return 1.0 if value >= hi else 0.0
+    frac = (value - lo) / (hi - lo)
+    return float(np.clip(frac, 0.0, 1.0))
+
+
+def compute_split_duplicate(
+    points_a: np.ndarray,
+    points_b: np.ndarray,
+    edge_means: Optional[dict] = None,
+) -> dict:
+    """Score whether two instances are one animal split across both.
+
+    Detects the *complementary split* failure mode that bbox-IoU and
+    co-visible node overlap miss: the two instances are visible on **largely
+    disjoint** node sets (few co-visible nodes), yet together their union pose
+    forms a single coherent animal -- the two "halves" are spatially
+    contiguous (small inter-instance nearest-node distance relative to scale)
+    and the union's extent matches a single animal rather than two side by
+    side.
+
+    The score is the product of three graded, scale-normalized signals:
+
+    1. **Disjointness** -- the two visible-node sets must be largely
+       complementary (this is the precondition that distinguishes a split from
+       an identical overlapping copy, which shares nodes).
+    2. **Proximity** -- the nearest node of A must be close to the nearest node
+       of B (the halves meet at the body). This is the key signal that keeps
+       the detector from firing on two genuinely distinct animals labeled on
+       disjoint nodes, which leave a clear gap between them.
+    3. **Coherence** -- the inter-instance gap must be small relative to the
+       instances' own internal node spacing, i.e. the two halves join like a
+       normal skeleton edge ("nested") rather than sitting several body-widths
+       apart as two animals side by side would.
+
+    Distances are normalized by the median edge length from ``edge_means`` (or
+    the larger instance's bbox diagonal as a fallback), so the result is
+    translation-, rotation-, and scale-invariant and thresholdable with a
+    single cutoff.
+
+    Args:
+        points_a: ``(n_nodes, 2)`` coordinates of instance A (NaN = invisible).
+        points_b: ``(n_nodes, 2)`` coordinates of instance B (NaN = invisible).
+        edge_means: Optional mapping of edge ``(src, dst)`` -> mean edge length
+            (from learned dataset stats) used to set the length scale. If
+            ``None``/empty, the bbox diagonal of the larger instance is used.
+
+    Returns:
+        Dictionary with:
+
+        - ``split_duplicate_score``: float in ``[0, 1]``. High = likely one
+          animal split across the two instances.
+        - ``reason``: short human-readable explanation of the score.
+    """
+    points_a = np.asarray(points_a, dtype=float)
+    points_b = np.asarray(points_b, dtype=float)
+
+    visible_a = _visible_mask(points_a)
+    visible_b = _visible_mask(points_b)
+    n_a = int(visible_a.sum())
+    n_b = int(visible_b.sum())
+
+    # Degenerate: need enough visible nodes in each instance to judge a split.
+    if n_a < _MIN_VISIBLE or n_b < _MIN_VISIBLE:
+        return {
+            "split_duplicate_score": 0.0,
+            "reason": "too few visible nodes",
+        }
+
+    union_visible = visible_a | visible_b
+    if int(union_visible.sum()) < _MIN_VISIBLE:
+        return {
+            "split_duplicate_score": 0.0,
+            "reason": "too few visible nodes",
+        }
+
+    scale = _resolve_scale(points_a, points_b, edge_means)
+
+    # (1) Disjointness precondition: a split labels complementary node sets.
+    # High co-visibility (shared nodes) means this is the identical/overlap
+    # case, not a split -> disjoint score collapses to 0.
+    disjointness = _disjointness(visible_a, visible_b)
+    s_disjoint = _linear_score(disjointness, _DISJOINT_MIN, _DISJOINT_FULL)
+    if s_disjoint <= 0.0:
+        return {
+            "split_duplicate_score": 0.0,
+            "reason": (
+                f"node sets overlap (disjointness={disjointness:.2f}); "
+                "not a split"
+            ),
+        }
+
+    # (2) Proximity: the two halves of one animal touch at the body. Two
+    # distinct animals labeled on disjoint nodes leave a clear gap.
+    gap = _nearest_node_distance(points_a, points_b, visible_a, visible_b)
+    gap_norm = gap / scale
+    s_gap = _linear_score(gap_norm, _GAP_TOL, 0.0)
+    if s_gap <= 0.0:
+        return {
+            "split_duplicate_score": 0.0,
+            "reason": (
+                f"instances too far apart (gap={gap_norm:.2f} scale units); "
+                "likely distinct animals"
+            ),
+        }
+
+    # (3) Coherence ("nested rather than side-by-side"): the two halves of one
+    # animal join like a normal skeleton edge, so the inter-instance gap is
+    # about one of the instances' own internal node spacings. Two animals side
+    # by side sit several internal spacings apart. This is scale-free and so
+    # complements the absolute-scale proximity check above.
+    spacing_a = _internal_spacing(points_a, visible_a)
+    spacing_b = _internal_spacing(points_b, visible_b)
+    spacings = [s for s in (spacing_a, spacing_b) if np.isfinite(s) and s > 1e-8]
+    if spacings:
+        rel_gap = gap / float(np.mean(spacings))
+        s_coherent = _linear_score(rel_gap, _COHERENCE_MAX, _COHERENCE_OK)
+    else:
+        # Each instance is a single point (no internal spacing to compare to);
+        # the absolute proximity check already governs, so don't penalize.
+        rel_gap = float("nan")
+        s_coherent = 1.0
+
+    score = float(s_disjoint * s_gap * s_coherent)
+
+    reason = (
+        f"complementary split: disjointness={disjointness:.2f}, "
+        f"gap={gap_norm:.2f} scale units, relative gap={rel_gap:.2f} spacings"
+    )
+    if s_coherent <= 0.0:
+        reason = (
+            f"instances form separate clusters (relative gap={rel_gap:.2f} "
+            "spacings); likely two animals side by side"
+        )
+
+    return {
+        "split_duplicate_score": score,
+        "reason": reason,
+    }
+
+
+def duplicate_score(
+    iou: float,
+    node_overlap_ratio: float,
+    split_duplicate_score: float,
+) -> float:
+    """Combine duplicate signals into one graded confidence in ``[0, 1]``.
+
+    Merges the three complementary duplicate signals so a caller can apply a
+    single threshold and get a graded confidence instead of three booleans:
+
+    - ``iou`` -- bbox intersection-over-union (overlapping copies).
+    - ``node_overlap_ratio`` -- fraction of co-visible nodes that coincide
+      (partial overlapping copies, even at low IoU).
+    - ``split_duplicate_score`` -- the complementary split signal from
+      :func:`compute_split_duplicate` (one animal split on disjoint nodes).
+
+    A saturating ``max`` is used: any one signal firing strongly is enough to
+    flag a duplicate, and the score never exceeds 1. Inputs are individually
+    clamped to ``[0, 1]`` and NaN inputs are treated as ``0`` so a missing
+    signal cannot inflate or corrupt the result.
+
+    Args:
+        iou: Bounding-box IoU between the two instances.
+        node_overlap_ratio: Co-visible node overlap ratio.
+        split_duplicate_score: Split-duplicate score.
+
+    Returns:
+        Combined duplicate confidence in ``[0, 1]``.
+    """
+
+    def _clean(x: float) -> float:
+        x = float(x)
+        if not np.isfinite(x):
+            return 0.0
+        return float(np.clip(x, 0.0, 1.0))
+
+    return max(
+        _clean(iou),
+        _clean(node_overlap_ratio),
+        _clean(split_duplicate_score),
+    )

--- a/sleap/qc/features/duplicate_split.py
+++ b/sleap/qc/features/duplicate_split.py
@@ -263,8 +263,7 @@ def compute_split_duplicate(
         return {
             "split_duplicate_score": 0.0,
             "reason": (
-                f"node sets overlap (disjointness={disjointness:.2f}); "
-                "not a split"
+                f"node sets overlap (disjointness={disjointness:.2f}); not a split"
             ),
         }
 

--- a/sleap/qc/features/missing_node.py
+++ b/sleap/qc/features/missing_node.py
@@ -1,0 +1,162 @@
+"""Missing-node detection: labelable points left unlabeled.
+
+This module implements a *geometry/visibility-only* heuristic (Tier-1) for
+detector (f): "labelable points left unlabeled". The idea is to flag instances
+that are missing a node which their *peers* (instances where the same
+co-visible nodes are present) usually keep visible.
+
+The detector reuses the co-visibility statistics learned by
+:class:`sleap.qc.features.visibility.VisibilityModel`: the integration layer
+fits that model on the labeled dataset and passes the learned
+``co_visibility_matrix`` (``P(node_j visible | node_i visible)``) here. This
+module itself is a pure function and learns nothing.
+
+Honest scope / limitations:
+    This only catches *outlier* drops -- an individual instance that is missing
+    a node its co-visible peers keep. It does NOT catch dataset-wide systematic
+    under-labeling (e.g. nobody in the project ever labels the tail tip). When a
+    node is rarely labeled, the co-visibility column for that node is small for
+    everyone, so its expected probability stays low and it is never flagged.
+    Detecting systematic under-labeling requires a model-based (Tier-2)
+    approach that compares against learned appearance/geometry rather than only
+    the project's own visibility statistics.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def score_missing_nodes(
+    visibility_mask: np.ndarray,
+    co_visibility_matrix: np.ndarray,
+    edges: list[tuple[int, int]],
+    threshold: float = 0.9,
+    require_neighbors_visible: bool = False,
+) -> dict:
+    """Score whether an instance is missing nodes its peers usually keep.
+
+    For each *invisible* node ``k`` we estimate the probability that it
+    *should* be visible given the nodes that are actually present::
+
+        p_expected[k] = mean over visible nodes i of co_visibility_matrix[i, k]
+
+    where ``co_visibility_matrix[i, k] = P(node k visible | node i visible)``
+    (the convention used by :class:`VisibilityModel`). A node is flagged as
+    suspiciously-missing when ``p_expected[k] >= threshold`` -- i.e. nodes that
+    co-occur with the visible nodes nearly always also bring ``k`` along, yet
+    ``k`` is absent here.
+
+    Optionally (``require_neighbors_visible=True``) a node is only flagged when
+    *all* of its skeleton neighbors (from ``edges``) are visible, which makes
+    the heuristic stricter: an isolated missing node surrounded by present
+    neighbors is a much stronger signal of an accidental drop than a node on
+    the boundary of an occluded region.
+
+    Args:
+        visibility_mask: ``(n_nodes,)`` boolean (or boolean-like) array. ``True``
+            = node visible/labeled, ``False`` = invisible/missing. Non-boolean
+            input is coerced with :func:`numpy.asarray(..., dtype=bool)`.
+        co_visibility_matrix: ``(n_nodes, n_nodes)`` array where entry
+            ``[i, j] = P(node j visible | node i visible)``, as learned by
+            :meth:`VisibilityModel.fit`.
+        edges: List of ``(src, dst)`` node-index pairs describing the skeleton
+            graph. Only used when ``require_neighbors_visible`` is set. May be
+            empty.
+        threshold: Minimum expected visibility probability for a missing node to
+            be flagged as suspicious. Defaults to ``0.9``.
+        require_neighbors_visible: If ``True``, only flag a missing node when all
+            of its skeleton neighbors are visible. Defaults to ``False``.
+
+    Returns:
+        Dictionary with:
+
+        - ``missing_node_score``: ``float`` in ``[0, 1]``. The maximum expected
+          visibility probability over all invisible nodes (0.0 if no node is
+          invisible). High values mean at least one missing node is one the
+          peers almost always keep.
+        - ``suspicious_nodes``: ``list[int]`` of node indices that were flagged
+          (``p_expected >= threshold`` and, if requested, all-neighbors-visible),
+          sorted ascending. Useful for naming the nodes in an explanation.
+        - ``n_suspicious``: ``int`` count of flagged nodes.
+    """
+    visibility_mask = np.asarray(visibility_mask, dtype=bool).ravel()
+    co_visibility_matrix = np.asarray(co_visibility_matrix, dtype=float)
+    n_nodes = visibility_mask.shape[0]
+
+    # Guard against an empty skeleton or a co-visibility matrix that does not
+    # match the mask -- there is nothing meaningful to flag in either case.
+    if (
+        n_nodes == 0
+        or co_visibility_matrix.shape != (n_nodes, n_nodes)
+    ):
+        return {
+            "missing_node_score": 0.0,
+            "suspicious_nodes": [],
+            "n_suspicious": 0,
+        }
+
+    visible_indices = np.where(visibility_mask)[0]
+    invisible_indices = np.where(~visibility_mask)[0]
+
+    # All nodes visible (nothing missing) or no visible node to condition on
+    # (we have no evidence about what *should* be present). Either way: score 0.
+    if len(invisible_indices) == 0 or len(visible_indices) == 0:
+        return {
+            "missing_node_score": 0.0,
+            "suspicious_nodes": [],
+            "n_suspicious": 0,
+        }
+
+    # Build neighbor adjacency only if we need it (avoids work in the common
+    # require_neighbors_visible=False path).
+    neighbors: list[list[int]] = []
+    if require_neighbors_visible:
+        neighbors = [[] for _ in range(n_nodes)]
+        for src, dst in edges:
+            # Ignore edges that reference nodes outside this skeleton.
+            if 0 <= src < n_nodes and 0 <= dst < n_nodes:
+                neighbors[src].append(dst)
+                neighbors[dst].append(src)
+
+    # Expected visibility for each invisible node: mean over visible nodes i of
+    # P(node k visible | node i visible) = column k restricted to visible rows.
+    # NaN-guard: a co-visibility column may contain NaN if VisibilityModel ever
+    # saw a node that was never visible; nanmean keeps the estimate finite and
+    # treats such entries as "no evidence" rather than poisoning the mean.
+    suspicious: list[int] = []
+    p_expected_values: list[float] = []
+    for k in invisible_indices:
+        col = co_visibility_matrix[visible_indices, k]
+        finite = col[np.isfinite(col)]
+        if len(finite) == 0:
+            # No usable evidence for this node; cannot be suspicious.
+            p_expected = 0.0
+        else:
+            p_expected = float(np.mean(finite))
+
+        p_expected_values.append(p_expected)
+
+        if p_expected < threshold:
+            continue
+
+        if require_neighbors_visible:
+            node_neighbors = neighbors[k]
+            # A node with no neighbors cannot have "all neighbors visible" in a
+            # meaningful sense; skip it under the stricter rule.
+            if not node_neighbors:
+                continue
+            if not all(visibility_mask[n] for n in node_neighbors):
+                continue
+
+        suspicious.append(int(k))
+
+    missing_node_score = float(np.max(p_expected_values)) if p_expected_values else 0.0
+    # Clamp defensively in case of tiny floating-point overshoot above 1.0.
+    missing_node_score = float(np.clip(missing_node_score, 0.0, 1.0))
+
+    return {
+        "missing_node_score": missing_node_score,
+        "suspicious_nodes": sorted(suspicious),
+        "n_suspicious": len(suspicious),
+    }

--- a/sleap/qc/features/missing_node.py
+++ b/sleap/qc/features/missing_node.py
@@ -86,10 +86,7 @@ def score_missing_nodes(
 
     # Guard against an empty skeleton or a co-visibility matrix that does not
     # match the mask -- there is nothing meaningful to flag in either case.
-    if (
-        n_nodes == 0
-        or co_visibility_matrix.shape != (n_nodes, n_nodes)
-    ):
+    if n_nodes == 0 or co_visibility_matrix.shape != (n_nodes, n_nodes):
         return {
             "missing_node_score": 0.0,
             "suspicious_nodes": [],

--- a/sleap/qc/features/ordering.py
+++ b/sleap/qc/features/ordering.py
@@ -1,0 +1,285 @@
+"""Keypoint ordering features: turning angles along chains.
+
+Detects nodes that are labeled out of order along an ordered chain
+(e.g. a tail ``TTI -> Tail_0 -> Tail_1 -> Tail_2 -> TailTip``).
+
+The core idea (maintainer's design): treat consecutive chain segments as
+vectors ``v_i = node_i - node_{i-1}`` and look at the *turning angle* between
+consecutive segments at each interior node (the angle between ``v_i`` and
+``v_{i+1}``). A correctly ordered chain -- even one that is naturally curled --
+has gentle turning angles. A mislabel (e.g. an adjacent swap) produces a sharp
+direction reversal, which shows up as one or two large turning angles. An
+out-of-order pair that is not adjacent (e.g. ``Tail_1`` swapped with
+``Tail_3``) additionally makes two non-adjacent segments geometrically cross,
+which is a strong, unambiguous signal.
+
+The turning angle is invariant to translation, rotation, and uniform scale, so
+these features do not need any learned per-dataset statistics.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Default per-chain threshold (radians) above which a turning angle at an
+# interior node is considered a sharp reversal / likely mislabel. 60 degrees is
+# permissive enough that a smoothly curled chain is not flagged while still
+# catching adjacent swaps (which approach 180 degrees).
+DEFAULT_MAX_TURN_ANGLE = np.deg2rad(60.0)
+
+# Numerical tolerance for zero-length segments.
+_EPS = 1e-8
+
+
+def _turning_angle(v1: np.ndarray, v2: np.ndarray) -> float:
+    """Turning (deflection) angle between two consecutive segment vectors.
+
+    The turning angle is ``pi - interior_angle``: it is 0 when the two segments
+    point in the same direction (the chain continues straight) and approaches
+    ``pi`` when the chain reverses direction (a sharp hairpin).
+
+    Args:
+        v1: First segment vector ``node_i - node_{i-1}``.
+        v2: Second segment vector ``node_{i+1} - node_i``.
+
+    Returns:
+        Turning angle in radians in ``[0, pi]``, or NaN if either segment has
+        (near) zero length.
+    """
+    norm1 = float(np.linalg.norm(v1))
+    norm2 = float(np.linalg.norm(v2))
+    if norm1 < _EPS or norm2 < _EPS:
+        return np.nan
+
+    # Angle between the two segment directions. cos = v1.v2 / (|v1||v2|).
+    cos_angle = float(np.dot(v1, v2) / (norm1 * norm2))
+    cos_angle = float(np.clip(cos_angle, -1.0, 1.0))
+    return float(np.arccos(cos_angle))
+
+
+def _segments_intersect(
+    p1: np.ndarray,
+    p2: np.ndarray,
+    p3: np.ndarray,
+    p4: np.ndarray,
+) -> bool:
+    """Whether segment ``p1->p2`` properly intersects segment ``p3->p4``.
+
+    Uses the orientation (signed-area) test. Collinear/touching configurations
+    are treated as non-intersecting to avoid false positives from shared
+    endpoints or numerically borderline cases.
+
+    Args:
+        p1: First endpoint of segment A (2,).
+        p2: Second endpoint of segment A (2,).
+        p3: First endpoint of segment B (2,).
+        p4: Second endpoint of segment B (2,).
+
+    Returns:
+        True if the two open segments cross.
+    """
+
+    def orient(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> float:
+        # Signed area * 2 of triangle (a, b, c). Sign gives turn direction.
+        return float((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]))
+
+    d1 = orient(p3, p4, p1)
+    d2 = orient(p3, p4, p2)
+    d3 = orient(p1, p2, p3)
+    d4 = orient(p1, p2, p4)
+
+    # Strict straddle on both segments => proper crossing. Using strict
+    # inequalities avoids flagging collinear or endpoint-touching segments
+    # (which arise naturally for a straight, correctly ordered chain).
+    if ((d1 > 0) != (d2 > 0)) and ((d3 > 0) != (d4 > 0)):
+        # Guard against the degenerate case where an orientation is exactly 0
+        # (collinear point): that is a touch, not a proper crossing.
+        if min(abs(d1), abs(d2), abs(d3), abs(d4)) > _EPS:
+            return True
+    return False
+
+
+def resolve_chains(
+    skeleton_node_names: list[str],
+    ordered_chains_by_name: list[list[str]] | None,
+    auto_chains: list[list[int]] | None,
+) -> list[list[int]]:
+    """Resolve ordered chains to node-index sequences.
+
+    A user-declared ordering is treated as ground truth: when
+    ``ordered_chains_by_name`` is provided, those chains (given as lists of node
+    *names*) are resolved to node indices and used directly. This makes the
+    turning-angle rule deterministic, since the intended order is known.
+
+    When no user-defined chains are given, falls back to ``auto_chains`` (chain
+    index sequences inferred from the skeleton graph, e.g. from
+    ``SkeletonAnalyzer.get_curvature_chains()``).
+
+    Args:
+        skeleton_node_names: Ordered list of node names; index ``i`` is the node
+            index of name ``skeleton_node_names[i]``.
+        ordered_chains_by_name: Optional list of user-defined chains, each a
+            list of node names in the intended order (e.g.
+            ``[["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]]``). Names not
+            present in the skeleton are skipped; chains with fewer than 3
+            resolvable nodes are dropped.
+        auto_chains: Optional fallback list of chains as node-index sequences.
+
+    Returns:
+        List of chains as node-index sequences. Empty if nothing resolves.
+    """
+    name_to_idx = {name: i for i, name in enumerate(skeleton_node_names)}
+
+    if ordered_chains_by_name:
+        resolved: list[list[int]] = []
+        for chain_names in ordered_chains_by_name:
+            idx_chain = [
+                name_to_idx[name] for name in chain_names if name in name_to_idx
+            ]
+            # A chain needs at least 3 nodes to have an interior turning angle.
+            if len(idx_chain) >= 3:
+                resolved.append(idx_chain)
+        if resolved:
+            return resolved
+        # If user-defined chains were given but none resolved (e.g. all names
+        # missing or too short), fall through to auto chains below.
+
+    if auto_chains:
+        return [list(chain) for chain in auto_chains if len(chain) >= 3]
+
+    return []
+
+
+def compute_chain_ordering(
+    points: np.ndarray,
+    chains: list[list[int]],
+    max_turn_angle: float = DEFAULT_MAX_TURN_ANGLE,
+) -> dict:
+    """Detect wrong keypoint order along ordered chains via turning angles.
+
+    For each chain, the turning angle is computed at every interior node from
+    the two adjacent segment vectors. The ``order_inversion_rate`` is the
+    fraction of interior nodes whose turning angle exceeds ``max_turn_angle``
+    (a sharp reversal). The ``chain_intersection_count`` is the number of
+    non-adjacent segment pairs that geometrically cross -- a strong signal of a
+    non-local swap (e.g. ``Tail_1`` <-> ``Tail_3``). Results are aggregated as
+    the maximum over all chains, and the worst chain/node are recorded for use
+    in an explanation.
+
+    All metrics are invariant to translation, rotation, and uniform scale, and
+    NaN (invisible/missing) nodes are skipped without leaking into results.
+
+    Args:
+        points: ``(N_nodes, 2)`` array of node coordinates; NaN marks
+            invisible/missing nodes.
+        chains: List of chains, each an ordered list of node indices. Use
+            :func:`resolve_chains` to obtain these from user-defined names or
+            auto-detected chains.
+        max_turn_angle: Per-interior-node turning-angle threshold in radians
+            above which a node is counted as an inversion. Default ~60 degrees.
+
+    Returns:
+        Dictionary with:
+        - ``order_inversion_rate``: float in ``[0, 1]``, max over chains of the
+          fraction of interior nodes whose turning angle exceeds the threshold.
+        - ``chain_intersection_count``: int, max over chains of the number of
+          crossing non-adjacent segment pairs.
+        - ``max_turn_angle``: float (radians), largest turning angle seen at any
+          interior node across all chains.
+        - ``worst_chain``: tuple of node indices for the chain with the largest
+          turning angle (empty tuple if none evaluable).
+        - ``worst_node``: int, the interior node index (into ``points``) with
+          the largest turning angle, or ``-1`` if none evaluable.
+    """
+    default = {
+        "order_inversion_rate": 0.0,
+        "chain_intersection_count": 0,
+        "max_turn_angle": 0.0,
+        "worst_chain": (),
+        "worst_node": -1,
+    }
+
+    if not chains:
+        return default
+
+    points = np.asarray(points, dtype=float)
+
+    best_inversion_rate = 0.0
+    best_intersection_count = 0
+    overall_max_angle = 0.0
+    worst_chain: tuple[int, ...] = ()
+    worst_node = -1
+
+    for chain in chains:
+        if len(chain) < 3:
+            continue
+
+        # --- Turning angles at interior nodes ---
+        n_interior = 0
+        n_inversions = 0
+        for i in range(1, len(chain) - 1):
+            prev_idx, curr_idx, next_idx = chain[i - 1], chain[i], chain[i + 1]
+            p_prev = points[prev_idx]
+            p_curr = points[curr_idx]
+            p_next = points[next_idx]
+
+            # Skip interior node if any of the three involved nodes is missing.
+            if (
+                np.isnan(p_prev).any()
+                or np.isnan(p_curr).any()
+                or np.isnan(p_next).any()
+            ):
+                continue
+
+            v1 = p_curr - p_prev  # incoming segment direction
+            v2 = p_next - p_curr  # outgoing segment direction
+            theta = _turning_angle(v1, v2)
+            if np.isnan(theta):
+                # Degenerate (coincident nodes); not an evaluable turn.
+                continue
+
+            n_interior += 1
+            if theta > max_turn_angle:
+                n_inversions += 1
+
+            if theta > overall_max_angle:
+                overall_max_angle = theta
+                worst_chain = tuple(chain)
+                worst_node = int(curr_idx)
+
+        inversion_rate = (n_inversions / n_interior) if n_interior > 0 else 0.0
+        if inversion_rate > best_inversion_rate:
+            best_inversion_rate = inversion_rate
+
+        # --- Non-adjacent segment crossings ---
+        # Build the list of visible segments (consecutive node pairs in chain).
+        segments: list[tuple[int, np.ndarray, np.ndarray]] = []
+        for i in range(len(chain) - 1):
+            a_idx, b_idx = chain[i], chain[i + 1]
+            pa, pb = points[a_idx], points[b_idx]
+            if np.isnan(pa).any() or np.isnan(pb).any():
+                continue
+            segments.append((i, pa, pb))
+
+        intersection_count = 0
+        for si in range(len(segments)):
+            i_pos, pa, pb = segments[si]
+            for sj in range(si + 1, len(segments)):
+                j_pos, pc, pd = segments[sj]
+                # Only non-adjacent segments: adjacent segments share an
+                # endpoint by construction and would always "touch".
+                if abs(i_pos - j_pos) <= 1:
+                    continue
+                if _segments_intersect(pa, pb, pc, pd):
+                    intersection_count += 1
+
+        if intersection_count > best_intersection_count:
+            best_intersection_count = intersection_count
+
+    return {
+        "order_inversion_rate": float(best_inversion_rate),
+        "chain_intersection_count": int(best_intersection_count),
+        "max_turn_angle": float(overall_max_angle),
+        "worst_chain": worst_chain,
+        "worst_node": worst_node,
+    }

--- a/sleap/qc/features/pose_split.py
+++ b/sleap/qc/features/pose_split.py
@@ -169,9 +169,7 @@ def compute_pose_split_fallback(
     # (nearest pair of points from opposite clusters) to the typical *within*
     # cluster spacing. For two genuine blobs the boundary gap dominates; for a
     # uniform spread they are comparable.
-    cross = np.linalg.norm(
-        pts_a[:, None, :] - pts_b[None, :, :], axis=2
-    )
+    cross = np.linalg.norm(pts_a[:, None, :] - pts_b[None, :, :], axis=2)
     boundary_gap = float(cross.min())
 
     within = _typical_within_spacing(pts_a, pts_b)
@@ -243,9 +241,7 @@ def _silhouette_like(pts_a: np.ndarray, pts_b: np.ndarray) -> float:
         for k in range(len(own)):
             p = own[k]
             if len(own) > 1:
-                a = float(
-                    np.sum(np.linalg.norm(own - p, axis=1)) / (len(own) - 1)
-                )
+                a = float(np.sum(np.linalg.norm(own - p, axis=1)) / (len(own) - 1))
             else:
                 a = 0.0
             b = float(np.mean(np.linalg.norm(other - p, axis=1)))
@@ -427,8 +423,10 @@ def compute_pose_split(
     # many leaves) cannot be split into two balanced clusters by cutting one
     # edge, and very few internal edges also make the bridging test unreliable.
     # In those cases, defer to the geometry-only fallback.
-    if best_edge is None or len(visible_edges) < 2 or _is_star_like(
-        visible_edges, vis_idx
+    if (
+        best_edge is None
+        or len(visible_edges) < 2
+        or _is_star_like(visible_edges, vis_idx)
     ):
         return compute_pose_split_fallback(points, min_visible=min_visible)
 

--- a/sleap/qc/features/pose_split.py
+++ b/sleap/qc/features/pose_split.py
@@ -1,0 +1,499 @@
+"""Pose-split (chimera) features.
+
+A *chimera* is a single labeled instance whose keypoints actually span two
+different animals: e.g. the head/thorax of animal A connected to the abdomen of
+animal B. This typically shows up as a skeleton that is internally consistent in
+two tight clusters joined by a single, abnormally stretched "bridging" edge.
+
+This module provides a pure function :func:`compute_pose_split` that scores how
+chimera-like a single pose is. It is deliberately argument-driven (points,
+adjacency, learned edge-length stats) so it can be unit-tested in isolation and
+so the detector's already-computed baseline statistics can be reused.
+
+The primary signal is graph-based:
+
+1. On the subgraph induced by the *visible* nodes, find the connected bridging
+   edge whose normalized length z-score ``z = (len - mean) / std`` is largest.
+2. Cut that edge. If the visible subgraph splits cleanly into two components,
+   measure how *balanced* the split is (``split_ratio = smaller / total``).
+3. Measure how far apart the two clusters sit relative to their own internal
+   spread (``gap_ratio``). A real chimera has two compact clusters separated by
+   a wide gap.
+
+A high ``split_score`` requires *all three* (large bridging z, balanced split,
+large gap). This gating is what keeps it from firing on a normal pose or on a
+partially-occluded single animal (whose visible subgraph is merely disconnected
+without an abnormally long bridging edge).
+
+For skeletons where the graph signal is weak or unavailable (star skeletons,
+very short skeletons, or missing adjacency), a skeleton-agnostic 2-means
+bimodality :func:`compute_pose_split_fallback` is used instead.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+
+# Minimum number of visible nodes required for a meaningful split analysis.
+# With fewer points a "split" is not distinguishable from a normal small pose.
+MIN_VISIBLE_NODES = 4
+
+# Floors to keep ratios finite/stable.
+_EPS = 1e-9
+
+
+def _visible_mask(points: np.ndarray) -> np.ndarray:
+    """Return a boolean (N_nodes,) mask of visible (non-NaN) nodes."""
+    return ~np.isnan(points).any(axis=1)
+
+
+def _cluster_spread(points: np.ndarray, indices: np.ndarray) -> float:
+    """Mean distance of a cluster's points to their centroid.
+
+    Args:
+        points: (N_nodes, 2) coordinate array (may contain NaN).
+        indices: 1-D array of node indices belonging to the cluster.
+
+    Returns:
+        Mean radial spread of the cluster. ``0.0`` for a single-point cluster.
+    """
+    pts = points[indices]
+    if len(pts) < 2:
+        return 0.0
+    centroid = pts.mean(axis=0)
+    return float(np.mean(np.linalg.norm(pts - centroid, axis=1)))
+
+
+def _components_after_cut(
+    nodes: list[int],
+    edges: list[tuple[int, int]],
+    cut_edge: tuple[int, int],
+) -> list[set[int]]:
+    """Connected components of a node set after removing one edge.
+
+    A tiny union-find over the visible subgraph (so we don't require networkx
+    here and stay dependency-light, matching the pure-function contract).
+
+    Args:
+        nodes: Node indices present in the subgraph.
+        edges: Undirected edges (i, j) within the subgraph.
+        cut_edge: The edge to remove, as a sorted (i, j) tuple.
+
+    Returns:
+        List of components, each a set of node indices.
+    """
+    parent = {n: n for n in nodes}
+
+    def find(x: int) -> int:
+        root = x
+        while parent[root] != root:
+            root = parent[root]
+        # Path compression.
+        while parent[x] != root:
+            parent[x], x = root, parent[x]
+        return root
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    for i, j in edges:
+        if tuple(sorted((i, j))) == cut_edge:
+            continue
+        union(i, j)
+
+    groups: dict[int, set[int]] = {}
+    for n in nodes:
+        groups.setdefault(find(n), set()).add(n)
+    return list(groups.values())
+
+
+def compute_pose_split_fallback(
+    points: np.ndarray,
+    min_visible: int = MIN_VISIBLE_NODES,
+) -> dict[str, float]:
+    """Skeleton-agnostic 2-means bimodality fallback.
+
+    Used for star/short skeletons or when adjacency is unavailable. Splits the
+    visible nodes into two clusters with 2-means and reports a silhouette-like
+    separation score. This intentionally ignores skeleton edges, so it cannot
+    use a bridging-edge z-score; the gate therefore relies entirely on geometry
+    (balanced split + wide gap).
+
+    Args:
+        points: (N_nodes, 2) coordinate array (NaN for invisible nodes).
+        min_visible: Minimum visible nodes required to attempt a split.
+
+    Returns:
+        Dictionary with keys ``split_score``, ``split_ratio``, ``gap_ratio``
+        (all floats, ``split_score >= 0``).
+    """
+    zero = {"split_score": 0.0, "split_ratio": 0.0, "gap_ratio": 0.0}
+
+    vis = _visible_mask(points)
+    vis_idx = np.where(vis)[0]
+    n_vis = len(vis_idx)
+    if n_vis < min_visible:
+        return dict(zero)
+
+    coords = points[vis_idx]
+
+    # 2-means via KMeans (deterministic seeding for test stability).
+    try:
+        from sklearn.cluster import KMeans
+
+        km = KMeans(n_clusters=2, n_init=10, random_state=0)
+        labels = km.fit_predict(coords)
+    except Exception:
+        return dict(zero)
+
+    idx_a = vis_idx[labels == 0]
+    idx_b = vis_idx[labels == 1]
+    if len(idx_a) == 0 or len(idx_b) == 0:
+        return dict(zero)
+
+    n_small = min(len(idx_a), len(idx_b))
+    split_ratio = n_small / n_vis
+
+    pts_a = points[idx_a]
+    pts_b = points[idx_b]
+
+    # Bimodality via a boundary-gap test rather than a centroid-distance test.
+    # A *uniformly* spread pose (e.g. an evenly spaced line) trivially splits in
+    # half with a large centroid distance, so centroid distance alone gives
+    # false positives. Instead compare the gap *across the cluster boundary*
+    # (nearest pair of points from opposite clusters) to the typical *within*
+    # cluster spacing. For two genuine blobs the boundary gap dominates; for a
+    # uniform spread they are comparable.
+    cross = np.linalg.norm(
+        pts_a[:, None, :] - pts_b[None, :, :], axis=2
+    )
+    boundary_gap = float(cross.min())
+
+    within = _typical_within_spacing(pts_a, pts_b)
+    gap_ratio = boundary_gap / max(within, _EPS)
+
+    # Silhouette-like separation: how much closer points are to their own
+    # cluster than to the other. ~1 for well-separated blobs, ~0 for a uniform
+    # spread that was split arbitrarily.
+    silhouette = _silhouette_like(pts_a, pts_b)
+
+    split_score = _combine_score(
+        bridge_z=gap_ratio,  # No edge z available; use gap as the strength term.
+        split_ratio=split_ratio,
+        gap_ratio=gap_ratio,
+        is_fallback=True,
+        silhouette=silhouette,
+    )
+
+    return {
+        "split_score": float(split_score),
+        "split_ratio": float(split_ratio),
+        "gap_ratio": float(gap_ratio),
+    }
+
+
+def _typical_within_spacing(pts_a: np.ndarray, pts_b: np.ndarray) -> float:
+    """Typical nearest-neighbor spacing within clusters.
+
+    For each cluster with >= 2 points, take each point's distance to its
+    nearest same-cluster neighbor; the typical (median) of those is the
+    "within" scale. Used to normalize the boundary gap.
+
+    Args:
+        pts_a: (Na, 2) points of cluster A.
+        pts_b: (Nb, 2) points of cluster B.
+
+    Returns:
+        Median within-cluster nearest-neighbor distance (>= 0).
+    """
+    nn_dists: list[float] = []
+    for pts in (pts_a, pts_b):
+        if len(pts) < 2:
+            continue
+        d = np.linalg.norm(pts[:, None, :] - pts[None, :, :], axis=2)
+        np.fill_diagonal(d, np.inf)
+        nn_dists.extend(d.min(axis=1).tolist())
+    if not nn_dists:
+        return 0.0
+    return float(np.median(nn_dists))
+
+
+def _silhouette_like(pts_a: np.ndarray, pts_b: np.ndarray) -> float:
+    """Mean silhouette coefficient for a 2-cluster split (simplified).
+
+    For each point, ``s = (b - a) / max(a, b)`` where ``a`` is the mean
+    distance to other points in its own cluster and ``b`` is the mean distance
+    to the other cluster. Ranges in [-1, 1]; ~1 means tight, well-separated
+    clusters; ~0 means the split is arbitrary (uniform data).
+
+    Args:
+        pts_a: (Na, 2) points of cluster A.
+        pts_b: (Nb, 2) points of cluster B.
+
+    Returns:
+        Mean silhouette coefficient over all points.
+    """
+    scores: list[float] = []
+    for own, other in ((pts_a, pts_b), (pts_b, pts_a)):
+        for k in range(len(own)):
+            p = own[k]
+            if len(own) > 1:
+                a = float(
+                    np.sum(np.linalg.norm(own - p, axis=1)) / (len(own) - 1)
+                )
+            else:
+                a = 0.0
+            b = float(np.mean(np.linalg.norm(other - p, axis=1)))
+            denom = max(a, b)
+            scores.append((b - a) / denom if denom > _EPS else 0.0)
+    return float(np.mean(scores)) if scores else 0.0
+
+
+def _balance_factor(split_ratio: float) -> float:
+    """Map split_ratio to a 0..1 balance weight peaking in [0.3, 0.5].
+
+    A genuine chimera divides the keypoints into two non-trivial groups. A
+    ratio near 0.5 is perfectly balanced; near 0 means one stray node (the
+    occlusion / mislabel-of-a-single-node case, which we do *not* want to flag
+    as a chimera). The factor is 0 below ~0.18 and ramps to 1 by ~0.3.
+
+    Args:
+        split_ratio: smaller_cluster_size / total_visible (in [0, 0.5]).
+
+    Returns:
+        Weight in [0, 1].
+    """
+    lo, hi = 0.18, 0.30
+    if split_ratio <= lo:
+        return 0.0
+    if split_ratio >= hi:
+        return 1.0
+    return (split_ratio - lo) / (hi - lo)
+
+
+# Minimum mean-silhouette for the fallback to treat a split as truly bimodal.
+# A uniformly spread pose split in half scores well below this.
+_FALLBACK_SILHOUETTE_FLOOR = 0.5
+
+
+def _combine_score(
+    bridge_z: float,
+    split_ratio: float,
+    gap_ratio: float,
+    is_fallback: bool = False,
+    silhouette: float = 1.0,
+) -> float:
+    """Combine the sub-signals into a gated split score.
+
+    The score is multiplicative so that *all* conditions must hold: a large
+    bridging stretch, a balanced split, and a wide gap. Any one being small
+    drives the score toward zero.
+
+    Args:
+        bridge_z: Normalized stretch of the bridging edge (or boundary-gap ratio
+            in the fallback path). Clamped at 0.
+        split_ratio: smaller / total visible nodes.
+        gap_ratio: graph path: inter-cluster distance / max intra-cluster
+            spread. Fallback path: boundary gap / within-cluster spacing.
+        is_fallback: Whether this is the geometry-only fallback path.
+        silhouette: Mean silhouette coefficient (fallback only); used to gate
+            out arbitrary splits of uniformly spread points.
+
+    Returns:
+        Non-negative split score.
+    """
+    bridge_term = max(bridge_z, 0.0)
+    balance = _balance_factor(split_ratio)
+
+    # Gap must clear a floor before it contributes (two clusters whose gap is
+    # comparable to their own internal scale are just one diffuse animal).
+    gap_floor = 1.5
+    gap_term = max(gap_ratio - gap_floor, 0.0)
+
+    if is_fallback:
+        # Geometry-only: additionally require a genuinely bimodal split so we do
+        # not fire on uniformly spread points (which 2-means always halves with
+        # a large centroid gap but a near-zero silhouette).
+        if silhouette < _FALLBACK_SILHOUETTE_FLOOR:
+            return 0.0
+        return float(balance * gap_term)
+
+    return float(bridge_term * balance * gap_term)
+
+
+def compute_pose_split(
+    points: np.ndarray,
+    adjacency: Optional[dict[int, list[int]]],
+    edge_means: dict[tuple[int, int], float],
+    edge_stds: dict[tuple[int, int], float],
+    min_visible: int = MIN_VISIBLE_NODES,
+) -> dict[str, float]:
+    """Score how *chimera-like* a single pose is (one instance, two animals).
+
+    Operates on the subgraph induced by the visible nodes:
+
+    1. **Bridging edge.** Among visible edges with learned length stats, find
+       the one with the largest normalized stretch ``z = (len - mean) / std``.
+    2. **Balanced split.** Remove that edge; if the visible subgraph splits into
+       exactly two components, ``split_ratio = smaller / total`` measures
+       balance (ideal ~0.3-0.5).
+    3. **Gap.** ``gap_ratio = ||centroidA - centroidB|| / max(spread_A, spread_B)``
+       measures how far the clusters sit relative to their own internal spread.
+
+    The returned ``split_score`` is the *gated product* of these signals, so it
+    is only high when a long bridging edge separates two balanced, well-spaced
+    clusters. This is what prevents false positives on:
+
+    - a **normal pose** (no bridging edge with a large z; small gap_ratio),
+    - a **partially occluded** single animal (the visible subgraph may be
+      disconnected, but there is no abnormally stretched bridging edge joining
+      two balanced clusters), and
+    - two genuinely close, correctly-merged animals (small gap relative to
+      spread).
+
+    If adjacency is unavailable, or the skeleton is too star-like / short for a
+    bridging edge to be meaningful, falls back to
+    :func:`compute_pose_split_fallback` (2-means bimodality).
+
+    Args:
+        points: (N_nodes, 2) coordinate array (NaN for invisible nodes).
+        adjacency: Maps node_index -> list of neighbor indices (skeleton
+            edges). Pass ``SkeletonAnalyzer.get_adjacency()``. If ``None``, the
+            geometry-only fallback is used.
+        edge_means: Maps sorted ``(i, j)`` edge tuples -> learned mean edge
+            length (reuse ``DatasetStats.edge_means``).
+        edge_stds: Maps sorted ``(i, j)`` edge tuples -> learned edge-length std
+            (reuse ``DatasetStats.edge_stds``). Values should be floored away
+            from zero by the caller (the baseline extractor already does this).
+        min_visible: Minimum visible nodes required to attempt a split.
+
+    Returns:
+        Dictionary with:
+
+        - ``split_score``: non-negative chimera score (0 = not a chimera; the
+          integration layer thresholds this, e.g. on the training distribution).
+        - ``split_ratio``: smaller-cluster fraction of visible nodes (0..0.5).
+        - ``gap_ratio``: inter-cluster distance / max intra-cluster spread.
+    """
+    zero = {"split_score": 0.0, "split_ratio": 0.0, "gap_ratio": 0.0}
+
+    vis = _visible_mask(points)
+    vis_idx = set(np.where(vis)[0].tolist())
+    n_vis = len(vis_idx)
+
+    # Too few visible nodes -> not analyzable.
+    if n_vis < min_visible:
+        return dict(zero)
+
+    # No adjacency -> geometry-only fallback.
+    if not adjacency:
+        return compute_pose_split_fallback(points, min_visible=min_visible)
+
+    # Build the visible subgraph's edge list with z-scores, deduplicating
+    # undirected edges via sorted tuples.
+    visible_edges: list[tuple[int, int]] = []
+    seen: set[tuple[int, int]] = set()
+    best_z = -np.inf
+    best_edge: Optional[tuple[int, int]] = None
+
+    for node, neighbors in adjacency.items():
+        if node not in vis_idx:
+            continue
+        for nb in neighbors:
+            if nb not in vis_idx:
+                continue
+            key = tuple(sorted((int(node), int(nb))))
+            if key in seen:
+                continue
+            seen.add(key)
+            visible_edges.append(key)
+
+            mean = edge_means.get(key)
+            std = edge_stds.get(key)
+            if mean is None or std is None:
+                continue
+            length = float(np.linalg.norm(points[key[1]] - points[key[0]]))
+            z = (length - mean) / max(std, _EPS)
+            if z > best_z:
+                best_z = z
+                best_edge = key
+
+    # Decide whether the graph signal is usable. A star skeleton (a hub with
+    # many leaves) cannot be split into two balanced clusters by cutting one
+    # edge, and very few internal edges also make the bridging test unreliable.
+    # In those cases, defer to the geometry-only fallback.
+    if best_edge is None or len(visible_edges) < 2 or _is_star_like(
+        visible_edges, vis_idx
+    ):
+        return compute_pose_split_fallback(points, min_visible=min_visible)
+
+    nodes_list = sorted(vis_idx)
+    components = _components_after_cut(nodes_list, visible_edges, best_edge)
+
+    # We require the cut to produce exactly two components (a clean bridge). If
+    # the subgraph was already disconnected (occlusion) the cut yields >2
+    # components; if the edge was redundant (a cycle) it yields 1. Either way it
+    # is not a clean chimera bridge.
+    if len(components) != 2:
+        return dict(zero)
+
+    comp_a, comp_b = components
+    idx_a = np.array(sorted(comp_a))
+    idx_b = np.array(sorted(comp_b))
+
+    n_small = min(len(idx_a), len(idx_b))
+    split_ratio = n_small / n_vis
+
+    centroid_a = points[idx_a].mean(axis=0)
+    centroid_b = points[idx_b].mean(axis=0)
+    gap = float(np.linalg.norm(centroid_a - centroid_b))
+
+    spread_a = _cluster_spread(points, idx_a)
+    spread_b = _cluster_spread(points, idx_b)
+    max_spread = max(spread_a, spread_b)
+    gap_ratio = gap / max(max_spread, _EPS)
+
+    split_score = _combine_score(
+        bridge_z=best_z,
+        split_ratio=split_ratio,
+        gap_ratio=gap_ratio,
+        is_fallback=False,
+    )
+
+    return {
+        "split_score": float(split_score),
+        "split_ratio": float(split_ratio),
+        "gap_ratio": float(gap_ratio),
+    }
+
+
+def _is_star_like(edges: list[tuple[int, int]], vis_idx: set[int]) -> bool:
+    """Heuristic: is the visible subgraph a star (one hub, many leaves)?
+
+    A star cannot be split into two balanced clusters by removing a single
+    edge, so the bridging-edge test is meaningless and we should fall back to
+    geometry. We call the subgraph star-like when a single node touches almost
+    all edges.
+
+    Args:
+        edges: Undirected edges within the visible subgraph.
+        vis_idx: Set of visible node indices.
+
+    Returns:
+        True if the subgraph looks like a star.
+    """
+    if len(vis_idx) < 4 or len(edges) == 0:
+        return False
+    degree: dict[int, int] = {}
+    for i, j in edges:
+        degree[i] = degree.get(i, 0) + 1
+        degree[j] = degree.get(j, 0) + 1
+    max_deg = max(degree.values())
+    # If one hub touches (n_visible - 1) edges, it's a pure star. Allow one
+    # extra edge of slack for near-stars.
+    return max_deg >= (len(vis_idx) - 1) and max_deg >= len(edges) - 1

--- a/sleap/qc/frame_level.py
+++ b/sleap/qc/frame_level.py
@@ -165,7 +165,8 @@ def compute_node_overlap(
         Dictionary with:
         - common_nodes: list of node indices visible in both
         - overlapping_nodes: list of nodes within threshold
-        - mean_distance: mean distance at common nodes
+        - mean_distance / min_distance / max_distance: distance stats at common
+          nodes (all ``inf`` when there are no commonly visible nodes)
         - overlap_ratio: overlapping_nodes / common_nodes
     """
     # Find commonly visible nodes
@@ -179,6 +180,8 @@ def compute_node_overlap(
             "common_nodes": [],
             "overlapping_nodes": [],
             "mean_distance": float("inf"),
+            "min_distance": float("inf"),
+            "max_distance": float("inf"),
             "overlap_ratio": 0.0,
         }
 

--- a/sleap/qc/frame_level.py
+++ b/sleap/qc/frame_level.py
@@ -7,6 +7,8 @@ from typing import Optional
 
 import numpy as np
 
+from sleap.qc.features.duplicate_split import compute_split_duplicate, duplicate_score
+
 
 class InstanceCountChecker:
     """Detect frames with unusual instance counts (incomplete annotation).
@@ -209,23 +211,40 @@ def detect_duplicates(
     iou_threshold: float = 0.5,
     node_distance_threshold: float = 10.0,
     node_overlap_ratio: float = 0.8,
+    edge_means: Optional[dict] = None,
+    duplicate_score_threshold: float = 0.5,
 ) -> list[dict]:
     """Detect duplicate instances in a frame.
 
-    Uses both IOU and node-wise overlap to catch partial duplicates.
+    Uses three complementary signals: bbox IOU and node-wise overlap (both catch
+    overlapping copies), plus the complementary split-duplicate signal (one
+    animal split across two instances labeled on largely disjoint nodes). The
+    three are combined by :func:`~sleap.qc.features.duplicate_split.duplicate_score`
+    into a single graded confidence.
+
+    A pair is flagged when the combined ``dscore >= duplicate_score_threshold``
+    OR the existing IOU / node-overlap criteria fire, so this remains additive
+    and never drops a pair the previous logic would have flagged.
 
     Args:
         instances: List of (N_nodes, 2) arrays.
         iou_threshold: IOU above this = duplicate.
         node_distance_threshold: Distance for node overlap.
         node_overlap_ratio: Min overlap ratio to flag as duplicate.
+        edge_means: Optional learned mean edge lengths (sorted ``(i, j)`` ->
+            length) used to scale the split-duplicate signal. ``None`` falls
+            back to the bbox-diagonal scale inside ``compute_split_duplicate``.
+        duplicate_score_threshold: Combined-score cutoff at/above which a pair is
+            flagged as a duplicate.
 
     Returns:
         List of duplicate pair dictionaries with:
         - index_a, index_b: instance indices
         - iou: IOU value
         - node_overlap: node overlap info
-        - reason: "iou" or "node_overlap"
+        - split_duplicate_score: complementary-split signal (0-1)
+        - duplicate_score: combined graded confidence (0-1)
+        - reason: "iou", "node_overlap", or "split_duplicate"
     """
     duplicates = []
     n_instances = len(instances)
@@ -236,6 +255,11 @@ def detect_duplicates(
             node_overlap = compute_node_overlap(
                 instances[i], instances[j], node_distance_threshold
             )
+
+            sd = compute_split_duplicate(
+                instances[i], instances[j], edge_means
+            )["split_duplicate_score"]
+            dscore = duplicate_score(iou, node_overlap["overlap_ratio"], sd)
 
             is_duplicate = False
             reason = None
@@ -253,6 +277,12 @@ def detect_duplicates(
                 is_duplicate = True
                 reason = "node_overlap"
 
+            # Check the combined/split signal (catches complementary splits that
+            # neither IOU nor node-overlap fire on).
+            elif dscore >= duplicate_score_threshold:
+                is_duplicate = True
+                reason = "split_duplicate"
+
             if is_duplicate:
                 duplicates.append(
                     {
@@ -260,6 +290,8 @@ def detect_duplicates(
                         "index_b": j,
                         "iou": iou,
                         "node_overlap": node_overlap,
+                        "split_duplicate_score": sd,
+                        "duplicate_score": dscore,
                         "reason": reason,
                     }
                 )

--- a/sleap/qc/frame_level.py
+++ b/sleap/qc/frame_level.py
@@ -256,9 +256,9 @@ def detect_duplicates(
                 instances[i], instances[j], node_distance_threshold
             )
 
-            sd = compute_split_duplicate(
-                instances[i], instances[j], edge_means
-            )["split_duplicate_score"]
+            sd = compute_split_duplicate(instances[i], instances[j], edge_means)[
+                "split_duplicate_score"
+            ]
             dscore = duplicate_score(iou, node_overlap["overlap_ratio"], sd)
 
             is_duplicate = False

--- a/sleap/qc/insample_prediction.py
+++ b/sleap/qc/insample_prediction.py
@@ -1,0 +1,509 @@
+"""In-sample model prediction: labelable-but-unlabeled points (Tier-2).
+
+This module implements the *model-based* (Tier-2) variant of detector (f),
+"labelable points left unlabeled" -- the maintainer's active-learning idea.
+
+The geometry/visibility-only sibling
+(:mod:`sleap.qc.features.missing_node`) can only catch *outlier* drops: an
+instance missing a node its co-visible peers usually keep. It is blind to
+dataset-wide systematic under-labeling (e.g. nobody ever labels the tail tip),
+because the project's own visibility statistics never expect a node that is
+rarely labeled.
+
+This detector instead runs a *trained model* on the ALREADY-labeled frames
+(in-sample inference). For each node a human left UNLABELED/invisible, it reads
+the model's predicted confidence at the matched predicted instance's node and
+flags the cases where the model *confidently* localizes a part the human left
+blank. That distinguishes:
+
+    * "truly occluded" -- the model is also unsure (low confidence), and
+    * "labelable but skipped" -- the model is confident the part is there.
+
+Design / scope:
+    * **Import-safe.** Importing this module never imports ``torch`` or
+      ``sleap_nn``; those heavy imports happen lazily inside
+      :func:`run_insample_prediction`.
+    * **Graceful.** If ``sleap_nn``/the model is unavailable, or the model's
+      skeleton node-names do not match ``labels.skeletons[0]``, the function
+      logs a reason and returns an empty/zero result instead of crashing.
+    * **Non-GMM channel.** The per-instance ``prediction_disagreement_score`` is
+      surfaced via :attr:`QCResults.channel_scores` (like the missing-node
+      channel), not as a GMM feature. Default-OFF / experimental.
+
+The matching + scoring logic (:func:`match_predictions_to_users` and
+:func:`score_instance_disagreement`) is a pure, model-free core so it can be
+unit-tested with canned predicted instances and without any torch dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    import sleap_io as sio
+
+logger = logging.getLogger(__name__)
+
+
+# Default score for an instance with no disagreement (or that could not be
+# evaluated). Surfaced as the channel score; 0.0 means "nothing to flag".
+_NO_DISAGREEMENT = 0.0
+
+
+def _visible_mask(points: np.ndarray) -> np.ndarray:
+    """Boolean ``(n_nodes,)`` mask of nodes with finite (visible) coordinates.
+
+    A node is "visible/labeled" when both of its coordinates are finite. NaN
+    (the convention for invisible/unlabeled nodes) -> ``False``.
+    """
+    points = np.asarray(points, dtype=float)
+    return ~np.isnan(points[:, :2]).any(axis=1)
+
+
+def _instance_centroid(points: np.ndarray) -> np.ndarray:
+    """Mean of the visible node coordinates, or NaNs if none are visible."""
+    points = np.asarray(points, dtype=float)
+    mask = _visible_mask(points)
+    if not mask.any():
+        return np.array([np.nan, np.nan])
+    return np.nanmean(points[mask, :2], axis=0)
+
+
+def _predicted_scores(pred_points: np.ndarray, n_nodes: int) -> np.ndarray:
+    """Extract the per-node confidence column from a predicted-instance array.
+
+    ``sio.PredictedInstance.numpy(scores=True)`` returns an ``(n_nodes, 3)``
+    array of ``(x, y, score)``. This pulls out the score column and pads/truncates
+    defensively to ``n_nodes`` so a malformed prediction can never index out of
+    range against the user skeleton. Missing entries -> ``NaN`` (treated as "no
+    prediction").
+
+    Args:
+        pred_points: ``(n_nodes, 3)`` predicted array of ``(x, y, score)``.
+        n_nodes: Expected node count (from the user skeleton).
+
+    Returns:
+        ``(n_nodes,)`` float array of per-node confidences (``NaN`` where the
+        model produced no usable score).
+    """
+    pred_points = np.asarray(pred_points, dtype=float)
+    scores = np.full(n_nodes, np.nan, dtype=float)
+    if pred_points.ndim != 2 or pred_points.shape[1] < 3:
+        return scores
+    k = min(n_nodes, pred_points.shape[0])
+    scores[:k] = pred_points[:k, 2]
+    return scores
+
+
+def match_predictions_to_users(
+    user_points: list[np.ndarray],
+    pred_points: list[np.ndarray],
+) -> list[Optional[int]]:
+    """Match each USER instance to the nearest PREDICTED instance in a frame.
+
+    Bottom-up (and top-down) models emit predicted instances with no guaranteed
+    correspondence to the user instances in the same frame, so we associate them
+    by spatial proximity: each user instance is paired with the predicted
+    instance whose visible-node centroid is closest (greedy nearest, one
+    predicted instance per user instance, mutually exclusive).
+
+    The matching is symmetric in spirit to "match each predicted instance to the
+    nearest user instance" -- a greedy global nearest-centroid assignment -- but
+    is indexed by user instance so the caller can directly look up the prediction
+    for a given user instance.
+
+    Args:
+        user_points: List of ``(n_nodes, 2)`` user pose arrays (NaN = invisible).
+        pred_points: List of ``(n_nodes, >=2)`` predicted pose arrays. Only the
+            first two columns (x, y) are used for centroid matching.
+
+    Returns:
+        A list parallel to ``user_points``: ``match[i]`` is the index into
+        ``pred_points`` of the predicted instance matched to user instance ``i``,
+        or ``None`` if no prediction could be matched (no predictions in the
+        frame, or no usable centroid).
+    """
+    n_user = len(user_points)
+    matches: list[Optional[int]] = [None] * n_user
+    if n_user == 0 or len(pred_points) == 0:
+        return matches
+
+    user_centroids = [_instance_centroid(p) for p in user_points]
+    pred_centroids = [_instance_centroid(p) for p in pred_points]
+
+    # Build all valid (distance, user_idx, pred_idx) pairs, then assign greedily
+    # from the closest pair outward. This is O(U*P) which is tiny per frame.
+    pairs: list[tuple[float, int, int]] = []
+    for ui, uc in enumerate(user_centroids):
+        if np.isnan(uc).any():
+            continue
+        for pi, pc in enumerate(pred_centroids):
+            if np.isnan(pc).any():
+                continue
+            dist = float(np.hypot(uc[0] - pc[0], uc[1] - pc[1]))
+            pairs.append((dist, ui, pi))
+
+    pairs.sort(key=lambda t: t[0])
+    used_pred: set[int] = set()
+    assigned_user: set[int] = set()
+    for _dist, ui, pi in pairs:
+        if ui in assigned_user or pi in used_pred:
+            continue
+        matches[ui] = pi
+        assigned_user.add(ui)
+        used_pred.add(pi)
+
+    return matches
+
+
+def score_instance_disagreement(
+    user_points: np.ndarray,
+    pred_scores: Optional[np.ndarray],
+    min_confidence: float = 0.5,
+) -> dict:
+    """Score how strongly a model disagrees with a user's *unlabeled* nodes.
+
+    For each node the user left invisible/unlabeled (NaN), look up the matched
+    predicted instance's confidence at that node. A node is a *disagreement* when
+    the model is confident the part is present::
+
+        disagreement at node k  <=>  user node k is invisible
+                                      AND pred_scores[k] >= min_confidence
+
+    The per-instance ``prediction_disagreement_score`` is the maximum predicted
+    confidence over the instance's unlabeled nodes, but only counting nodes whose
+    confidence clears ``min_confidence`` (so it is gated -- a model that is mildly
+    unsure about every blank node yields 0.0). The result is therefore in
+    ``[0, 1]`` and 0.0 when the model never confidently fills a human-left blank.
+
+    Args:
+        user_points: ``(n_nodes, 2)`` user pose array (NaN = invisible/unlabeled).
+        pred_scores: ``(n_nodes,)`` per-node predicted confidence for the matched
+            predicted instance, or ``None`` if the user instance had no matched
+            prediction. ``NaN`` entries mean "model produced no peak there".
+        min_confidence: Confidence at/above which a model prediction at an
+            unlabeled node counts as a disagreement. Defaults to ``0.5``.
+
+    Returns:
+        Dictionary with:
+
+        - ``prediction_disagreement_score``: ``float`` in ``[0, 1]`` (gated max,
+          see above).
+        - ``disagreement_nodes``: ``list[int]`` of flagged node indices
+          (ascending) -- nodes the user left blank that the model localized at
+          ``>= min_confidence``.
+        - ``unlabeled_confidences``: ``dict[int, float]`` mapping every unlabeled
+          node index to the model's confidence there (NaN-confidence nodes
+          omitted). Useful for explanations / per-node records.
+        - ``n_disagreements``: ``int`` count of flagged nodes.
+    """
+    user_points = np.asarray(user_points, dtype=float)
+    n_nodes = user_points.shape[0]
+    invisible = ~_visible_mask(user_points)
+    invisible_idx = np.where(invisible)[0]
+
+    empty = {
+        "prediction_disagreement_score": _NO_DISAGREEMENT,
+        "disagreement_nodes": [],
+        "unlabeled_confidences": {},
+        "n_disagreements": 0,
+    }
+
+    # No unlabeled nodes, or no matched prediction -> nothing to evaluate.
+    if len(invisible_idx) == 0 or pred_scores is None:
+        return empty
+
+    pred_scores = np.asarray(pred_scores, dtype=float)
+    if pred_scores.shape[0] != n_nodes:
+        # Shape mismatch (should not happen given _predicted_scores padding);
+        # be defensive and report nothing rather than mis-index.
+        return empty
+
+    unlabeled_confidences: dict[int, float] = {}
+    disagreement_nodes: list[int] = []
+    confident_values: list[float] = []
+    for k in invisible_idx:
+        conf = pred_scores[k]
+        if not np.isfinite(conf):
+            continue
+        unlabeled_confidences[int(k)] = float(conf)
+        if conf >= min_confidence:
+            disagreement_nodes.append(int(k))
+            confident_values.append(float(conf))
+
+    score = float(np.max(confident_values)) if confident_values else _NO_DISAGREEMENT
+    # Clamp defensively: predicted confidences are nominally in [0, 1] but
+    # refinement could overshoot by a hair.
+    score = float(np.clip(score, 0.0, 1.0))
+
+    return {
+        "prediction_disagreement_score": score,
+        "disagreement_nodes": sorted(disagreement_nodes),
+        "unlabeled_confidences": unlabeled_confidences,
+        "n_disagreements": len(disagreement_nodes),
+    }
+
+
+def _skeleton_node_names(skeleton) -> list[str]:
+    """Best-effort list of node names from a sleap-io skeleton."""
+    nodes = getattr(skeleton, "nodes", None)
+    if nodes is None:
+        return []
+    names: list[str] = []
+    for n in nodes:
+        name = getattr(n, "name", None)
+        names.append(name if isinstance(name, str) else str(n))
+    return names
+
+
+def _video_key(video, video_idx: int) -> str:
+    """Stable, hashable identifier for a video (mirrors LabelQCDetector).
+
+    ``Video.filename`` is a list for image-sequence backends, which is
+    unhashable, so fall back to the video index.
+    """
+    filename = getattr(video, "filename", None)
+    if isinstance(filename, str) and filename:
+        return filename
+    return str(video_idx)
+
+
+def _empty_result(reason: str) -> dict:
+    """Build a no-op result and log why we bailed out."""
+    logger.info("In-sample prediction detector: %s", reason)
+    return {
+        "instance_scores": {},
+        "records": [],
+        "ran": False,
+        "reason": reason,
+    }
+
+
+def run_insample_prediction(
+    labels: "sio.Labels",
+    model_path: str,
+    peak_threshold: float = 0.2,
+    min_confidence: float = 0.5,
+    device: str = "auto",
+    progress_callback=None,
+) -> dict:
+    """Flag labelable-but-unlabeled points via in-sample model prediction.
+
+    Runs a trained ``sleap_nn`` model on the ALREADY-labeled frames of
+    ``labels`` (in-sample), matches each predicted instance to the nearest user
+    instance, and -- for every node the user left invisible -- reads the matched
+    prediction's confidence there. A confident prediction at a blank node is a
+    "disagreement" (the model expects a labeled part the human skipped).
+
+    This is the model-based (Tier-2) variant of detector (f). It is import-safe
+    (no top-level torch/``sleap_nn`` import) and graceful: any failure to load
+    or run the model, or a skeleton node-name mismatch, returns a zero result
+    with ``ran=False`` and a logged ``reason`` rather than raising.
+
+    Args:
+        labels: Labels with user-annotated instances to evaluate (in-sample).
+        model_path: Path to a trained ``sleap_nn`` model directory (containing
+            ``best.ckpt`` + ``training_config.yaml``). If falsy (``None``/empty),
+            the detector no-ops -- callers should not run this stage without a
+            configured model path.
+        peak_threshold: Minimum peak confidence for the model's peak finding.
+            Lower values let the model report weaker peaks (more candidate
+            disagreements). Passed through to inference. Defaults to ``0.2``.
+        min_confidence: Confidence at/above which a model prediction at an
+            unlabeled node counts as a disagreement (gates the per-instance
+            score). Defaults to ``0.5``.
+        device: Torch device for inference (``"auto"``/``"cpu"``/``"cuda"``/
+            ``"mps"``). Defaults to ``"auto"``.
+        progress_callback: Optional callable ``(step, fraction, detail)`` for
+            progress reporting (matches ``LabelQCDetector`` callbacks). May be
+            ``None``.
+
+    Returns:
+        Dictionary with:
+
+        - ``instance_scores``: ``dict[(video_idx, frame_idx, instance_idx),
+          float]`` of per-user-instance ``prediction_disagreement_score`` in
+          ``[0, 1]``. Only instances with a non-zero score are included (so the
+          integration layer can copy them straight into
+          ``QCResults.channel_scores["prediction"]``).
+        - ``records``: ``list[dict]`` of per-node disagreement records, one per
+          ``(video_idx, frame_idx, instance_idx, node_idx)`` where the user left
+          the node blank and the model was confident. Each record has keys
+          ``video_idx, frame_idx, instance_idx, node_idx, node_name,
+          predicted_confidence``.
+        - ``ran``: ``bool`` -- whether inference actually ran.
+        - ``reason``: ``str`` -- why it did not run (empty when ``ran`` is True).
+    """
+
+    def _report(step: str, fraction: float, detail: Optional[str] = None) -> None:
+        if progress_callback is not None:
+            progress_callback(step, fraction, detail)
+
+    if not model_path:
+        return _empty_result("no model path configured; skipping (no-op)")
+
+    if not labels.skeletons:
+        return _empty_result("labels have no skeleton; skipping")
+
+    user_skeleton = labels.skeletons[0]
+    user_node_names = _skeleton_node_names(user_skeleton)
+    n_nodes = len(user_node_names)
+    if n_nodes == 0:
+        return _empty_result("user skeleton has no nodes; skipping")
+
+    # --- Lazy, guarded model load + inference. All torch/sleap_nn touching code
+    # lives below this point so importing this module stays cheap and safe. ---
+    _report("In-sample prediction", 0.0, "Loading model")
+    try:
+        from sleap_nn.predict import run_inference
+    except Exception as e:  # pragma: no cover - environment-dependent
+        return _empty_result(f"sleap_nn unavailable ({e!r}); skipping")
+
+    # ``run_inference`` ALWAYS writes the predicted Labels to disk when
+    # make_labels=True (defaulting to ``./results.predictions.slp``), with no
+    # flag to disable it. We are only after the in-memory predictions, so direct
+    # the output into a throwaway temp dir and remove it afterward to avoid
+    # littering the user's working directory.
+    try:
+        with tempfile.TemporaryDirectory(prefix="sleap_qc_insample_") as tmpdir:
+            out_path = os.path.join(tmpdir, "insample.predictions.slp")
+            predicted_labels = run_inference(
+                input_labels=labels,
+                model_paths=[model_path],
+                only_labeled_frames=True,
+                exclude_user_labeled=False,
+                peak_threshold=peak_threshold,
+                make_labels=True,
+                device=device,
+                output_path=out_path,
+            )
+    except Exception as e:
+        return _empty_result(f"inference failed ({e!r}); skipping")
+
+    if predicted_labels is None or not getattr(predicted_labels, "skeletons", None):
+        return _empty_result("inference returned no predictions; skipping")
+
+    # Node-name match guard: the predicted skeleton must line up with the user
+    # skeleton or the per-node confidence lookup would be meaningless.
+    pred_node_names = _skeleton_node_names(predicted_labels.skeletons[0])
+    if pred_node_names != user_node_names:
+        return _empty_result(
+            "model skeleton node-names do not match labels.skeletons[0] "
+            f"(model={pred_node_names!r} vs labels={user_node_names!r}); skipping"
+        )
+
+    _report("In-sample prediction", 0.5, "Matching predictions")
+
+    # Index predicted frames by (video_idx, frame_idx) so we can align them to
+    # the user frames regardless of frame ordering in the returned Labels.
+    # Map predicted videos back to user-video indices by identifier so a
+    # video_idx is stable across the two Labels objects.
+    user_video_key_to_idx = {_video_key(v, i): i for i, v in enumerate(labels.videos)}
+
+    def _resolve_video_idx(video, fallback_idx: int) -> int:
+        return user_video_key_to_idx.get(_video_key(video, fallback_idx), fallback_idx)
+
+    pred_by_frame: dict[tuple[int, int], list] = {}
+    for pv_idx, pvideo in enumerate(predicted_labels.videos):
+        v_idx = _resolve_video_idx(pvideo, pv_idx)
+        for lf in predicted_labels:
+            if lf.video is not pvideo:
+                continue
+            pred_by_frame.setdefault((v_idx, lf.frame_idx), []).extend(
+                list(lf.instances)
+            )
+
+    instance_scores: dict[tuple[int, int, int], float] = {}
+    records: list[dict] = []
+
+    for video_idx, video in enumerate(labels.videos):
+        labeled_frames = [lf for lf in labels if lf.video == video]
+        for lf in labeled_frames:
+            frame_idx = lf.frame_idx
+            user_instances = list(lf.user_instances)
+            if not user_instances:
+                continue
+
+            user_points = [inst.numpy(invisible_as_nan=True) for inst in user_instances]
+            pred_instances = pred_by_frame.get((video_idx, frame_idx), [])
+            pred_points = [
+                _predicted_scores_array(pi, n_nodes) for pi in pred_instances
+            ]
+
+            matches = match_predictions_to_users(
+                user_points, [pp["xy"] for pp in pred_points]
+            )
+
+            for inst_idx, upts in enumerate(user_points):
+                match_idx = matches[inst_idx]
+                pred_scores = (
+                    pred_points[match_idx]["scores"] if match_idx is not None else None
+                )
+                result = score_instance_disagreement(
+                    upts, pred_scores, min_confidence=min_confidence
+                )
+
+                score = result["prediction_disagreement_score"]
+                if score > 0.0:
+                    instance_scores[(video_idx, frame_idx, inst_idx)] = score
+
+                confs = result["unlabeled_confidences"]
+                for node_idx in result["disagreement_nodes"]:
+                    records.append(
+                        {
+                            "video_idx": video_idx,
+                            "frame_idx": frame_idx,
+                            "instance_idx": inst_idx,
+                            "node_idx": node_idx,
+                            "node_name": user_node_names[node_idx]
+                            if node_idx < len(user_node_names)
+                            else str(node_idx),
+                            "predicted_confidence": confs.get(node_idx, float("nan")),
+                        }
+                    )
+
+    _report(
+        "In-sample prediction",
+        1.0,
+        f"{len(instance_scores)} instances with disagreements",
+    )
+
+    return {
+        "instance_scores": instance_scores,
+        "records": records,
+        "ran": True,
+        "reason": "",
+    }
+
+
+def _predicted_scores_array(pred_instance, n_nodes: int) -> dict:
+    """Extract ``{"xy": (n,2), "scores": (n,)}`` from a predicted instance.
+
+    Uses ``PredictedInstance.numpy(scores=True)`` -> ``(n_nodes, 3)`` of
+    ``(x, y, score)``. Splits out the coordinate columns (for centroid matching)
+    and the score column (for the disagreement lookup). Defensive against odd
+    shapes / instances that don't support ``scores=True``.
+    """
+    try:
+        arr = np.asarray(pred_instance.numpy(scores=True), dtype=float)
+    except TypeError:
+        # Older/odd instance without a scores kwarg: fall back to coords only,
+        # treating confidence as "present but unknown" -> NaN (never flags).
+        arr = np.asarray(pred_instance.numpy(), dtype=float)
+        xy = np.full((n_nodes, 2), np.nan)
+        k = min(n_nodes, arr.shape[0])
+        if arr.ndim == 2 and arr.shape[1] >= 2:
+            xy[:k] = arr[:k, :2]
+        return {"xy": xy, "scores": np.full(n_nodes, np.nan)}
+
+    xy = np.full((n_nodes, 2), np.nan)
+    if arr.ndim == 2 and arr.shape[1] >= 2:
+        k = min(n_nodes, arr.shape[0])
+        xy[:k] = arr[:k, :2]
+    scores = _predicted_scores(arr, n_nodes)
+    return {"xy": xy, "scores": scores}

--- a/sleap/qc/results.py
+++ b/sleap/qc/results.py
@@ -27,7 +27,11 @@ class FrameKey(NamedTuple):
 
 # Human-readable labels for channel-only issues (scored outside the GMM and
 # merged into get_flagged). Keyed by channel name.
-CHANNEL_ISSUE_LABELS = {"missing_node": "Missing labelable node"}
+CHANNEL_ISSUE_LABELS = {
+    "missing_node": "Missing labelable node",
+    "appearance": "Appearance outlier",
+    "prediction": "Model expects a labeled part here",
+}
 
 
 @dataclass

--- a/sleap/qc/results.py
+++ b/sleap/qc/results.py
@@ -25,6 +25,11 @@ class FrameKey(NamedTuple):
     frame_idx: int
 
 
+# Human-readable labels for channel-only issues (scored outside the GMM and
+# merged into get_flagged). Keyed by channel name.
+CHANNEL_ISSUE_LABELS = {"missing_node": "Missing labelable node"}
+
+
 @dataclass
 class FrameQC:
     """Quality check results for a single frame."""
@@ -34,6 +39,8 @@ class FrameQC:
     actual_instance_count: int = 0
     duplicate_pairs: list[tuple[int, int]] = field(default_factory=list)
     duplicate_reasons: list[str] = field(default_factory=list)
+    # Combined duplicate confidence (0-1) parallel to duplicate_pairs/reasons.
+    duplicate_scores: list[float] = field(default_factory=list)
     is_negative_with_instances: bool = False
 
 
@@ -73,6 +80,12 @@ class QCResults:
         frame_results: Mapping from frame key to frame-level QC results.
         feature_contributions: Mapping from instance key to per-feature scores.
         feature_names: List of feature names used.
+        forced_issues: Mapping from instance key to a forced top-issue label set
+            by a detector hard rule (e.g. "Whole-instance L/R flip"). Takes
+            precedence over inferred/channel issues in ``get_flagged``.
+        channel_scores: Mapping from channel name (e.g. "missing_node") to a
+            ``{InstanceKey: float}`` of per-instance scores produced outside the
+            GMM. Merged with the GMM score in ``get_flagged``.
     """
 
     instance_scores: dict[InstanceKey, float] = field(default_factory=dict)
@@ -81,37 +94,76 @@ class QCResults:
         default_factory=dict
     )
     feature_names: list[str] = field(default_factory=list)
+    forced_issues: dict[InstanceKey, str] = field(default_factory=dict)
+    channel_scores: dict[str, dict[InstanceKey, float]] = field(default_factory=dict)
 
     def get_flagged(self, threshold: float = 0.7) -> list[QCFlag]:
         """Get instances flagged above threshold.
 
+        Merges the GMM-based ``instance_scores`` with any per-channel scores
+        (e.g. the missing-node channel) scored outside the GMM: the final score
+        for an instance is the max of its GMM score and its best channel score.
+        An instance can therefore be flagged purely on a channel even if it had
+        no GMM score (its ``feature_contributions`` may be absent, in which case
+        an empty dict is used safely).
+
         Args:
-            threshold: Score threshold (0-1). Instances with scores >= threshold
-                are flagged.
+            threshold: Score threshold (0-1). Instances with a final score
+                >= threshold are flagged.
 
         Returns:
             List of QCFlag objects, sorted by score descending.
         """
-        flagged = []
-        for key, score in self.instance_scores.items():
-            if score >= threshold:
-                contributions = self.feature_contributions.get(key, {})
-                top_issue = self._infer_top_issue(contributions)
-                confidence = self._get_confidence(score, contributions)
-                explanation = self._generate_explanation(
-                    score, top_issue, contributions
-                )
+        # Union of all keys: GMM-scored instances plus any channel-only ones.
+        keys = set(self.instance_scores)
+        for channel in self.channel_scores.values():
+            keys.update(channel)
 
-                flagged.append(
-                    QCFlag(
-                        instance_key=key,
-                        score=score,
-                        confidence=confidence,
-                        top_issue=top_issue,
-                        feature_contributions=contributions,
-                        explanation=explanation,
-                    )
+        flagged = []
+        for key in keys:
+            gmm_score = self.instance_scores.get(key, 0.0)
+
+            # Best channel score (and which channel won) for this key.
+            chan = float("-inf")
+            winning_channel = None
+            for channel_name, channel in self.channel_scores.items():
+                value = channel.get(key)
+                if value is not None and value > chan:
+                    chan = value
+                    winning_channel = channel_name
+
+            final = max(gmm_score, chan)
+            if final < threshold:
+                continue
+
+            contributions = self.feature_contributions.get(key, {})
+
+            # Top-issue precedence: a forced hard-rule issue wins; otherwise, if
+            # a channel out-scored the GMM, use that channel's label; otherwise
+            # infer from feature contributions.
+            forced = self.forced_issues.get(key)
+            if forced is not None:
+                top_issue = forced
+            elif winning_channel is not None and chan > gmm_score:
+                top_issue = CHANNEL_ISSUE_LABELS.get(
+                    winning_channel, f"High {winning_channel}"
                 )
+            else:
+                top_issue = self._infer_top_issue(contributions)
+
+            confidence = self._get_confidence(final, contributions)
+            explanation = self._generate_explanation(final, top_issue, contributions)
+
+            flagged.append(
+                QCFlag(
+                    instance_key=key,
+                    score=final,
+                    confidence=confidence,
+                    top_issue=top_issue,
+                    feature_contributions=contributions,
+                    explanation=explanation,
+                )
+            )
 
         # Sort by score descending
         flagged.sort(key=lambda f: f.score, reverse=True)

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -1423,6 +1423,30 @@ class TestQCUXLayout:
         widget._charts_group.setChecked(True)
         assert widget._viz_tabs.isVisible()
 
+    def test_charts_height_capped_and_panel_scrolls(self, qtbot):
+        """Charts can't expand without bound; the panel is scrollable.
+
+        Regression for #2769 item 4: the matplotlib canvases used to grow the
+        panel (and the whole window) without limit, so users couldn't reach the
+        flagged-instances table to review. The charts now have a locked maximum
+        height and the whole panel lives in a resizable scroll area.
+        """
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        # Charts height is locked so the canvases can't expand without bound.
+        assert 0 < widget._viz_tabs.maximumHeight() <= 300
+        assert (
+            widget._viz_tabs.sizePolicy().verticalPolicy()
+            == QtWidgets.QSizePolicy.Maximum
+        )
+        # The whole panel lives inside a resizable scroll area...
+        assert isinstance(widget._scroll, QtWidgets.QScrollArea)
+        assert widget._scroll.widgetResizable()
+        # ...and the table is still reachable through the scroll container.
+        container = widget._scroll.widget()
+        assert container is not None
+        assert widget._table_view in container.findChildren(QtWidgets.QTableView)
+
     # --- Item 7: plain-language Selected Instance + Statistics ------------
 
     def test_friendly_issue_maps_known_labels(self):

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -9,6 +9,7 @@ from sleap.gui.widgets.qc import (
     CheckableFilterMenu,
     CollapsibleGroupBox,
     QCAnalysisWorker,
+    QCChainTraceDialog,
     QCFlagTableModel,
     QCSkeletonTraceCanvas,
     QCWidget,
@@ -1935,6 +1936,7 @@ class TestQCListReviewedIntegration:
         widget = self._make_widget_with_flags(qtbot, flags)
         widget._table_model.set_reviewed(flags[0], True)
         widget._on_issue_type_toggled("Angle", False)
+        widget._hide_reviewed_check.setChecked(True)
         assert widget._reviewed_keys
         assert widget._visible_issue_types is not None
 
@@ -1948,6 +1950,189 @@ class TestQCListReviewedIntegration:
         assert widget._all_flagged == []
         assert widget._reviewed_count_label.text() == "0 / 0 reviewed"
         assert not widget._issue_filter_button.isEnabled()
+        # The "Hide reviewed" filter is reset and disabled for a fresh project.
+        assert not widget._hide_reviewed_check.isChecked()
+        assert not widget._hide_reviewed_check.isEnabled()
+
+
+class TestQCListHideReviewedFilter:
+    """Tests for the "Hide reviewed" not-reviewed filter (Group C / #2769).
+
+    The filter shows only flagged instances NOT in ``_reviewed_keys``, combined
+    (logical AND) with the issue-type filter, and updates the table live as rows
+    are marked reviewed/unreviewed.
+    """
+
+    def _make_widget_with_flags(self, qtbot, flags):
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._results = _fake_results(flags)
+        widget._update_flagged_display()
+        return widget
+
+    def test_hide_reviewed_checkbox_exists_and_gated_on_results(self, qtbot):
+        """The control exists, defaults off, and is disabled before results."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert widget._hide_reviewed_check is not None
+        assert widget._hide_reviewed_check.text() == "Hide reviewed"
+        # Unchecked + disabled until there are flagged rows to hide.
+        assert not widget._hide_reviewed_check.isChecked()
+        assert not widget._hide_reviewed_check.isEnabled()
+
+        # Once results with flags exist, the checkbox becomes usable.
+        flags = [MockQCFlag(0, 1, 0, 0.95, "high", "Flip")]
+        widget._results = _fake_results(flags)
+        widget._update_flagged_display()
+        assert widget._hide_reviewed_check.isEnabled()
+
+    def test_hide_reviewed_shows_only_unreviewed(self, qtbot):
+        """Enabling the filter shows exactly the not-reviewed instances."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+            MockQCFlag(0, 3, 0, 0.85, "medium", "Appearance"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        # Mark two of the three reviewed.
+        widget._table_model.set_reviewed(flags[0], True)
+        widget._table_model.set_reviewed(flags[2], True)
+
+        # Turn on "Hide reviewed": only the single unreviewed flag remains.
+        widget._hide_reviewed_check.setChecked(True)
+        shown = {
+            widget._table_model.items[r].instance_key
+            for r in range(widget._table_model.rowCount())
+        }
+        assert shown == {(0, 2, 0)}
+        # The shown rows are all unreviewed, so the counter reads 0 / 1.
+        assert widget._reviewed_count_label.text() == "0 / 1 reviewed"
+
+        # Unchecking restores the full (issue-filtered) set.
+        widget._hide_reviewed_check.setChecked(False)
+        assert widget._table_model.rowCount() == 3
+
+    def test_hide_reviewed_intersects_with_issue_filter(self, qtbot):
+        """The not-reviewed filter AND-combines with the issue-type filter."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+            MockQCFlag(0, 3, 0, 0.85, "medium", "Angle"),
+            MockQCFlag(0, 4, 0, 0.80, "medium", "Appearance"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        # Review one Angle flag (frame 2) and the Flip flag (frame 1).
+        widget._table_model.set_reviewed(flags[0], True)  # Flip
+        widget._table_model.set_reviewed(flags[1], True)  # Angle (frame 2)
+
+        # Show only the "Angle" issue type...
+        widget._set_all_issue_types(False)
+        widget._on_issue_type_toggled("Angle", True)
+        # ...and hide reviewed. Intersection = unreviewed Angle = frame 3 only.
+        widget._hide_reviewed_check.setChecked(True)
+
+        shown = {
+            widget._table_model.items[r].instance_key
+            for r in range(widget._table_model.rowCount())
+        }
+        assert shown == {(0, 3, 0)}
+
+    def test_marking_shown_row_reviewed_removes_it_live(self, qtbot):
+        """Ticking a shown row reviewed drops it from the unreviewed view live."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        # Hide reviewed with nothing reviewed yet -> both rows show.
+        widget._hide_reviewed_check.setChecked(True)
+        assert widget._table_model.rowCount() == 2
+
+        # Tick the first shown row reviewed via the model (as the checkbox does).
+        idx = widget._table_model.index(0, QCFlagTableModel.REVIEWED_COL)
+        first_key = widget._table_model.items[0].instance_key
+        widget._table_model.setData(idx, QtCore.Qt.Checked, QtCore.Qt.CheckStateRole)
+
+        # The re-filter is deferred to the next event-loop turn; let it run.
+        qtbot.wait(20)
+
+        keys = {
+            widget._table_model.items[r].instance_key
+            for r in range(widget._table_model.rowCount())
+        }
+        assert first_key not in keys
+        assert widget._table_model.rowCount() == 1
+        # Only the remaining unreviewed row is shown -> 0 / 1 reviewed.
+        assert widget._reviewed_count_label.text() == "0 / 1 reviewed"
+
+    def test_navigate_auto_mark_removes_row_live_when_hiding(self, qtbot):
+        """Selecting a row auto-marks it reviewed; it leaves the hidden view."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+        widget._hide_reviewed_check.setChecked(True)
+
+        selected_key = widget._table_model.items[0].instance_key
+        widget._table_view.selectRow(0)
+        # Selection auto-marks reviewed and schedules the deferred re-filter.
+        qtbot.wait(20)
+
+        keys = {
+            widget._table_model.items[r].instance_key
+            for r in range(widget._table_model.rowCount())
+        }
+        assert selected_key not in keys
+        assert selected_key in widget._reviewed_keys
+        assert widget._table_model.rowCount() == 1
+
+    def test_unhiding_brings_reviewed_rows_back(self, qtbot):
+        """Toggling the filter off re-shows reviewed rows (state preserved)."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        widget._table_model.set_reviewed(flags[0], True)
+        widget._hide_reviewed_check.setChecked(True)
+        assert widget._table_model.rowCount() == 1  # only the unreviewed one
+
+        widget._hide_reviewed_check.setChecked(False)
+        # Both rows back; the reviewed mark on frame 1 is intact.
+        assert widget._table_model.rowCount() == 2
+        assert widget._table_model.is_reviewed(flags[0])
+        assert widget._reviewed_count_label.text() == "1 / 2 reviewed"
+
+    def test_hide_reviewed_survives_threshold_refilter(self, qtbot):
+        """A raised threshold re-applies the active not-reviewed filter."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+            MockQCFlag(0, 3, 0, 0.80, "medium", "Appearance"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        # Review frame 2, then hide reviewed -> frames 1 and 3 show.
+        widget._table_model.set_reviewed(flags[1], True)
+        widget._hide_reviewed_check.setChecked(True)
+        assert widget._table_model.rowCount() == 2
+
+        # Raise the threshold so the 0.80 Appearance flag (frame 3) drops out;
+        # the still-active "Hide reviewed" filter leaves only the unreviewed
+        # frame 1.
+        widget._results.get_flagged.return_value = [f for f in flags if f.score >= 0.85]
+        widget._update_flagged_display()
+
+        shown = {
+            widget._table_model.items[r].instance_key
+            for r in range(widget._table_model.rowCount())
+        }
+        assert shown == {(0, 1, 0)}
 
 
 class _FakeNode:
@@ -2198,3 +2383,479 @@ class TestQCChainTracePanel:
         assert not widget._chain_trace_panel.isEnabled()
         widget._cb_chain.setChecked(True)
         assert widget._chain_trace_panel.isEnabled()
+
+
+class TestCollapsibleDisclosure:
+    """Tests for the ``<details>``-style disclosure arrow on CollapsibleGroupBox.
+
+    The header should read like a GitHub ``<details>``/``<summary>`` disclosure:
+    a ``▶`` arrow when collapsed and a ``▼`` arrow when expanded, while keeping
+    the caller's title queryable without the arrow (issue #2769 follow-up).
+    """
+
+    def test_collapsed_shows_right_arrow(self, qtbot):
+        """A collapsed box prefixes its title with a ▶ arrow."""
+        box = CollapsibleGroupBox("Detector Settings", collapsed=True)
+        qtbot.addWidget(box)
+        # ``title()`` returns the clean caller text; the displayed (Qt) title
+        # carries the arrow prefix.
+        assert box.title() == "Detector Settings"
+        assert QtWidgets.QGroupBox.title(box).startswith("▶")
+        assert "Detector Settings" in QtWidgets.QGroupBox.title(box)
+
+    def test_expanded_shows_down_arrow(self, qtbot):
+        """An expanded box prefixes its title with a ▼ arrow."""
+        box = CollapsibleGroupBox("Charts", collapsed=False)
+        qtbot.addWidget(box)
+        assert QtWidgets.QGroupBox.title(box).startswith("▼")
+
+    def test_arrow_flips_on_toggle(self, qtbot):
+        """Toggling the header flips the disclosure arrow ▶ <-> ▼."""
+        box = CollapsibleGroupBox("Stats", collapsed=True)
+        qtbot.addWidget(box)
+        assert QtWidgets.QGroupBox.title(box).startswith("▶")
+
+        box.setChecked(True)
+        assert QtWidgets.QGroupBox.title(box).startswith("▼")
+
+        box.setChecked(False)
+        assert QtWidgets.QGroupBox.title(box).startswith("▶")
+
+    def test_set_title_keeps_arrow(self, qtbot):
+        """Re-setting the title keeps the leading disclosure arrow in sync."""
+        box = CollapsibleGroupBox("Old", collapsed=False)
+        qtbot.addWidget(box)
+        box.setTitle("New title")
+        assert box.title() == "New title"
+        displayed = QtWidgets.QGroupBox.title(box)
+        assert displayed.startswith("▼")
+        assert "New title" in displayed
+
+    def test_detector_settings_header_has_arrow(self, qtbot):
+        """The Detector Settings panel renders the disclosure arrow."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        group = widget._detector_settings_group
+        # Collapsed by default -> right arrow; clean title still queryable.
+        assert group.title() == "Detector Settings"
+        assert QtWidgets.QGroupBox.title(group).startswith("▶")
+
+
+class TestQCRestoreDefaults:
+    """Tests for the Detector Settings "Restore defaults" button (item #2769).
+
+    Changing several controls and then clicking Restore defaults must put every
+    control back to a fresh ``QCConfig()`` -- enable checkboxes, thresholds,
+    ordered chains, the in-sample model path and the B2 toggles.
+    """
+
+    def test_restore_button_exists_in_panel(self, qtbot):
+        """A "Restore defaults" button lives inside the Detector Settings panel."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert widget._restore_defaults_btn is not None
+        assert widget._restore_defaults_btn.text() == "Restore defaults"
+        # It is a descendant of the Detector Settings group.
+        buttons = widget._detector_settings_group.findChildren(QtWidgets.QPushButton)
+        assert widget._restore_defaults_btn in buttons
+
+    def test_restore_resets_every_control_to_qcconfig_defaults(self, qtbot):
+        """Mutating many controls then restoring matches QCConfig() defaults."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # --- Mutate a wide spread of controls away from their defaults. ---
+        widget._cb_flip.setChecked(False)
+        widget._cb_chimera.setChecked(False)
+        widget._cb_duplicate.setChecked(False)
+        widget._cb_chain.setChecked(True)
+        widget._cb_missing.setChecked(True)
+        widget._cb_appearance.setChecked(True)
+        widget._cb_insample.setChecked(True)
+
+        widget._sb_flip_thr.setValue(0.95)
+        widget._sb_dup_thr.setValue(0.1)
+        widget._sb_chain_angle.setValue(120)
+        widget._sb_order_thr.setValue(0.8)
+        widget._sb_missing_thr.setValue(0.2)
+
+        widget._insample_model_edit.setText("/tmp/some/model")
+        widget._ordered_chains_edit.setPlainText("a, b, c")
+        widget._traced_chains = [["head", "tail"]]
+        widget._trace_in_progress = ["head"]
+
+        # --- Restore. ---
+        widget._restore_defaults_btn.click()
+
+        defaults = QCConfig()
+
+        # Enable checkboxes back to documented GUI defaults.
+        assert widget._cb_flip.isChecked()
+        assert widget._cb_chimera.isChecked()
+        assert widget._cb_duplicate.isChecked()
+        assert not widget._cb_chain.isChecked()
+        assert not widget._cb_missing.isChecked()
+        assert not widget._cb_appearance.isChecked()
+        assert not widget._cb_insample.isChecked()
+
+        # Thresholds back to defaults.
+        assert widget._sb_flip_thr.value() == defaults.chirality_flip_threshold
+        assert widget._sb_dup_thr.value() == defaults.duplicate_score_threshold
+        assert widget._sb_chain_angle.value() == int(defaults.chain_turn_angle_deg)
+        assert widget._sb_order_thr.value() == defaults.order_inversion_threshold
+        assert widget._sb_missing_thr.value() == defaults.missing_node_prob_threshold
+
+        # In-sample path + ordered chains cleared (QCConfig defaults are ""/[]).
+        assert widget._insample_model_edit.text() == defaults.insample_model_path
+        assert widget._ordered_chains_edit.toPlainText() == ""
+        assert widget._traced_chains == []
+        assert widget._trace_in_progress == []
+        assert widget._chains_list.count() == 0
+
+    def test_restore_yields_config_equal_to_defaults(self, qtbot):
+        """After restore, the rebuilt config matches a fresh QCConfig()."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        widget._cb_chain.setChecked(True)
+        widget._sb_missing_thr.setValue(0.42)
+        widget._traced_chains = [["x", "y"]]
+
+        widget._on_restore_detector_defaults()
+
+        built = widget._build_qc_config()
+        defaults = QCConfig()
+        # The GUI exposes a subset of fields; assert each round-trips to default.
+        assert built.use_chirality is True  # "auto" -> ON in GUI
+        assert built.use_split_detection == defaults.use_split_detection
+        assert built.use_duplicate_score == defaults.use_duplicate_score
+        assert built.use_chain_ordering is False
+        assert built.use_missing_node_check is False
+        assert built.use_appearance is False
+        assert built.use_insample_prediction is False
+        assert built.chirality_flip_threshold == defaults.chirality_flip_threshold
+        assert built.duplicate_score_threshold == defaults.duplicate_score_threshold
+        assert built.chain_turn_angle_deg == defaults.chain_turn_angle_deg
+        assert built.order_inversion_threshold == defaults.order_inversion_threshold
+        assert built.missing_node_prob_threshold == defaults.missing_node_prob_threshold
+        assert built.insample_model_path == defaults.insample_model_path
+        assert built.ordered_chains == defaults.ordered_chains
+
+    def test_apply_config_to_widgets_loads_values(self, qtbot):
+        """_apply_config_to_widgets pushes a non-default config into the panel."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        config = QCConfig(
+            use_chirality=False,
+            use_chain_ordering=True,
+            use_appearance=True,
+            chirality_flip_threshold=0.25,
+            chain_turn_angle_deg=90.0,
+            missing_node_prob_threshold=0.55,
+            insample_model_path="/models/best",
+            ordered_chains=[["base", "mid", "tip"]],
+        )
+        widget._apply_config_to_widgets(config)
+
+        assert not widget._cb_flip.isChecked()
+        assert widget._cb_chain.isChecked()
+        assert widget._cb_appearance.isChecked()
+        assert widget._sb_flip_thr.value() == 0.25
+        assert widget._sb_chain_angle.value() == 90
+        assert widget._sb_missing_thr.value() == 0.55
+        assert widget._insample_model_edit.text() == "/models/best"
+        assert widget._traced_chains == [["base", "mid", "tip"]]
+        assert widget._chains_list.count() == 1
+
+
+def _real_labels(node_names, edges, instance_coords):
+    """Build a real sleap-io ``Labels`` with one frame of user instances.
+
+    Args:
+        node_names: Ordered node names for the skeleton.
+        edges: List of ``(src, dst)`` name pairs for skeleton edges.
+        instance_coords: List of ``(n_nodes, 2)`` array-likes, one per instance.
+            ``np.nan`` rows are treated as invisible nodes.
+
+    Returns:
+        A ``Labels`` object whose single frame holds the given user instances,
+        all sharing one ``Skeleton``.
+    """
+    import numpy as np
+    from sleap_io.model.skeleton import Skeleton
+    from sleap_io.model.instance import Instance
+    from sleap_io.model.labeled_frame import LabeledFrame
+    from sleap_io.model.labels import Labels
+    from sleap_io.model.video import Video
+
+    skeleton = Skeleton(list(node_names), edges=[list(e) for e in edges])
+    video = Video(filename="dummy.mp4")
+    instances = [
+        Instance.from_numpy(np.asarray(coords, dtype=float), skeleton=skeleton)
+        for coords in instance_coords
+    ]
+    lf = LabeledFrame(video=video, frame_idx=0, instances=instances)
+    return Labels([lf])
+
+
+class TestQCSkeletonTraceCanvasRealCoords:
+    """Real-animal layout for the trace canvas (issue #2769 follow-up).
+
+    The canvas should draw the skeleton using real labeled coordinates when they
+    are provided, and fall back to the spring/line layout when they are not.
+    """
+
+    def test_set_node_positions_drives_layout(self, qtbot):
+        """Real coords are normalized into the display frame and used as-is."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        # An L-shaped animal: B is right of A, C is below B (image coords, y down).
+        canvas.set_skeleton(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            node_positions={"A": (0.0, 0.0), "B": (100.0, 0.0), "C": (100.0, 50.0)},
+        )
+        pos = canvas._positions
+        assert set(pos) == {"A", "B", "C"}
+        # Normalized to ~[-1, 1] (max half-extent maps to 1).
+        for x, y in pos.values():
+            assert -1.0001 <= x <= 1.0001
+            assert -1.0001 <= y <= 1.0001
+        # Horizontal order from the real coords is preserved (A left of B).
+        assert pos["A"][0] < pos["B"][0]
+        # y is flipped (image y grows down): C is *below* B, so its drawn y is
+        # smaller than B's.
+        assert pos["C"][1] < pos["B"][1]
+        # The layout came from the real coords, not the seeded spring layout.
+        assert canvas._node_coords != {}
+
+    def test_set_node_positions_keeps_hit_testing(self, qtbot):
+        """Click hit-testing works against the real-coordinate positions."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            node_positions={"A": (0.0, 0.0), "B": (100.0, 0.0), "C": (200.0, 0.0)},
+        )
+        bx, by = canvas._positions["B"]
+        assert canvas.node_at(bx, by) == "B"
+        # A far-away point still misses everything.
+        assert canvas.node_at(50.0, 50.0) is None
+
+    def test_falls_back_to_spring_when_no_coords(self, qtbot):
+        """With no real coords the seeded spring/line layout is used."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton(["A", "B", "C"], [("A", "B"), ("B", "C")])
+        assert canvas._node_coords == {}
+        assert set(canvas._positions) == {"A", "B", "C"}
+
+    def test_single_real_coord_falls_back(self, qtbot):
+        """Fewer than two finite coords cannot define a scale -> fall back."""
+        import numpy as np
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (5.0, 5.0), "B": (np.nan, np.nan)},
+        )
+        # Only one finite coord -> _layout_from_coords returns None, spring used,
+        # but both nodes still get a position.
+        assert set(canvas._positions) == {"A", "B"}
+
+    def test_node_without_coord_is_not_drawn(self, qtbot):
+        """A node missing a real coord gets no position (and edges skip it)."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            node_positions={"A": (0.0, 0.0), "B": (10.0, 0.0)},  # C omitted
+        )
+        assert set(canvas._positions) == {"A", "B"}
+        # Redraw must not raise even though edge B->C references a missing node.
+        canvas.update_plot()
+
+
+class TestQCRealAnimalLayout:
+    """Widget-level real-animal layout fed from labeled instances."""
+
+    def test_set_labels_computes_median_node_positions(self, qtbot):
+        """set_labels derives per-node medians and feeds them to the canvas."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Three instances of the same L-shaped pose, translated to different
+        # parts of the frame. After per-instance centering the medians recover
+        # the shared shape, so the canvas uses real coords (not a spring layout).
+        base = [[0.0, 0.0], [40.0, 0.0], [40.0, 30.0]]
+
+        def shifted(dx, dy):
+            return [[x + dx, y + dy] for x, y in base]
+
+        labels = _real_labels(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            [shifted(0, 0), shifted(500, 10), shifted(-300, 200)],
+        )
+        widget.set_labels(labels)
+
+        coords = widget._skeleton_canvas._node_coords
+        assert set(coords) == {"A", "B", "C"}
+        # The recovered shape keeps B to the right of A and C below B (the L).
+        assert coords["B"][0] > coords["A"][0]
+        assert coords["C"][1] > coords["B"][1]  # raw image coords: y grows down
+
+    def test_representative_positions_skips_invisible_nodes(self, qtbot):
+        """A node never visible in any instance gets no representative coord."""
+        import numpy as np
+
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        nan = [np.nan, np.nan]
+        labels = _real_labels(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            [
+                [[0.0, 0.0], [10.0, 0.0], nan],
+                [[1.0, 1.0], [11.0, 1.0], nan],
+            ],
+        )
+        widget.set_labels(labels)
+        coords = widget._skeleton_canvas._node_coords
+        # C was invisible everywhere -> no representative position for it.
+        assert "C" not in coords
+        assert {"A", "B"} <= set(coords)
+
+    def test_set_labels_without_instances_uses_spring(self, qtbot):
+        """Labels with a skeleton but no instances fall back to spring layout."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        skeleton = _FakeSkeleton(["A", "B", "C"], [("A", "B"), ("B", "C")])
+        labels = MagicMock()
+        labels.skeletons = [skeleton]
+        labels.__len__ = MagicMock(return_value=0)
+        labels.__iter__ = MagicMock(return_value=iter([]))
+
+        widget.set_labels(labels)
+        # No instances -> no real coords, but the spring layout still positions
+        # every node so the user can trace.
+        assert widget._skeleton_canvas._node_coords == {}
+        assert set(widget._skeleton_canvas._positions) == {"A", "B", "C"}
+
+
+class TestQCChainTraceDialog:
+    """Pop-up ordered-chains editor (issue #2769 follow-up).
+
+    The full tracing UI now lives in a dialog opened from a "Configure
+    chains..." button; the inline summary reflects the configured chains and the
+    chains still feed ``QCConfig.ordered_chains``.
+    """
+
+    def test_configure_button_and_summary_exist(self, qtbot):
+        """The chain row exposes a button + summary instead of the inline panel."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert widget._chain_config_btn is not None
+        assert widget._chain_summary_label is not None
+        # Nothing configured yet.
+        assert widget._chain_summary_label.text() == "No chains"
+        # The trace panel is NOT a child of the detector grid container now; it
+        # is held off to the side for the dialog to host.
+        assert widget._chain_trace_panel is not None
+
+    def test_summary_updates_when_chains_added(self, qtbot):
+        """Adding/removing chains updates the inline summary text."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        widget._traced_chains = [["TTI", "Tail_0", "TailTip"], ["Head", "Neck"]]
+        widget._refresh_chains_list()
+
+        text = widget._chain_summary_label.text()
+        assert text.startswith("2 chains:")
+        # Long chains are abbreviated to endpoints; short ones shown in full.
+        assert "TTI→…→TailTip" in text
+        assert "Head→Neck" in text
+
+        # Removing all chains resets the summary.
+        widget._traced_chains = []
+        widget._refresh_chains_list()
+        assert widget._chain_summary_label.text() == "No chains"
+
+    def test_summary_includes_free_text_chains(self, qtbot):
+        """Advanced free-text chains count toward the summary too."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._ordered_chains_edit.setPlainText("A, B, C")
+        widget._refresh_chain_summary()
+        assert widget._chain_summary_label.text().startswith("1 chain:")
+        assert "A→…→C" in widget._chain_summary_label.text()
+
+    def test_open_dialog_hosts_panel_and_edits_chains(self, qtbot):
+        """Opening the dialog hosts the panel; edits flow back into the config."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._cb_chain.setChecked(True)
+
+        opened = {}
+
+        def _drive_dialog():
+            dialog = widget._chain_trace_dialog
+            opened["dialog"] = dialog
+            # The live trace panel is hosted inside the dialog.
+            assert widget._chain_trace_panel.parent() is dialog
+            assert widget._chain_trace_panel.isVisible()
+            # Trace a chain by clicking nodes, then commit it -- exactly the
+            # interaction a user performs in the pop-up.
+            for name in ["TTI", "Tail_0", "TailTip"]:
+                widget._on_trace_node_clicked(name)
+            widget._on_trace_add_chain()
+            dialog.accept()
+
+        QtCore.QTimer.singleShot(0, _drive_dialog)
+        widget._open_chain_trace_dialog()
+
+        assert isinstance(opened["dialog"], QCChainTraceDialog)
+        # The chain edited in the dialog is now in the saved list + the summary.
+        assert widget._traced_chains == [["TTI", "Tail_0", "TailTip"]]
+        assert widget._chain_summary_label.text().startswith("1 chain:")
+        # ...and feeds QCConfig.ordered_chains so analysis picks it up.
+        config = widget._build_qc_config()
+        assert config.ordered_chains == [["TTI", "Tail_0", "TailTip"]]
+
+    def test_dialog_reused_across_opens(self, qtbot):
+        """The dialog instance is created once and reused on subsequent opens."""
+
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        def _close():
+            widget._chain_trace_dialog.reject()
+
+        QtCore.QTimer.singleShot(0, _close)
+        widget._open_chain_trace_dialog()
+        first = widget._chain_trace_dialog
+
+        QtCore.QTimer.singleShot(0, _close)
+        widget._open_chain_trace_dialog()
+        assert widget._chain_trace_dialog is first
+        # Panel is still hosted by (the same) dialog after reopening.
+        assert widget._chain_trace_panel.parent() is first
+
+    def test_configure_controls_follow_chain_checkbox(self, qtbot):
+        """The button + summary enable/disable with the chain detector."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert not widget._cb_chain.isChecked()
+        assert not widget._chain_config_btn.isEnabled()
+        assert not widget._chain_summary_label.isEnabled()
+        widget._cb_chain.setChecked(True)
+        assert widget._chain_config_btn.isEnabled()
+        assert widget._chain_summary_label.isEnabled()

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -2,10 +2,34 @@
 
 from unittest.mock import MagicMock, patch
 
-from qtpy import QtCore
+from qtpy import QtCore, QtWidgets
 
-from sleap.gui.widgets.qc import QCAnalysisWorker, QCFlagTableModel, QCWidget
+from sleap.gui.widgets.qc import (
+    DETECTOR_HELP,
+    CheckableFilterMenu,
+    CollapsibleGroupBox,
+    QCAnalysisWorker,
+    QCFlagTableModel,
+    QCSkeletonTraceCanvas,
+    QCWidget,
+    _friendly_issue,
+)
 from sleap.qc.config import QCConfig
+
+
+def _fake_results(flags):
+    """Build a QCResults-like stub whose get_flagged returns ``flags``.
+
+    Mirrors only the attributes the QCWidget display path touches, so the
+    flagged-list filter/reviewed tests can drive ``_update_flagged_display``
+    without running real detectors.
+    """
+    results = MagicMock()
+    results.get_flagged.return_value = list(flags)
+    results.feature_contributions = {}
+    results.instance_scores = {}
+    results.feature_names = []
+    return results
 
 
 class MockQCFlag:
@@ -35,12 +59,17 @@ class TestQCFlagTableModel:
         assert "Score" in model.COLUMNS
         assert "Issue" in model.COLUMNS
         assert "Confidence" in model.COLUMNS
+        # Reviewed checkmark column (issue #2769, item 6), appended last so the
+        # existing Frame..Issue column indices are unchanged.
+        assert "Reviewed" in model.COLUMNS
+        assert model.COLUMNS[model.REVIEWED_COL] == "Reviewed"
 
     def test_empty_model(self):
         """Test model can be created empty."""
         model = QCFlagTableModel()
         assert model.rowCount() == 0
-        assert model.columnCount() == 5
+        # 5 data columns + the trailing Reviewed checkmark column.
+        assert model.columnCount() == 6
 
     def test_data_display_role(self):
         """Test data retrieval with DisplayRole."""
@@ -906,10 +935,11 @@ class TestQCDetectorSettings:
         widget = QCWidget()
         qtbot.addWidget(widget)
 
-        # Group box header (checkable, expanded by default).
+        # Group box header (checkable). Advanced panel starts COLLAPSED so the
+        # first-time view stays clean (issue #2769, item 4).
         assert widget._detector_settings_group is not None
         assert widget._detector_settings_group.isCheckable()
-        assert widget._detector_settings_group.isChecked()
+        assert not widget._detector_settings_group.isChecked()
 
         # Reliable detectors default-ON.
         assert widget._cb_flip.isChecked()
@@ -1029,14 +1059,20 @@ class TestQCDetectorSettings:
         widget._cb_flip.setChecked(False)
         assert not widget._sb_flip_thr.isEnabled()
 
-        # Chain is off by default -> chain widgets disabled.
+        # Chain is off by default -> chain widgets + skeleton-trace panel
+        # disabled. The advanced free-text edit now lives inside the trace panel
+        # (issue #2769, item 2), so we check the panel's enabled state and the
+        # edit's enabled-state relative to its own collapsible section.
         assert not widget._sb_chain_angle.isEnabled()
         assert not widget._sb_order_thr.isEnabled()
-        assert not widget._ordered_chains_edit.isEnabled()
+        assert not widget._chain_trace_panel.isEnabled()
+        edit_parent = widget._ordered_chains_edit.parent()
         widget._cb_chain.setChecked(True)
         assert widget._sb_chain_angle.isEnabled()
         assert widget._sb_order_thr.isEnabled()
-        assert widget._ordered_chains_edit.isEnabled()
+        assert widget._chain_trace_panel.isEnabled()
+        # The free-text edit is reachable once its advanced section is expanded.
+        assert widget._ordered_chains_edit.isEnabledTo(edit_parent)
 
 
 class TestQCB2DetectorSettings:
@@ -1194,3 +1230,947 @@ class TestQCAnalysisWorkerConfig:
         assert isinstance(captured["config"], QCConfig)
         assert captured["config"].use_chain_ordering is True
         assert captured["config"].ordered_chains == [["A", "B", "C"]]
+
+
+class TestCollapsibleGroupBox:
+    """Tests for the CollapsibleGroupBox helper (issue #2769, item 4)."""
+
+    def test_starts_expanded_by_default(self, qtbot):
+        """Default (collapsed=False) starts checked with the body visible."""
+        box = CollapsibleGroupBox("Title")
+        qtbot.addWidget(box)
+        assert box.isCheckable()
+        assert box.isChecked()
+        assert box.content.isVisible() or not box.isVisible()  # body tracks header
+
+    def test_starts_collapsed_when_requested(self, qtbot):
+        """collapsed=True starts unchecked with the body hidden."""
+        box = CollapsibleGroupBox("Title", collapsed=True)
+        qtbot.addWidget(box)
+        assert not box.isChecked()
+        assert not box.content.isVisible()
+
+    def test_toggle_shows_and_hides_body(self, qtbot):
+        """Toggling the header shows/hides the content frame."""
+        box = CollapsibleGroupBox("Title", collapsed=True)
+        qtbot.addWidget(box)
+        box.show()
+
+        # Expand.
+        box.setChecked(True)
+        assert box.content.isVisible()
+
+        # Collapse again.
+        box.setChecked(False)
+        assert not box.content.isVisible()
+
+    def test_body_children_stay_enabled_when_collapsed(self, qtbot):
+        """Collapsing must not disable body widgets (visibility-only collapse).
+
+        A plain checkable QGroupBox would disable all descendants when
+        unchecked; CollapsibleGroupBox must keep the body enabled so per-widget
+        enable/disable logic survives collapsing.
+        """
+        box = CollapsibleGroupBox("Title", collapsed=True)
+        qtbot.addWidget(box)
+
+        line = QtWidgets.QLineEdit()
+        layout = QtWidgets.QVBoxLayout(box.content)
+        layout.addWidget(line)
+        box.apply_collapsed_state()
+
+        # Even though the box is collapsed, the child's effective enabled state
+        # follows its own flag, not the collapsed header.
+        assert line.isEnabled()
+        line.setEnabled(False)
+        assert not line.isEnabled()
+
+
+class TestQCUXLayout:
+    """Tests for the overall UX/layout revamp (issue #2769, items 1, 3, 4, 7)."""
+
+    # --- Item 1: two-line progress row ------------------------------------
+
+    def test_progress_label_wraps_on_its_own_line(self, qtbot):
+        """Status text wraps and sits separately from the progress bar."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        # Word wrap lets the status text use its own line without squeezing.
+        assert widget._progress_label.wordWrap()
+        # The status label and progress bar are distinct widgets (two lines).
+        assert widget._progress_label is not widget._progress_bar
+
+    # --- Item 3: per-detector "?" help buttons ----------------------------
+
+    def test_detector_help_has_all_detectors(self):
+        """DETECTOR_HELP covers every detector mentioned in #2769."""
+        for key in [
+            "flip",
+            "chimera",
+            "duplicate",
+            "chain",
+            "missing",
+            "appearance",
+            "insample",
+        ]:
+            assert key in DETECTOR_HELP
+            title, body = DETECTOR_HELP[key]
+            assert title and body
+            # Friendly, biologist-facing copy: reasonably descriptive.
+            assert len(body) > 40
+
+    def test_help_buttons_present_for_each_detector(self, qtbot):
+        """A "?" tool button exists in the settings grid for each detector."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        help_buttons = [
+            b
+            for b in widget._detector_settings_group.findChildren(QtWidgets.QToolButton)
+            if b.text() == "?"
+        ]
+        # One per detector row (7 detectors).
+        assert len(help_buttons) == 7
+
+    def test_show_detector_help_pops_message_box(self, qtbot):
+        """Clicking help shows a QMessageBox carrying the plain-language body."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        created = {}
+
+        class FakeBox:
+            def __init__(self, *a, **k):
+                created["instance"] = self
+
+            def setIcon(self, *a):
+                pass
+
+            def setWindowTitle(self, t):
+                created["title"] = t
+
+            def setText(self, t):
+                created["text"] = t
+
+            def setInformativeText(self, t):
+                created["informative"] = t
+
+            def setStandardButtons(self, *a):
+                pass
+
+            def exec_(self):
+                created["shown"] = True
+
+        with patch("sleap.gui.widgets.qc.QtWidgets.QMessageBox") as mock_box:
+            mock_box.side_effect = FakeBox
+            mock_box.Information = 0
+            mock_box.Ok = 0
+            widget._show_detector_help("flip")
+
+        assert created.get("shown")
+        # The informative text is the friendly body for the flip detector.
+        assert created["informative"] == DETECTOR_HELP["flip"][1]
+        assert "left" in created["informative"].lower()
+
+    def test_help_button_click_invokes_help(self, qtbot):
+        """The "?" button is wired to _show_detector_help."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        help_buttons = [
+            b
+            for b in widget._detector_settings_group.findChildren(QtWidgets.QToolButton)
+            if b.text() == "?"
+        ]
+        with patch.object(widget, "_show_detector_help") as mock_help:
+            help_buttons[0].click()
+        mock_help.assert_called_once()
+
+    # --- Item 4: collapsible panels --------------------------------------
+
+    def test_collapsible_panels_exist(self, qtbot):
+        """Charts + Selected Instance + Statistics are collapsible sections."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        for group in (
+            widget._charts_group,
+            widget._details_group,
+            widget._stats_group,
+            widget._detector_settings_group,
+        ):
+            assert isinstance(group, CollapsibleGroupBox)
+
+    def test_detector_settings_collapsed_charts_expanded_by_default(self, qtbot):
+        """Advanced panel starts collapsed; the everyday panels start expanded."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        # Advanced -> collapsed.
+        assert not widget._detector_settings_group.isChecked()
+        # Everyday panels -> expanded.
+        assert widget._charts_group.isChecked()
+        assert widget._details_group.isChecked()
+        assert widget._stats_group.isChecked()
+
+    def test_collapsing_charts_hides_tabs(self, qtbot):
+        """Collapsing the charts group hides the visualization tabs."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget.show()
+
+        assert widget._viz_tabs.isVisible()
+        widget._charts_group.setChecked(False)
+        assert not widget._viz_tabs.isVisible()
+        widget._charts_group.setChecked(True)
+        assert widget._viz_tabs.isVisible()
+
+    # --- Item 7: plain-language Selected Instance + Statistics ------------
+
+    def test_friendly_issue_maps_known_labels(self):
+        """_friendly_issue turns raw issue labels into plain-language clauses."""
+        assert _friendly_issue("Whole-instance L/R flip") == (
+            "left/right sides look swapped"
+        )
+        assert "out of order" in _friendly_issue("Wrong keypoint order along chain")
+        assert _friendly_issue("Unusual joint angle") == (
+            "a joint bends at an unusual angle"
+        )
+
+    def test_friendly_issue_falls_back_gracefully(self):
+        """Unknown / raw labels are cleaned up rather than shown verbatim."""
+        # "High <feature>" fallbacks drop the prefix and underscores.
+        assert _friendly_issue("High pose_split_score") == "pose split score"
+        # A bare unknown label is lowercased.
+        assert _friendly_issue("Some Weird Thing") == "some weird thing"
+
+    def test_selected_details_plain_language(self, qtbot):
+        """Selected Instance panel says WHY in plain language, with location."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        widget._selected_flag = MockQCFlag(
+            video_idx=0,
+            frame_idx=1837,
+            instance_idx=1,
+            score=0.91,
+            confidence="high",
+            top_issue="Whole-instance L/R flip",
+        )
+        widget._update_selected_details()
+        text = widget._details_label.text()
+
+        assert "Flagged:" in text
+        # The clause is capitalized into a sentence.
+        assert "Left/right sides look swapped" in text
+        assert "0.91" in text
+        assert "Frame 1837" in text
+        assert "instance 1" in text
+        # No raw feature names leaking through.
+        assert "edge_zscore" not in text
+
+    def test_statistics_plain_language_summary(self, qtbot):
+        """Statistics panel summarizes counts + most common issue in words."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # 1200 user instances across the labels.
+        mock_lf = MagicMock()
+        mock_lf.user_instances = [MagicMock()] * 1200
+        mock_labels = MagicMock()
+        mock_labels.__len__ = MagicMock(return_value=300)
+        mock_labels.__iter__ = MagicMock(return_value=iter([mock_lf]))
+        widget._labels = mock_labels
+
+        # 45 flagged, most common issue "Unusual joint angle" (x27).
+        flagged = []
+        for i in range(27):
+            flagged.append(MockQCFlag(0, i, 0, 0.95, "high", "Unusual joint angle"))
+        for i in range(18):
+            flagged.append(MockQCFlag(0, 100 + i, 0, 0.72, "medium", "Likely L/R swap"))
+
+        mock_results = MagicMock()
+        mock_results.get_flagged.return_value = flagged
+        widget._results = mock_results
+        widget._threshold_slider.setValue(70)
+
+        widget._update_statistics()
+        text = widget._stats_label.text()
+
+        assert "45" in text and "1,200" in text  # comma-formatted totals
+        assert "3.8%" in text
+        assert "Most common issue" in text
+        assert "Unusual Joint Angle" in text  # titled like the table column
+        assert "(27)" in text
+
+    def test_statistics_no_flags_is_reassuring(self, qtbot):
+        """With nothing flagged, Statistics reassures instead of dumping zeros."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        mock_lf = MagicMock()
+        mock_lf.user_instances = [MagicMock()] * 10
+        mock_labels = MagicMock()
+        mock_labels.__len__ = MagicMock(return_value=5)
+        mock_labels.__iter__ = MagicMock(return_value=iter([mock_lf]))
+        widget._labels = mock_labels
+
+        mock_results = MagicMock()
+        mock_results.get_flagged.return_value = []
+        widget._results = mock_results
+        widget._update_statistics()
+
+        text = widget._stats_label.text()
+        assert "No issues flagged" in text
+
+    def test_statistics_ready_message_before_analysis(self, qtbot):
+        """Pre-analysis Statistics reads as a friendly call to action."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        mock_lf = MagicMock()
+        mock_lf.user_instances = [MagicMock()] * 1500
+        mock_labels = MagicMock()
+        mock_labels.__len__ = MagicMock(return_value=42)
+        mock_labels.__iter__ = MagicMock(return_value=iter([mock_lf]))
+        widget.set_labels(mock_labels)
+
+        text = widget._stats_label.text()
+        assert "Ready to analyze" in text
+        assert "1,500" in text  # comma-formatted
+        assert "Run Analysis" in text
+
+
+class TestQCFlagReviewedColumn:
+    """Tests for the model's Reviewed checkmark column (issue #2769, item 6)."""
+
+    def test_reviewed_column_is_appended_last(self):
+        """Reviewed is the last column; data indices Frame..Issue are unchanged."""
+        model = QCFlagTableModel()
+        assert model.COLUMNS[-1] == "Reviewed"
+        assert model.REVIEWED_COL == len(model.COLUMNS) - 1
+        # The original data columns keep their positions.
+        assert model.COLUMNS[:5] == [
+            "Frame",
+            "Instance",
+            "Score",
+            "Confidence",
+            "Issue",
+        ]
+
+    def test_reviewed_column_is_user_checkable(self):
+        """The Reviewed column carries the user-checkable item flag."""
+        model = QCFlagTableModel()
+        model.items = [MockQCFlag(0, 1, 0, 0.9, "high", "flip")]
+        idx = model.index(0, QCFlagTableModel.REVIEWED_COL)
+        assert model.flags(idx) & QtCore.Qt.ItemIsUserCheckable
+        # Other columns are not user-checkable.
+        other = model.index(0, 0)
+        assert not (model.flags(other) & QtCore.Qt.ItemIsUserCheckable)
+
+    def test_reviewed_defaults_unchecked(self):
+        """A fresh flag shows an unchecked Reviewed box."""
+        model = QCFlagTableModel()
+        model.items = [MockQCFlag(0, 1, 0, 0.9, "high", "flip")]
+        idx = model.index(0, QCFlagTableModel.REVIEWED_COL)
+        assert model.data(idx, QtCore.Qt.CheckStateRole) == QtCore.Qt.Unchecked
+
+    def test_setdata_toggles_reviewed(self):
+        """Setting CheckStateRole marks the flag reviewed and back."""
+        model = QCFlagTableModel()
+        flag = MockQCFlag(0, 1, 0, 0.9, "high", "flip")
+        model.items = [flag]
+        idx = model.index(0, QCFlagTableModel.REVIEWED_COL)
+
+        assert model.setData(idx, QtCore.Qt.Checked, QtCore.Qt.CheckStateRole)
+        assert model.is_reviewed(flag)
+        assert model.data(idx, QtCore.Qt.CheckStateRole) == QtCore.Qt.Checked
+        assert model.reviewed_count() == 1
+
+        assert model.setData(idx, QtCore.Qt.Unchecked, QtCore.Qt.CheckStateRole)
+        assert not model.is_reviewed(flag)
+        assert model.reviewed_count() == 0
+
+    def test_setdata_ignores_non_reviewed_columns(self):
+        """setData on a non-Reviewed column / wrong role is a no-op."""
+        model = QCFlagTableModel()
+        model.items = [MockQCFlag(0, 1, 0, 0.9, "high", "flip")]
+        # Wrong column.
+        assert not model.setData(
+            model.index(0, 0), QtCore.Qt.Checked, QtCore.Qt.CheckStateRole
+        )
+        # Wrong role on the Reviewed column.
+        assert not model.setData(
+            model.index(0, QCFlagTableModel.REVIEWED_COL), "x", QtCore.Qt.EditRole
+        )
+
+    def test_reviewed_state_keyed_by_identity_not_row(self):
+        """Reviewed-state follows the instance identity across row reshuffles."""
+        shared = set()
+        model = QCFlagTableModel(reviewed_keys=shared)
+        f1 = MockQCFlag(0, 1, 0, 0.9, "high", "flip")
+        f2 = MockQCFlag(0, 2, 1, 0.8, "medium", "angle")
+        model.items = [f1, f2]
+
+        model.set_reviewed(f1, True)
+        assert (0, 1, 0) in shared
+
+        # Replace the row list with NEW flag objects that share f1's identity:
+        # the model must still treat that identity as reviewed.
+        f1b = MockQCFlag(0, 1, 0, 0.95, "high", "flip")
+        f3 = MockQCFlag(0, 3, 0, 0.7, "low", "scale")
+        model.items = [f3, f1b]
+        idx_f1b = model.index(1, QCFlagTableModel.REVIEWED_COL)
+        assert model.data(idx_f1b, QtCore.Qt.CheckStateRole) == QtCore.Qt.Checked
+        idx_f3 = model.index(0, QCFlagTableModel.REVIEWED_COL)
+        assert model.data(idx_f3, QtCore.Qt.CheckStateRole) == QtCore.Qt.Unchecked
+
+    def test_reviewed_count_only_counts_shown_rows(self):
+        """reviewed_count reflects only the rows currently in the model."""
+        shared = set()
+        model = QCFlagTableModel(reviewed_keys=shared)
+        f1 = MockQCFlag(0, 1, 0, 0.9, "high", "flip")
+        f2 = MockQCFlag(0, 2, 0, 0.8, "medium", "angle")
+        model.items = [f1, f2]
+        model.set_reviewed(f1, True)
+        model.set_reviewed(f2, True)
+        assert model.reviewed_count() == 2
+
+        # Show only f2's row; the count drops even though f1 is still reviewed.
+        model.items = [f2]
+        assert model.reviewed_count() == 1
+        assert (0, 1, 0) in shared  # f1 remains reviewed in the shared set
+
+    def test_sort_by_reviewed_column(self):
+        """Sorting by the Reviewed column groups reviewed/unreviewed rows."""
+        shared = set()
+        model = QCFlagTableModel(reviewed_keys=shared)
+        f1 = MockQCFlag(0, 1, 0, 0.9, "high", "flip")
+        f2 = MockQCFlag(0, 2, 0, 0.8, "medium", "angle")
+        f3 = MockQCFlag(0, 3, 0, 0.7, "low", "scale")
+        model.items = [f1, f2, f3]
+        model.set_reviewed(f2, True)
+
+        # Ascending: unreviewed (False) first.
+        model.sort(QCFlagTableModel.REVIEWED_COL, QtCore.Qt.AscendingOrder)
+        assert not model.is_reviewed(model.items[0])
+        assert model.is_reviewed(model.items[-1])
+
+        # Descending: reviewed first.
+        model.sort(QCFlagTableModel.REVIEWED_COL, QtCore.Qt.DescendingOrder)
+        assert model.is_reviewed(model.items[0])
+
+
+class TestCheckableFilterMenu:
+    """Tests for the multi-select menu that stays open (issue #2769, item 5)."""
+
+    def test_checkable_action_toggles_without_closing(self, qtbot):
+        """Releasing the mouse on a checkable action toggles it in place."""
+        menu = CheckableFilterMenu()
+        qtbot.addWidget(menu)
+        action = menu.addAction("Type A")
+        action.setCheckable(True)
+        action.setChecked(False)
+
+        # Make it the active action and simulate a mouse release on it.
+        menu.setActiveAction(action)
+        with patch.object(CheckableFilterMenu, "activeAction", return_value=action):
+            # super().mouseReleaseEvent must NOT be called for checkable items;
+            # the action is toggled directly instead.
+            with patch(
+                "sleap.gui.widgets.qc.QtWidgets.QMenu.mouseReleaseEvent"
+            ) as super_release:
+                menu.mouseReleaseEvent(MagicMock())
+        assert action.isChecked()  # toggled on
+        super_release.assert_not_called()  # menu kept open
+
+    def test_non_checkable_action_uses_default_behavior(self, qtbot):
+        """A non-checkable action falls through to the default (closes menu)."""
+        menu = CheckableFilterMenu()
+        qtbot.addWidget(menu)
+        action = menu.addAction("Select all")  # not checkable
+
+        with patch.object(CheckableFilterMenu, "activeAction", return_value=action):
+            with patch(
+                "sleap.gui.widgets.qc.QtWidgets.QMenu.mouseReleaseEvent"
+            ) as super_release:
+                menu.mouseReleaseEvent(MagicMock())
+        super_release.assert_called_once()
+
+
+class TestQCListIssueFilter:
+    """Tests for the flagged-list issue-type filter (issue #2769, item 5)."""
+
+    def _make_widget_with_flags(self, qtbot, flags):
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._results = _fake_results(flags)
+        widget._update_flagged_display()
+        return widget
+
+    def test_filter_button_disabled_until_results(self, qtbot):
+        """The issue-type filter button is disabled before any results exist."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert widget._issue_filter_button is not None
+        assert not widget._issue_filter_button.isEnabled()
+        assert widget._issue_filter_button.text() == "Issue types: all"
+
+    def test_menu_lists_present_issue_types(self, qtbot):
+        """The menu has one checkable entry per issue type present, all shown."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Whole-instance L/R flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Unusual joint angle"),
+            MockQCFlag(0, 3, 0, 0.85, "medium", "Unusual joint angle"),
+            MockQCFlag(0, 4, 0, 0.80, "medium", "Appearance outlier"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        # One action per unique raw issue (3 of them), button enabled.
+        assert widget._issue_filter_button.isEnabled()
+        assert set(widget._issue_filter_actions.keys()) == {
+            "Whole-instance L/R flip",
+            "Unusual joint angle",
+            "Appearance outlier",
+        }
+        # All present and selected by default -> all four rows shown.
+        assert widget._table_model.rowCount() == 4
+        assert widget._issue_filter_button.text() == "Issue types: all"
+        # Menu labels are the friendly, title-cased category names.
+        labels = {a.text() for a in widget._issue_filter_actions.values()}
+        assert "Whole-Instance L/R Flip" in labels
+
+    def test_deselecting_issue_type_filters_table(self, qtbot):
+        """Unchecking an issue type removes those rows from the table live."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Whole-instance L/R flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Unusual joint angle"),
+            MockQCFlag(0, 3, 0, 0.85, "medium", "Unusual joint angle"),
+            MockQCFlag(0, 4, 0, 0.80, "medium", "Appearance outlier"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        widget._on_issue_type_toggled("Unusual joint angle", False)
+        assert widget._table_model.rowCount() == 2
+        shown = {
+            widget._table_model.items[r].top_issue
+            for r in range(widget._table_model.rowCount())
+        }
+        assert shown == {"Whole-instance L/R flip", "Appearance outlier"}
+        assert widget._issue_filter_button.text() == "Issue types: 2 of 3"
+
+    def test_select_none_and_all(self, qtbot):
+        """Select-none empties the table; select-all restores every row."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        widget._set_all_issue_types(False)
+        assert widget._table_model.rowCount() == 0
+        assert widget._issue_filter_button.text() == "Issue types: none"
+
+        widget._set_all_issue_types(True)
+        assert widget._table_model.rowCount() == 2
+        assert widget._issue_filter_button.text() == "Issue types: all"
+
+    def test_filter_selection_survives_threshold_refilter(self, qtbot):
+        """A de-selected issue type stays hidden across a threshold re-filter."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+            MockQCFlag(0, 3, 0, 0.80, "medium", "Appearance"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        # Hide "Flip".
+        widget._on_issue_type_toggled("Flip", False)
+        assert "Flip" not in widget._visible_issue_types
+
+        # Simulate raising the threshold so the 0.80 Appearance flag drops out.
+        widget._results.get_flagged.return_value = [f for f in flags if f.score >= 0.85]
+        widget._update_flagged_display()
+
+        # Flip is still present but remains hidden; only Angle shows.
+        assert set(widget._issue_filter_actions.keys()) == {"Flip", "Angle"}
+        assert widget._visible_issue_types == {"Angle"}
+        shown = {
+            widget._table_model.items[r].top_issue
+            for r in range(widget._table_model.rowCount())
+        }
+        assert shown == {"Angle"}
+
+    def test_breakdown_reflects_full_set_not_filter(self, qtbot):
+        """The Issue Breakdown chart shows ALL flagged, ignoring the table filter."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+            MockQCFlag(0, 3, 0, 0.85, "medium", "Angle"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        widget._on_issue_type_toggled("Angle", False)  # hide Angle in the table
+        # Table shows only Flip now...
+        assert widget._table_model.rowCount() == 1
+        # ...but the breakdown still counts all three (Flip=1, Angle=2).
+        counts = widget._breakdown_canvas._issue_counts
+        assert counts.get("Flip") == 1
+        assert counts.get("Angle") == 2
+
+
+class TestQCListReviewedIntegration:
+    """Widget-level reviewed-state + counter tests (issue #2769, item 6)."""
+
+    def _make_widget_with_flags(self, qtbot, flags):
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._results = _fake_results(flags)
+        widget._update_flagged_display()
+        return widget
+
+    def test_reviewed_counter_widgets_exist(self, qtbot):
+        """The running reviewed counter starts at 0 / 0."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert widget._reviewed_count_label is not None
+        assert widget._reviewed_count_label.text() == "0 / 0 reviewed"
+
+    def test_counter_updates_when_box_checked(self, qtbot):
+        """Ticking a Reviewed box updates the running counter."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+        assert widget._reviewed_count_label.text() == "0 / 2 reviewed"
+
+        idx = widget._table_model.index(0, QCFlagTableModel.REVIEWED_COL)
+        widget._table_model.setData(idx, QtCore.Qt.Checked, QtCore.Qt.CheckStateRole)
+        assert widget._reviewed_count_label.text() == "1 / 2 reviewed"
+
+    def test_navigate_auto_marks_reviewed(self, qtbot):
+        """Selecting a row (navigating) auto-marks that instance reviewed."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        widget._table_view.selectRow(0)
+        qtbot.wait(20)
+        assert widget._table_model.is_reviewed(flags[0])
+        assert widget._reviewed_count_label.text() == "1 / 2 reviewed"
+
+    def test_reviewed_survives_threshold_refilter(self, qtbot):
+        """Reviewed marks persist across a threshold re-filter (identity-keyed)."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+            MockQCFlag(0, 3, 0, 0.80, "medium", "Appearance"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        # Mark the highest-score flag (frame 1) reviewed.
+        idx = widget._table_model.index(0, QCFlagTableModel.REVIEWED_COL)
+        widget._table_model.setData(idx, QtCore.Qt.Checked, QtCore.Qt.CheckStateRole)
+        assert (0, 1, 0) in widget._reviewed_keys
+
+        # Raise threshold so frame-3 (0.80) drops; frame-1 stays and is still
+        # reviewed -> counter is 1 / 2.
+        widget._results.get_flagged.return_value = [f for f in flags if f.score >= 0.85]
+        widget._update_flagged_display()
+        assert (0, 1, 0) in widget._reviewed_keys
+        assert widget._reviewed_count_label.text() == "1 / 2 reviewed"
+
+    def test_reviewed_survives_issue_filter(self, qtbot):
+        """Reviewed marks persist when an issue type is hidden then re-shown."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+
+        # Review the Angle flag.
+        widget._table_model.set_reviewed(flags[1], True)
+        assert widget._reviewed_count_label.text() == "1 / 2 reviewed"
+
+        # Hide Angle: counter now reflects only the shown (Flip) rows.
+        widget._on_issue_type_toggled("Angle", False)
+        assert widget._reviewed_count_label.text() == "0 / 1 reviewed"
+
+        # Re-show Angle: its reviewed mark is intact.
+        widget._on_issue_type_toggled("Angle", True)
+        assert widget._reviewed_count_label.text() == "1 / 2 reviewed"
+        assert widget._table_model.is_reviewed(flags[1])
+
+    def test_set_labels_resets_filter_and_reviewed(self, qtbot):
+        """Loading a new project clears reviewed marks and the issue filter."""
+        flags = [
+            MockQCFlag(0, 1, 0, 0.95, "high", "Flip"),
+            MockQCFlag(0, 2, 0, 0.90, "high", "Angle"),
+        ]
+        widget = self._make_widget_with_flags(qtbot, flags)
+        widget._table_model.set_reviewed(flags[0], True)
+        widget._on_issue_type_toggled("Angle", False)
+        assert widget._reviewed_keys
+        assert widget._visible_issue_types is not None
+
+        mock_labels = MagicMock()
+        mock_labels.__len__ = MagicMock(return_value=3)
+        mock_labels.__iter__ = MagicMock(return_value=iter([]))
+        widget.set_labels(mock_labels)
+
+        assert widget._reviewed_keys == set()
+        assert widget._visible_issue_types is None
+        assert widget._all_flagged == []
+        assert widget._reviewed_count_label.text() == "0 / 0 reviewed"
+        assert not widget._issue_filter_button.isEnabled()
+
+
+class _FakeNode:
+    """Minimal stand-in for a sleap-io skeleton Node (just a ``.name``)."""
+
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeEdge:
+    """Minimal stand-in for a sleap-io skeleton Edge (source/destination)."""
+
+    def __init__(self, src, dst):
+        self.source = _FakeNode(src)
+        self.destination = _FakeNode(dst)
+
+
+class _FakeSkeleton:
+    """Minimal skeleton exposing ``node_names`` and ``edges`` like sleap-io."""
+
+    def __init__(self, node_names, edges):
+        self.node_names = list(node_names)
+        self.edges = [_FakeEdge(s, d) for s, d in edges]
+
+
+class TestQCSkeletonTraceCanvas:
+    """Tests for the click-to-trace skeleton canvas (issue #2769, item 2)."""
+
+    def test_starts_empty(self, qtbot):
+        """A fresh canvas has no skeleton and an empty trace."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        assert canvas._positions == {}
+        assert canvas.trace == []
+
+    def test_set_skeleton_lays_out_nodes(self, qtbot):
+        """Setting a skeleton computes a position for every node."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton(["A", "B", "C"], [("A", "B"), ("B", "C")])
+        assert set(canvas._positions.keys()) == {"A", "B", "C"}
+        # Edges are kept as validated name pairs.
+        assert ("A", "B") in canvas._edges
+
+    def test_set_skeleton_drops_unknown_edges(self, qtbot):
+        """Edges referencing missing nodes are filtered out."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton(["A", "B"], [("A", "B"), ("B", "Z")])
+        assert canvas._edges == [("A", "B")]
+
+    def test_set_trace_filters_to_known_nodes(self, qtbot):
+        """set_trace keeps only nodes that exist in the current skeleton."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton(["A", "B", "C"], [])
+        canvas.set_trace(["A", "Q", "C"])
+        assert canvas.trace == ["A", "C"]
+
+    def test_node_at_hit_and_miss(self, qtbot):
+        """node_at returns the nearest node within radius, else None."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton(["A", "B", "C"], [("A", "B"), ("B", "C")])
+        ax, ay = canvas._positions["A"]
+        assert canvas.node_at(ax, ay) == "A"
+        # A point far outside the spring layout extent hits nothing.
+        assert canvas.node_at(999.0, 999.0) is None
+
+    def test_click_emits_node_clicked(self, qtbot):
+        """A button-press over a node emits node_clicked with its name."""
+        from matplotlib.backend_bases import MouseEvent
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton(["A", "B", "C"], [("A", "B"), ("B", "C")])
+        canvas.resize(400, 300)
+        canvas.draw()
+
+        received = []
+        canvas.node_clicked.connect(received.append)
+
+        disp = canvas.axes.transData.transform(canvas._positions["B"])
+        event = MouseEvent("button_press_event", canvas, disp[0], disp[1], button=1)
+        canvas._on_click(event)
+        assert received == ["B"]
+
+    def test_empty_skeleton_redraw_is_safe(self, qtbot):
+        """Updating the plot with no skeleton does not raise."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        canvas.set_skeleton([], [])
+        canvas.update_plot()  # Should render the placeholder without error.
+        assert canvas._positions == {}
+
+
+class TestQCChainTracePanel:
+    """Tests for the chain-order skeleton-tracing UI (issue #2769, item 2)."""
+
+    def test_trace_panel_widgets_exist(self, qtbot):
+        """The trace panel and its key controls are constructed."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert widget._chain_trace_panel is not None
+        assert isinstance(widget._skeleton_canvas, QCSkeletonTraceCanvas)
+        assert widget._chains_list is not None
+        # The advanced free-text fallback still exists.
+        assert widget._ordered_chains_edit is not None
+
+    def test_clicking_nodes_builds_trace(self, qtbot):
+        """Node clicks append to the in-progress trace; the canvas mirrors it."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._on_trace_node_clicked("Base")
+        widget._on_trace_node_clicked("Mid")
+        widget._on_trace_node_clicked("Tip")
+        assert widget._trace_in_progress == ["Base", "Mid", "Tip"]
+        assert widget._skeleton_canvas.trace == []  # no skeleton loaded -> filtered
+
+    def test_consecutive_duplicate_click_ignored(self, qtbot):
+        """Clicking the same node twice in a row does not duplicate it."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._on_trace_node_clicked("Base")
+        widget._on_trace_node_clicked("Base")
+        assert widget._trace_in_progress == ["Base"]
+
+    def test_undo_and_clear_trace(self, qtbot):
+        """Undo removes the last node; clear empties the trace."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        for name in ["A", "B", "C"]:
+            widget._on_trace_node_clicked(name)
+        widget._on_trace_undo()
+        assert widget._trace_in_progress == ["A", "B"]
+        widget._on_trace_clear()
+        assert widget._trace_in_progress == []
+
+    def test_add_chain_requires_two_nodes(self, qtbot):
+        """A chain of fewer than two nodes is rejected (warning shown)."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._on_trace_node_clicked("OnlyOne")
+        with patch.object(QtWidgets.QMessageBox, "information") as info:
+            widget._on_trace_add_chain()
+        info.assert_called_once()
+        assert widget._traced_chains == []
+
+    def test_add_chain_commits_and_resets(self, qtbot):
+        """Adding a valid chain stores it and clears the in-progress trace."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        for name in ["Base", "Mid", "Tip"]:
+            widget._on_trace_node_clicked(name)
+        widget._on_trace_add_chain()
+        assert widget._traced_chains == [["Base", "Mid", "Tip"]]
+        assert widget._trace_in_progress == []
+        assert widget._chains_list.count() == 1
+
+    def test_reorder_saved_chains(self, qtbot):
+        """Up/down moves a selected saved chain within the list."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._traced_chains = [["A", "B"], ["C", "D"], ["E", "F"]]
+        widget._refresh_chains_list()
+        widget._chains_list.setCurrentRow(2)
+        widget._move_selected_chain(-1)
+        assert widget._traced_chains == [["A", "B"], ["E", "F"], ["C", "D"]]
+        assert widget._chains_list.currentRow() == 1
+        # Moving past the end is a no-op.
+        widget._chains_list.setCurrentRow(2)
+        widget._move_selected_chain(1)
+        assert widget._traced_chains == [["A", "B"], ["E", "F"], ["C", "D"]]
+
+    def test_remove_saved_chain(self, qtbot):
+        """Removing the selected chain drops it from the list and state."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._traced_chains = [["A", "B"], ["C", "D"]]
+        widget._refresh_chains_list()
+        widget._chains_list.setCurrentRow(0)
+        widget._on_remove_selected_chain()
+        assert widget._traced_chains == [["C", "D"]]
+        assert widget._chains_list.count() == 1
+
+    def test_collect_ordered_chains_merges_traced_and_text(self, qtbot):
+        """Traced chains come first, then free-text chains, de-duplicated."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._traced_chains = [["Base", "Mid", "Tip"]]
+        widget._ordered_chains_edit.setPlainText("Head, Neck\nBase, Mid, Tip")
+        # The duplicate (Base, Mid, Tip) typed after tracing is dropped.
+        assert widget._collect_ordered_chains() == [
+            ["Base", "Mid", "Tip"],
+            ["Head", "Neck"],
+        ]
+
+    def test_build_qc_config_uses_traced_chains(self, qtbot):
+        """Traced chains flow into QCConfig.ordered_chains."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        widget._cb_chain.setChecked(True)
+        widget._traced_chains = [["TTI", "Tail_0", "Tail_1"]]
+        config = widget._build_qc_config()
+        assert config.ordered_chains == [["TTI", "Tail_0", "Tail_1"]]
+
+    def test_set_labels_loads_skeleton_into_canvas(self, qtbot):
+        """Loading labels with a skeleton populates the trace canvas."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        skeleton = _FakeSkeleton(
+            ["TTI", "Tail_0", "Tail_1"], [("TTI", "Tail_0"), ("Tail_0", "Tail_1")]
+        )
+        labels = MagicMock()
+        labels.skeletons = [skeleton]
+        labels.__len__ = MagicMock(return_value=0)
+        labels.__iter__ = MagicMock(return_value=iter([]))
+
+        widget.set_labels(labels)
+        assert set(widget._skeleton_canvas._positions.keys()) == {
+            "TTI",
+            "Tail_0",
+            "Tail_1",
+        }
+
+    def test_set_labels_without_skeleton_clears_canvas(self, qtbot):
+        """Labels whose skeleton access raises leave the canvas empty."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Seed a skeleton, then load labels that expose no usable skeleton.
+        widget._skeleton_canvas.set_skeleton(["A", "B"], [("A", "B")])
+
+        labels = MagicMock()
+        labels.skeletons = []  # no skeletons -> canvas cleared
+        labels.__len__ = MagicMock(return_value=0)
+        labels.__iter__ = MagicMock(return_value=iter([]))
+
+        widget.set_labels(labels)
+        assert widget._skeleton_canvas._positions == {}
+
+    def test_trace_panel_disabled_with_chain_off(self, qtbot):
+        """The trace panel follows the chain detector checkbox."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert not widget._cb_chain.isChecked()
+        assert not widget._chain_trace_panel.isEnabled()
+        widget._cb_chain.setChecked(True)
+        assert widget._chain_trace_panel.isEnabled()

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 
 from qtpy import QtCore
 
-from sleap.gui.widgets.qc import QCFlagTableModel, QCWidget
+from sleap.gui.widgets.qc import QCAnalysisWorker, QCFlagTableModel, QCWidget
+from sleap.qc.config import QCConfig
 
 
 class MockQCFlag:
@@ -895,3 +896,198 @@ class TestQCDockNavigation:
         main_window.state.get = MagicMock(return_value=False)
         dock._sync_fit_selection_checkbox()
         assert not dock._fit_selection_checkbox.isChecked()
+
+
+class TestQCDetectorSettings:
+    """Tests for the per-detector settings controls and config building."""
+
+    def test_detector_controls_exist_with_defaults(self, qtbot):
+        """Detector controls exist with documented default states."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Group box header (checkable, expanded by default).
+        assert widget._detector_settings_group is not None
+        assert widget._detector_settings_group.isCheckable()
+        assert widget._detector_settings_group.isChecked()
+
+        # Reliable detectors default-ON.
+        assert widget._cb_flip.isChecked()
+        assert widget._cb_chimera.isChecked()
+        assert widget._cb_duplicate.isChecked()
+
+        # Experimental detectors default-OFF.
+        assert not widget._cb_chain.isChecked()
+        assert not widget._cb_missing.isChecked()
+
+        # Threshold spinbox defaults.
+        assert widget._sb_flip_thr.value() == 0.5
+        assert widget._sb_dup_thr.value() == 0.5
+        assert widget._sb_chain_angle.value() == 60
+        assert widget._sb_order_thr.value() == 0.3
+        assert widget._sb_missing_thr.value() == 0.9
+
+        # Ordered-chains edit starts empty.
+        assert widget._ordered_chains_edit.toPlainText() == ""
+
+    def test_chimera_has_no_threshold_widget(self, qtbot):
+        """Chimera detector exposes no tunable threshold spinbox."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert not hasattr(widget, "_sb_chimera_thr")
+
+    def test_build_qc_config_defaults(self, qtbot):
+        """_build_qc_config reflects the default control states."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        config = widget._build_qc_config()
+        assert isinstance(config, QCConfig)
+
+        # Toggles map to the default checkbox states.
+        assert config.use_chirality is True
+        assert config.use_split_detection is True
+        assert config.use_duplicate_score is True
+        assert config.use_chain_ordering is False
+        assert config.use_missing_node_check is False
+
+        # Thresholds map to the default spinbox values.
+        assert config.chirality_flip_threshold == 0.5
+        assert config.duplicate_score_threshold == 0.5
+        assert config.chain_turn_angle_deg == 60.0
+        assert config.order_inversion_threshold == 0.3
+        assert config.missing_node_prob_threshold == 0.9
+
+        # No chains entered by default.
+        assert config.ordered_chains == []
+
+    def test_build_qc_config_reflects_toggles(self, qtbot):
+        """Toggling checkboxes is reflected in the built config."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        widget._cb_flip.setChecked(False)
+        widget._cb_chimera.setChecked(False)
+        widget._cb_duplicate.setChecked(False)
+        widget._cb_missing.setChecked(True)
+
+        config = widget._build_qc_config()
+        assert config.use_chirality is False
+        assert config.use_split_detection is False
+        assert config.use_duplicate_score is False
+        assert config.use_missing_node_check is True
+
+    def test_build_qc_config_reflects_thresholds(self, qtbot):
+        """Changing spinboxes is reflected in the built config."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        widget._sb_flip_thr.setValue(0.75)
+        widget._sb_dup_thr.setValue(0.6)
+        widget._sb_chain_angle.setValue(90)
+        widget._sb_order_thr.setValue(0.45)
+        widget._sb_missing_thr.setValue(0.8)
+
+        config = widget._build_qc_config()
+        assert config.chirality_flip_threshold == 0.75
+        assert config.duplicate_score_threshold == 0.6
+        assert config.chain_turn_angle_deg == 90.0
+        assert config.order_inversion_threshold == 0.45
+        assert config.missing_node_prob_threshold == 0.8
+
+    def test_build_qc_config_parses_ordered_chains(self, qtbot):
+        """Enabling chain order + entering chains populates the config."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        widget._cb_chain.setChecked(True)
+        widget._ordered_chains_edit.setPlainText("A, B, C\nD, E, F")
+
+        config = widget._build_qc_config()
+        assert config.use_chain_ordering is True
+        assert config.ordered_chains == [["A", "B", "C"], ["D", "E", "F"]]
+
+    def test_parse_ordered_chains_strips_and_drops_empties(self, qtbot):
+        """Chain parsing strips whitespace and drops empty lines/tokens."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Blank lines, trailing commas, and extra spaces should be cleaned up.
+        widget._ordered_chains_edit.setPlainText(
+            "  TTI , Tail_0 ,, Tail_1 \n\n  \nHead,Neck,\n"
+        )
+        chains = widget._parse_ordered_chains()
+        assert chains == [["TTI", "Tail_0", "Tail_1"], ["Head", "Neck"]]
+
+    def test_threshold_widgets_disable_when_unchecked(self, qtbot):
+        """A detector's threshold widgets disable when its checkbox is off."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Flip is on by default -> threshold enabled.
+        assert widget._sb_flip_thr.isEnabled()
+        widget._cb_flip.setChecked(False)
+        assert not widget._sb_flip_thr.isEnabled()
+
+        # Chain is off by default -> chain widgets disabled.
+        assert not widget._sb_chain_angle.isEnabled()
+        assert not widget._sb_order_thr.isEnabled()
+        assert not widget._ordered_chains_edit.isEnabled()
+        widget._cb_chain.setChecked(True)
+        assert widget._sb_chain_angle.isEnabled()
+        assert widget._sb_order_thr.isEnabled()
+        assert widget._ordered_chains_edit.isEnabled()
+
+
+class TestQCAnalysisWorkerConfig:
+    """Tests for threading the QCConfig into the analysis worker."""
+
+    def test_worker_stores_config(self, qtbot):
+        """QCAnalysisWorker stores the config passed to it."""
+        labels = MagicMock()
+        cfg = QCConfig()
+        worker = QCAnalysisWorker(labels, config=cfg)
+        assert worker._config is cfg
+
+    def test_worker_config_defaults_to_none(self, qtbot):
+        """QCAnalysisWorker config defaults to None when omitted."""
+        worker = QCAnalysisWorker(MagicMock())
+        assert worker._config is None
+
+    def test_run_analysis_builds_worker_with_config(self, qtbot):
+        """_on_run_analysis builds a worker with a non-None config.
+
+        Patches QCAnalysisWorker to capture the config arg without spinning up
+        the background thread.
+        """
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Tweak a couple of controls so the built config is non-default.
+        widget._cb_chain.setChecked(True)
+        widget._ordered_chains_edit.setPlainText("A, B, C")
+
+        # Provide labels with enough user instances to pass the guard.
+        mock_lf = MagicMock()
+        mock_lf.user_instances = [MagicMock(), MagicMock()]
+        mock_labels = MagicMock()
+        mock_labels.__iter__ = MagicMock(return_value=iter([mock_lf]))
+        widget._labels = mock_labels
+
+        captured = {}
+
+        def fake_worker(labels, config=None, parent=None):
+            captured["labels"] = labels
+            captured["config"] = config
+            # Return a stub that looks like a non-running worker.
+            stub = MagicMock()
+            stub.isRunning.return_value = False
+            return stub
+
+        with patch("sleap.gui.widgets.qc.QCAnalysisWorker", side_effect=fake_worker):
+            widget._on_run_analysis()
+
+        assert captured["labels"] is mock_labels
+        assert isinstance(captured["config"], QCConfig)
+        assert captured["config"].use_chain_ordering is True
+        assert captured["config"].ordered_chains == [["A", "B", "C"]]

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -2837,11 +2837,30 @@ class TestQCTraceCanvasImageMode:
         )
         x0, x1 = canvas.axes.get_xlim()
         y0, y1 = canvas.axes.get_ylim()
-        # x grows left->right over the image width.
+        # x grows left->right; the default view fits the instance, so it spans
+        # at most the full image width and contains the instance's x-extent.
         assert x0 < x1
-        assert abs(x1 - x0 - 120) < 2.0
+        assert (x1 - x0) <= 120 + 2.0
+        assert x0 <= 10.0 and x1 >= 90.0
         # y is inverted so (0, 0) is at the top, like an image.
         assert y0 > y1
+
+    def test_image_mode_defaults_to_instance_fit(self, qtbot):
+        """The default image-mode view zooms to the instance, not the full frame."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(400, 600)  # 600 wide x 400 tall
+        # Instance occupies a small central region of the frame.
+        coords = {"A": (280.0, 190.0), "B": (320.0, 210.0)}
+        canvas.set_skeleton(["A", "B"], [("A", "B")], node_positions=coords, image=img)
+        x0, x1 = canvas.axes.get_xlim()
+        y_bottom, y_top = canvas.axes.get_ylim()  # inverted: bottom > top
+        # Tighter than the full image extent on every side...
+        assert -0.5 < x0 < 280.0 and 320.0 < x1 < 599.5
+        assert -0.5 < y_top < 190.0 and 210.0 < y_bottom < 399.5
+        # ...but still contains the whole instance bounding box.
+        assert x0 <= 280.0 and x1 >= 320.0
+        assert y_top <= 190.0 and y_bottom >= 210.0
 
     def test_grayscale_channel_image_is_squeezed(self, qtbot):
         """An (H, W, 1) grayscale image is squeezed to 2D for imshow."""
@@ -2943,8 +2962,8 @@ class TestQCTraceCanvasImageMode:
         canvas._on_scroll(down)
         assert _width() > zoomed_in
 
-    def test_reset_view_restores_full_extent(self, qtbot):
-        """reset_view (and double-click) restores the full image extent."""
+    def test_reset_view_restores_default_view(self, qtbot):
+        """reset_view returns to the default (instance-fit) view after zooming."""
         from matplotlib.backend_bases import MouseEvent
 
         canvas = QCSkeletonTraceCanvas()
@@ -2958,14 +2977,18 @@ class TestQCTraceCanvasImageMode:
         )
         canvas.resize(500, 400)
         canvas.draw()
+        lo0, hi0 = canvas.axes.get_xlim()
+        default_w = abs(hi0 - lo0)
         # Zoom in, then reset.
         disp = canvas.axes.transData.transform((75.0, 50.0))
         up = MouseEvent("scroll_event", canvas, disp[0], disp[1], step=1)
         up.button = "up"
         canvas._on_scroll(up)
+        zoomed = abs(canvas.axes.get_xlim()[1] - canvas.axes.get_xlim()[0])
+        assert zoomed < default_w
         canvas.reset_view()
         lo, hi = canvas.axes.get_xlim()
-        assert abs(abs(hi - lo) - 150) < 2.0
+        assert abs(abs(hi - lo) - default_w) < 2.0
 
     def test_trace_edit_preserves_zoom(self, qtbot):
         """Editing the trace after zooming keeps the user's zoomed view."""
@@ -3044,7 +3067,7 @@ class TestQCTraceCanvasImageMode:
         assert canvas._pan_anchor is None
 
     def test_double_click_resets_view(self, qtbot):
-        """A left double-click resets the zoomed view to the full extent."""
+        """A left double-click resets the zoomed view to the default view."""
         from matplotlib.backend_bases import MouseEvent
 
         canvas = QCSkeletonTraceCanvas()
@@ -3058,6 +3081,7 @@ class TestQCTraceCanvasImageMode:
         )
         canvas.resize(500, 400)
         canvas.draw()
+        default_w = abs(canvas.axes.get_xlim()[1] - canvas.axes.get_xlim()[0])
         # Zoom in first.
         disp = canvas.axes.transData.transform((75.0, 50.0))
         up = MouseEvent("scroll_event", canvas, disp[0], disp[1], step=1)
@@ -3068,7 +3092,7 @@ class TestQCTraceCanvasImageMode:
         dbl.dblclick = True
         canvas._on_click(dbl)
         lo, hi = canvas.axes.get_xlim()
-        assert abs(abs(hi - lo) - 150) < 2.0
+        assert abs(abs(hi - lo) - default_w) < 2.0
 
     def test_image_without_coords_falls_back_to_abstract(self, qtbot):
         """An image with no real coords cannot place nodes -> abstract layout."""

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -2440,6 +2440,25 @@ class TestCollapsibleDisclosure:
         assert group.title() == "Detector Settings"
         assert QtWidgets.QGroupBox.title(group).startswith("▶")
 
+    def test_disclosure_hides_native_checkbox(self, qtbot):
+        """Header shows only the arrow -- the native checkbox is hidden.
+
+        A checkable QGroupBox draws a native checkbox next to the title (very
+        visible on macOS); we keep it checkable (so isChecked()/setChecked()/
+        click-to-expand work) but style its indicator to zero size so only the
+        ▶/▼ disclosure arrow shows (issue #2769 follow-up).
+        """
+        box = CollapsibleGroupBox("Detector Settings", collapsed=True)
+        qtbot.addWidget(box)
+        # Still checkable, so the toggle API + click-to-expand keep working.
+        assert box.isCheckable()
+        box.setChecked(True)
+        assert box.isChecked()
+        # The native checkbox indicator is styled to nothing.
+        ss = box.styleSheet().replace(" ", "").lower()
+        assert "qgroupbox::indicator" in ss
+        assert "width:0" in ss and "height:0" in ss
+
 
 class TestQCRestoreDefaults:
     """Tests for the Detector Settings "Restore defaults" button (item #2769).

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -1,6 +1,6 @@
 """Tests for QC widget components."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from qtpy import QtCore, QtWidgets
 
@@ -2241,6 +2241,8 @@ class TestQCChainTracePanel:
         assert widget._chains_list is not None
         # The advanced free-text fallback still exists.
         assert widget._ordered_chains_edit is not None
+        # The zoom/pan canvas exposes a Reset view affordance.
+        assert widget._reset_view_btn is not None
 
     def test_clicking_nodes_builds_trace(self, qtbot):
         """Node clicks append to the in-progress trace; the canvas mirrors it."""
@@ -2767,6 +2769,470 @@ class TestQCRealAnimalLayout:
         # every node so the user can trace.
         assert widget._skeleton_canvas._node_coords == {}
         assert set(widget._skeleton_canvas._positions) == {"A", "B", "C"}
+
+
+def _synthetic_image(h=80, w=120, channels=None):
+    """Build a small deterministic image for trace-canvas tests.
+
+    Args:
+        h: Image height in pixels.
+        w: Image width in pixels.
+        channels: ``None`` for a 2D grayscale image, or an int (1 or 3) for a
+            trailing channel dimension.
+
+    Returns:
+        A ``uint8`` ``np.ndarray`` of shape ``(h, w)``, ``(h, w, 1)``, or
+        ``(h, w, 3)``.
+    """
+    import numpy as np
+
+    base = (np.add.outer(np.linspace(0, 200, h), np.linspace(0, 50, w))).astype("uint8")
+    if channels is None:
+        return base
+    if channels == 1:
+        return base[..., None]
+    return np.stack([base, base, base], axis=-1)
+
+
+class TestQCTraceCanvasImageMode:
+    """Image-backed trace canvas: photo background + pixel-space overlay.
+
+    The user traces directly on a real labeled frame, so the canvas shows the
+    frame image and overlays the skeleton at true pixel coordinates, with mouse
+    zoom/pan (issue #2769 follow-up).
+    """
+
+    def test_image_sets_background_and_pixel_positions(self, qtbot):
+        """With an image, the canvas shows it and uses pixel-space node coords."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(80, 120)
+        coords = {"A": (40.0, 30.0), "B": (80.0, 50.0), "C": (100.0, 70.0)}
+        canvas.set_skeleton(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            node_positions=coords,
+            image=img,
+        )
+        # The background image is stored and an AxesImage was drawn.
+        assert canvas._background_image is not None
+        assert canvas._image_artist is not None
+        from matplotlib.image import AxesImage
+
+        assert any(isinstance(a, AxesImage) for a in canvas.axes.get_images())
+        # Nodes sit at their *pixel* coords, not a normalized [-1, 1] value.
+        assert canvas._positions["A"] == (40.0, 30.0)
+        assert canvas._positions["C"] == (100.0, 70.0)
+
+    def test_image_view_uses_top_left_origin(self, qtbot):
+        """The view spans the image extent with y inverted (top-left origin)."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(80, 120)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (10.0, 10.0), "B": (90.0, 70.0)},
+            image=img,
+        )
+        x0, x1 = canvas.axes.get_xlim()
+        y0, y1 = canvas.axes.get_ylim()
+        # x grows left->right over the image width.
+        assert x0 < x1
+        assert abs(x1 - x0 - 120) < 2.0
+        # y is inverted so (0, 0) is at the top, like an image.
+        assert y0 > y1
+
+    def test_grayscale_channel_image_is_squeezed(self, qtbot):
+        """An (H, W, 1) grayscale image is squeezed to 2D for imshow."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(60, 90, channels=1)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (10.0, 10.0), "B": (50.0, 40.0)},
+            image=img,
+        )
+        assert canvas._background_image is not None
+        assert canvas._background_image.ndim == 2
+
+    def test_rgb_image_passes_through(self, qtbot):
+        """An (H, W, 3) RGB image is kept 3-channel for imshow."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(60, 90, channels=3)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (10.0, 10.0), "B": (50.0, 40.0)},
+            image=img,
+        )
+        assert canvas._background_image is not None
+        assert canvas._background_image.ndim == 3
+        assert canvas._background_image.shape[-1] == 3
+
+    def test_node_at_pixel_space(self, qtbot):
+        """node_at hits a node at its pixel coordinate and misses far away."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(100, 150)
+        canvas.set_skeleton(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            node_positions={"A": (20.0, 20.0), "B": (75.0, 50.0), "C": (130.0, 90.0)},
+            image=img,
+        )
+        assert canvas.node_at(75.0, 50.0) == "B"
+        # A pixel between far-apart nodes hits nothing.
+        assert canvas.node_at(0.0, 99.0) is None
+
+    def test_node_at_still_works_after_zoom(self, qtbot):
+        """Hit-testing keeps working after a wheel zoom (pixel pick radius)."""
+        from matplotlib.backend_bases import MouseEvent
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(100, 150)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (20.0, 20.0), "B": (120.0, 80.0)},
+            image=img,
+        )
+        canvas.resize(500, 400)
+        canvas.draw()
+        # Zoom in around node B.
+        disp = canvas.axes.transData.transform((120.0, 80.0))
+        ev = MouseEvent("scroll_event", canvas, disp[0], disp[1], step=1)
+        ev.button = "up"
+        canvas._on_scroll(ev)
+        # B is still selectable at its pixel coordinate after zooming.
+        assert canvas.node_at(120.0, 80.0) == "B"
+
+    def test_scroll_zooms_changes_limits(self, qtbot):
+        """Scrolling up shrinks the view; scrolling down grows it."""
+        from matplotlib.backend_bases import MouseEvent
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(100, 150)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (20.0, 20.0), "B": (120.0, 80.0)},
+            image=img,
+        )
+        canvas.resize(500, 400)
+        canvas.draw()
+
+        def _width():
+            lo, hi = canvas.axes.get_xlim()
+            return abs(hi - lo)
+
+        before = _width()
+        disp = canvas.axes.transData.transform((75.0, 50.0))
+        up = MouseEvent("scroll_event", canvas, disp[0], disp[1], step=1)
+        up.button = "up"
+        canvas._on_scroll(up)
+        zoomed_in = _width()
+        assert zoomed_in < before
+
+        down = MouseEvent("scroll_event", canvas, disp[0], disp[1], step=1)
+        down.button = "down"
+        canvas._on_scroll(down)
+        assert _width() > zoomed_in
+
+    def test_reset_view_restores_full_extent(self, qtbot):
+        """reset_view (and double-click) restores the full image extent."""
+        from matplotlib.backend_bases import MouseEvent
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(100, 150)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (20.0, 20.0), "B": (120.0, 80.0)},
+            image=img,
+        )
+        canvas.resize(500, 400)
+        canvas.draw()
+        # Zoom in, then reset.
+        disp = canvas.axes.transData.transform((75.0, 50.0))
+        up = MouseEvent("scroll_event", canvas, disp[0], disp[1], step=1)
+        up.button = "up"
+        canvas._on_scroll(up)
+        canvas.reset_view()
+        lo, hi = canvas.axes.get_xlim()
+        assert abs(abs(hi - lo) - 150) < 2.0
+
+    def test_trace_edit_preserves_zoom(self, qtbot):
+        """Editing the trace after zooming keeps the user's zoomed view."""
+        from matplotlib.backend_bases import MouseEvent
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(100, 150)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (20.0, 20.0), "B": (120.0, 80.0)},
+            image=img,
+        )
+        canvas.resize(500, 400)
+        canvas.draw()
+        disp = canvas.axes.transData.transform((75.0, 50.0))
+        up = MouseEvent("scroll_event", canvas, disp[0], disp[1], step=1)
+        up.button = "up"
+        canvas._on_scroll(up)
+        zoomed = canvas.axes.get_xlim()
+        # A trace change triggers a redraw but must not snap back to full extent.
+        canvas.set_trace(["A", "B"])
+        assert canvas.axes.get_xlim() == zoomed
+
+    def test_pan_with_right_button_shifts_view(self, qtbot):
+        """Dragging with the right button pans the view; left does not."""
+        from matplotlib.backend_bases import MouseEvent
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(100, 150)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (20.0, 20.0), "B": (120.0, 80.0)},
+            image=img,
+        )
+        canvas.resize(500, 400)
+        canvas.draw()
+        start = canvas.axes.transData.transform((75.0, 50.0))
+        press = MouseEvent("button_press_event", canvas, start[0], start[1], button=3)
+        canvas._on_pan_press(press)
+        # Move 40 display px to the right.
+        move = MouseEvent(
+            "motion_notify_event", canvas, start[0] + 40, start[1], button=3
+        )
+        canvas._on_pan_move(move)
+        x0, x1 = canvas.axes.get_xlim()
+        # Panning right shows smaller-x content (limits decrease).
+        assert x0 < -0.5
+        release = MouseEvent(
+            "button_release_event", canvas, start[0] + 40, start[1], button=3
+        )
+        canvas._on_pan_release(release)
+        assert canvas._pan_anchor is None
+
+    def test_left_click_does_not_pan(self, qtbot):
+        """The left button is reserved for selection and never starts a pan."""
+        from matplotlib.backend_bases import MouseEvent
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(100, 150)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (20.0, 20.0), "B": (120.0, 80.0)},
+            image=img,
+        )
+        canvas.resize(500, 400)
+        canvas.draw()
+        start = canvas.axes.transData.transform((75.0, 50.0))
+        press = MouseEvent("button_press_event", canvas, start[0], start[1], button=1)
+        canvas._on_pan_press(press)
+        assert canvas._pan_anchor is None
+
+    def test_double_click_resets_view(self, qtbot):
+        """A left double-click resets the zoomed view to the full extent."""
+        from matplotlib.backend_bases import MouseEvent
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(100, 150)
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (20.0, 20.0), "B": (120.0, 80.0)},
+            image=img,
+        )
+        canvas.resize(500, 400)
+        canvas.draw()
+        # Zoom in first.
+        disp = canvas.axes.transData.transform((75.0, 50.0))
+        up = MouseEvent("scroll_event", canvas, disp[0], disp[1], step=1)
+        up.button = "up"
+        canvas._on_scroll(up)
+        # A double-click resets.
+        dbl = MouseEvent("button_press_event", canvas, disp[0], disp[1], button=1)
+        dbl.dblclick = True
+        canvas._on_click(dbl)
+        lo, hi = canvas.axes.get_xlim()
+        assert abs(abs(hi - lo) - 150) < 2.0
+
+    def test_image_without_coords_falls_back_to_abstract(self, qtbot):
+        """An image with no real coords cannot place nodes -> abstract layout."""
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        img = _synthetic_image(60, 90)
+        # No node_positions -> nothing to overlay on the photo.
+        canvas.set_skeleton(["A", "B", "C"], [("A", "B"), ("B", "C")], image=img)
+        assert canvas._background_image is None
+        assert set(canvas._positions) == {"A", "B", "C"}
+
+    def test_bad_image_is_ignored(self, qtbot):
+        """A malformed image (wrong rank) is dropped, not drawn."""
+        import numpy as np
+
+        canvas = QCSkeletonTraceCanvas()
+        qtbot.addWidget(canvas)
+        bad = np.zeros((4, 4, 4, 4), dtype="uint8")  # rank-4, not an image
+        canvas.set_skeleton(
+            ["A", "B"],
+            [("A", "B")],
+            node_positions={"A": (1.0, 1.0), "B": (2.0, 2.0)},
+            image=bad,
+        )
+        # Falls back to the abstract layout (no usable background).
+        assert canvas._background_image is None
+
+
+def _real_labels_with_image(node_names, edges, instance_coords, image):
+    """Build a ``Labels`` whose single frame returns ``image`` from ``.image``.
+
+    Mirrors :func:`_real_labels` but returns the frame plus the ``Labels`` so the
+    caller can patch ``LabeledFrame.image`` to yield a synthetic frame without a
+    real video file on disk.
+
+    Args:
+        node_names: Ordered node names for the skeleton.
+        edges: List of ``(src, dst)`` name pairs for skeleton edges.
+        instance_coords: List of ``(n_nodes, 2)`` array-likes, one per instance.
+        image: The synthetic frame image the patched ``.image`` should return.
+
+    Returns:
+        A ``(labels, frame, image)`` tuple.
+    """
+    import numpy as np
+    from sleap_io.model.skeleton import Skeleton
+    from sleap_io.model.instance import Instance
+    from sleap_io.model.labeled_frame import LabeledFrame
+    from sleap_io.model.labels import Labels
+    from sleap_io.model.video import Video
+
+    skeleton = Skeleton(list(node_names), edges=[list(e) for e in edges])
+    video = Video(filename="dummy.mp4")
+    instances = [
+        Instance.from_numpy(np.asarray(coords, dtype=float), skeleton=skeleton)
+        for coords in instance_coords
+    ]
+    lf = LabeledFrame(video=video, frame_idx=0, instances=instances)
+    return Labels([lf]), lf, image
+
+
+class TestQCBestLabeledInstanceImage:
+    """Widget-level best-instance + frame-image feeding (issue #2769 follow-up).
+
+    ``set_labels`` should pick the labeled instance with the most present nodes,
+    decode its frame image, and feed the canvas real pixel coordinates + the
+    photo, degrading gracefully when no image can be decoded.
+    """
+
+    def test_picks_instance_with_most_present_nodes(self, qtbot):
+        """The fully-labeled instance wins over a partially-labeled one."""
+        import numpy as np
+
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        nan = [np.nan, np.nan]
+        # Frame holds two instances: a partial one (2 nodes) and a full one (3).
+        partial = [[10.0, 10.0], [20.0, 20.0], nan]
+        full = [[30.0, 30.0], [40.0, 40.0], [50.0, 60.0]]
+        labels, lf, img = _real_labels_with_image(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            [partial, full],
+            _synthetic_image(80, 120),
+        )
+
+        with patch.object(
+            type(lf), "image", new_callable=PropertyMock, return_value=img
+        ):
+            widget.set_labels(labels)
+
+        canvas = widget._skeleton_canvas
+        # Image mode is active and the FULL instance drove the overlay.
+        assert canvas._background_image is not None
+        assert canvas._positions["A"] == (30.0, 30.0)
+        assert canvas._positions["C"] == (50.0, 60.0)
+
+    def test_best_instance_helper_returns_positions_and_image(self, qtbot):
+        """The helper returns pixel coords for present nodes + the frame image."""
+        import numpy as np
+
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        nan = [np.nan, np.nan]
+        labels, lf, img = _real_labels_with_image(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            [[[5.0, 5.0], [15.0, 25.0], nan]],
+            _synthetic_image(70, 100),
+        )
+        widget._labels = labels
+        skeleton = labels.skeletons[0]
+
+        with patch.object(
+            type(lf), "image", new_callable=PropertyMock, return_value=img
+        ):
+            positions, image = widget._best_labeled_instance_image(
+                skeleton, list(skeleton.node_names)
+            )
+        assert positions["A"] == (5.0, 5.0)
+        assert positions["B"] == (15.0, 25.0)
+        # The invisible node is omitted (no pixel coordinate).
+        assert "C" not in positions
+        assert image is not None
+        assert np.asarray(image).shape == (70, 100)
+
+    def test_falls_back_to_abstract_when_image_decode_fails(self, qtbot):
+        """A frame whose image cannot be decoded uses the abstract layout."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # No patched image: the dummy video cannot be opened, so .image raises.
+        base = [[0.0, 0.0], [40.0, 0.0], [40.0, 30.0]]
+
+        def shifted(dx, dy):
+            return [[x + dx, y + dy] for x, y in base]
+
+        labels = _real_labels(
+            ["A", "B", "C"],
+            [("A", "B"), ("B", "C")],
+            [shifted(0, 0), shifted(200, 10)],
+        )
+        widget.set_labels(labels)
+        canvas = widget._skeleton_canvas
+        # No image -> abstract layout (normalized coords, no background).
+        assert canvas._background_image is None
+        assert set(canvas._positions) == {"A", "B", "C"}
+        for x, y in canvas._positions.values():
+            assert -1.0001 <= x <= 1.0001
+            assert -1.0001 <= y <= 1.0001
+
+    def test_no_instances_returns_empty(self, qtbot):
+        """With a skeleton but no instances the helper returns no image/coords."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        skeleton = _FakeSkeleton(["A", "B"], [("A", "B")])
+        labels = MagicMock()
+        labels.labeled_frames = []
+        positions, image = widget._best_labeled_instance_image(skeleton, ["A", "B"])
+        assert positions == {}
+        assert image is None
 
 
 class TestQCChainTraceDialog:

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -1039,6 +1039,109 @@ class TestQCDetectorSettings:
         assert widget._ordered_chains_edit.isEnabled()
 
 
+class TestQCB2DetectorSettings:
+    """Tests for the two B2 channel controls (appearance + in-sample model)."""
+
+    def test_b2_controls_exist_with_defaults(self, qtbot):
+        """The appearance + in-sample controls exist and default OFF."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Appearance / wrong-object checkbox, experimental default-OFF.
+        assert widget._cb_appearance is not None
+        assert widget._cb_appearance.text() == "Appearance / wrong-object"
+        assert not widget._cb_appearance.isChecked()
+
+        # In-sample model prediction checkbox, experimental default-OFF.
+        assert widget._cb_insample is not None
+        assert widget._cb_insample.text() == "In-sample model prediction"
+        assert not widget._cb_insample.isChecked()
+
+        # Model-path picker exists: a placeholder line edit + a Browse button.
+        assert widget._insample_model_edit is not None
+        assert widget._insample_model_edit.text() == ""
+        assert "model" in widget._insample_model_edit.placeholderText().lower()
+        assert widget._insample_browse_btn is not None
+        assert "Browse" in widget._insample_browse_btn.text()
+
+    def test_insample_tooltip_warns_about_slow_inference(self, qtbot):
+        """The in-sample checkbox tooltip warns that it runs full inference."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        tip = widget._cb_insample.toolTip().lower()
+        assert "inference" in tip
+        assert "slow" in tip
+
+    def test_insample_picker_disabled_when_unchecked(self, qtbot):
+        """The model picker + Browse button disable when in-sample is off."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        # Off by default -> picker + browse disabled.
+        assert not widget._insample_model_edit.isEnabled()
+        assert not widget._insample_browse_btn.isEnabled()
+
+        # Enabling the checkbox enables both.
+        widget._cb_insample.setChecked(True)
+        assert widget._insample_model_edit.isEnabled()
+        assert widget._insample_browse_btn.isEnabled()
+
+        # Disabling again disables both.
+        widget._cb_insample.setChecked(False)
+        assert not widget._insample_model_edit.isEnabled()
+        assert not widget._insample_browse_btn.isEnabled()
+
+    def test_browse_sets_model_path_from_dialog(self, qtbot):
+        """Clicking Browse opens getExistingDirectory and sets the line edit."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        with patch(
+            "sleap.gui.widgets.qc.QtWidgets.QFileDialog.getExistingDirectory",
+            return_value="/path/to/model",
+        ) as mock_dialog:
+            widget._on_browse_insample_model()
+            mock_dialog.assert_called_once()
+        assert widget._insample_model_edit.text() == "/path/to/model"
+
+    def test_browse_cancel_leaves_path_unchanged(self, qtbot):
+        """Cancelling the folder dialog (empty return) leaves the path empty."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        with patch(
+            "sleap.gui.widgets.qc.QtWidgets.QFileDialog.getExistingDirectory",
+            return_value="",
+        ):
+            widget._on_browse_insample_model()
+        assert widget._insample_model_edit.text() == ""
+
+    def test_build_qc_config_b2_defaults(self, qtbot):
+        """_build_qc_config maps the B2 controls; both channels default OFF."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        config = widget._build_qc_config()
+        assert config.use_appearance is False
+        assert config.use_insample_prediction is False
+        assert config.insample_model_path == ""
+
+    def test_build_qc_config_reflects_b2_toggles(self, qtbot):
+        """Toggling the B2 checkboxes + path is reflected in the built config."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        widget._cb_appearance.setChecked(True)
+        widget._cb_insample.setChecked(True)
+        widget._insample_model_edit.setText("  /models/best  ")
+
+        config = widget._build_qc_config()
+        assert config.use_appearance is True
+        assert config.use_insample_prediction is True
+        # Path is stripped of surrounding whitespace.
+        assert config.insample_model_path == "/models/best"
+
+
 class TestQCAnalysisWorkerConfig:
     """Tests for threading the QCConfig into the analysis worker."""
 

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -2386,6 +2386,35 @@ class TestQCChainTracePanel:
         widget._cb_chain.setChecked(True)
         assert widget._chain_trace_panel.isEnabled()
 
+    def test_chain_order_warns_when_enabled_without_chains(self, qtbot):
+        """Ticking 'Wrong chain order' with no chains prompts to open the editor."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        assert widget._collect_ordered_chains() == []
+        with patch.object(
+            QtWidgets.QMessageBox,
+            "question",
+            return_value=QtWidgets.QMessageBox.Yes,
+        ) as mq:
+            with patch.object(widget, "_open_chain_trace_dialog") as mopen:
+                widget._on_chain_checked(True)
+        mq.assert_called_once()
+        mopen.assert_called_once()
+
+    def test_chain_order_no_warning_when_chains_exist_or_unchecked(self, qtbot):
+        """No prompt when chains already exist, or when the box is unchecked."""
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+        # Chains already defined -> ticking on does not prompt.
+        with patch.object(widget, "_collect_ordered_chains", return_value=[["A", "B"]]):
+            with patch.object(QtWidgets.QMessageBox, "question") as mq:
+                widget._on_chain_checked(True)
+            mq.assert_not_called()
+        # Unchecking never prompts.
+        with patch.object(QtWidgets.QMessageBox, "question") as mq2:
+            widget._on_chain_checked(False)
+        mq2.assert_not_called()
+
 
 class TestCollapsibleDisclosure:
     """Tests for the ``<details>``-style disclosure arrow on CollapsibleGroupBox.

--- a/tests/qc/test_appearance.py
+++ b/tests/qc/test_appearance.py
@@ -1,0 +1,373 @@
+"""Tests for sleap.qc.features.appearance.
+
+These tests cover the appearance-outlier detector (e): "points placed on
+occluders / wrong object". The detector learns a per-node image-patch
+descriptor distribution and flags nodes whose local pixels do not match what
+that node usually sits on (e.g. a keypoint dragged onto bright cotton bedding
+over a dark mouse).
+
+Synthetic frames give us precise control over appearance: a node placed on a
+region matching its learned appearance should score ~0, while a node moved onto
+a visually-distinct patch (a bright square on a dark background) should score
+high. Degenerate cases (too few samples, all-NaN, edge patches, undecodable
+frames) must be safe. A final opt-in smoke test exercises the real grayscale
+``train.slp`` end-to-end.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.appearance import (
+    DEFAULT_MIN_SAMPLES,
+    extract_patch_descriptor,
+    fit_appearance,
+    score_appearance,
+)
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-frame helpers.
+# ---------------------------------------------------------------------------
+
+H, W = 64, 64
+N_NODES = 3
+
+# Per-node "home" location and intensity (grayscale background is dark = 20).
+# Each node sits on a distinct-but-modest grey level so descriptors differ.
+BG = 20
+NODE_LOCS = [(16, 16), (32, 40), (48, 24)]  # (y, x)
+NODE_GREY = [80, 130, 60]
+BLOB_HALF = 5  # half-size of the painted region around each node
+
+
+def _make_grayscale_frame(jitter: int = 0, seed: int = 0) -> np.ndarray:
+    """Build a (H, W, 1) uint8 frame with a grey blob at each node's home.
+
+    A small amount of additive noise (controlled by ``jitter``) makes the
+    per-node descriptors non-degenerate so a real covariance can be fit.
+    """
+    rng = np.random.default_rng(seed)
+    frame = np.full((H, W, 1), BG, dtype=np.float64)
+    for (y, x), grey in zip(NODE_LOCS, NODE_GREY):
+        frame[
+            y - BLOB_HALF : y + BLOB_HALF + 1,
+            x - BLOB_HALF : x + BLOB_HALF + 1,
+            0,
+        ] = grey
+    if jitter:
+        frame += rng.normal(0.0, jitter, size=frame.shape)
+    return np.clip(frame, 0, 255).astype(np.uint8)
+
+
+def _home_points() -> np.ndarray:
+    """(N_NODES, 2) array placing every node on its home blob (x, y order)."""
+    pts = np.full((N_NODES, 2), np.nan)
+    for i, (y, x) in enumerate(NODE_LOCS):
+        pts[i] = [x, y]
+    return pts
+
+
+def _build_training_set(n_frames: int = 30, seed0: int = 0) -> list[tuple]:
+    """List of (frame, home_points) pairs for fitting."""
+    pairs = []
+    for k in range(n_frames):
+        frame = _make_grayscale_frame(jitter=3, seed=seed0 + k)
+        pairs.append((frame, _home_points()))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# extract_patch_descriptor.
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPatchDescriptor:
+    def test_grayscale_descriptor_length_two(self):
+        frame = _make_grayscale_frame()
+        desc = extract_patch_descriptor(frame, x=16, y=16, patch_size=7)
+        assert desc is not None
+        assert desc.shape == (2,)  # [mean, std]
+        # Centre of node-0 blob -> mean near its grey level, std ~0.
+        assert desc[0] == pytest.approx(NODE_GREY[0], abs=1.0)
+        assert desc[1] == pytest.approx(0.0, abs=1.0)
+
+    def test_rgb_descriptor_length_six(self):
+        frame = np.zeros((32, 32, 3), dtype=np.uint8)
+        frame[:, :, 0] = 200  # red channel high
+        desc = extract_patch_descriptor(frame, x=16, y=16, patch_size=5)
+        assert desc is not None
+        assert desc.shape == (6,)  # [mean_rgb..., std_rgb...]
+        assert desc[0] == pytest.approx(200.0, abs=1.0)
+        assert desc[1] == pytest.approx(0.0, abs=1.0)
+
+    def test_2d_frame_promoted_to_single_channel(self):
+        frame2d = np.full((32, 32), 100, dtype=np.uint8)
+        desc = extract_patch_descriptor(frame2d, x=10, y=10, patch_size=5)
+        assert desc is not None
+        assert desc.shape == (2,)
+        assert desc[0] == pytest.approx(100.0, abs=1e-6)
+
+    def test_bright_patch_distinct_from_dark(self):
+        frame = _make_grayscale_frame()
+        # Background (dark) vs node blob (brighter) -> clearly different means.
+        dark = extract_patch_descriptor(frame, x=2, y=2, patch_size=7)
+        bright = extract_patch_descriptor(frame, x=16, y=16, patch_size=7)
+        assert dark[0] < bright[0]
+
+    def test_edge_patch_is_clipped_not_error(self):
+        frame = _make_grayscale_frame()
+        # Corner node: patch extends off the top-left but should still return.
+        desc = extract_patch_descriptor(frame, x=0, y=0, patch_size=7)
+        assert desc is not None
+        assert desc.shape == (2,)
+        assert np.all(np.isfinite(desc))
+
+    def test_nan_coordinate_returns_none(self):
+        frame = _make_grayscale_frame()
+        assert extract_patch_descriptor(frame, x=np.nan, y=10) is None
+        assert extract_patch_descriptor(frame, x=10, y=np.nan) is None
+
+    def test_centre_fully_outside_returns_none(self):
+        frame = _make_grayscale_frame()
+        assert extract_patch_descriptor(frame, x=1000, y=1000, patch_size=7) is None
+        assert extract_patch_descriptor(frame, x=-50, y=-50, patch_size=7) is None
+
+    def test_none_or_empty_frame_returns_none(self):
+        assert extract_patch_descriptor(None, x=1, y=1) is None
+        assert extract_patch_descriptor(np.zeros((0, 0, 1)), x=0, y=0) is None
+
+
+# ---------------------------------------------------------------------------
+# fit_appearance.
+# ---------------------------------------------------------------------------
+
+
+class TestFitAppearance:
+    def test_models_nodes_with_enough_samples(self):
+        # 30 frames -> 30 samples per node, above the default of 20.
+        pairs = _build_training_set(n_frames=30)
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7)
+
+        assert set(model["node_models"].keys()) == {0, 1, 2}
+        for node_idx in range(N_NODES):
+            assert model["node_sample_counts"][node_idx] == 30
+            nm = model["node_models"][node_idx]
+            assert nm["center"].shape == (2,)
+            assert nm["inv_cov"].shape == (2, 2)
+            assert nm["dist_scale"] > 0
+            assert nm["n_samples"] == 30
+        assert model["descriptor_dim"] == 2
+        assert model["patch_size"] == 7
+        assert model["n_nodes"] == N_NODES
+
+    def test_node_below_min_samples_not_modeled(self):
+        # Only 5 frames -> 5 samples/node, below default 20 -> no models.
+        pairs = _build_training_set(n_frames=5)
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7)
+        assert model["node_models"] == {}
+        for node_idx in range(N_NODES):
+            assert model["node_sample_counts"][node_idx] == 5
+
+    def test_custom_min_samples_threshold(self):
+        pairs = _build_training_set(n_frames=10)
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7, min_samples=5)
+        # 10 >= 5 -> all nodes modeled.
+        assert set(model["node_models"].keys()) == {0, 1, 2}
+
+    def test_invisible_node_contributes_no_samples(self):
+        # Node 1 is NaN in every frame -> never sampled, never modeled.
+        pairs = []
+        for k in range(30):
+            frame = _make_grayscale_frame(jitter=3, seed=k)
+            pts = _home_points()
+            pts[1] = [np.nan, np.nan]
+            pairs.append((frame, pts))
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7)
+        assert model["node_sample_counts"][1] == 0
+        assert 1 not in model["node_models"]
+        assert {0, 2}.issubset(model["node_models"].keys())
+
+    def test_none_frames_skipped(self):
+        pairs = _build_training_set(n_frames=25)
+        pairs.append((None, _home_points()))  # undecodable frame
+        pairs.append(None)  # malformed pair
+        model = fit_appearance(pairs, n_nodes=N_NODES, patch_size=7)
+        # The bad entries are ignored; valid frames still produce models.
+        assert set(model["node_models"].keys()) == {0, 1, 2}
+        assert model["node_sample_counts"][0] == 25
+
+    def test_empty_training_set(self):
+        model = fit_appearance([], n_nodes=N_NODES, patch_size=7)
+        assert model["node_models"] == {}
+        assert model["descriptor_dim"] is None
+        assert model["n_nodes"] == N_NODES
+
+    def test_default_min_samples_constant(self):
+        assert DEFAULT_MIN_SAMPLES == 20
+
+
+# ---------------------------------------------------------------------------
+# score_appearance.
+# ---------------------------------------------------------------------------
+
+
+class TestScoreAppearance:
+    def _fit(self, n_frames=30):
+        return fit_appearance(
+            _build_training_set(n_frames=n_frames), n_nodes=N_NODES, patch_size=7
+        )
+
+    def test_matching_appearance_scores_low(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=999)
+        result = score_appearance(frame, _home_points(), model)
+        # All nodes on their learned blobs -> low outlier score.
+        assert result["appearance_outlier_score"] < 0.3
+        assert set(result["node_scores"].keys()) == {0, 1, 2}
+        assert result["worst_node"] in (0, 1, 2)
+
+    def test_node_on_bright_anomaly_scores_high(self):
+        model = self._fit()
+        # Paint a bright square far from any blob and drag node 0 onto it.
+        frame = _make_grayscale_frame(jitter=3, seed=7)
+        frame[4:14, 4:14, 0] = 255  # bright cotton-like patch on dark bg
+        pts = _home_points()
+        pts[0] = [9, 9]  # move node 0 onto the bright square
+
+        result = score_appearance(frame, pts, model)
+        assert result["worst_node"] == 0
+        assert result["node_scores"][0] > 0.7
+        assert result["appearance_outlier_score"] > 0.7
+        # The untouched nodes (1, 2) remain low.
+        assert result["node_scores"][1] < 0.3
+        assert result["node_scores"][2] < 0.3
+
+    def test_score_is_max_over_nodes(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=11)
+        frame[4:14, 4:14, 0] = 255
+        pts = _home_points()
+        pts[2] = [9, 9]  # only node 2 is on the anomaly
+
+        result = score_appearance(frame, pts, model)
+        assert result["worst_node"] == 2
+        assert result["appearance_outlier_score"] == pytest.approx(
+            max(result["node_scores"].values())
+        )
+
+    def test_all_nan_instance_scores_zero(self):
+        model = self._fit()
+        frame = _make_grayscale_frame()
+        pts = np.full((N_NODES, 2), np.nan)
+        result = score_appearance(frame, pts, model)
+        assert result["appearance_outlier_score"] == 0.0
+        assert result["worst_node"] == -1
+        assert result["node_scores"] == {}
+
+    def test_none_frame_scores_zero(self):
+        model = self._fit()
+        result = score_appearance(None, _home_points(), model)
+        assert result["appearance_outlier_score"] == 0.0
+        assert result["worst_node"] == -1
+
+    def test_empty_model_scores_zero(self):
+        # Model with no node models (e.g. too few training samples).
+        empty_model = fit_appearance(
+            _build_training_set(n_frames=3), n_nodes=N_NODES, patch_size=7
+        )
+        assert empty_model["node_models"] == {}
+        result = score_appearance(_make_grayscale_frame(), _home_points(), empty_model)
+        assert result["appearance_outlier_score"] == 0.0
+        assert result["worst_node"] == -1
+
+    def test_none_model_scores_zero(self):
+        result = score_appearance(_make_grayscale_frame(), _home_points(), None)
+        assert result["appearance_outlier_score"] == 0.0
+
+    def test_only_modeled_visible_nodes_scored(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=42)
+        pts = _home_points()
+        pts[1] = [np.nan, np.nan]  # node 1 invisible in this instance
+        result = score_appearance(frame, pts, model)
+        # Node 1 was modeled but is invisible here -> not scored.
+        assert set(result["node_scores"].keys()) == {0, 2}
+
+    def test_edge_node_scored_safely(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=5)
+        pts = _home_points()
+        pts[0] = [0, 0]  # node 0 dragged to the corner (clipped patch)
+        result = score_appearance(frame, pts, model)
+        # Must return a finite score without raising on the clipped patch.
+        assert np.isfinite(result["appearance_outlier_score"])
+        assert 0.0 <= result["appearance_outlier_score"] <= 1.0
+
+    def test_scores_clamped_to_unit_interval(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=3)
+        frame[4:14, 4:14, 0] = 255
+        pts = _home_points()
+        pts[0] = [9, 9]
+        result = score_appearance(frame, pts, model)
+        for s in result["node_scores"].values():
+            assert 0.0 <= s <= 1.0
+        assert 0.0 <= result["appearance_outlier_score"] <= 1.0
+
+    def test_patch_size_defaults_to_model(self):
+        model = self._fit()
+        frame = _make_grayscale_frame(jitter=3, seed=8)
+        # Not passing patch_size should reuse the fit-time size and work.
+        result = score_appearance(frame, _home_points(), model)
+        assert set(result["node_scores"].keys()) == {0, 1, 2}
+
+
+# ---------------------------------------------------------------------------
+# Real-data smoke test (opt-in; needs the local train.slp).
+# ---------------------------------------------------------------------------
+
+REAL_SLP = "/home/talmolab/als2h_0922CVATNN/train.slp"
+
+
+@pytest.mark.skipif(not os.path.exists(REAL_SLP), reason="real train.slp not available")
+def test_real_data_smoke():
+    """End-to-end on real grayscale frames: fit on a subset, score a couple."""
+    import sleap_io as sio
+
+    labels = sio.load_slp(REAL_SLP)
+    n_nodes = len(labels.skeletons[0].nodes)
+
+    # Decode a handful of labeled frames (cap decode cost).
+    pairs = []
+    decoded = []
+    for lf in labels:
+        if not lf.user_instances:
+            continue
+        try:
+            frame = lf.video[lf.frame_idx]
+        except Exception:
+            continue
+        for inst in lf.user_instances:
+            pairs.append((frame, inst.numpy(invisible_as_nan=True)))
+        decoded.append((frame, lf))
+        if len(decoded) >= 5:
+            break
+
+    assert pairs, "expected at least one labeled instance to decode"
+    # Confirm real frames are grayscale (H, W, 1) uint8 as documented.
+    assert decoded[0][0].ndim == 3
+
+    # Lower min_samples so a 5-frame subset can actually model some nodes.
+    model = fit_appearance(pairs, n_nodes=n_nodes, patch_size=7, min_samples=3)
+
+    # Score the instances of the first couple decoded frames.
+    n_scored = 0
+    for frame, lf in decoded[:2]:
+        for inst in lf.user_instances:
+            res = score_appearance(frame, inst.numpy(invisible_as_nan=True), model)
+            assert np.isfinite(res["appearance_outlier_score"])
+            assert 0.0 <= res["appearance_outlier_score"] <= 1.0
+            n_scored += 1
+    assert n_scored > 0

--- a/tests/qc/test_b1_integration.py
+++ b/tests/qc/test_b1_integration.py
@@ -1,0 +1,708 @@
+"""Integration tests for the B1 detector wiring in LabelQCDetector.
+
+These cover the five detector modules (chirality, pose-split, chain-ordering,
+missing-node, split-duplicate) once they are wired into the detector scaffold:
+
+- the fixed-width feature vector (width invariance under config toggles),
+- the positional coupling between ``_extract_features`` and
+  ``V3_FEATURE_NAMES`` (contributions must map to the right names),
+- end-to-end flagging via the forced hard rules (flip, chain order),
+- the GMM-feature path for the chimera detector,
+- the missing-node channel surfacing through ``QCResults.get_flagged``, and
+- the complementary-split signal in frame-level duplicate detection.
+
+Note on GMM scores: for the small synthetic datasets used here the GMM's
+percentile-normalized score is degenerate (most instances saturate at ~1.0),
+exactly as in the existing ``test_detector`` suite. These tests therefore assert
+on the *forced* hard-rule issues, on the raw feature values, and on the channel
+merge -- none of which depend on the GMM cleanly separating instances by score.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import sleap_io as sio
+from sleap_io import LabeledFrame
+from sleap_io.model.instance import Instance
+
+from sleap.qc import LabelQCDetector, QCConfig, QCResults
+from sleap.qc.detector import V3_FEATURE_NAMES
+from sleap.qc.features.baseline import BASELINE_FEATURE_NAMES
+from sleap.qc.features.chirality import (
+    compute_chirality,
+    infer_symmetry_pairs_by_name,
+)
+from sleap.qc.features.pose_split import compute_pose_split
+from sleap.qc.features.ordering import compute_chain_ordering
+from sleap.qc.frame_level import detect_duplicates
+from sleap.qc.results import CHANNEL_ISSUE_LABELS, FrameKey, InstanceKey
+
+
+# ---------------------------------------------------------------------------
+# Skeleton / pose fixtures
+# ---------------------------------------------------------------------------
+#
+# Quadruped midline-chain skeleton. The longest path (the SkeletonAnalyzer
+# "spine") runs nose -> ... -> tailtip, so the chirality axis nodes
+# (spine[0], spine[-1]) are the true body midline endpoints, and there are two
+# symmetric pairs (ear_L/R, hip_L/R) -- enough for compute_chirality's
+# min_pairs=2. Symmetry is left UNdefined on the skeleton so the detector must
+# infer it from the _L/_R node names.
+QUAD_NAMES = [
+    "nose",
+    "head",
+    "spine1",
+    "spine2",
+    "tailbase",
+    "tailtip",
+    "ear_L",
+    "ear_R",
+    "hip_L",
+    "hip_R",
+]
+
+QUAD_CANONICAL = np.array(
+    [
+        [0.0, 20.0],  # nose
+        [0.0, 16.0],  # head
+        [0.0, 11.0],  # spine1
+        [0.0, 6.0],  # spine2
+        [0.0, 2.0],  # tailbase
+        [0.0, -2.0],  # tailtip
+        [-3.0, 16.0],  # ear_L
+        [3.0, 16.0],  # ear_R
+        [-3.0, 2.0],  # hip_L
+        [3.0, 2.0],  # hip_R
+    ],
+    dtype=float,
+)
+
+
+def _quad_skeleton() -> sio.Skeleton:
+    # sio.Skeleton mutates the names list in place (strings -> Node objects), so
+    # pass a copy to keep the shared QUAD_NAMES constant pristine for tests that
+    # use it directly (e.g. name-based symmetry inference).
+    skel = sio.Skeleton(list(QUAD_NAMES))
+    skel.add_edges(
+        [
+            ("nose", "head"),
+            ("head", "spine1"),
+            ("spine1", "spine2"),
+            ("spine2", "tailbase"),
+            ("tailbase", "tailtip"),
+            ("head", "ear_L"),
+            ("head", "ear_R"),
+            ("tailbase", "hip_L"),
+            ("tailbase", "hip_R"),
+        ]
+    )
+    return skel
+
+
+def _line_skeleton(n: int = 6) -> sio.Skeleton:
+    """A simple ``n``-node line graph 0-1-...-(n-1) (tail-like chain)."""
+    names = [f"n{i}" for i in range(n)]  # fresh list each call (safe to mutate)
+    skel = sio.Skeleton(names)
+    skel.add_edges([(f"n{i}", f"n{i + 1}") for i in range(n - 1)])
+    return skel
+
+
+def _line_base(n: int = 6, spacing: float = 10.0) -> np.ndarray:
+    return np.array([[i * spacing, 0.0] for i in range(n)], dtype=float)
+
+
+def _mirror_x(points: np.ndarray) -> np.ndarray:
+    """Whole-instance left/right mirror flip about the x = 0 midline."""
+    out = points.copy()
+    out[:, 0] *= -1.0
+    return out
+
+
+def _labels_from_poses(
+    skeleton: sio.Skeleton, poses: list[np.ndarray]
+) -> sio.Labels:
+    """Build a single-video Labels with one instance per frame."""
+    video = sio.Video.from_filename("test_video.mp4")
+    labels = sio.Labels()
+    for frame_idx, pts in enumerate(poses):
+        inst = Instance.from_numpy(pts, skeleton=skeleton)
+        labels.append(LabeledFrame(video=video, frame_idx=frame_idx, instances=[inst]))
+    return labels
+
+
+# ---------------------------------------------------------------------------
+# Width invariance
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureWidthInvariance:
+    """The fitted feature vector must always be the same fixed width."""
+
+    EXPECTED_WIDTH = 22  # 12 baseline + 10 v3 (incl. the 4 B1 features).
+
+    def test_feature_names_width(self):
+        """feature_names == 12 baseline + 10 v3 == 22."""
+        assert len(BASELINE_FEATURE_NAMES) == 12
+        assert len(V3_FEATURE_NAMES) == 10
+        total = len(BASELINE_FEATURE_NAMES) + len(V3_FEATURE_NAMES)
+        assert total == self.EXPECTED_WIDTH
+
+    def test_v3_feature_order_is_pinned(self):
+        """The B1 names append after hull_compactness in the documented order."""
+        assert V3_FEATURE_NAMES == [
+            "max_curvature",
+            "curvature_std",
+            "visibility_pattern_score",
+            "nn_distance",
+            "hull_area_zscore",
+            "hull_compactness",
+            "chirality_wrong_fraction",
+            "pose_split_score",
+            "order_inversion_rate",
+            "chain_intersection_count",
+        ]
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            QCConfig(),  # defaults: reliable ON, experimental OFF
+            QCConfig(use_chirality=True),
+            QCConfig(use_chirality=False),
+            QCConfig(use_split_detection=False),
+            QCConfig(use_chain_ordering=True),
+            QCConfig(use_missing_node_check=True),
+            QCConfig(
+                use_chirality=True,
+                use_split_detection=True,
+                use_chain_ordering=True,
+                use_missing_node_check=True,
+            ),
+        ],
+    )
+    def test_extracted_vector_matches_feature_names(self, config):
+        """fit() + a single _extract_features always yield width-22 vectors.
+
+        Holds for the default config and with every experimental flag toggled.
+        """
+        skel = _quad_skeleton()
+        rng = np.random.default_rng(0)
+        poses = [
+            QUAD_CANONICAL + rng.normal(0, 0.3, size=QUAD_CANONICAL.shape)
+            for _ in range(60)
+        ]
+        detector = LabelQCDetector(config)
+        detector.fit(_labels_from_poses(skel, poses))
+
+        assert len(detector.feature_names) == self.EXPECTED_WIDTH
+        feats = detector._extract_features(QUAD_CANONICAL)
+        assert feats.shape == (self.EXPECTED_WIDTH,)
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            QCConfig(),
+            QCConfig(use_chirality=True),
+            QCConfig(use_chain_ordering=True),
+            QCConfig(use_missing_node_check=True),
+        ],
+    )
+    def test_fit_and_score_round_trip(self, config):
+        """fit() then score() works under default and experimental configs."""
+        skel = _quad_skeleton()
+        rng = np.random.default_rng(1)
+        poses = [
+            QUAD_CANONICAL + rng.normal(0, 0.3, size=QUAD_CANONICAL.shape)
+            for _ in range(60)
+        ]
+        labels = _labels_from_poses(skel, poses)
+        detector = LabelQCDetector(config)
+        detector.fit(labels)
+        results = detector.score(labels)
+
+        assert len(results.instance_scores) == 60
+        # Every contribution dict is exactly the fixed feature width and holds
+        # only finite floats (the forced marker is popped before storage).
+        for contributions in results.feature_contributions.values():
+            assert len(contributions) == self.EXPECTED_WIDTH
+            assert "_forced_top_issue" not in contributions
+            assert all(np.isfinite(v) for v in contributions.values())
+
+
+# ---------------------------------------------------------------------------
+# Positional contribution mapping (order coupling guard)
+# ---------------------------------------------------------------------------
+
+
+class TestPositionalContributionMapping:
+    """Each new contribution must equal the independently-computed module value."""
+
+    def test_contributions_match_module_outputs(self):
+        """For a known instance, the B1 contributions equal the module values.
+
+        This guards the order coupling between the append order in
+        ``_extract_features`` and the name order in ``V3_FEATURE_NAMES``: if the
+        two ever drift, the contribution under a name would no longer equal the
+        value that name's module produces.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(2)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        labels = _labels_from_poses(skel, poses)
+
+        # Turn on chain ordering so order_inversion_rate / chain_intersection
+        # are exercised on the genuine module path (not the 0.0 default).
+        config = QCConfig(use_chain_ordering=True)
+        detector = LabelQCDetector(config)
+        detector.fit(labels)
+
+        # A swapped-tail instance has a non-trivial value for several channels.
+        probe = base.copy()
+        probe[[2, 3]] = probe[[3, 2]]
+
+        features = detector._extract_features(probe)
+        score, contributions = detector._score_instance(features)
+
+        # (d) chimera / pose-split: log1p(raw split_score).
+        raw_ps = compute_pose_split(
+            probe,
+            detector._adjacency,
+            detector.baseline_extractor.stats.edge_means,
+            detector.baseline_extractor.stats.edge_stds,
+        )["split_score"]
+        assert contributions["pose_split_score"] == pytest.approx(
+            float(np.log1p(max(raw_ps, 0.0)))
+        )
+
+        # (b) chain ordering: order_inversion_rate + chain_intersection_count.
+        ord_result = compute_chain_ordering(
+            probe,
+            detector._ordering_chains,
+            max_turn_angle=np.deg2rad(config.chain_turn_angle_deg),
+        )
+        assert contributions["order_inversion_rate"] == pytest.approx(
+            ord_result["order_inversion_rate"]
+        )
+        assert contributions["chain_intersection_count"] == pytest.approx(
+            float(ord_result["chain_intersection_count"])
+        )
+
+        # The line skeleton has no symmetry, so chirality is the fixed default.
+        assert contributions["chirality_wrong_fraction"] == 0.0
+
+    def test_chirality_contribution_matches_module(self):
+        """On a symmetric skeleton the chirality contribution matches the module."""
+        skel = _quad_skeleton()
+        rng = np.random.default_rng(3)
+        poses = [
+            QUAD_CANONICAL + rng.normal(0, 0.3, size=QUAD_CANONICAL.shape)
+            for _ in range(60)
+        ]
+        detector = LabelQCDetector(QCConfig())  # auto chirality -> ON (has symmetry)
+        detector.fit(_labels_from_poses(skel, poses))
+        assert detector._chirality_model is not None
+
+        flipped = _mirror_x(QUAD_CANONICAL)
+        features = detector._extract_features(flipped)
+        _, contributions = detector._score_instance(features)
+
+        expected = compute_chirality(
+            flipped,
+            detector._symmetry_pairs,
+            detector._axis_nodes,
+            detector._chirality_model,
+        )["chirality_wrong_fraction"]
+        assert contributions["chirality_wrong_fraction"] == pytest.approx(expected)
+        # A clean whole-instance mirror flip should disagree on every pair.
+        assert expected == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Flip end-to-end (chirality, default config, name-inferred symmetry)
+# ---------------------------------------------------------------------------
+
+
+class TestFlipEndToEnd:
+    """A whole-instance mirror flip is flagged 'Whole-instance L/R flip'."""
+
+    def _flip_dataset(self):
+        skel = _quad_skeleton()
+        rng = np.random.default_rng(4)
+        poses = [
+            QUAD_CANONICAL + rng.normal(0, 0.3, size=QUAD_CANONICAL.shape)
+            for _ in range(60)
+        ]
+        flip_frame = len(poses)
+        poses.append(_mirror_x(QUAD_CANONICAL))
+        return _labels_from_poses(skel, poses), flip_frame
+
+    def test_symmetry_inferred_by_name(self):
+        """The detector infers ear/hip L-R pairs purely from node names."""
+        assert infer_symmetry_pairs_by_name(QUAD_NAMES) == [(6, 7), (8, 9)]
+
+    def test_flip_flagged_with_lr_issue(self):
+        """The flipped instance is flagged with the L/R-flip top issue."""
+        labels, flip_frame = self._flip_dataset()
+        detector = LabelQCDetector(QCConfig())  # default config
+        detector.fit(labels)
+
+        # Symmetry inferred from names; axis is the spine midline endpoints.
+        assert detector._chirality_model is not None
+        assert detector._symmetry_pairs == [(6, 7), (8, 9)]
+
+        results = detector.score(labels)
+        flip_key = InstanceKey(0, flip_frame, 0)
+
+        assert results.forced_issues.get(flip_key) == "Whole-instance L/R flip"
+        assert results.feature_contributions[flip_key][
+            "chirality_wrong_fraction"
+        ] == pytest.approx(1.0)
+
+        flagged = results.get_flagged(threshold=0.7)
+        flip_flags = [f for f in flagged if f.instance_key == flip_key]
+        assert len(flip_flags) == 1
+        assert flip_flags[0].top_issue == "Whole-instance L/R flip"
+        assert flip_flags[0].score >= 0.9
+
+        # Normal instances are never given the L/R-flip label.
+        for f in flagged:
+            if f.instance_key != flip_key:
+                assert f.top_issue != "Whole-instance L/R flip"
+
+    def test_flip_not_flagged_when_chirality_disabled(self):
+        """With use_chirality=False there is no chirality model or forced flip."""
+        labels, flip_frame = self._flip_dataset()
+        detector = LabelQCDetector(QCConfig(use_chirality=False))
+        detector.fit(labels)
+
+        assert detector._chirality_model is None
+        results = detector.score(labels)
+        flip_key = InstanceKey(0, flip_frame, 0)
+        assert flip_key not in results.forced_issues
+        # The chirality feature falls back to its fixed 0.0 default.
+        contrib = results.feature_contributions[flip_key]
+        assert contrib["chirality_wrong_fraction"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Chimera (pose-split) feature
+# ---------------------------------------------------------------------------
+
+
+class TestChimeraFeature:
+    """A split pose yields a high pose_split_score feature."""
+
+    def test_split_pose_high_feature(self):
+        """The chimera's pose_split_score far exceeds the normal-pose mean."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(5)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        # Chimera: nodes 0-2 near origin, nodes 3-5 displaced far -> one long
+        # bridging edge (n2-n3) joining two balanced, well-separated clusters.
+        chimera = base.copy()
+        chimera[3:, 0] += 200.0
+        labels = _labels_from_poses(skel, poses)
+
+        detector = LabelQCDetector(QCConfig())  # split detection ON by default
+        detector.fit(labels)
+
+        chimera_feat = detector._extract_features(chimera)
+        _, chim_contrib = detector._score_instance(chimera_feat)
+
+        normal_vals = [
+            detector._score_instance(detector._extract_features(p))[1][
+                "pose_split_score"
+            ]
+            for p in poses
+        ]
+        normal_mean = float(np.mean(normal_vals))
+
+        assert chim_contrib["pose_split_score"] > 1.0
+        assert chim_contrib["pose_split_score"] > 5 * (normal_mean + 1e-6)
+
+    def test_split_detection_off_zeroes_feature(self):
+        """With use_split_detection=False the feature is the fixed 0.0 default."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(6)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        chimera = base.copy()
+        chimera[3:, 0] += 200.0
+
+        detector = LabelQCDetector(QCConfig(use_split_detection=False))
+        detector.fit(_labels_from_poses(skel, poses))
+        _, contrib = detector._score_instance(detector._extract_features(chimera))
+        assert contrib["pose_split_score"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Chain ordering (experimental flag ON)
+# ---------------------------------------------------------------------------
+
+
+class TestChainOrdering:
+    """A swapped-tail instance is flagged 'Wrong keypoint order along chain'."""
+
+    def _swap_dataset(self, config):
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(7)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        swap_frame = len(poses)
+        swapped = base.copy()
+        swapped[[2, 3]] = swapped[[3, 2]]  # adjacent label swap
+        poses.append(swapped)
+        return skel, _labels_from_poses(skel, poses), swap_frame
+
+    def test_swapped_tail_flagged(self):
+        """With chain ordering on, the swap is force-flagged."""
+        config = QCConfig(use_chain_ordering=True)
+        _, labels, swap_frame = self._swap_dataset(config)
+        detector = LabelQCDetector(config)
+        detector.fit(labels)
+        assert detector._ordering_chains == [[0, 1, 2, 3, 4, 5]]
+
+        results = detector.score(labels)
+        swap_key = InstanceKey(0, swap_frame, 0)
+        assert results.forced_issues.get(swap_key) == "Wrong keypoint order along chain"
+
+        flagged = results.get_flagged(threshold=0.7)
+        swap_flags = [f for f in flagged if f.instance_key == swap_key]
+        assert len(swap_flags) == 1
+        assert swap_flags[0].top_issue == "Wrong keypoint order along chain"
+
+    def test_chain_ordering_off_by_default(self):
+        """Default config (chain ordering OFF) does not force the order issue."""
+        _, labels, swap_frame = self._swap_dataset(QCConfig())
+        detector = LabelQCDetector(QCConfig())  # default: use_chain_ordering=False
+        detector.fit(labels)
+        results = detector.score(labels)
+        swap_key = InstanceKey(0, swap_frame, 0)
+        assert swap_key not in results.forced_issues
+        # Feature falls back to fixed defaults.
+        contrib = results.feature_contributions[swap_key]
+        assert contrib["order_inversion_rate"] == 0.0
+        assert contrib["chain_intersection_count"] == 0.0
+
+    def test_user_defined_ordered_chains_by_name_honored(self):
+        """User-defined ordered_chains (by NAME) resolve to node indices."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(8)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+
+        # A user-declared partial chain by name (subset, reordered names).
+        config = QCConfig(
+            use_chain_ordering=True,
+            ordered_chains=[["n1", "n2", "n3", "n4"]],
+        )
+        detector = LabelQCDetector(config)
+        detector.fit(_labels_from_poses(skel, poses))
+
+        # The user-defined chain (by name) is used verbatim, overriding the
+        # auto-detected full-line chain.
+        assert detector._ordering_chains == [[1, 2, 3, 4]]
+
+
+# ---------------------------------------------------------------------------
+# Missing-node channel (experimental flag ON)
+# ---------------------------------------------------------------------------
+
+
+class TestMissingNodeChannel:
+    """An outlier missing-node instance surfaces with 'Missing labelable node'."""
+
+    def test_detector_populates_missing_node_channel(self):
+        """The detector records a missing_node channel score for the outlier.
+
+        All training instances are fully visible, so the co-visibility column
+        for any node is ~1.0; an instance that drops node n3 then exceeds the
+        probability threshold and is recorded in channel_scores.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(11)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        outlier = base + rng.normal(0, 0.4, size=base.shape)
+        outlier[3] = np.nan  # drop a node the peers always keep
+        out_frame = len(poses)
+        poses.append(outlier)
+
+        detector = LabelQCDetector(QCConfig(use_missing_node_check=True))
+        detector.fit(_labels_from_poses(skel, poses))
+        results = detector.score(_labels_from_poses(skel, poses))
+
+        out_key = InstanceKey(0, out_frame, 0)
+        assert "missing_node" in results.channel_scores
+        chan = results.channel_scores["missing_node"]
+        assert out_key in chan
+        assert chan[out_key] >= detector.config.missing_node_prob_threshold
+
+        # Fully-visible instances are never recorded on the channel.
+        for frame_idx in range(60):
+            assert InstanceKey(0, frame_idx, 0) not in chan
+
+    def test_missing_node_check_off_by_default(self):
+        """Default config does not populate the missing_node channel."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(12)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        outlier = base + rng.normal(0, 0.4, size=base.shape)
+        outlier[3] = np.nan
+        poses.append(outlier)
+
+        detector = LabelQCDetector(QCConfig())  # missing-node check OFF
+        detector.fit(_labels_from_poses(skel, poses))
+        results = detector.score(_labels_from_poses(skel, poses))
+        assert "missing_node" not in results.channel_scores
+
+    def test_get_flagged_surfaces_missing_node_label(self):
+        """A channel-dominant key surfaces via get_flagged with the channel label.
+
+        Mirrors the documented merge: the final score is max(gmm, channel) and,
+        when the channel wins (chan > gmm), its CHANNEL_ISSUE_LABELS label is the
+        top issue. A channel-only key (no GMM score, so no feature
+        contributions) must also be handled safely.
+        """
+        results = QCResults(feature_names=["max_edge_zscore"])
+        gmm_key = InstanceKey(0, 0, 0)  # GMM-only
+        chan_only_key = InstanceKey(0, 1, 0)  # channel-only, no GMM score
+        both_key = InstanceKey(0, 2, 0)  # both, channel dominant
+
+        results.instance_scores = {gmm_key: 0.9, both_key: 0.4}
+        results.feature_contributions = {
+            gmm_key: {"max_edge_zscore": 5.0},
+            both_key: {"max_edge_zscore": 1.0},
+        }
+        results.channel_scores = {
+            "missing_node": {chan_only_key: 0.85, both_key: 0.95}
+        }
+
+        flagged = results.get_flagged(threshold=0.7)
+        by_key = {f.instance_key: f for f in flagged}
+
+        # Channel-only key: flagged on the channel, with the channel label.
+        assert chan_only_key in by_key
+        assert by_key[chan_only_key].score == pytest.approx(0.85)
+        assert by_key[chan_only_key].top_issue == CHANNEL_ISSUE_LABELS["missing_node"]
+        # Absent feature contributions are tolerated (empty dict).
+        assert by_key[chan_only_key].feature_contributions == {}
+
+        # Both present, channel wins -> channel label and the higher score.
+        assert by_key[both_key].score == pytest.approx(0.95)
+        assert by_key[both_key].top_issue == CHANNEL_ISSUE_LABELS["missing_node"]
+
+        # GMM-only key keeps its inferred (feature-based) issue.
+        assert by_key[gmm_key].top_issue != CHANNEL_ISSUE_LABELS["missing_node"]
+
+
+# ---------------------------------------------------------------------------
+# Duplicate (complementary split) at the frame level
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateSplit:
+    """A complementary split pair raises the frame-level duplicate score."""
+
+    def test_complementary_split_flagged_by_score(self):
+        """Two disjoint contiguous halves flag via the split_duplicate reason."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(13)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        detector = LabelQCDetector(QCConfig())  # use_duplicate_score ON by default
+        detector.fit(_labels_from_poses(skel, poses))
+        edge_means = detector.baseline_extractor.stats.edge_means
+
+        # Instance A labels the front half, B labels the back half; together
+        # they form one coherent animal (no shared nodes, abutting at the body).
+        inst_a = base.copy()
+        inst_a[3:] = np.nan
+        inst_b = base.copy()
+        inst_b[:3] = np.nan
+
+        # IoU/node-overlap thresholds set high so only the split signal can fire.
+        dups = detect_duplicates(
+            [inst_a, inst_b],
+            iou_threshold=0.99,
+            node_overlap_ratio=0.99,
+            edge_means=edge_means,
+            duplicate_score_threshold=0.5,
+        )
+        assert len(dups) == 1
+        assert dups[0]["reason"] == "split_duplicate"
+        assert dups[0]["duplicate_score"] >= 0.5
+        assert dups[0]["split_duplicate_score"] >= 0.5
+
+    def test_detector_records_duplicate_scores_in_frameqc(self):
+        """_check_frame stores a duplicate_score parallel to pairs/reasons."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(14)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        detector = LabelQCDetector(QCConfig())
+        detector.fit(_labels_from_poses(skel, poses))
+
+        inst_a = base.copy()
+        inst_a[3:] = np.nan
+        inst_b = base.copy()
+        inst_b[:3] = np.nan
+        video = sio.Video.from_filename("dup.mp4")
+        dup_labels = sio.Labels()
+        dup_labels.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    Instance.from_numpy(inst_a, skeleton=skel),
+                    Instance.from_numpy(inst_b, skeleton=skel),
+                ],
+            )
+        )
+        results = detector.score(dup_labels)
+        frame_qc = results.frame_results[FrameKey(0, 0)]
+
+        assert len(frame_qc.duplicate_pairs) == 1
+        # The new parallel list stays aligned with pairs/reasons.
+        assert len(frame_qc.duplicate_scores) == len(frame_qc.duplicate_pairs)
+        assert len(frame_qc.duplicate_reasons) == len(frame_qc.duplicate_pairs)
+        assert frame_qc.duplicate_reasons[0] == "split_duplicate"
+        assert frame_qc.duplicate_scores[0] >= 0.5
+
+    def test_duplicate_score_off_keeps_legacy_behavior(self):
+        """With use_duplicate_score off, the split pair is NOT flagged.
+
+        The legacy IoU + node-overlap path does not catch a complementary
+        split (disjoint nodes, near-zero IoU and node overlap), so no duplicate
+        is recorded and duplicate_scores stays empty.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(15)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+        detector = LabelQCDetector(QCConfig(use_duplicate_score=False))
+        detector.fit(_labels_from_poses(skel, poses))
+
+        inst_a = base.copy()
+        inst_a[3:] = np.nan
+        inst_b = base.copy()
+        inst_b[:3] = np.nan
+        video = sio.Video.from_filename("dup.mp4")
+        dup_labels = sio.Labels()
+        dup_labels.append(
+            LabeledFrame(
+                video=video,
+                frame_idx=0,
+                instances=[
+                    Instance.from_numpy(inst_a, skeleton=skel),
+                    Instance.from_numpy(inst_b, skeleton=skel),
+                ],
+            )
+        )
+        results = detector.score(dup_labels)
+        frame_qc = results.frame_results[FrameKey(0, 0)]
+        assert frame_qc.duplicate_pairs == []
+        assert frame_qc.duplicate_scores == []

--- a/tests/qc/test_b1_integration.py
+++ b/tests/qc/test_b1_integration.py
@@ -43,12 +43,12 @@ from sleap.qc.results import CHANNEL_ISSUE_LABELS, FrameKey, InstanceKey
 # Skeleton / pose fixtures
 # ---------------------------------------------------------------------------
 #
-# Quadruped midline-chain skeleton. The longest path (the SkeletonAnalyzer
-# "spine") runs nose -> ... -> tailtip, so the chirality axis nodes
-# (spine[0], spine[-1]) are the true body midline endpoints, and there are two
-# symmetric pairs (ear_L/R, hip_L/R) -- enough for compute_chirality's
-# min_pairs=2. Symmetry is left UNdefined on the skeleton so the detector must
-# infer it from the _L/_R node names.
+# Quadruped midline-chain skeleton. The non-symmetric nodes (nose, head,
+# spine1, spine2, tailbase, tailtip) form the chirality midline polyline,
+# ordered nose -> tailtip by PCA, and there are two symmetric pairs (ear_L/R,
+# hip_L/R) -- enough for compute_chirality's min_pairs=2. Symmetry is left
+# UNdefined on the skeleton so the detector must infer it from the _L/_R node
+# names.
 QUAD_NAMES = [
     "nose",
     "head",
@@ -308,8 +308,9 @@ class TestPositionalContributionMapping:
         expected = compute_chirality(
             flipped,
             detector._symmetry_pairs,
-            detector._axis_nodes,
+            detector._midline_nodes,
             detector._chirality_model,
+            axis_node_indices=detector._axis_nodes,
         )["chirality_wrong_fraction"]
         assert contributions["chirality_wrong_fraction"] == pytest.approx(expected)
         # A clean whole-instance mirror flip should disagree on every pair.
@@ -345,9 +346,11 @@ class TestFlipEndToEnd:
         detector = LabelQCDetector(QCConfig())  # default config
         detector.fit(labels)
 
-        # Symmetry inferred from names; axis is the spine midline endpoints.
+        # Symmetry inferred from names; midline = ordered non-symmetric nodes.
         assert detector._chirality_model is not None
         assert detector._symmetry_pairs == [(6, 7), (8, 9)]
+        # All six non-symmetric nodes form the midline (not just spine endpoints).
+        assert set(detector._midline_nodes) == {0, 1, 2, 3, 4, 5}
 
         results = detector.score(labels)
         flip_key = InstanceKey(0, flip_frame, 0)

--- a/tests/qc/test_b1_integration.py
+++ b/tests/qc/test_b1_integration.py
@@ -119,9 +119,7 @@ def _mirror_x(points: np.ndarray) -> np.ndarray:
     return out
 
 
-def _labels_from_poses(
-    skeleton: sio.Skeleton, poses: list[np.ndarray]
-) -> sio.Labels:
+def _labels_from_poses(skeleton: sio.Skeleton, poses: list[np.ndarray]) -> sio.Labels:
     """Build a single-video Labels with one instance per frame."""
     video = sio.Video.from_filename("test_video.mp4")
     labels = sio.Labels()
@@ -577,9 +575,7 @@ class TestMissingNodeChannel:
             gmm_key: {"max_edge_zscore": 5.0},
             both_key: {"max_edge_zscore": 1.0},
         }
-        results.channel_scores = {
-            "missing_node": {chan_only_key: 0.85, both_key: 0.95}
-        }
+        results.channel_scores = {"missing_node": {chan_only_key: 0.85, both_key: 0.95}}
 
         flagged = results.get_flagged(threshold=0.7)
         by_key = {f.instance_key: f for f in flagged}

--- a/tests/qc/test_b2_integration.py
+++ b/tests/qc/test_b2_integration.py
@@ -1,0 +1,450 @@
+"""Integration tests for the B2 non-GMM channel wiring in LabelQCDetector.
+
+These cover the two B2 channel modules once they are wired into the detector:
+
+- the appearance-outlier channel (detector (e)): scored against a per-node
+  image-appearance model built at fit time from decoded frames, surfaced via
+  ``QCResults.channel_scores["appearance"]`` and labeled "Appearance outlier",
+- the in-sample model-prediction channel (detector (f), Tier-2): a single
+  batched ``run_insample_prediction`` call run after the per-instance loop,
+  surfaced via ``QCResults.channel_scores["prediction"]`` and labeled "Model
+  expects a labeled part here".
+
+Both are non-GMM channels (default-OFF / experimental), wired exactly like the
+existing missing-node channel. They MUST NOT change the fixed 22-wide feature
+vector (they are channels, not GMM features). Real model inference is never run
+here -- ``run_insample_prediction`` is monkeypatched, and the appearance model
+is exercised either against tiny real decodable frames or via a monkeypatched
+``fit_appearance``/``score_appearance`` to test the wiring in isolation.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+import numpy as np
+import pytest
+import sleap_io as sio
+from sleap_io import LabeledFrame
+from sleap_io.model.instance import Instance
+
+import sleap.qc.detector as detector_mod
+from sleap.qc import LabelQCDetector, QCConfig, QCResults
+from sleap.qc.detector import V3_FEATURE_NAMES
+from sleap.qc.features.baseline import BASELINE_FEATURE_NAMES
+from sleap.qc.results import CHANNEL_ISSUE_LABELS, InstanceKey
+
+
+# ---------------------------------------------------------------------------
+# Skeleton / pose / labels fixtures (mirror the B1 integration helpers)
+# ---------------------------------------------------------------------------
+
+
+def _line_skeleton(n: int = 6) -> sio.Skeleton:
+    """A simple ``n``-node line graph 0-1-...-(n-1)."""
+    names = [f"n{i}" for i in range(n)]
+    skel = sio.Skeleton(names)
+    skel.add_edges([(f"n{i}", f"n{i + 1}") for i in range(n - 1)])
+    return skel
+
+
+def _line_base(n: int = 6, spacing: float = 10.0) -> np.ndarray:
+    return np.array([[i * spacing, 0.0] for i in range(n)], dtype=float)
+
+
+def _labels_from_poses(skeleton: sio.Skeleton, poses: list[np.ndarray]) -> sio.Labels:
+    """Build a single-video Labels with one instance per frame."""
+    video = sio.Video.from_filename("test_video.mp4")
+    labels = sio.Labels()
+    for frame_idx, pts in enumerate(poses):
+        inst = Instance.from_numpy(pts, skeleton=skeleton)
+        labels.append(LabeledFrame(video=video, frame_idx=frame_idx, instances=[inst]))
+    return labels
+
+
+# ---------------------------------------------------------------------------
+# Real decodable frames for the appearance channel
+# ---------------------------------------------------------------------------
+
+
+def _make_image_video(images: list[np.ndarray], tmpdir: str) -> sio.Video:
+    """Write grayscale image frames to PNGs and wrap them in an ImageVideo.
+
+    Decoding ``video[idx]`` returns an ``(H, W, 1)`` uint8 array, exactly the
+    decoded-frame shape the appearance module expects, so this exercises the
+    real ``fit()`` decode path without depending on a video codec.
+    """
+    try:
+        import imageio.v3 as iio
+    except Exception:  # pragma: no cover - older imageio
+        import imageio as iio
+
+    paths = []
+    for i, img in enumerate(images):
+        path = os.path.join(tmpdir, f"frame_{i:04d}.png")
+        iio.imwrite(path, np.asarray(img, dtype=np.uint8))
+        paths.append(path)
+    return sio.Video.from_filename(paths)
+
+
+def _appearance_labels_real_frames(tmpdir: str):
+    """Build a Labels over real decodable frames with one planted outlier.
+
+    A 3-node line skeleton is placed at fixed pixel locations in a dark
+    background. For most frames every node sits on dark pixels; in the final
+    (outlier) frame node 1 is dragged onto a bright square (the "wrong object"),
+    so its appearance descriptor is far from the learned dark-pixel model.
+
+    Returns ``(labels, skeleton, outlier_frame_idx, node_xy)``.
+    """
+    height, width = 40, 60
+    n_frames = 40
+    rng = np.random.default_rng(7)
+
+    # Fixed node pixel locations (kept away from borders so full patches fit).
+    node_xy = np.array([[12.0, 20.0], [30.0, 20.0], [48.0, 20.0]], dtype=float)
+
+    images = []
+    poses = []
+    for _ in range(n_frames):
+        # Dark, low-contrast background under every node.
+        img = rng.integers(0, 25, size=(height, width), dtype=np.uint8)
+        images.append(img)
+        # Tiny jitter so descriptors are not perfectly identical.
+        poses.append(node_xy + rng.normal(0, 0.3, size=node_xy.shape))
+
+    # Outlier frame: paint a bright block under node 1's location.
+    outlier_idx = n_frames
+    out_img = rng.integers(0, 25, size=(height, width), dtype=np.uint8)
+    cx, cy = int(round(node_xy[1, 0])), int(round(node_xy[1, 1]))
+    out_img[cy - 5 : cy + 6, cx - 5 : cx + 6] = 250  # bright "wrong object"
+    images.append(out_img)
+    poses.append(node_xy.copy())
+
+    skel = _line_skeleton(3)
+    video = _make_image_video(images, tmpdir)
+    labels = sio.Labels(videos=[video], skeletons=[skel])
+    for frame_idx, pts in enumerate(poses):
+        inst = Instance.from_numpy(pts, skeleton=skel)
+        labels.append(LabeledFrame(video=video, frame_idx=frame_idx, instances=[inst]))
+    return labels, skel, outlier_idx, node_xy
+
+
+# ---------------------------------------------------------------------------
+# Width invariance: the B2 channels must not change the 22-wide feature vector
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureWidthInvariance:
+    """The B2 channels are channels, not GMM features -> width stays 22."""
+
+    EXPECTED_WIDTH = 22  # 12 baseline + 10 v3.
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            QCConfig(),  # both B2 channels OFF
+            QCConfig(use_appearance=True),
+            QCConfig(use_insample_prediction=True),
+            QCConfig(use_appearance=True, use_insample_prediction=True),
+        ],
+    )
+    def test_feature_vector_stays_22_with_b2_channels(self, config):
+        """fit() + a single _extract_features still yield width-22 vectors.
+
+        Holds with either or both B2 channels toggled on. (use_appearance with
+        the synthetic .mp4 video here decodes nothing, so the appearance model
+        is empty -- which is exactly fine for the width check.)
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(0)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(60)]
+
+        detector = LabelQCDetector(config)
+        detector.fit(_labels_from_poses(skel, poses))
+
+        assert len(detector.feature_names) == self.EXPECTED_WIDTH
+        assert V3_FEATURE_NAMES == [
+            "max_curvature",
+            "curvature_std",
+            "visibility_pattern_score",
+            "nn_distance",
+            "hull_area_zscore",
+            "hull_compactness",
+            "chirality_wrong_fraction",
+            "pose_split_score",
+            "order_inversion_rate",
+            "chain_intersection_count",
+        ]
+        feats = detector._extract_features(base)
+        assert feats.shape == (self.EXPECTED_WIDTH,)
+        total = len(BASELINE_FEATURE_NAMES) + len(V3_FEATURE_NAMES)
+        assert total == self.EXPECTED_WIDTH
+
+
+# ---------------------------------------------------------------------------
+# Appearance channel
+# ---------------------------------------------------------------------------
+
+
+class TestAppearanceChannelRealFrames:
+    """End-to-end appearance channel against tiny real decodable frames."""
+
+    def test_outlier_populates_appearance_channel_and_surfaces_label(self):
+        """A node dragged onto a bright block is flagged 'Appearance outlier'.
+
+        Exercises the genuine fit-time decode path (``video[frame_idx]``), the
+        per-node appearance model, and the score-time channel population +
+        get_flagged label surfacing -- no mocking of the appearance module.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            labels, _skel, outlier_idx, _xy = _appearance_labels_real_frames(tmpdir)
+
+            # min_samples low enough that 40 frames (40 patches/node) model it.
+            config = QCConfig(use_appearance=True, appearance_min_samples=20)
+            detector = LabelQCDetector(config)
+            detector.fit(labels)
+
+            # The appearance model actually learned at least node 1.
+            assert detector._appearance_model is not None
+            assert 1 in detector._appearance_model["node_models"]
+
+            results = detector.score(labels)
+
+            assert "appearance" in results.channel_scores
+            chan = results.channel_scores["appearance"]
+            out_key = InstanceKey(0, outlier_idx, 0)
+            assert out_key in chan
+            assert chan[out_key] > 0.0
+
+            # The clean training frames sit on dark pixels -> near-zero outlier
+            # score, so they should out-score the planted bright-block frame.
+            assert chan[out_key] > max(
+                (chan.get(InstanceKey(0, i, 0), 0.0) for i in range(40)),
+                default=0.0,
+            )
+
+            # When the appearance channel wins for the outlier, get_flagged
+            # surfaces it with the channel's human-readable label.
+            flagged = detector.score(labels).get_flagged(
+                threshold=min(chan[out_key], 0.99)
+            )
+            by_key = {f.instance_key: f for f in flagged}
+            assert out_key in by_key
+            assert by_key[out_key].top_issue == CHANNEL_ISSUE_LABELS["appearance"]
+
+
+class TestAppearanceChannelWiring:
+    """Appearance channel wiring tested with a monkeypatched module (no I/O)."""
+
+    def test_channel_populated_via_monkeypatched_module(self, monkeypatch):
+        """With canned fit/score values, the appearance channel is populated.
+
+        Monkeypatches ``fit_appearance``/``score_appearance`` as imported into
+        ``sleap.qc.detector`` so the test is independent of any real frame
+        decoding (the synthetic .mp4 video here cannot be decoded). This pins
+        the WIRING: a non-empty model is built, frames are decoded once, and a
+        positive ``appearance_outlier_score`` lands in channel_scores.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(1)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(8)]
+        outlier_idx = len(poses)
+        poses.append(base.copy())
+        labels = _labels_from_poses(skel, poses)
+
+        # Canned model + a frame stub so the decode try/except yields non-None.
+        canned_model = {"node_models": {0: {}}, "patch_size": 7}
+        monkeypatch.setattr(
+            detector_mod, "fit_appearance", lambda *a, **k: canned_model
+        )
+
+        # Make every frame decode to a tiny non-None array.
+        fake_frame = np.zeros((4, 4, 1), dtype=np.uint8)
+        for video in labels.videos:
+            monkeypatch.setattr(
+                type(video), "__getitem__", lambda self, idx: fake_frame, raising=False
+            )
+
+        # Only the outlier frame gets a positive score; the rest score 0.
+        def fake_score(frame, points, model, patch_size=None):
+            is_outlier = bool(np.allclose(np.nan_to_num(points), base))
+            return {
+                "appearance_outlier_score": 0.92 if is_outlier else 0.0,
+                "worst_node": 0 if is_outlier else -1,
+                "node_scores": {0: 0.92} if is_outlier else {},
+            }
+
+        monkeypatch.setattr(detector_mod, "score_appearance", fake_score)
+
+        detector = LabelQCDetector(QCConfig(use_appearance=True))
+        detector.fit(labels)
+        assert detector._appearance_model is canned_model
+
+        results = detector.score(labels)
+        assert "appearance" in results.channel_scores
+        out_key = InstanceKey(0, outlier_idx, 0)
+        assert results.channel_scores["appearance"][out_key] == pytest.approx(0.92)
+        # A zero-scoring frame is never recorded (mirrors missing_node).
+        assert InstanceKey(0, 0, 0) not in results.channel_scores["appearance"]
+
+    def test_appearance_off_by_default_no_model_no_channel(self, monkeypatch):
+        """Default config builds no appearance model and never decodes frames."""
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(2)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(8)]
+        labels = _labels_from_poses(skel, poses)
+
+        # fit_appearance/score_appearance must never be called with the default.
+        def _boom(*a, **k):  # pragma: no cover - asserts non-invocation
+            raise AssertionError("appearance module called with use_appearance=False")
+
+        monkeypatch.setattr(detector_mod, "fit_appearance", _boom)
+        monkeypatch.setattr(detector_mod, "score_appearance", _boom)
+
+        detector = LabelQCDetector(QCConfig())  # appearance OFF
+        detector.fit(labels)
+        assert detector._appearance_model is None
+
+        results = detector.score(labels)
+        assert "appearance" not in results.channel_scores
+
+
+# ---------------------------------------------------------------------------
+# In-sample model-prediction channel (run_insample_prediction is MOCKED)
+# ---------------------------------------------------------------------------
+
+
+class TestInsamplePredictionChannel:
+    """In-sample prediction channel wiring; never runs real inference."""
+
+    def test_channel_populated_via_monkeypatched_inference(self, monkeypatch):
+        """Canned run_insample_prediction output lands in channel_scores.
+
+        Monkeypatches ``run_insample_prediction`` (as imported into the
+        detector) to return a fixed result, so no torch/sleap_nn or real
+        inference is involved. Pins that the single batched call's
+        ``instance_scores`` are copied into the ``"prediction"`` channel.
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(3)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(8)]
+        labels = _labels_from_poses(skel, poses)
+
+        captured = {}
+
+        def fake_run(labels_arg, **kwargs):
+            captured["labels"] = labels_arg
+            captured["kwargs"] = kwargs
+            return {
+                "ran": True,
+                "reason": "",
+                "instance_scores": {(0, 0, 0): 0.9},
+                "records": [],
+            }
+
+        monkeypatch.setattr(detector_mod, "run_insample_prediction", fake_run)
+
+        config = QCConfig(
+            use_insample_prediction=True, insample_model_path="/fake/model"
+        )
+        detector = LabelQCDetector(config)
+        detector.fit(labels)
+        results = detector.score(labels)
+
+        # Called exactly once, in-sample, with the labels + configured params.
+        assert captured["labels"] is labels
+        assert captured["kwargs"]["model_path"] == "/fake/model"
+        assert captured["kwargs"]["peak_threshold"] == config.insample_peak_threshold
+        assert captured["kwargs"]["min_confidence"] == config.insample_min_confidence
+        assert captured["kwargs"]["device"] == config.insample_device
+
+        # The canned score is surfaced under the "prediction" channel.
+        assert "prediction" in results.channel_scores
+        pred_key = InstanceKey(0, 0, 0)
+        assert results.channel_scores["prediction"][pred_key] == pytest.approx(0.9)
+
+    def test_insample_off_by_default_not_called(self, monkeypatch):
+        """Default config never calls run_insample_prediction; no channel.
+
+        This is the key safety guard: with use_insample_prediction=False (the
+        default) the expensive inference path is not even invoked, and behavior
+        is unchanged (no "prediction" channel).
+        """
+        skel = _line_skeleton(6)
+        base = _line_base(6)
+        rng = np.random.default_rng(5)
+        poses = [base + rng.normal(0, 0.4, size=base.shape) for _ in range(8)]
+        labels = _labels_from_poses(skel, poses)
+
+        called = {"count": 0}
+
+        def fake_run(*a, **k):  # pragma: no cover - asserts non-invocation
+            called["count"] += 1
+            raise AssertionError("run_insample_prediction called with channel OFF")
+
+        monkeypatch.setattr(detector_mod, "run_insample_prediction", fake_run)
+
+        detector = LabelQCDetector(QCConfig())  # in-sample prediction OFF
+        detector.fit(labels)
+        results = detector.score(labels)
+
+        assert called["count"] == 0
+        assert "prediction" not in results.channel_scores
+        # Behavior unchanged: every instance still scored as before.
+        assert len(results.instance_scores) == len(poses)
+
+
+# ---------------------------------------------------------------------------
+# get_flagged label surfacing for the B2 channels
+# ---------------------------------------------------------------------------
+
+
+class TestB2ChannelLabelSurfacing:
+    """A B2-channel-dominant key surfaces via get_flagged with the right label.
+
+    Built on a hand-constructed QCResults (mirrors the B1 missing-node label
+    test) so the channel cleanly out-scores the GMM. On the tiny synthetic
+    datasets used elsewhere the GMM's normalized score saturates near 1.0, which
+    would otherwise mask the channel label in an end-to-end run; the detector
+    population of these channels is covered by the wiring tests above.
+    """
+
+    @pytest.mark.parametrize(
+        "channel",
+        ["appearance", "prediction"],
+    )
+    def test_channel_dominant_key_uses_channel_label(self, channel):
+        results = QCResults(feature_names=["max_edge_zscore"])
+        gmm_key = InstanceKey(0, 0, 0)  # GMM-only
+        chan_only_key = InstanceKey(0, 1, 0)  # channel-only, no GMM score
+        both_key = InstanceKey(0, 2, 0)  # both, channel dominant
+
+        results.instance_scores = {gmm_key: 0.9, both_key: 0.4}
+        results.feature_contributions = {
+            gmm_key: {"max_edge_zscore": 5.0},
+            both_key: {"max_edge_zscore": 1.0},
+        }
+        results.channel_scores = {channel: {chan_only_key: 0.85, both_key: 0.95}}
+
+        flagged = results.get_flagged(threshold=0.7)
+        by_key = {f.instance_key: f for f in flagged}
+
+        # Channel-only key: flagged on the channel, with the channel label, and
+        # absent feature contributions are tolerated (empty dict).
+        assert chan_only_key in by_key
+        assert by_key[chan_only_key].score == pytest.approx(0.85)
+        assert by_key[chan_only_key].top_issue == CHANNEL_ISSUE_LABELS[channel]
+        assert by_key[chan_only_key].feature_contributions == {}
+
+        # Both present, channel wins -> channel label and the higher score.
+        assert by_key[both_key].score == pytest.approx(0.95)
+        assert by_key[both_key].top_issue == CHANNEL_ISSUE_LABELS[channel]
+
+        # GMM-only key keeps its inferred (feature-based) issue.
+        assert by_key[gmm_key].top_issue != CHANNEL_ISSUE_LABELS[channel]

--- a/tests/qc/test_chirality.py
+++ b/tests/qc/test_chirality.py
@@ -416,8 +416,14 @@ class TestWithSleapIO:
     def test_skeleton_without_symmetries_uses_name_inference(self):
         """CVAT-style skeleton with no symmetries -> infer pairs from names."""
         skel = sio.Skeleton(
-            ["spine_front", "spine_back", "Ear_L", "Ear_R", "Haunch_left",
-             "Haunch_right"]
+            [
+                "spine_front",
+                "spine_back",
+                "Ear_L",
+                "Ear_R",
+                "Haunch_left",
+                "Haunch_right",
+            ]
         )
         assert skel.symmetries == []  # none defined
 

--- a/tests/qc/test_chirality.py
+++ b/tests/qc/test_chirality.py
@@ -1,0 +1,448 @@
+"""Tests for sleap.qc.features.chirality (left/right mirror flip detection)."""
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap.qc.features.chirality import (
+    compute_chirality,
+    fit_chirality,
+    infer_symmetry_pairs_by_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures: a quadruped-like layout.
+#
+# Node layout (index : name):
+#   0 : spine_front  (axis anchor, "head" end)
+#   1 : spine_back   (axis anchor, "tail" end)
+#   2 : ear_L        3 : ear_R
+#   4 : shoulder_L   5 : shoulder_R
+#   6 : hip_L        7 : hip_R
+#
+# The body axis runs from spine_front (top) to spine_back (bottom) along -y.
+# Left nodes have x < 0, right nodes have x > 0 in the canonical pose.
+# ---------------------------------------------------------------------------
+
+CANONICAL = np.array(
+    [
+        [0.0, 12.0],  # 0 spine_front
+        [0.0, 0.0],  # 1 spine_back
+        [-3.0, 10.0],  # 2 ear_L
+        [3.0, 10.0],  # 3 ear_R
+        [-4.0, 7.0],  # 4 shoulder_L
+        [4.0, 7.0],  # 5 shoulder_R
+        [-4.0, 2.0],  # 6 hip_L
+        [4.0, 2.0],  # 7 hip_R
+    ],
+    dtype=float,
+)
+
+SYM_PAIRS = [(2, 3), (4, 5), (6, 7)]
+AXIS = (0, 1)
+
+
+def _rotate(points: np.ndarray, degrees: float) -> np.ndarray:
+    """Rotate points about the origin by ``degrees``."""
+    t = np.deg2rad(degrees)
+    rot = np.array([[np.cos(t), -np.sin(t)], [np.sin(t), np.cos(t)]])
+    return points @ rot.T
+
+
+def _jitter(points: np.ndarray, scale: float, seed: int) -> np.ndarray:
+    """Add small Gaussian jitter (deterministic via seed)."""
+    rng = np.random.default_rng(seed)
+    return points + rng.normal(scale=scale, size=points.shape)
+
+
+def _mirror_about_axis(points: np.ndarray) -> np.ndarray:
+    """Whole-instance mirror flip about the body axis (the line x = 0).
+
+    Keeps node identities/labels fixed (so the left ear point now sits on the
+    right side), which is exactly the mislabel a chirality detector must catch.
+    """
+    flipped = points.copy()
+    flipped[:, 0] *= -1
+    return flipped
+
+
+@pytest.fixture
+def clean_model():
+    """A chirality model fit on jittered copies of the canonical pose."""
+    instances = [_jitter(CANONICAL, scale=0.3, seed=i) for i in range(20)]
+    return fit_chirality(instances, SYM_PAIRS, AXIS)
+
+
+# ---------------------------------------------------------------------------
+# fit_chirality
+# ---------------------------------------------------------------------------
+
+
+class TestFitChirality:
+    def test_learns_canonical_side_for_all_pairs(self, clean_model):
+        """All co-visible pairs should get a learned canonical side."""
+        assert set(clean_model["canonical_side"].keys()) == set(SYM_PAIRS)
+        for side in clean_model["canonical_side"].values():
+            assert side in (-1.0, 1.0)
+
+    def test_records_support_counts(self, clean_model):
+        """Support count equals the number of contributing instances."""
+        assert all(c == 20 for c in clean_model["pair_support"].values())
+        assert clean_model["n_instances"] == 20
+
+    def test_canonical_side_is_consistent_left_member(self, clean_model):
+        """Left members sit on a single consistent side of the downward axis.
+
+        With the axis pointing from spine_front (top) to spine_back (bottom),
+        a left node (x < 0) lies on a fixed side; all left members must share
+        that canonical sign.
+        """
+        sides = set(clean_model["canonical_side"].values())
+        assert len(sides) == 1
+
+    def test_no_pairs_yields_empty_model(self):
+        """No symmetry pairs -> empty canonical map, but valid model dict."""
+        model = fit_chirality([CANONICAL], [], AXIS)
+        assert model["canonical_side"] == {}
+        assert model["pair_support"] == {}
+
+    def test_pairs_never_covisible_are_omitted(self):
+        """A pair that is never co-visible gets no canonical side."""
+        pts = CANONICAL.copy()
+        pts[6] = np.nan  # hip_L invisible in every instance
+        model = fit_chirality([pts] * 5, SYM_PAIRS, AXIS)
+        assert (6, 7) not in model["canonical_side"]
+        assert (2, 3) in model["canonical_side"]
+
+
+# ---------------------------------------------------------------------------
+# compute_chirality: positive / negative / intermediate cases
+# ---------------------------------------------------------------------------
+
+
+class TestComputeChirality:
+    def test_clean_pose_scores_zero(self, clean_model):
+        """A clean canonical pose -> wrong_fraction ~ 0."""
+        result = compute_chirality(CANONICAL, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+        assert result["n_pairs"] == 3
+
+    def test_jittered_clean_pose_scores_zero(self, clean_model):
+        """Small noise must not trip the detector."""
+        noisy = _jitter(CANONICAL, scale=0.4, seed=999)
+        result = compute_chirality(noisy, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+
+    def test_whole_mirror_flip_scores_one(self, clean_model):
+        """A whole-instance mirror flip -> wrong_fraction ~ 1.0."""
+        flipped = _mirror_about_axis(CANONICAL)
+        result = compute_chirality(flipped, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(1.0)
+        assert result["n_pairs"] == 3
+
+    def test_subset_swap_is_intermediate(self, clean_model):
+        """Swapping one of three pairs -> intermediate (0 < frac < 1)."""
+        swapped = CANONICAL.copy()
+        swapped[[2, 3]] = swapped[[3, 2]]  # swap ear_L/ear_R coordinates
+        result = compute_chirality(swapped, SYM_PAIRS, AXIS, clean_model)
+        assert 0.0 < result["chirality_wrong_fraction"] < 1.0
+        assert result["chirality_wrong_fraction"] == pytest.approx(1.0 / 3.0)
+        assert result["n_pairs"] == 3
+
+    def test_two_of_three_swapped(self, clean_model):
+        """Swapping two of three pairs -> 2/3."""
+        swapped = CANONICAL.copy()
+        swapped[[2, 3]] = swapped[[3, 2]]
+        swapped[[4, 5]] = swapped[[5, 4]]
+        result = compute_chirality(swapped, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(2.0 / 3.0)
+
+
+class TestInvariance:
+    """Chirality must be invariant to translation, rotation, and scale,
+    but must flip under reflection."""
+
+    def test_translation_invariant(self, clean_model):
+        moved = CANONICAL + np.array([123.0, -45.0])
+        result = compute_chirality(moved, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+
+    def test_rotation_invariant(self, clean_model):
+        for deg in (15.0, 90.0, 137.0, -60.0, 180.0):
+            rotated = _rotate(CANONICAL, deg)
+            result = compute_chirality(rotated, SYM_PAIRS, AXIS, clean_model)
+            assert result["chirality_wrong_fraction"] == pytest.approx(0.0), deg
+
+    def test_scale_invariant(self, clean_model):
+        scaled = CANONICAL * 3.7
+        result = compute_chirality(scaled, SYM_PAIRS, AXIS, clean_model)
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+
+    def test_combined_similarity_transform_clean_and_flip(self, clean_model):
+        """Rotation+scale+translation: clean stays 0, mirror stays 1."""
+
+        def transform(p):
+            return _rotate(p, 53.0) * 2.1 + np.array([10.0, 200.0])
+
+        clean = transform(CANONICAL)
+        flipped = transform(_mirror_about_axis(CANONICAL))
+        assert compute_chirality(clean, SYM_PAIRS, AXIS, clean_model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(0.0)
+        assert compute_chirality(flipped, SYM_PAIRS, AXIS, clean_model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Degenerate cases
+# ---------------------------------------------------------------------------
+
+
+class TestDegenerate:
+    def test_fewer_than_min_pairs_returns_zero(self, clean_model):
+        """Only one co-visible pair -> below min_pairs -> 0.0."""
+        pts = CANONICAL.copy()
+        pts[4:] = np.nan  # only the ear pair (2, 3) remains co-visible
+        result = compute_chirality(pts, SYM_PAIRS, AXIS, clean_model)
+        assert result["n_pairs"] == 1
+        assert result["chirality_wrong_fraction"] == 0.0
+
+    def test_even_a_flip_with_too_few_pairs_returns_zero(self, clean_model):
+        """A real flip but with <2 visible pairs is not scored (safety)."""
+        flipped = _mirror_about_axis(CANONICAL)
+        flipped[4:] = np.nan
+        result = compute_chirality(flipped, SYM_PAIRS, AXIS, clean_model)
+        assert result["n_pairs"] == 1
+        assert result["chirality_wrong_fraction"] == 0.0
+
+    def test_pca_axis_when_no_anchors_given(self):
+        """With axis_node_indices=None, the axis is taken from PCA of the
+        visible non-symmetric points (here the two spine nodes)."""
+        model = fit_chirality(
+            [_jitter(CANONICAL, 0.2, i) for i in range(10)], SYM_PAIRS, None
+        )
+        # PCA axis from the two visible spine nodes; clean -> 0, flip -> 1.
+        clean = compute_chirality(CANONICAL, SYM_PAIRS, None, model)
+        flipped = compute_chirality(
+            _mirror_about_axis(CANONICAL), SYM_PAIRS, None, model
+        )
+        assert clean["chirality_wrong_fraction"] == pytest.approx(0.0)
+        assert flipped["chirality_wrong_fraction"] == pytest.approx(1.0)
+
+    def test_no_usable_axis_returns_zero(self, clean_model):
+        """No anchors and no non-symmetric points -> no axis -> 0.0."""
+        pts = CANONICAL.copy()
+        pts[0] = np.nan  # spine_front
+        pts[1] = np.nan  # spine_back (only non-symmetric nodes)
+        # axis_node_indices given but NaN -> PCA fallback, which has 0 non-sym
+        # visible points -> no axis.
+        result = compute_chirality(pts, SYM_PAIRS, AXIS, clean_model)
+        assert result["n_pairs"] == 0
+        assert result["chirality_wrong_fraction"] == 0.0
+
+    def test_all_nan_instance_returns_zero(self, clean_model):
+        pts = np.full_like(CANONICAL, np.nan)
+        result = compute_chirality(pts, SYM_PAIRS, AXIS, clean_model)
+        assert result == {"chirality_wrong_fraction": 0.0, "n_pairs": 0}
+
+    def test_pair_without_learned_side_is_skipped(self, clean_model):
+        """A symmetry pair absent from the model is not scored."""
+        extra_pairs = SYM_PAIRS + [(0, 1)]  # (0, 1) has no canonical side
+        result = compute_chirality(CANONICAL, extra_pairs, AXIS, clean_model)
+        # Only the three learned pairs contribute.
+        assert result["n_pairs"] == 3
+
+    def test_no_symmetry_no_pairs(self, clean_model):
+        """No symmetry pairs at all -> trivially 0.0 with n_pairs 0."""
+        result = compute_chirality(CANONICAL, [], AXIS, clean_model)
+        assert result == {"chirality_wrong_fraction": 0.0, "n_pairs": 0}
+
+    def test_never_emits_nan(self, clean_model):
+        """Output must never contain NaN even for ragged inputs."""
+        for pts in (
+            CANONICAL,
+            _mirror_about_axis(CANONICAL),
+            _jitter(CANONICAL, 5.0, 1),
+            np.full_like(CANONICAL, np.nan),
+        ):
+            res = compute_chirality(pts, SYM_PAIRS, AXIS, clean_model)
+            assert np.isfinite(res["chirality_wrong_fraction"])
+            assert 0.0 <= res["chirality_wrong_fraction"] <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# infer_symmetry_pairs_by_name
+# ---------------------------------------------------------------------------
+
+
+class TestInferSymmetryPairsByName:
+    def test_underscore_l_r_suffix(self):
+        names = ["spine_front", "spine_back", "Ear_L", "Ear_R"]
+        assert infer_symmetry_pairs_by_name(names) == [(2, 3)]
+
+    def test_left_right_suffix(self):
+        names = ["Shoulder_left", "Shoulder_right"]
+        assert infer_symmetry_pairs_by_name(names) == [(0, 1)]
+
+    def test_haunch_left_right(self):
+        names = ["nose", "Haunch_left", "Haunch_right", "tail"]
+        assert infer_symmetry_pairs_by_name(names) == [(1, 2)]
+
+    def test_camelcase_left_right(self):
+        names = ["EarLeft", "EarRight", "Snout"]
+        assert infer_symmetry_pairs_by_name(names) == [(0, 1)]
+
+    def test_prefix_l_r(self):
+        names = ["L_Eye", "R_Eye", "Nose"]
+        assert infer_symmetry_pairs_by_name(names) == [(0, 1)]
+
+    def test_prefix_left_right_word(self):
+        names = ["left_paw", "right_paw"]
+        assert infer_symmetry_pairs_by_name(names) == [(0, 1)]
+
+    def test_dash_and_dot_separators(self):
+        assert infer_symmetry_pairs_by_name(["Ear-L", "Ear-R"]) == [(0, 1)]
+        assert infer_symmetry_pairs_by_name(["Ear.L", "Ear.R"]) == [(0, 1)]
+
+    def test_multiple_pairs_ordered_by_left_index(self):
+        names = [
+            "spine_front",
+            "spine_back",
+            "Ear_L",
+            "Ear_R",
+            "Shoulder_left",
+            "Shoulder_right",
+            "Haunch_left",
+            "Haunch_right",
+        ]
+        assert infer_symmetry_pairs_by_name(names) == [(2, 3), (4, 5), (6, 7)]
+
+    def test_lone_left_token_no_partner(self):
+        """A single-letter L with no matching R must not form a pair."""
+        assert infer_symmetry_pairs_by_name(["paw_L", "head", "tail"]) == []
+
+    def test_midline_names_not_paired(self):
+        """Names without L/R tokens are never paired."""
+        assert infer_symmetry_pairs_by_name(["spine", "nose", "tail_base"]) == []
+
+    def test_each_node_in_at_most_one_pair(self):
+        """Duplicate stems do not cause a node to be reused."""
+        names = ["Ear_L", "Ear_R", "Ear_L", "Ear_R"]
+        pairs = infer_symmetry_pairs_by_name(names)
+        used = [i for pair in pairs for i in pair]
+        assert len(used) == len(set(used))
+
+    def test_distinct_stems_do_not_cross_pair(self):
+        """Ear_L should not pair with Eye_R."""
+        names = ["Ear_L", "Eye_R"]
+        assert infer_symmetry_pairs_by_name(names) == []
+
+    def test_empty_node_names(self):
+        assert infer_symmetry_pairs_by_name([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration with sleap_io: the path the integration layer actually uses.
+# ---------------------------------------------------------------------------
+
+
+class TestWithSleapIO:
+    """Build skeletons/instances via sleap_io to mirror real usage."""
+
+    @pytest.fixture
+    def skeleton(self):
+        skel = sio.Skeleton(
+            [
+                "spine_front",
+                "spine_back",
+                "ear_L",
+                "ear_R",
+                "shoulder_L",
+                "shoulder_R",
+                "hip_L",
+                "hip_R",
+            ]
+        )
+        skel.add_symmetry("ear_L", "ear_R")
+        skel.add_symmetry("shoulder_L", "shoulder_R")
+        skel.add_symmetry("hip_L", "hip_R")
+        return skel
+
+    def test_symmetry_inds_drive_detection(self, skeleton):
+        """Use sleap_io's symmetry_inds as the symmetry_pairs argument."""
+        sym_pairs = [tuple(p) for p in skeleton.symmetry_inds]
+        assert len(sym_pairs) == 3
+
+        instances = [
+            sio.Instance.from_numpy(
+                _jitter(CANONICAL, 0.25, i), skeleton=skeleton
+            ).numpy()
+            for i in range(15)
+        ]
+        model = fit_chirality(instances, sym_pairs, AXIS)
+
+        clean = sio.Instance.from_numpy(CANONICAL, skeleton=skeleton).numpy()
+        flipped = sio.Instance.from_numpy(
+            _mirror_about_axis(CANONICAL), skeleton=skeleton
+        ).numpy()
+
+        assert compute_chirality(clean, sym_pairs, AXIS, model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(0.0)
+        assert compute_chirality(flipped, sym_pairs, AXIS, model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(1.0)
+
+    def test_invisible_node_via_instance(self, skeleton):
+        """An invisible node (NaN through .numpy()) is handled cleanly."""
+        sym_pairs = [tuple(p) for p in skeleton.symmetry_inds]
+        instances = [
+            sio.Instance.from_numpy(
+                _jitter(CANONICAL, 0.25, i), skeleton=skeleton
+            ).numpy()
+            for i in range(15)
+        ]
+        model = fit_chirality(instances, sym_pairs, AXIS)
+
+        partial = CANONICAL.copy()
+        partial[2] = np.nan  # ear_L invisible -> ear pair not scorable
+        inst = sio.Instance.from_numpy(partial, skeleton=skeleton).numpy()
+        result = compute_chirality(inst, sym_pairs, AXIS, model)
+        assert result["n_pairs"] == 2  # shoulder + hip pairs only
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+
+    def test_skeleton_without_symmetries_uses_name_inference(self):
+        """CVAT-style skeleton with no symmetries -> infer pairs from names."""
+        skel = sio.Skeleton(
+            ["spine_front", "spine_back", "Ear_L", "Ear_R", "Haunch_left",
+             "Haunch_right"]
+        )
+        assert skel.symmetries == []  # none defined
+
+        sym_pairs = infer_symmetry_pairs_by_name([n.name for n in skel.nodes])
+        assert sym_pairs == [(2, 3), (4, 5)]
+
+        layout = np.array(
+            [
+                [0.0, 10.0],
+                [0.0, 0.0],
+                [-3.0, 8.0],
+                [3.0, 8.0],
+                [-3.0, 2.0],
+                [3.0, 2.0],
+            ],
+            dtype=float,
+        )
+        instances = [_jitter(layout, 0.2, i) for i in range(10)]
+        model = fit_chirality(instances, sym_pairs, AXIS)
+
+        assert compute_chirality(layout, sym_pairs, AXIS, model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(0.0)
+        flipped = layout.copy()
+        flipped[:, 0] *= -1
+        assert compute_chirality(flipped, sym_pairs, AXIS, model)[
+            "chirality_wrong_fraction"
+        ] == pytest.approx(1.0)

--- a/tests/qc/test_chirality.py
+++ b/tests/qc/test_chirality.py
@@ -8,6 +8,7 @@ from sleap.qc.features.chirality import (
     compute_chirality,
     fit_chirality,
     infer_symmetry_pairs_by_name,
+    order_midline_by_pca,
 )
 
 
@@ -193,6 +194,180 @@ class TestInvariance:
         assert compute_chirality(flipped, SYM_PAIRS, AXIS, clean_model)[
             "chirality_wrong_fraction"
         ] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Local (spine-relative) midline axis: robustness to body curling.
+#
+# A long-bodied animal whose body curls back on itself is the case that breaks a
+# single STRAIGHT nose->tail axis: a correctly-labeled pair near the curled tail
+# ends up on the "wrong" side of the global chord even though it is on the right
+# side of the LOCAL body direction. The fix measures each pair against the local
+# tangent of the ordered midline polyline.
+#
+# Layout (index : node), a 5-node midline plus two L/R pairs hanging off it:
+#   0..4 : midline m0(nose) .. m4(tail)
+#   5/6  : ear_L / ear_R   (straddle m1)
+#   7/8  : hip_L / hip_R   (straddle m3)
+# ---------------------------------------------------------------------------
+
+CURL_MIDLINE = [0, 1, 2, 3, 4]
+CURL_PAIRS = [(5, 6), (7, 8)]
+CURL_AXIS = (0, 4)  # straight nose->tail anchor (two-node fallback)
+
+
+def _curl_straight_pose() -> np.ndarray:
+    """Canonical, fully extended pose: midline along +x, left = +y, right = -y."""
+    p = np.zeros((9, 2), dtype=float)
+    for k in range(5):
+        p[k] = [k * 4.0, 0.0]
+    p[5] = [4.0, 2.0]  # ear_L
+    p[6] = [4.0, -2.0]  # ear_R
+    p[7] = [12.0, 2.0]  # hip_L
+    p[8] = [12.0, -2.0]  # hip_R
+    return p
+
+
+def _curl_curled_pose() -> np.ndarray:
+    """A correctly-labeled but heavily curled (U-shaped) pose.
+
+    The midline bends back on itself; each pair is placed on its correct side of
+    the *local* body direction (left = +90 deg of travel), which for the curled
+    tail half points the opposite way in global coordinates from the head half.
+    """
+    p = np.zeros((9, 2), dtype=float)
+    mid = np.array([[0, 0], [4, 0], [7, 3], [6, 7], [2, 8]], dtype=float)
+    p[:5] = mid
+    # Ears straddle m1, where travel is ~ +x, so left = +y.
+    p[5] = mid[1] + [0.0, 2.0]
+    p[6] = mid[1] + [0.0, -2.0]
+    # Hips straddle m3, where the body has curled back; left = +90 deg of the
+    # local travel direction (m2 -> m4), which now points roughly -x.
+    d = mid[4] - mid[2]
+    d = d / np.linalg.norm(d)
+    left_normal = np.array([-d[1], d[0]])  # +90 deg = left of travel
+    p[7] = mid[3] + 2.0 * left_normal  # hip_L
+    p[8] = mid[3] - 2.0 * left_normal  # hip_R
+    return p
+
+
+class TestLocalMidlineCurlRobustness:
+    """The local-tangent midline tolerates body curl that the straight axis
+    misreads, while still firing on a genuine whole-instance reflection."""
+
+    @pytest.fixture
+    def curl_models(self):
+        """Models fit on jittered straight poses: one local-midline, one straight.
+
+        Both learn identical canonical sides (the straight extended pose is
+        unambiguous); they differ only in how a *curled* pose is scored.
+        """
+        insts = [_jitter(_curl_straight_pose(), 0.15, i) for i in range(40)]
+        local = fit_chirality(
+            insts, CURL_PAIRS, CURL_MIDLINE, axis_node_indices=CURL_AXIS
+        )
+        straight = fit_chirality(insts, CURL_PAIRS, None, axis_node_indices=CURL_AXIS)
+        return local, straight
+
+    def test_both_models_learn_same_canonical_side(self, curl_models):
+        """Local and straight fits agree on the canonical sides (per design)."""
+        local, straight = curl_models
+        assert local["canonical_side"] == straight["canonical_side"]
+        assert set(local["canonical_side"].keys()) == set(CURL_PAIRS)
+
+    def test_straight_axis_false_positives_on_curl(self, curl_models):
+        """REGRESSION: the straight nose->tail axis flags a correct curled pose.
+
+        This is the false positive the local-midline fix removes; it is asserted
+        here so the failure mode stays documented and detectable.
+        """
+        _, straight = curl_models
+        curled = _curl_curled_pose()
+        result = compute_chirality(
+            curled, CURL_PAIRS, None, straight, axis_node_indices=CURL_AXIS
+        )
+        assert result["n_pairs"] == 2
+        assert result["chirality_wrong_fraction"] == pytest.approx(1.0)
+
+    def test_local_midline_clears_curl(self, curl_models):
+        """The local-tangent midline scores the correct curled pose ~0."""
+        local, _ = curl_models
+        curled = _curl_curled_pose()
+        result = compute_chirality(
+            curled, CURL_PAIRS, CURL_MIDLINE, local, axis_node_indices=CURL_AXIS
+        )
+        assert result["n_pairs"] == 2
+        assert result["chirality_wrong_fraction"] == pytest.approx(0.0)
+
+    def test_local_midline_still_flags_reflected_curl(self, curl_models):
+        """A genuine whole-instance reflection of the curled pose still scores 1.
+
+        Curl-robustness must not cost flip sensitivity: reflecting the curled
+        pose (a real L/R flip) flips every pair's side, so the local method
+        fires fully.
+        """
+        local, _ = curl_models
+        reflected = _curl_curled_pose()
+        reflected[:, 1] *= -1.0  # reflect across the x-axis -> chirality flips
+        result = compute_chirality(
+            reflected, CURL_PAIRS, CURL_MIDLINE, local, axis_node_indices=CURL_AXIS
+        )
+        assert result["n_pairs"] == 2
+        assert result["chirality_wrong_fraction"] == pytest.approx(1.0)
+
+    def test_extended_pose_unaffected(self, curl_models):
+        """The local method leaves an ordinary extended pose at ~0 (clean) and
+        ~1 (whole-instance mirror), matching the straight axis."""
+        local, _ = curl_models
+        clean = _curl_straight_pose()
+        flipped = clean.copy()
+        flipped[:, 1] *= -1.0
+        assert compute_chirality(
+            clean, CURL_PAIRS, CURL_MIDLINE, local, axis_node_indices=CURL_AXIS
+        )["chirality_wrong_fraction"] == pytest.approx(0.0)
+        assert compute_chirality(
+            flipped, CURL_PAIRS, CURL_MIDLINE, local, axis_node_indices=CURL_AXIS
+        )["chirality_wrong_fraction"] == pytest.approx(1.0)
+
+
+class TestOrderMidlineByPCA:
+    """order_midline_by_pca recovers anatomical node order robustly."""
+
+    @pytest.fixture
+    def straight_instances(self):
+        return [_jitter(_curl_straight_pose(), 0.15, i) for i in range(40)]
+
+    def test_recovers_order_from_scrambled_input(self, straight_instances):
+        """Any permutation of the midline indices comes back in axis order."""
+        assert order_midline_by_pca(straight_instances, [4, 2, 0, 3, 1]) == [
+            0,
+            1,
+            2,
+            3,
+            4,
+        ]
+        assert order_midline_by_pca(straight_instances, [3, 1, 4, 0, 2]) == [
+            0,
+            1,
+            2,
+            3,
+            4,
+        ]
+
+    def test_orientation_is_deterministic(self, straight_instances):
+        """Reordering is unique up to (a fixed) reversal: same input order out."""
+        a = order_midline_by_pca(straight_instances, [0, 1, 2, 3, 4])
+        b = order_midline_by_pca(straight_instances, [4, 3, 2, 1, 0])
+        assert a == b
+
+    def test_single_or_empty_returned_unchanged(self, straight_instances):
+        assert order_midline_by_pca(straight_instances, [2]) == [2]
+        assert order_midline_by_pca(straight_instances, []) == []
+
+    def test_no_usable_axis_returns_input_order(self):
+        """All-NaN instances yield no axis, so the input order is preserved."""
+        nan_insts = [np.full((9, 2), np.nan) for _ in range(5)]
+        assert order_midline_by_pca(nan_insts, [3, 1, 2]) == [3, 1, 2]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/qc/test_detector.py
+++ b/tests/qc/test_detector.py
@@ -359,6 +359,58 @@ class TestLabelQCDetector:
         assert len(detector.feature_names) > 0
         assert "max_edge_zscore" in detector.feature_names
         assert "nn_distance" in detector.feature_names
+        # PR-A: the hull feature name must match the issue_map key
+        # ("hull_area_zscore") so the "Unusual pose extent" label can fire.
+        assert "hull_area_zscore" in detector.feature_names
+        assert "hull_area" not in detector.feature_names
+
+    def test_instance_to_array_forces_invisible_as_nan(self, skeleton):
+        """#2753: invisible nodes are NaN'd regardless of the sleap-io default.
+
+        Invisible (visible=False) nodes keep display-only coordinates; QC must
+        never read them. ``_instance_to_array`` passes ``invisible_as_nan=True``
+        explicitly so this holds even if the sleap-io default changes.
+        """
+        pts = np.array(
+            [[100, 100], [100, 120], [100, 150], [80, 115], [120, 115]], dtype=float
+        )
+        inst = Instance.from_numpy(pts, skeleton=skeleton)
+        inst[3]["visible"] = False
+
+        arr = LabelQCDetector()._instance_to_array(inst)
+
+        assert np.all(np.isnan(arr[3]))
+        assert not np.any(np.isnan(arr[[0, 1, 2, 4]]))
+
+    def test_invisible_far_node_does_not_leak_into_geometry(
+        self, simple_labels, skeleton
+    ):
+        """#2753 regression: a far-away invisible node must not inflate geometry.
+
+        A node dragged far away leaks into edge/angle/distance features ONLY
+        when it is visible; when invisible it must be excluded entirely.
+        """
+        detector = LabelQCDetector()
+        detector.fit(simple_labels)
+        i_edge = detector.feature_names.index("max_edge_zscore")
+
+        far = np.array(
+            [[100, 100], [100, 120], [100, 150], [9999, 9999], [120, 115]],
+            dtype=float,
+        )
+        inst_visible = Instance.from_numpy(far, skeleton=skeleton)
+        inst_invisible = Instance.from_numpy(far, skeleton=skeleton)
+        inst_invisible[3]["visible"] = False
+
+        f_visible = detector._extract_features(
+            detector._instance_to_array(inst_visible)
+        )
+        f_invisible = detector._extract_features(
+            detector._instance_to_array(inst_invisible)
+        )
+
+        assert f_visible[i_edge] > 10.0
+        assert f_invisible[i_edge] < 5.0
 
     def test_skeleton_analyzer_properties(self, simple_labels):
         """Test skeleton analyzer extracts properties."""

--- a/tests/qc/test_duplicate_split.py
+++ b/tests/qc/test_duplicate_split.py
@@ -1,0 +1,368 @@
+"""Tests for sleap.qc.features.duplicate_split.
+
+Covers the split-duplicate detector (one animal split across two instances on
+largely disjoint node sets) and the ``duplicate_score`` signal combiner.
+
+The module functions are pure (numpy arrays + a learned-stats dict in, dict /
+float out), so most tests build poses directly as numpy arrays. A couple of
+tests build real ``sleap_io`` instances to exercise the same arrays the
+integration layer would extract.
+"""
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.duplicate_split import (
+    compute_split_duplicate,
+    duplicate_score,
+)
+
+
+# A vertical 6-node chain standing in for a head->tail skeleton, edge ~20 px:
+# 0 head, 1 neck, 2 thorax, 3 abd1, 4 abd2, 5 tail.
+FULL_POSE = np.array(
+    [[100, 100], [100, 120], [100, 140], [100, 160], [100, 180], [100, 200]],
+    dtype=float,
+)
+
+# Learned mean edge lengths keyed by sorted (src, dst) tuples, matching
+# DatasetStats.edge_means. Median is 20.0 -> the scale.
+EDGE_MEANS = {(0, 1): 20.0, (1, 2): 20.0, (2, 3): 20.0, (3, 4): 20.0, (4, 5): 20.0}
+
+# A score this high is unambiguously a split for these tests; well above any
+# sensible operating threshold.
+HIGH = 0.5
+# A score this low means "not a split".
+LOW = 0.1
+
+
+def front_half(pose=FULL_POSE):
+    """Pose with only the front (head-side) nodes visible."""
+    p = pose.copy()
+    p[3:] = np.nan
+    return p
+
+
+def back_half(pose=FULL_POSE):
+    """Pose with only the back (tail-side) nodes visible."""
+    p = pose.copy()
+    p[:3] = np.nan
+    return p
+
+
+def rotate(pose, degrees, about=(100.0, 150.0)):
+    """Rotate a pose about a pivot (preserving NaNs)."""
+    th = np.deg2rad(degrees)
+    rot = np.array([[np.cos(th), -np.sin(th)], [np.sin(th), np.cos(th)]])
+    about = np.asarray(about, dtype=float)
+    return (pose - about) @ rot.T + about
+
+
+class TestComputeSplitDuplicatePositive:
+    """The detector should fire on one animal split across two instances."""
+
+    def test_complementary_head_tail_split_is_high(self):
+        """A = head/front, B = tail/back, disjoint nodes -> high score."""
+        result = compute_split_duplicate(front_half(), back_half(), EDGE_MEANS)
+
+        assert result["split_duplicate_score"] > HIGH
+        assert "split" in result["reason"].lower()
+
+    def test_split_with_one_shared_node_is_high(self):
+        """Halves that meet at a shared node are the clearest split."""
+        a = FULL_POSE.copy()
+        a[4:] = np.nan  # nodes 0,1,2,3
+        b = FULL_POSE.copy()
+        b[:3] = np.nan  # nodes 3,4,5 (node 3 shared, coincident)
+
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] > HIGH
+
+    def test_score_is_in_unit_interval(self):
+        """Score is always a float in [0, 1]."""
+        for a, b in [
+            (front_half(), back_half()),
+            (FULL_POSE, FULL_POSE.copy()),
+            (front_half(), front_half()),
+        ]:
+            score = compute_split_duplicate(a, b, EDGE_MEANS)["split_duplicate_score"]
+            assert isinstance(score, float)
+            assert 0.0 <= score <= 1.0
+
+    def test_uses_bbox_diagonal_fallback_without_edge_means(self):
+        """Without edge_means, the bbox-diagonal scale still yields high."""
+        result = compute_split_duplicate(front_half(), back_half(), None)
+
+        assert result["split_duplicate_score"] > HIGH
+
+    def test_empty_edge_means_falls_back(self):
+        """An empty edge_means dict behaves like None (fallback scale)."""
+        result = compute_split_duplicate(front_half(), back_half(), {})
+
+        assert result["split_duplicate_score"] > HIGH
+
+
+class TestSplitInvariance:
+    """Split detection should be translation/rotation/scale invariant."""
+
+    def test_translation_invariant(self):
+        offset = np.array([500.0, -300.0])
+        base = compute_split_duplicate(front_half(), back_half(), EDGE_MEANS)
+        moved = compute_split_duplicate(
+            front_half(FULL_POSE + offset),
+            back_half(FULL_POSE + offset),
+            EDGE_MEANS,
+        )
+        assert moved["split_duplicate_score"] == pytest.approx(
+            base["split_duplicate_score"], abs=1e-6
+        )
+
+    def test_rotation_invariant(self):
+        base = compute_split_duplicate(front_half(), back_half(), EDGE_MEANS)
+        rotated_pose = rotate(FULL_POSE, 37.0)
+        rot = compute_split_duplicate(
+            front_half(rotated_pose), back_half(rotated_pose), EDGE_MEANS
+        )
+        assert rot["split_duplicate_score"] == pytest.approx(
+            base["split_duplicate_score"], abs=1e-6
+        )
+
+    def test_scale_invariant_with_fallback(self):
+        """3x larger pose with the bbox fallback gives the same score."""
+        base = compute_split_duplicate(front_half(), back_half(), None)
+        big = compute_split_duplicate(
+            front_half(FULL_POSE * 3.0), back_half(FULL_POSE * 3.0), None
+        )
+        assert big["split_duplicate_score"] == pytest.approx(
+            base["split_duplicate_score"], abs=1e-6
+        )
+
+    def test_scale_invariant_with_scaled_edge_means(self):
+        """3x pose with 3x edge stats also matches the 1x score."""
+        base = compute_split_duplicate(front_half(), back_half(), EDGE_MEANS)
+        big_edges = {k: v * 3.0 for k, v in EDGE_MEANS.items()}
+        big = compute_split_duplicate(
+            front_half(FULL_POSE * 3.0), back_half(FULL_POSE * 3.0), big_edges
+        )
+        assert big["split_duplicate_score"] == pytest.approx(
+            base["split_duplicate_score"], abs=1e-6
+        )
+
+
+class TestComputeSplitDuplicateNegative:
+    """The detector must NOT fire on non-splits."""
+
+    def test_identical_copies_are_not_split(self):
+        """Identical copies share all nodes (high co-visibility) -> not split.
+
+        This case is meant to be caught by the IoU / node-overlap signals, not
+        the split signal.
+        """
+        result = compute_split_duplicate(FULL_POSE, FULL_POSE.copy(), EDGE_MEANS)
+
+        assert result["split_duplicate_score"] < LOW
+
+    def test_two_distinct_animals_side_by_side_full_labels(self):
+        """Two fully-labeled distinct animals share node sets -> not split."""
+        b = FULL_POSE.copy()
+        b[:, 0] += 60  # shift right by ~3 edges
+
+        result = compute_split_duplicate(FULL_POSE, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] < LOW
+
+    def test_two_distinct_animals_disjoint_nodes_with_gap(self):
+        """Disjoint node sets but a clear spatial gap -> distinct, not split.
+
+        This is the hardest negative: low co-visibility (so the disjointness
+        precondition passes) but the two point clouds are far apart, which the
+        proximity / coherence checks reject.
+        """
+        a = front_half()  # left animal, front nodes
+        b = FULL_POSE.copy()
+        b[:, 0] += 80
+        b[:3] = np.nan  # right animal, back nodes
+
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] < LOW
+
+    def test_huddling_overlapping_full_animals_low(self):
+        """Two close, fully-labeled (huddling) animals -> not a split.
+
+        High co-visibility is the precondition violation here.
+        """
+        b = FULL_POSE.copy()
+        b[:, 0] += 8  # very close, still both fully labeled
+
+        result = compute_split_duplicate(FULL_POSE, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] < LOW
+
+
+class TestComputeSplitDuplicateDegenerate:
+    """Degenerate inputs must never raise or leak NaN."""
+
+    def test_one_instance_too_few_visible(self):
+        a = FULL_POSE.copy()
+        a[1:] = np.nan  # only one visible node
+        result = compute_split_duplicate(a, back_half(), EDGE_MEANS)
+
+        assert result["split_duplicate_score"] == 0.0
+        assert "too few" in result["reason"].lower()
+
+    def test_each_single_node_too_few_visible(self):
+        a = np.full((6, 2), np.nan)
+        a[0] = [0.0, 0.0]
+        b = np.full((6, 2), np.nan)
+        b[5] = [1.0, 1.0]
+
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] == 0.0
+
+    def test_all_invisible(self):
+        nan_pose = np.full((6, 2), np.nan)
+        result = compute_split_duplicate(nan_pose, nan_pose.copy(), EDGE_MEANS)
+
+        assert result["split_duplicate_score"] == 0.0
+
+    def test_score_never_nan(self):
+        """No combination should produce a NaN score."""
+        cases = [
+            (front_half(), back_half()),
+            (FULL_POSE, FULL_POSE.copy()),
+            (np.full((6, 2), np.nan), back_half()),
+            (front_half(), np.full((6, 2), np.nan)),
+        ]
+        for a, b in cases:
+            score = compute_split_duplicate(a, b, EDGE_MEANS)["split_duplicate_score"]
+            assert np.isfinite(score)
+
+    def test_coincident_points_no_internal_spacing(self):
+        """Instances whose visible nodes are all coincident don't crash.
+
+        Each instance has 2+ visible nodes but zero internal spacing; the
+        coherence factor must degrade gracefully (governed by proximity).
+        """
+        a = np.full((6, 2), np.nan)
+        a[0:2] = [10.0, 10.0]  # two coincident visible nodes
+        b = np.full((6, 2), np.nan)
+        b[3:5] = [10.0, 10.0]  # disjoint node indices, same location
+
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert 0.0 <= result["split_duplicate_score"] <= 1.0
+        assert np.isfinite(result["split_duplicate_score"])
+
+    def test_accepts_list_inputs(self):
+        """Plain nested lists are coerced to arrays without error."""
+        a = front_half().tolist()
+        b = back_half().tolist()
+        result = compute_split_duplicate(a, b, EDGE_MEANS)
+
+        assert result["split_duplicate_score"] > HIGH
+
+
+class TestComputeSplitDuplicateWithSleapIO:
+    """Exercise the same arrays the integration layer extracts from instances."""
+
+    def test_split_from_real_instances(self):
+        """One long-bodied animal split front/back across two instances.
+
+        Uses a 6-node linear (head->tail) skeleton, the shape where the split
+        failure mode actually occurs: instance A labels the front half,
+        instance B the disjoint back half, and together they form one animal.
+        """
+        from sleap_io import Skeleton
+        from sleap_io.model.instance import Instance
+
+        sk = Skeleton(nodes=["n0", "n1", "n2", "n3", "n4", "n5"], name="worm")
+        sk.add_edges(
+            [
+                ("n0", "n1"),
+                ("n1", "n2"),
+                ("n2", "n3"),
+                ("n3", "n4"),
+                ("n4", "n5"),
+            ]
+        )
+
+        inst_a = Instance.from_numpy(front_half(), skeleton=sk)
+        inst_b = Instance.from_numpy(back_half(), skeleton=sk)
+
+        result = compute_split_duplicate(
+            inst_a.numpy(invisible_as_nan=True),
+            inst_b.numpy(invisible_as_nan=True),
+            EDGE_MEANS,
+        )
+        assert result["split_duplicate_score"] > HIGH
+
+    def test_distinct_fly_instances_low(self, skeleton):
+        """Two separate, fully-labeled flies -> not a split."""
+        from sleap_io.model.instance import Instance
+
+        fly_a = np.array(
+            [[100, 100], [100, 115], [100, 130], [85, 110], [115, 110]], dtype=float
+        )
+        fly_b = fly_a.copy()
+        fly_b[:, 0] += 60  # well separated
+
+        inst_a = Instance.from_numpy(fly_a, skeleton=skeleton)
+        inst_b = Instance.from_numpy(fly_b, skeleton=skeleton)
+
+        edge_means = {(0, 1): 15.0, (1, 2): 15.0, (1, 3): 15.0, (1, 4): 15.0}
+
+        result = compute_split_duplicate(
+            inst_a.numpy(invisible_as_nan=True),
+            inst_b.numpy(invisible_as_nan=True),
+            edge_means,
+        )
+        assert result["split_duplicate_score"] < LOW
+
+
+class TestDuplicateScore:
+    """Tests for the duplicate_score signal combiner."""
+
+    def test_identical_via_iou(self):
+        """A strong IoU alone flags a duplicate."""
+        assert duplicate_score(1.0, 0.0, 0.0) == 1.0
+
+    def test_partial_via_node_overlap(self):
+        """A strong node overlap alone flags a duplicate."""
+        assert duplicate_score(0.0, 0.95, 0.0) == pytest.approx(0.95)
+
+    def test_split_via_split_signal(self):
+        """A strong split signal alone flags a duplicate."""
+        assert duplicate_score(0.0, 0.0, 0.85) == pytest.approx(0.85)
+
+    def test_distinct_instances_low(self):
+        """Weak signals across the board -> low combined score."""
+        assert duplicate_score(0.05, 0.1, 0.0) == pytest.approx(0.1)
+        assert duplicate_score(0.0, 0.0, 0.0) == 0.0
+
+    def test_saturating_max(self):
+        """Combined score is the max of the (clamped) signals."""
+        assert duplicate_score(0.3, 0.6, 0.4) == pytest.approx(0.6)
+
+    def test_output_in_unit_interval(self):
+        """Out-of-range inputs are clamped into [0, 1]."""
+        assert duplicate_score(2.0, 5.0, 3.0) == 1.0
+        assert duplicate_score(-1.0, -2.0, -0.5) == 0.0
+
+    def test_nan_and_inf_treated_as_zero(self):
+        """Non-finite signals never inflate or corrupt the result.
+
+        Both NaN and +/-inf are treated as 0 so a garbage/missing signal cannot
+        spuriously flag a duplicate (an inf must not saturate the score).
+        """
+        assert duplicate_score(np.nan, np.nan, np.nan) == 0.0
+        # inf is dropped to 0, so the real 0.7 split signal wins.
+        assert duplicate_score(np.inf, 0.3, 0.7) == pytest.approx(0.7)
+        # All non-finite -> 0, never 1.
+        assert duplicate_score(np.nan, 0.0, np.inf) == 0.0
+
+    def test_returns_float(self):
+        result = duplicate_score(0.4, 0.2, 0.1)
+        assert isinstance(result, float)

--- a/tests/qc/test_frame_level.py
+++ b/tests/qc/test_frame_level.py
@@ -184,6 +184,10 @@ class TestComputeNodeOverlap:
 
         assert len(result["common_nodes"]) == 0
         assert result["overlap_ratio"] == 0.0
+        # Key parity with the normal-path return so callers never KeyError.
+        assert result["mean_distance"] == float("inf")
+        assert result["min_distance"] == float("inf")
+        assert result["max_distance"] == float("inf")
 
 
 class TestDetectDuplicates:

--- a/tests/qc/test_insample_prediction.py
+++ b/tests/qc/test_insample_prediction.py
@@ -1,0 +1,387 @@
+"""Tests for the in-sample prediction detector (Tier-2 detector (f)).
+
+These unit tests exercise the matching + disagreement logic and the graceful
+no-op behavior WITHOUT requiring torch. The model inference call
+(``sleap_nn.predict.run_inference``) is monkeypatched to return canned
+``sio.PredictedInstance`` objects, so the whole pipeline can be tested
+deterministically and cheaply.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import numpy as np
+import pytest
+import sleap_io as sio
+
+from sleap.qc.insample_prediction import (
+    match_predictions_to_users,
+    score_instance_disagreement,
+    run_insample_prediction,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build tiny Labels / predicted instances.
+# ---------------------------------------------------------------------------
+
+NODE_NAMES = ["A", "B", "C", "D"]
+
+
+def _skeleton(names=NODE_NAMES):
+    return sio.Skeleton(list(names))
+
+
+def _user_instance(skeleton, points):
+    """User instance from an (n_nodes, 2) array (NaN -> invisible)."""
+    return sio.Instance.from_numpy(np.asarray(points, dtype=float), skeleton=skeleton)
+
+
+def _pred_instance(skeleton, points, scores, instance_score=0.9):
+    """Predicted instance with per-node scores."""
+    return sio.PredictedInstance.from_numpy(
+        points_data=np.asarray(points, dtype=float),
+        skeleton=skeleton,
+        point_scores=np.asarray(scores, dtype=float),
+        score=instance_score,
+    )
+
+
+def _labels_one_frame(skeleton, user_arrays):
+    """A Labels with a single video + single frame holding user instances."""
+    video = sio.Video.from_filename("fake_video.mp4")
+    insts = [_user_instance(skeleton, a) for a in user_arrays]
+    lf = sio.LabeledFrame(video=video, frame_idx=0, instances=insts)
+    return sio.Labels(labeled_frames=[lf], videos=[video], skeletons=[skeleton])
+
+
+def _patch_run_inference(monkeypatch, predicted_labels):
+    """Install a fake ``sleap_nn.predict`` module returning canned predictions.
+
+    Avoids importing the real (torch-backed) ``sleap_nn`` entirely.
+    """
+    fake_predict = types.ModuleType("sleap_nn.predict")
+
+    def fake_run_inference(*args, **kwargs):  # noqa: ANN001, ANN002
+        return predicted_labels
+
+    fake_predict.run_inference = fake_run_inference
+
+    fake_pkg = sys.modules.get("sleap_nn")
+    if fake_pkg is None:
+        fake_pkg = types.ModuleType("sleap_nn")
+        monkeypatch.setitem(sys.modules, "sleap_nn", fake_pkg)
+    monkeypatch.setitem(sys.modules, "sleap_nn.predict", fake_predict)
+
+
+# ---------------------------------------------------------------------------
+# Pure logic: match_predictions_to_users
+# ---------------------------------------------------------------------------
+
+
+class TestMatching:
+    def test_no_predictions_returns_all_none(self):
+        user = [np.array([[0.0, 0.0], [1.0, 1.0]])]
+        assert match_predictions_to_users(user, []) == [None]
+
+    def test_no_users_returns_empty(self):
+        pred = [np.array([[0.0, 0.0], [1.0, 1.0]])]
+        assert match_predictions_to_users([], pred) == []
+
+    def test_nearest_centroid_match_two_instances(self):
+        # User 0 near origin, user 1 near (100,100).
+        users = [
+            np.array([[0.0, 0.0], [2.0, 0.0]]),  # centroid (1,0)
+            np.array([[100.0, 100.0], [102.0, 100.0]]),  # centroid (101,100)
+        ]
+        # Predictions deliberately in swapped list order to prove it matches by
+        # geometry, not by index.
+        preds = [
+            np.array([[99.0, 100.0], [103.0, 100.0]]),  # centroid (101,100) -> user1
+            np.array([[1.0, 0.0], [1.0, 0.0]]),  # centroid (1,0) -> user0
+        ]
+        matches = match_predictions_to_users(users, preds)
+        assert matches == [1, 0]
+
+    def test_mutually_exclusive_assignment(self):
+        # Two users but only one prediction: the closer user wins, the other
+        # gets None (one prediction cannot be claimed twice).
+        users = [
+            np.array([[0.0, 0.0]]),  # centroid (0,0), closer
+            np.array([[10.0, 0.0]]),  # centroid (10,0)
+        ]
+        preds = [np.array([[1.0, 0.0]])]  # centroid (1,0)
+        matches = match_predictions_to_users(users, preds)
+        assert matches == [0, None]
+
+    def test_user_with_no_visible_nodes_is_unmatched(self):
+        users = [np.array([[np.nan, np.nan], [np.nan, np.nan]])]
+        preds = [np.array([[0.0, 0.0], [1.0, 1.0]])]
+        assert match_predictions_to_users(users, preds) == [None]
+
+
+# ---------------------------------------------------------------------------
+# Pure logic: score_instance_disagreement
+# ---------------------------------------------------------------------------
+
+
+class TestDisagreementScoring:
+    def test_confident_prediction_at_unlabeled_node_flags(self):
+        # Node 2 unlabeled by user; model confident (0.85) -> disagreement.
+        user = np.array([[0.0, 0.0], [1.0, 1.0], [np.nan, np.nan], [3.0, 3.0]])
+        pred_scores = np.array([0.9, 0.8, 0.85, 0.7])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["n_disagreements"] == 1
+        assert res["disagreement_nodes"] == [2]
+        assert res["prediction_disagreement_score"] == pytest.approx(0.85)
+        assert res["unlabeled_confidences"] == {2: pytest.approx(0.85)}
+
+    def test_occluded_node_with_low_model_confidence_not_flagged(self):
+        # Node 2 unlabeled AND model also unsure (0.1 < min_confidence) ->
+        # "truly occluded", not flagged.
+        user = np.array([[0.0, 0.0], [1.0, 1.0], [np.nan, np.nan], [3.0, 3.0]])
+        pred_scores = np.array([0.9, 0.8, 0.1, 0.7])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["n_disagreements"] == 0
+        assert res["disagreement_nodes"] == []
+        assert res["prediction_disagreement_score"] == 0.0
+        # The unlabeled node's (low) confidence is still recorded for context.
+        assert res["unlabeled_confidences"] == {2: pytest.approx(0.1)}
+
+    def test_score_is_gated_max_over_multiple_unlabeled(self):
+        # Two unlabeled nodes; one low (0.3), one high (0.95). Score = the
+        # high one (gated max), and only it is flagged.
+        user = np.array([[0.0, 0.0], [np.nan, np.nan], [np.nan, np.nan], [3.0, 3.0]])
+        pred_scores = np.array([0.9, 0.3, 0.95, 0.7])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["disagreement_nodes"] == [2]
+        assert res["prediction_disagreement_score"] == pytest.approx(0.95)
+
+    def test_labeled_node_never_flagged_even_if_model_confident(self):
+        # All nodes labeled -> nothing to flag regardless of model confidence.
+        user = np.array([[0.0, 0.0], [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+        pred_scores = np.array([0.99, 0.99, 0.99, 0.99])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["n_disagreements"] == 0
+        assert res["prediction_disagreement_score"] == 0.0
+
+    def test_no_matched_prediction_is_zero(self):
+        user = np.array([[0.0, 0.0], [np.nan, np.nan]])
+        res = score_instance_disagreement(user, None, min_confidence=0.5)
+        assert res["prediction_disagreement_score"] == 0.0
+        assert res["n_disagreements"] == 0
+
+    def test_nan_model_confidence_at_unlabeled_node_ignored(self):
+        # Model produced no peak (NaN score) at the unlabeled node -> not a
+        # disagreement and not recorded.
+        user = np.array([[0.0, 0.0], [np.nan, np.nan]])
+        pred_scores = np.array([0.9, np.nan])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["n_disagreements"] == 0
+        assert res["prediction_disagreement_score"] == 0.0
+        assert res["unlabeled_confidences"] == {}
+
+    def test_min_confidence_threshold_boundary(self):
+        # Exactly at threshold counts (>=).
+        user = np.array([[np.nan, np.nan], [1.0, 1.0]])
+        pred_scores = np.array([0.5, 0.9])
+        res = score_instance_disagreement(user, pred_scores, min_confidence=0.5)
+        assert res["disagreement_nodes"] == [0]
+        # Just below threshold does not.
+        res2 = score_instance_disagreement(
+            user, np.array([0.49, 0.9]), min_confidence=0.5
+        )
+        assert res2["disagreement_nodes"] == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end with a MOCKED predictor (no torch).
+# ---------------------------------------------------------------------------
+
+
+class TestRunInsamplePredictionMocked:
+    def test_confident_unlabeled_node_flagged_end_to_end(self, monkeypatch):
+        skel = _skeleton()
+        # User left node C (idx 2) blank.
+        user_arr = np.array([[0.0, 0.0], [1.0, 0.0], [np.nan, np.nan], [3.0, 0.0]])
+        labels = _labels_one_frame(skel, [user_arr])
+
+        # Model predicts ALL four nodes, confident at the blank node C (0.92).
+        pred = _pred_instance(
+            skel,
+            points=np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+            scores=np.array([0.95, 0.9, 0.92, 0.88]),
+        )
+        pred_video = labels.videos[0]
+        pred_lf = sio.LabeledFrame(video=pred_video, frame_idx=0, instances=[pred])
+        pred_labels = sio.Labels(
+            labeled_frames=[pred_lf], videos=[pred_video], skeletons=[skel]
+        )
+        _patch_run_inference(monkeypatch, pred_labels)
+
+        out = run_insample_prediction(
+            labels, model_path="/fake/model", min_confidence=0.5
+        )
+
+        assert out["ran"] is True
+        key = (0, 0, 0)
+        assert key in out["instance_scores"]
+        assert out["instance_scores"][key] == pytest.approx(0.92)
+        # One per-node record for node C.
+        assert len(out["records"]) == 1
+        rec = out["records"][0]
+        assert rec["node_idx"] == 2
+        assert rec["node_name"] == "C"
+        assert rec["predicted_confidence"] == pytest.approx(0.92)
+        assert (rec["video_idx"], rec["frame_idx"], rec["instance_idx"]) == key
+
+    def test_truly_occluded_node_not_flagged_end_to_end(self, monkeypatch):
+        skel = _skeleton()
+        # User left node C blank.
+        user_arr = np.array([[0.0, 0.0], [1.0, 0.0], [np.nan, np.nan], [3.0, 0.0]])
+        labels = _labels_one_frame(skel, [user_arr])
+
+        # Model is ALSO unsure at node C (0.12) -> truly occluded, no flag.
+        pred = _pred_instance(
+            skel,
+            points=np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+            scores=np.array([0.95, 0.9, 0.12, 0.88]),
+        )
+        pred_video = labels.videos[0]
+        pred_lf = sio.LabeledFrame(video=pred_video, frame_idx=0, instances=[pred])
+        pred_labels = sio.Labels(
+            labeled_frames=[pred_lf], videos=[pred_video], skeletons=[skel]
+        )
+        _patch_run_inference(monkeypatch, pred_labels)
+
+        out = run_insample_prediction(
+            labels, model_path="/fake/model", min_confidence=0.5
+        )
+        assert out["ran"] is True
+        assert out["instance_scores"] == {}
+        assert out["records"] == []
+
+    def test_two_instances_matched_independently(self, monkeypatch):
+        skel = _skeleton()
+        # Instance 0 (near origin) missing node C; instance 1 (far) fully labeled.
+        u0 = np.array([[0.0, 0.0], [1.0, 0.0], [np.nan, np.nan], [3.0, 0.0]])
+        u1 = np.array([[100.0, 0.0], [101.0, 0.0], [102.0, 0.0], [103.0, 0.0]])
+        labels = _labels_one_frame(skel, [u0, u1])
+
+        pred_video = labels.videos[0]
+        # Prediction near origin (matches u0), confident at C.
+        p0 = _pred_instance(
+            skel,
+            points=np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+            scores=np.array([0.95, 0.9, 0.93, 0.88]),
+        )
+        # Prediction near (100,0) (matches u1).
+        p1 = _pred_instance(
+            skel,
+            points=np.array([[100.0, 0.0], [101.0, 0.0], [102.0, 0.0], [103.0, 0.0]]),
+            scores=np.array([0.9, 0.9, 0.9, 0.9]),
+        )
+        pred_lf = sio.LabeledFrame(video=pred_video, frame_idx=0, instances=[p1, p0])
+        pred_labels = sio.Labels(
+            labeled_frames=[pred_lf], videos=[pred_video], skeletons=[skel]
+        )
+        _patch_run_inference(monkeypatch, pred_labels)
+
+        out = run_insample_prediction(labels, model_path="/fake/model")
+        # Only instance 0 has a blank node, and only it should be flagged.
+        assert (0, 0, 0) in out["instance_scores"]
+        assert (0, 0, 1) not in out["instance_scores"]
+        assert out["instance_scores"][(0, 0, 0)] == pytest.approx(0.93)
+
+    def test_node_name_mismatch_is_graceful_noop(self, monkeypatch):
+        skel = _skeleton(["A", "B", "C", "D"])
+        user_arr = np.array([[0.0, 0.0], [1.0, 0.0], [np.nan, np.nan], [3.0, 0.0]])
+        labels = _labels_one_frame(skel, [user_arr])
+
+        # Predicted skeleton has DIFFERENT node names -> must no-op gracefully.
+        wrong_skel = _skeleton(["W", "X", "Y", "Z"])
+        pred = _pred_instance(
+            wrong_skel,
+            points=np.array([[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]),
+            scores=np.array([0.95, 0.9, 0.92, 0.88]),
+        )
+        pred_video = labels.videos[0]
+        pred_lf = sio.LabeledFrame(video=pred_video, frame_idx=0, instances=[pred])
+        pred_labels = sio.Labels(
+            labeled_frames=[pred_lf], videos=[pred_video], skeletons=[wrong_skel]
+        )
+        _patch_run_inference(monkeypatch, pred_labels)
+
+        out = run_insample_prediction(labels, model_path="/fake/model")
+        assert out["ran"] is False
+        assert "node-names do not match" in out["reason"]
+        assert out["instance_scores"] == {}
+        assert out["records"] == []
+
+    def test_no_model_path_is_noop(self):
+        skel = _skeleton()
+        labels = _labels_one_frame(skel, [np.zeros((4, 2))])
+        out = run_insample_prediction(labels, model_path="")
+        assert out["ran"] is False
+        assert "no model path" in out["reason"]
+        assert out["instance_scores"] == {}
+
+    def test_no_model_path_none_is_noop(self):
+        skel = _skeleton()
+        labels = _labels_one_frame(skel, [np.zeros((4, 2))])
+        out = run_insample_prediction(labels, model_path=None)
+        assert out["ran"] is False
+        assert out["instance_scores"] == {}
+
+    def test_sleap_nn_unavailable_is_graceful(self, monkeypatch):
+        # Simulate an environment where importing sleap_nn.predict fails.
+        skel = _skeleton()
+        labels = _labels_one_frame(skel, [np.zeros((4, 2))])
+
+        import builtins
+
+        real_import = builtins.__import__
+
+        def boom(name, *args, **kwargs):
+            if name == "sleap_nn.predict" or name.startswith("sleap_nn"):
+                raise ImportError("simulated missing sleap_nn")
+            return real_import(name, *args, **kwargs)
+
+        # Remove cached module so the import is re-attempted and fails.
+        monkeypatch.delitem(sys.modules, "sleap_nn.predict", raising=False)
+        monkeypatch.setattr(builtins, "__import__", boom)
+
+        out = run_insample_prediction(labels, model_path="/fake/model")
+        assert out["ran"] is False
+        assert "sleap_nn unavailable" in out["reason"]
+
+    def test_inference_exception_is_graceful(self, monkeypatch):
+        skel = _skeleton()
+        labels = _labels_one_frame(skel, [np.zeros((4, 2))])
+
+        fake_predict = types.ModuleType("sleap_nn.predict")
+
+        def boom_inference(*args, **kwargs):
+            raise RuntimeError("CUDA OOM simulated")
+
+        fake_predict.run_inference = boom_inference
+        fake_pkg = sys.modules.get("sleap_nn") or types.ModuleType("sleap_nn")
+        monkeypatch.setitem(sys.modules, "sleap_nn", fake_pkg)
+        monkeypatch.setitem(sys.modules, "sleap_nn.predict", fake_predict)
+
+        out = run_insample_prediction(labels, model_path="/fake/model")
+        assert out["ran"] is False
+        assert "inference failed" in out["reason"]
+
+    def test_import_is_torch_free(self):
+        # Importing the module must NOT have pulled in torch / sleap_nn.
+        import importlib
+
+        # Fresh import check: the module itself imports neither at top level.
+        mod = importlib.import_module("sleap.qc.insample_prediction")
+        src = mod.__doc__ or ""
+        assert "Import-safe" in src
+        # The function references are present without torch imported by us.
+        assert callable(mod.run_insample_prediction)

--- a/tests/qc/test_missing_node.py
+++ b/tests/qc/test_missing_node.py
@@ -1,0 +1,341 @@
+"""Tests for sleap.qc.features.missing_node.
+
+These tests cover the Tier-1 (geometry/visibility-only) missing-node detector
+``score_missing_nodes``. The co-visibility matrix it consumes is normally
+learned by :class:`VisibilityModel`; here we both construct matrices by hand
+(for precise control) and fit a real ``VisibilityModel`` (to confirm the two
+interoperate as the integration layer expects).
+"""
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.missing_node import score_missing_nodes
+from sleap.qc.features.visibility import VisibilityModel
+
+
+# A simple 5-node line skeleton reused across tests: 0-1-2-3-4.
+LINE_EDGES = [(0, 1), (1, 2), (2, 3), (3, 4)]
+
+
+def _covis_from_masks(masks: np.ndarray) -> np.ndarray:
+    """Fit a VisibilityModel and return its co-visibility matrix.
+
+    This mirrors exactly what the integration layer does: learn co-visibility on
+    the dataset, then hand the matrix to ``score_missing_nodes``.
+    """
+    model = VisibilityModel()
+    model.fit(np.asarray(masks, dtype=bool))
+    return model.co_visibility_matrix
+
+
+class TestScoreMissingNodesPositive:
+    """The instance is missing a node its peers almost always keep."""
+
+    def test_flags_dropped_covisible_node(self):
+        # All five nodes are essentially always visible together.
+        masks = np.ones((50, 5), dtype=bool)
+        # A tiny bit of noise on node 4 so nothing is a degenerate 100%/0%.
+        masks[:2, 4] = False
+        covis = _covis_from_masks(masks)
+
+        # This instance is missing node 2, which peers keep ~100% of the time.
+        vis = np.array([True, True, False, True, True])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["n_suspicious"] == 1
+        assert result["suspicious_nodes"] == [2]
+        # Expected visibility of node 2 given the others is ~1.0.
+        assert result["missing_node_score"] == pytest.approx(1.0, abs=1e-6)
+
+    def test_flags_multiple_dropped_nodes(self):
+        masks = np.ones((40, 5), dtype=bool)
+        covis = _covis_from_masks(masks)
+
+        # Missing both node 1 and node 3.
+        vis = np.array([True, False, True, False, True])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["n_suspicious"] == 2
+        assert result["suspicious_nodes"] == [1, 3]
+        assert result["missing_node_score"] == pytest.approx(1.0, abs=1e-6)
+
+    def test_hand_built_matrix_positive(self):
+        # Hand-built: node 2 is visible with everything ~95% of the time.
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+
+        vis = np.array([True, True, False, True])
+        result = score_missing_nodes(vis, covis, [(0, 1), (1, 2), (2, 3)])
+
+        assert result["suspicious_nodes"] == [2]
+        assert result["missing_node_score"] == pytest.approx(0.95, abs=1e-6)
+
+
+class TestScoreMissingNodesNegative:
+    """The missing node is one peers usually also lack -> not suspicious."""
+
+    def test_usually_absent_node_not_flagged(self):
+        # Nodes 0,1,2 always visible; nodes 3,4 almost never visible.
+        masks = np.zeros((50, 5), dtype=bool)
+        masks[:, 0:3] = True
+        masks[:2, 3] = True  # 4% visibility for node 3
+        masks[:1, 4] = True  # 2% visibility for node 4
+        covis = _covis_from_masks(masks)
+
+        # Common pattern: 0,1,2 visible, 3,4 missing. Nothing suspicious.
+        vis = np.array([True, True, True, False, False])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["n_suspicious"] == 0
+        assert result["suspicious_nodes"] == []
+        # Score should be the (low) expected visibility of nodes 3/4.
+        assert result["missing_node_score"] < 0.1
+
+    def test_score_below_threshold_not_flagged(self):
+        # Node 2 co-visible only 80% of the time; default threshold is 0.9.
+        n = 4
+        covis = np.full((n, n), 0.8)
+        np.fill_diagonal(covis, 1.0)
+
+        vis = np.array([True, True, False, True])
+        result = score_missing_nodes(vis, covis, [(0, 1), (1, 2), (2, 3)])
+
+        assert result["n_suspicious"] == 0
+        # But the score still reflects the 0.8 expected probability.
+        assert result["missing_node_score"] == pytest.approx(0.8, abs=1e-6)
+
+
+class TestScoreMissingNodesAllVisible:
+    """All nodes visible -> nothing missing -> score 0."""
+
+    def test_all_visible_score_zero(self):
+        masks = np.ones((20, 5), dtype=bool)
+        covis = _covis_from_masks(masks)
+
+        vis = np.array([True, True, True, True, True])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["missing_node_score"] == 0.0
+        assert result["n_suspicious"] == 0
+        assert result["suspicious_nodes"] == []
+
+
+class TestThreshold:
+    """The threshold argument controls flagging."""
+
+    def test_custom_threshold_flags_lower_prob(self):
+        n = 4
+        covis = np.full((n, n), 0.8)
+        np.fill_diagonal(covis, 1.0)
+        vis = np.array([True, True, False, True])
+
+        # Default 0.9 -> not flagged.
+        assert score_missing_nodes(vis, covis, [])["n_suspicious"] == 0
+        # Lower threshold -> flagged.
+        result = score_missing_nodes(vis, covis, [], threshold=0.75)
+        assert result["suspicious_nodes"] == [2]
+
+    def test_threshold_is_inclusive(self):
+        n = 3
+        covis = np.full((n, n), 0.9)
+        np.fill_diagonal(covis, 1.0)
+        vis = np.array([True, False, True])
+
+        # p_expected == threshold exactly should flag (>=).
+        result = score_missing_nodes(vis, covis, [], threshold=0.9)
+        assert result["suspicious_nodes"] == [1]
+
+
+class TestRequireNeighborsVisible:
+    """The optional neighbor-strengthening rule."""
+
+    def test_flagged_when_all_neighbors_visible(self):
+        n = 5
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+
+        # Node 2 missing; its neighbors 1 and 3 are both visible.
+        vis = np.array([True, True, False, True, True])
+        result = score_missing_nodes(
+            vis, covis, LINE_EDGES, require_neighbors_visible=True
+        )
+        assert result["suspicious_nodes"] == [2]
+
+    def test_not_flagged_when_a_neighbor_invisible(self):
+        n = 5
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+
+        # Node 2 missing AND its neighbor 3 also missing -> looks like an
+        # occluded region, not an accidental single drop.
+        vis = np.array([True, True, False, False, True])
+        result = score_missing_nodes(
+            vis, covis, LINE_EDGES, require_neighbors_visible=True
+        )
+        # Node 2 has an invisible neighbor (3) so it is NOT flagged. Node 3's
+        # neighbor 2 is also invisible, so it is not flagged either.
+        assert result["suspicious_nodes"] == []
+        # The score (max expected prob over invisible nodes) is still high --
+        # the strengthening rule only gates *flagging*, not the raw score.
+        assert result["missing_node_score"] == pytest.approx(0.95, abs=1e-6)
+
+    def test_node_with_no_neighbors_not_flagged_under_rule(self):
+        # 4 nodes, but node 3 is isolated (no edges touch it).
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+        edges = [(0, 1), (1, 2)]  # node 3 has no neighbors
+
+        vis = np.array([True, True, True, False])
+        # Without the rule, node 3 is flagged.
+        assert score_missing_nodes(vis, covis, edges)["suspicious_nodes"] == [3]
+        # With the rule, a neighborless node cannot satisfy "all neighbors
+        # visible" and is skipped.
+        result = score_missing_nodes(
+            vis, covis, edges, require_neighbors_visible=True
+        )
+        assert result["suspicious_nodes"] == []
+
+
+class TestDegenerate:
+    """Degenerate / edge inputs must not raise or leak NaN."""
+
+    def test_no_visible_nodes_score_zero(self):
+        n = 4
+        covis = np.full((n, n), 0.95)
+        vis = np.array([False, False, False, False])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        # No visible node to condition on -> no evidence -> score 0.
+        assert result["missing_node_score"] == 0.0
+        assert result["n_suspicious"] == 0
+
+    def test_single_visible_node(self):
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+        vis = np.array([True, False, False, False])
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        # Only node 0 visible; nodes 1,2,3 each have p_expected ~0.95.
+        assert result["suspicious_nodes"] == [1, 2, 3]
+        assert result["missing_node_score"] == pytest.approx(0.95, abs=1e-6)
+
+    def test_empty_skeleton(self):
+        vis = np.array([], dtype=bool)
+        covis = np.zeros((0, 0))
+        result = score_missing_nodes(vis, covis, [])
+
+        assert result["missing_node_score"] == 0.0
+        assert result["suspicious_nodes"] == []
+        assert result["n_suspicious"] == 0
+
+    def test_matrix_shape_mismatch_returns_zero(self):
+        # A 5-node mask with a 3x3 matrix is inconsistent; do not crash.
+        vis = np.array([True, True, False, True, True])
+        covis = np.full((3, 3), 0.95)
+        result = score_missing_nodes(vis, covis, LINE_EDGES)
+
+        assert result["missing_node_score"] == 0.0
+        assert result["n_suspicious"] == 0
+
+    def test_nan_in_covis_column_does_not_leak(self):
+        # A node that was never visible during fitting can yield NaN columns.
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+        # Make every entry predicting node 2's visibility NaN.
+        covis[:, 2] = np.nan
+
+        vis = np.array([True, True, False, True])
+        result = score_missing_nodes(vis, covis, [(0, 1), (1, 2), (2, 3)])
+
+        # No usable evidence for node 2 -> p_expected treated as 0, not NaN.
+        assert np.isfinite(result["missing_node_score"])
+        assert result["missing_node_score"] == 0.0
+        assert result["n_suspicious"] == 0
+
+    def test_score_never_exceeds_one(self):
+        # Even with an out-of-range matrix, the score is clamped to [0, 1].
+        n = 3
+        covis = np.full((n, n), 1.5)  # pathological > 1 probabilities
+        vis = np.array([True, False, True])
+        result = score_missing_nodes(vis, covis, [])
+
+        assert 0.0 <= result["missing_node_score"] <= 1.0
+
+    def test_non_boolean_mask_is_coerced(self):
+        # Integer 0/1 masks (a common alternative encoding) must work.
+        n = 4
+        covis = np.full((n, n), 0.95)
+        np.fill_diagonal(covis, 1.0)
+        vis = np.array([1, 1, 0, 1])  # node 2 missing
+        result = score_missing_nodes(vis, covis, [(0, 1), (1, 2), (2, 3)])
+
+        assert result["suspicious_nodes"] == [2]
+
+
+class TestSleapIoIntegration:
+    """Build masks/skeleton from sleap_io and confirm end-to-end behavior."""
+
+    def test_end_to_end_with_sleap_io_instances(self):
+        import sleap_io as sio
+
+        # 4-node skeleton: head - thorax - abdomen - tail (a line).
+        skel = sio.Skeleton(
+            nodes=["head", "thorax", "abdomen", "tail"],
+            edges=[("head", "thorax"), ("thorax", "abdomen"), ("abdomen", "tail")],
+        )
+        name_to_idx = {n.name: i for i, n in enumerate(skel.nodes)}
+        edges = [
+            (name_to_idx[e.source.name], name_to_idx[e.destination.name])
+            for e in skel.edges
+        ]
+        n_nodes = len(skel.nodes)
+
+        # Build a dataset of instances. "tail" is frequently invisible
+        # (systematic), the rest are almost always visible.
+        rng = np.random.default_rng(0)
+        instances: list[sio.Instance] = []
+        masks: list[np.ndarray] = []
+        for _ in range(60):
+            pts = rng.normal(size=(n_nodes, 2)) * 5 + np.array([0, 0])
+            pts = pts.astype(float)
+            # Tail invisible ~70% of the time.
+            if rng.random() < 0.7:
+                pts[3] = np.nan
+            inst = sio.Instance.from_numpy(pts, skeleton=skel)
+            instances.append(inst)
+            masks.append(~np.isnan(pts).any(axis=1))
+
+        masks = np.asarray(masks, dtype=bool)
+        covis = _covis_from_masks(masks)
+
+        # Case 1: an instance missing "tail" -- which is systematically dropped.
+        # Tier-1 should NOT flag it (this is the documented limitation).
+        vis_systematic = np.array([True, True, True, False])
+        res_sys = score_missing_nodes(vis_systematic, covis, edges)
+        assert 3 not in res_sys["suspicious_nodes"]
+        assert res_sys["missing_node_score"] < 0.9
+
+        # Case 2: an instance missing "thorax" -- a node peers almost always
+        # keep. Tier-1 SHOULD flag it as a suspicious outlier drop.
+        vis_outlier = np.array([True, False, True, True])
+        res_out = score_missing_nodes(vis_outlier, covis, edges)
+        assert 1 in res_out["suspicious_nodes"]
+        assert res_out["missing_node_score"] >= 0.9
+
+    def test_covis_from_instances_matches_visibility_model(self):
+        # Sanity: feeding VisibilityModel's own matrix back yields a finite,
+        # in-range score for a typical pattern.
+        masks = np.ones((30, 5), dtype=bool)
+        masks[::3, 4] = False
+        model = VisibilityModel().fit(masks)
+
+        vis = np.array([True, True, False, True, True])
+        result = score_missing_nodes(vis, model.co_visibility_matrix, LINE_EDGES)
+
+        assert 0.0 <= result["missing_node_score"] <= 1.0
+        assert result["suspicious_nodes"] == [2]

--- a/tests/qc/test_missing_node.py
+++ b/tests/qc/test_missing_node.py
@@ -193,9 +193,7 @@ class TestRequireNeighborsVisible:
         assert score_missing_nodes(vis, covis, edges)["suspicious_nodes"] == [3]
         # With the rule, a neighborless node cannot satisfy "all neighbors
         # visible" and is skipped.
-        result = score_missing_nodes(
-            vis, covis, edges, require_neighbors_visible=True
-        )
+        result = score_missing_nodes(vis, covis, edges, require_neighbors_visible=True)
         assert result["suspicious_nodes"] == []
 
 

--- a/tests/qc/test_ordering.py
+++ b/tests/qc/test_ordering.py
@@ -23,9 +23,7 @@ CORRECT_CURVED_TAIL = np.array(
 def _rotate(points: np.ndarray, degrees: float) -> np.ndarray:
     """Rotate points about the origin by ``degrees`` (NaN-safe)."""
     theta = np.deg2rad(degrees)
-    R = np.array(
-        [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
-    )
+    R = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
     return points @ R.T
 
 
@@ -402,9 +400,7 @@ class TestEndToEndWithSleapIO:
 
         skel = self._tail_skeleton()
         # Swap Tail_1 <-> Tail_2 positions (adjacent swap).
-        coords = np.array(
-            [[0, 0], [1, 0.5], [3, 0.9], [2, 0.8], [4, 0.8]], dtype=float
-        )
+        coords = np.array([[0, 0], [1, 0.5], [3, 0.9], [2, 0.8], [4, 0.8]], dtype=float)
         inst = sio.Instance.from_numpy(coords, skeleton=skel)
 
         names = [n.name for n in skel.nodes]

--- a/tests/qc/test_ordering.py
+++ b/tests/qc/test_ordering.py
@@ -1,0 +1,434 @@
+"""Tests for sleap.qc.features.ordering (wrong keypoint order along a chain)."""
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.ordering import (
+    DEFAULT_MAX_TURN_ANGLE,
+    compute_chain_ordering,
+    resolve_chains,
+)
+
+
+# A canonical 5-node tail chain (indices used directly as the chain).
+TAIL_CHAIN = [0, 1, 2, 3, 4]
+
+# A correctly-ordered tail with a gentle 2D arc. Monotone in x with a small
+# bend in y -- a realistic, correctly-labeled (slightly curved) tail.
+CORRECT_CURVED_TAIL = np.array(
+    [[0, 0], [1, 0.5], [2, 0.8], [3, 0.9], [4, 0.8]], dtype=float
+)
+
+
+def _rotate(points: np.ndarray, degrees: float) -> np.ndarray:
+    """Rotate points about the origin by ``degrees`` (NaN-safe)."""
+    theta = np.deg2rad(degrees)
+    R = np.array(
+        [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
+    )
+    return points @ R.T
+
+
+class TestComputeChainOrderingStraight:
+    """A correctly-ordered chain should not be flagged."""
+
+    def test_straight_chain_zero_inversions(self):
+        """A perfectly straight chain -> ~0 turning angle, 0 inversions."""
+        points = np.array([[0, 0], [1, 0], [2, 0], [3, 0], [4, 0]], dtype=float)
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] < 1e-6
+
+    def test_gently_curved_chain_not_flagged(self):
+        """A gently curved (correct) tail has small turns, no inversions."""
+        result = compute_chain_ordering(CORRECT_CURVED_TAIL, [TAIL_CHAIN])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        # Largest turn is well under the 60-degree default threshold.
+        assert result["max_turn_angle"] < DEFAULT_MAX_TURN_ANGLE
+
+
+class TestComputeChainOrderingCurled:
+    """Robustness: a correctly-ordered but strongly curled chain is NOT flagged."""
+
+    def test_half_circle_curl_not_flagged(self):
+        """A half-circle (correct order) has gentle per-step turns."""
+        t = np.linspace(0, np.pi, 6)
+        points = np.stack([np.cos(t), np.sin(t)], axis=1) * 5.0
+        chain = list(range(6))
+
+        result = compute_chain_ordering(points, [chain])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] < DEFAULT_MAX_TURN_ANGLE
+
+    def test_strong_curl_three_quarter_circle_not_flagged(self):
+        """A 3/4-circle curl with enough nodes is still correctly ordered."""
+        t = np.linspace(0, 1.5 * np.pi, 8)
+        points = np.stack([np.cos(t), np.sin(t)], axis=1) * 5.0
+        chain = list(range(8))
+
+        result = compute_chain_ordering(points, [chain])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] < DEFAULT_MAX_TURN_ANGLE
+
+
+class TestComputeChainOrderingAdjacentSwap:
+    """An adjacent swap shows up as large turning angles + inversions."""
+
+    def test_adjacent_swap_high_turn_and_inversions(self):
+        """Swapping t1<->t2 (idx 2 & 3 positions) -> sharp reversals."""
+        # Correct straight tail is x = 0,1,2,3,4. Swap the positions held by
+        # node indices 2 and 3 (an adjacent label swap).
+        points = np.array([[0, 0], [1, 0], [3, 0], [2, 0], [4, 0]], dtype=float)
+
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        # Two consecutive interior nodes turn sharply -> high inversion rate.
+        assert result["order_inversion_rate"] > 0.5
+        # A full direction reversal approaches pi radians.
+        assert result["max_turn_angle"] > np.deg2rad(150.0)
+        assert result["worst_chain"] == tuple(TAIL_CHAIN)
+        assert result["worst_node"] in (2, 3)
+
+    def test_adjacent_swap_two_consecutive_large_turns(self):
+        """An adjacent swap produces (at least) two large turning angles."""
+        points = np.array([[0, 0], [1, 0], [3, 0], [2, 0], [4, 0]], dtype=float)
+
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        # 3 interior nodes; an adjacent swap flags 2 of them -> rate ~= 2/3.
+        assert result["order_inversion_rate"] == pytest.approx(2.0 / 3.0)
+
+
+class TestComputeChainOrderingNonAdjacentReversal:
+    """A non-adjacent swap makes segments geometrically cross."""
+
+    def test_t1_t3_reversal_has_intersection(self):
+        """Swapping t1<->t3 (idx 1 & 3) makes a self-crossing chain."""
+        points = CORRECT_CURVED_TAIL.copy()
+        points[[1, 3]] = points[[3, 1]]
+
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        assert result["chain_intersection_count"] > 0
+        # It also produces sharp turns.
+        assert result["order_inversion_rate"] > 0.0
+        assert result["max_turn_angle"] > DEFAULT_MAX_TURN_ANGLE
+
+    def test_correct_chain_has_no_intersection(self):
+        """A correctly ordered curved chain has zero self-crossings."""
+        result = compute_chain_ordering(CORRECT_CURVED_TAIL, [TAIL_CHAIN])
+        assert result["chain_intersection_count"] == 0
+
+
+class TestComputeChainOrderingInvariance:
+    """Turning angle is invariant to translation, rotation, and scale."""
+
+    def test_translation_invariant(self):
+        points = CORRECT_CURVED_TAIL.copy()
+        shifted = points + np.array([100.0, -50.0])
+
+        base = compute_chain_ordering(points, [TAIL_CHAIN])
+        moved = compute_chain_ordering(shifted, [TAIL_CHAIN])
+
+        assert moved["max_turn_angle"] == pytest.approx(base["max_turn_angle"])
+        assert moved["order_inversion_rate"] == base["order_inversion_rate"]
+
+    def test_rotation_invariant(self):
+        points = CORRECT_CURVED_TAIL.copy()
+        rotated = _rotate(points, 73.0)
+
+        base = compute_chain_ordering(points, [TAIL_CHAIN])
+        rot = compute_chain_ordering(rotated, [TAIL_CHAIN])
+
+        assert rot["max_turn_angle"] == pytest.approx(base["max_turn_angle"])
+        assert rot["order_inversion_rate"] == base["order_inversion_rate"]
+
+    def test_scale_invariant(self):
+        points = CORRECT_CURVED_TAIL.copy()
+        scaled = points * 17.0
+
+        base = compute_chain_ordering(points, [TAIL_CHAIN])
+        sc = compute_chain_ordering(scaled, [TAIL_CHAIN])
+
+        assert sc["max_turn_angle"] == pytest.approx(base["max_turn_angle"])
+        assert sc["order_inversion_rate"] == base["order_inversion_rate"]
+
+    def test_swap_detected_under_rotation(self):
+        """An adjacent swap is still flagged after an arbitrary rotation."""
+        swapped = np.array([[0, 0], [1, 0], [3, 0], [2, 0], [4, 0]], dtype=float)
+        rotated = _rotate(swapped, 41.0)
+
+        result = compute_chain_ordering(rotated, [TAIL_CHAIN])
+        assert result["order_inversion_rate"] > 0.5
+        assert result["max_turn_angle"] > np.deg2rad(150.0)
+
+
+class TestComputeChainOrderingThreshold:
+    """The per-chain turning-angle threshold is configurable."""
+
+    def test_lower_threshold_flags_gentle_curve(self):
+        """A very low threshold flags even a gentle (correct) curve."""
+        # CORRECT_CURVED_TAIL has a max turn of ~0.2 rad; threshold below it.
+        result = compute_chain_ordering(
+            CORRECT_CURVED_TAIL, [TAIL_CHAIN], max_turn_angle=0.1
+        )
+        assert result["order_inversion_rate"] > 0.0
+
+    def test_higher_threshold_tolerates_more(self):
+        """A high threshold tolerates a turn that the default would flag."""
+        # A ~90-degree turn at the middle node.
+        points = np.array([[0, 0], [1, 0], [2, 0], [2, 1], [2, 2]], dtype=float)
+
+        default_res = compute_chain_ordering(points, [TAIL_CHAIN])
+        loose_res = compute_chain_ordering(
+            points, [TAIL_CHAIN], max_turn_angle=np.deg2rad(170.0)
+        )
+
+        assert default_res["order_inversion_rate"] > 0.0
+        assert loose_res["order_inversion_rate"] == 0.0
+
+
+class TestComputeChainOrderingDegenerate:
+    """Degenerate inputs must never leak NaN or crash."""
+
+    def test_no_chains_returns_default(self):
+        points = CORRECT_CURVED_TAIL.copy()
+        result = compute_chain_ordering(points, [])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] == 0.0
+        assert result["worst_chain"] == ()
+        assert result["worst_node"] == -1
+
+    def test_chain_too_short(self):
+        """A chain with fewer than 3 nodes has no interior turning angle."""
+        points = np.array([[0, 0], [1, 0]], dtype=float)
+        result = compute_chain_ordering(points, [[0, 1]])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["max_turn_angle"] == 0.0
+        assert result["worst_node"] == -1
+
+    def test_all_invisible_chain(self):
+        """A fully occluded chain yields the default (no evaluable turns)."""
+        points = np.full((5, 2), np.nan)
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert result["max_turn_angle"] == 0.0
+        assert result["worst_node"] == -1
+        assert not np.isnan(result["max_turn_angle"])
+
+    def test_occluded_interior_node_skipped(self):
+        """An invisible interior node is skipped, not treated as a reversal."""
+        # Straight chain but node idx 2 (interior) is invisible.
+        points = np.array(
+            [[0, 0], [1, 0], [np.nan, np.nan], [3, 0], [4, 0]], dtype=float
+        )
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        # The two interior turns touching the NaN node are skipped; the
+        # remaining geometry is straight, so nothing is flagged and no NaN
+        # leaks through.
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+        assert not np.isnan(result["max_turn_angle"])
+
+    def test_partial_visibility_still_evaluates_visible_turns(self):
+        """With one endpoint occluded, the visible interior turn is evaluated."""
+        # Endpoint idx 0 invisible; interior nodes 1,2,3 form a sharp turn.
+        points = np.array(
+            [[np.nan, np.nan], [0, 0], [1, 0], [1, 1], [1, 2]], dtype=float
+        )
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        # Node 2 turn (idx1->idx2->idx3): straight->up is a 90-degree turn,
+        # which exceeds the 60-degree default and is flagged.
+        assert result["order_inversion_rate"] > 0.0
+        assert not np.isnan(result["max_turn_angle"])
+
+    def test_coincident_nodes_no_crash(self):
+        """Coincident (zero-length segment) nodes produce no NaN / crash."""
+        points = np.array([[0, 0], [0, 0], [0, 0], [3, 0], [4, 0]], dtype=float)
+        result = compute_chain_ordering(points, [TAIL_CHAIN])
+
+        assert not np.isnan(result["max_turn_angle"])
+        assert result["order_inversion_rate"] >= 0.0
+
+
+class TestComputeChainOrderingMultipleChains:
+    """Aggregation is the max over chains; worst chain/node are recorded."""
+
+    def test_aggregates_max_over_chains(self):
+        """The worst chain drives the reported metrics."""
+        # Two chains: a clean one (nodes 0-2) and a swapped one (nodes 3-7).
+        points = np.array(
+            [
+                [0, 0],  # 0  clean chain
+                [1, 0],  # 1
+                [2, 0],  # 2
+                [0, 5],  # 3  swapped chain start
+                [1, 5],  # 4
+                [3, 5],  # 5  <- swapped position
+                [2, 5],  # 6  <- swapped position
+                [4, 5],  # 7
+            ],
+            dtype=float,
+        )
+        clean_chain = [0, 1, 2]
+        swapped_chain = [3, 4, 5, 6, 7]
+
+        result = compute_chain_ordering(points, [clean_chain, swapped_chain])
+
+        assert result["order_inversion_rate"] > 0.0
+        # Worst node belongs to the swapped chain.
+        assert result["worst_chain"] == tuple(swapped_chain)
+        assert result["worst_node"] in swapped_chain
+
+
+class TestResolveChains:
+    """resolve_chains maps names to indices, with auto-chain fallback."""
+
+    NODE_NAMES = ["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]
+
+    def test_resolves_user_defined_names(self):
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]],
+            auto_chains=None,
+        )
+        assert chains == [[0, 1, 2, 3, 4]]
+
+    def test_user_defined_takes_priority_over_auto(self):
+        """A user-declared order is ground truth; auto chains are ignored."""
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["Tail_2", "Tail_1", "Tail_0"]],  # user's intended order
+            auto_chains=[[0, 1, 2, 3, 4]],
+        )
+        assert chains == [[3, 2, 1]]
+
+    def test_falls_back_to_auto_chains(self):
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            ordered_chains_by_name=None,
+            auto_chains=[[0, 1, 2, 3, 4]],
+        )
+        assert chains == [[0, 1, 2, 3, 4]]
+
+    def test_empty_when_nothing_provided(self):
+        chains = resolve_chains(self.NODE_NAMES, None, None)
+        assert chains == []
+
+    def test_unknown_names_skipped(self):
+        """Names not in the skeleton are dropped from the resolved chain."""
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["TTI", "NotANode", "Tail_1", "Tail_2", "TailTip"]],
+            auto_chains=None,
+        )
+        assert chains == [[0, 2, 3, 4]]
+
+    def test_too_short_user_chain_falls_back_to_auto(self):
+        """A user chain that resolves to <3 nodes falls back to auto chains."""
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["TTI", "Tail_0"]],  # only 2 nodes
+            auto_chains=[[0, 1, 2, 3, 4]],
+        )
+        assert chains == [[0, 1, 2, 3, 4]]
+
+    def test_multiple_user_chains(self):
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            [["TTI", "Tail_0", "Tail_1"], ["Tail_1", "Tail_2", "TailTip"]],
+            auto_chains=None,
+        )
+        assert chains == [[0, 1, 2], [2, 3, 4]]
+
+    def test_auto_chains_below_min_length_dropped(self):
+        """Auto chains shorter than 3 nodes are dropped in fallback."""
+        chains = resolve_chains(
+            self.NODE_NAMES,
+            None,
+            auto_chains=[[0, 1], [0, 1, 2, 3, 4]],
+        )
+        assert chains == [[0, 1, 2, 3, 4]]
+
+
+class TestEndToEndWithSleapIO:
+    """Build a real sleap-io skeleton/instance and run the detector end-to-end."""
+
+    def _tail_skeleton(self):
+        import sleap_io as sio
+
+        return sio.Skeleton(
+            nodes=["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"],
+            edges=[
+                ("TTI", "Tail_0"),
+                ("Tail_0", "Tail_1"),
+                ("Tail_1", "Tail_2"),
+                ("Tail_2", "TailTip"),
+            ],
+        )
+
+    def test_correct_instance_not_flagged(self):
+        import sleap_io as sio
+
+        skel = self._tail_skeleton()
+        inst = sio.Instance.from_numpy(CORRECT_CURVED_TAIL, skeleton=skel)
+
+        names = [n.name for n in skel.nodes]
+        chains = resolve_chains(
+            names, [["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]], None
+        )
+        result = compute_chain_ordering(inst.numpy(), chains)
+
+        assert result["order_inversion_rate"] == 0.0
+        assert result["chain_intersection_count"] == 0
+
+    def test_swapped_instance_flagged(self):
+        import sleap_io as sio
+
+        skel = self._tail_skeleton()
+        # Swap Tail_1 <-> Tail_2 positions (adjacent swap).
+        coords = np.array(
+            [[0, 0], [1, 0.5], [3, 0.9], [2, 0.8], [4, 0.8]], dtype=float
+        )
+        inst = sio.Instance.from_numpy(coords, skeleton=skel)
+
+        names = [n.name for n in skel.nodes]
+        chains = resolve_chains(
+            names, [["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]], None
+        )
+        result = compute_chain_ordering(inst.numpy(), chains)
+
+        assert result["order_inversion_rate"] > 0.0
+        assert result["max_turn_angle"] > DEFAULT_MAX_TURN_ANGLE
+
+    def test_occluded_instance_no_nan(self):
+        import sleap_io as sio
+
+        skel = self._tail_skeleton()
+        coords = CORRECT_CURVED_TAIL.copy()
+        coords[2] = np.nan  # occlude an interior tail node
+        inst = sio.Instance.from_numpy(coords, skeleton=skel)
+
+        names = [n.name for n in skel.nodes]
+        chains = resolve_chains(
+            names, [["TTI", "Tail_0", "Tail_1", "Tail_2", "TailTip"]], None
+        )
+        result = compute_chain_ordering(inst.numpy(), chains)
+
+        assert not np.isnan(result["max_turn_angle"])
+        assert result["order_inversion_rate"] == 0.0

--- a/tests/qc/test_pose_split.py
+++ b/tests/qc/test_pose_split.py
@@ -1,0 +1,422 @@
+"""Tests for sleap.qc.features.pose_split (chimera detector)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from sleap.qc.features.pose_split import (
+    compute_pose_split,
+    compute_pose_split_fallback,
+)
+
+
+# ---------------------------------------------------------------------------
+# Skeleton / baseline-stat helpers
+# ---------------------------------------------------------------------------
+
+
+def chain_adjacency(n_nodes: int) -> dict[int, list[int]]:
+    """Adjacency for a line graph 0-1-2-...-(n-1)."""
+    adj: dict[int, list[int]] = {i: [] for i in range(n_nodes)}
+    for i in range(n_nodes - 1):
+        adj[i].append(i + 1)
+        adj[i + 1].append(i)
+    return adj
+
+
+def edges_from_adjacency(adj: dict[int, list[int]]) -> list[tuple[int, int]]:
+    """Sorted unique undirected edges from an adjacency dict."""
+    seen = set()
+    for node, nbrs in adj.items():
+        for nb in nbrs:
+            seen.add(tuple(sorted((node, nb))))
+    return sorted(seen)
+
+
+def learn_edge_stats(
+    instances: list[np.ndarray],
+    edges: list[tuple[int, int]],
+    min_std: float = 1e-6,
+) -> tuple[dict[tuple[int, int], float], dict[tuple[int, int], float]]:
+    """Mimic BaselineFeatureExtractor's edge-length stats from clean poses.
+
+    Returns (edge_means, edge_stds) keyed by sorted (i, j) tuples.
+    """
+    lengths: dict[tuple[int, int], list[float]] = {e: [] for e in edges}
+    for pts in instances:
+        for i, j in edges:
+            p1, p2 = pts[i], pts[j]
+            if not (np.isnan(p1).any() or np.isnan(p2).any()):
+                lengths[(i, j)].append(float(np.linalg.norm(p2 - p1)))
+    means = {e: (float(np.mean(v)) if v else 0.0) for e, v in lengths.items()}
+    stds = {
+        e: max(float(np.std(v)) if v else min_std, min_std)
+        for e, v in lengths.items()
+    }
+    return means, stds
+
+
+@pytest.fixture
+def normal_chain_stats():
+    """A 6-node line skeleton with edge stats learned from normal poses.
+
+    Each segment ~10 units long with small jitter.
+    """
+    n_nodes = 6
+    adj = chain_adjacency(n_nodes)
+    edges = edges_from_adjacency(adj)
+
+    rng = np.random.default_rng(0)
+    instances = []
+    base = np.array([[i * 10.0, 0.0] for i in range(n_nodes)])
+    for _ in range(40):
+        instances.append(base + rng.normal(0, 0.4, size=(n_nodes, 2)))
+    means, stds = learn_edge_stats(instances, edges)
+    return adj, edges, means, stds
+
+
+# ---------------------------------------------------------------------------
+# Graph-based path: chimera vs normal vs occluded
+# ---------------------------------------------------------------------------
+
+
+def test_clear_chimera_high_score(normal_chain_stats):
+    """Two tight clusters joined by one very long edge -> high split_score."""
+    adj, _edges, means, stds = normal_chain_stats
+
+    # Cluster A: nodes 0-2 near origin (segments ~10). Cluster B: nodes 3-5 far
+    # away (also internally ~10 apart). The 2->3 edge is the stretched bridge.
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [10.0, 0.0],
+            [20.0, 0.0],
+            [320.0, 0.0],  # huge jump across the bridge edge (2,3)
+            [330.0, 0.0],
+            [340.0, 0.0],
+        ]
+    )
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result["split_score"] > 1.0
+    # Balanced 3/3 split -> ratio 0.5.
+    assert result["split_ratio"] == pytest.approx(0.5)
+    # Gap (~300) is huge relative to intra-cluster spread (~6.7).
+    assert result["gap_ratio"] > 10.0
+
+
+def test_normal_pose_low_score(normal_chain_stats):
+    """A normal in-distribution pose -> ~zero split_score."""
+    adj, _edges, means, stds = normal_chain_stats
+
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    points[2, 1] += 0.5  # tiny perturbation, still normal
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result["split_score"] < 0.5
+    # Gap between the two halves is comparable to their internal spread.
+    assert result["gap_ratio"] < 3.0
+
+
+def test_partially_occluded_normal_pose_low_score(normal_chain_stats):
+    """Occluded single animal (disconnected visible subgraph) -> low score.
+
+    Hiding an interior node breaks the chain into two visible components with
+    *no* bridging edge between them. Removing the largest-z edge then yields
+    more than two components, so we must not flag it.
+    """
+    adj, _edges, means, stds = normal_chain_stats
+
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    points[2] = np.nan  # occlude an interior node -> subgraph splits at 1|3
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result["split_score"] < 0.5
+
+
+def test_occluded_single_node_not_chimera(normal_chain_stats):
+    """One stray displaced node is a single-node error, not a chimera.
+
+    Node 5 is yanked far away. That is an unbalanced 1-vs-5 split, which the
+    balance gate must suppress even though the end edge is stretched.
+    """
+    adj, _edges, means, stds = normal_chain_stats
+
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    points[5] = [500.0, 0.0]  # single stretched leaf
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result["split_ratio"] < 0.2  # 1/6
+    assert result["split_score"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_two_close_overlapping_animals_low_score(normal_chain_stats):
+    """Two animals merged but spatially interleaved/overlapping -> low score.
+
+    When two correctly-merged animals genuinely overlap, the two halves of the
+    skeleton are interleaved in space: the gap between the cluster centroids is
+    small relative to the within-cluster spread, so gap_ratio stays below the
+    floor and the score is ~zero. (A *separated* pair with a stretched bridge is
+    a true chimera and is covered by ``test_clear_chimera_high_score``.)
+    """
+    adj, _edges, means, stds = normal_chain_stats
+
+    # Interleave: nodes alternate around the origin so neither graph-half forms
+    # a spatially distinct cluster. The bridge edge (2,3) is normal length.
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [10.0, 2.0],
+            [20.0, 0.0],
+            [25.0, 2.0],
+            [15.0, -2.0],
+            [5.0, 0.0],
+        ]
+    )
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    # Centroids of the two graph-halves nearly coincide -> tiny gap_ratio.
+    assert result["gap_ratio"] < 2.0
+    assert result["split_score"] < 1.0
+
+
+def test_score_is_nonnegative_and_finite(normal_chain_stats):
+    """split_score is always >= 0 and finite across cases."""
+    adj, _edges, means, stds = normal_chain_stats
+    rng = np.random.default_rng(7)
+    for _ in range(20):
+        pts = rng.normal(0, 50, size=(6, 2))
+        result = compute_pose_split(pts, adj, means, stds)
+        assert result["split_score"] >= 0.0
+        assert np.isfinite(result["split_score"])
+        assert np.isfinite(result["gap_ratio"])
+        assert 0.0 <= result["split_ratio"] <= 0.5
+
+
+# ---------------------------------------------------------------------------
+# Invariance
+# ---------------------------------------------------------------------------
+
+
+def test_translation_rotation_scale_invariance(normal_chain_stats):
+    """split_ratio and gap_ratio are invariant to translation and rotation.
+
+    (Scale invariance holds for gap_ratio/split_ratio; split_score depends on
+    the learned edge z-score which is scale-sensitive by design, so we only
+    assert the ratios are scale-invariant here.)
+    """
+    adj, _edges, means, stds = normal_chain_stats
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [10.0, 0.0],
+            [20.0, 0.0],
+            [320.0, 0.0],
+            [330.0, 0.0],
+            [340.0, 0.0],
+        ]
+    )
+    base = compute_pose_split(points, adj, means, stds)
+
+    # Rotate 37 degrees + translate.
+    theta = np.deg2rad(37.0)
+    rot = np.array(
+        [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
+    )
+    moved = points @ rot.T + np.array([123.4, -56.7])
+    rt = compute_pose_split(moved, adj, means, stds)
+
+    assert rt["split_ratio"] == pytest.approx(base["split_ratio"])
+    assert rt["gap_ratio"] == pytest.approx(base["gap_ratio"], rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Degenerate / guard cases
+# ---------------------------------------------------------------------------
+
+
+def test_too_few_visible_nodes_returns_zero(normal_chain_stats):
+    """Fewer than MIN_VISIBLE_NODES visible -> all-zero result."""
+    adj, _edges, means, stds = normal_chain_stats
+    points = np.full((6, 2), np.nan)
+    points[0] = [0.0, 0.0]
+    points[3] = [100.0, 0.0]  # only 2 visible
+
+    result = compute_pose_split(points, adj, means, stds)
+
+    assert result == {"split_score": 0.0, "split_ratio": 0.0, "gap_ratio": 0.0}
+
+
+def test_no_adjacency_uses_fallback():
+    """adjacency=None routes to the geometry-only fallback for a chimera."""
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [10.0, 0.0],
+            [20.0, 0.0],
+            [320.0, 0.0],
+            [330.0, 0.0],
+            [340.0, 0.0],
+        ]
+    )
+    result = compute_pose_split(points, None, {}, {})
+    assert result["split_score"] > 0.0
+    assert result["split_ratio"] == pytest.approx(0.5)
+    assert result["gap_ratio"] > 10.0
+
+
+def test_empty_adjacency_uses_fallback():
+    """Empty adjacency dict routes to the fallback; uniform line -> ~zero.
+
+    An evenly spaced line is *not* bimodal: 2-means halves it with a large
+    centroid gap but a near-zero silhouette, so the fallback's bimodality gate
+    suppresses it.
+    """
+    points = np.array([[0.0, 0.0], [10.0, 0.0], [20.0, 0.0], [30.0, 0.0]])
+    result = compute_pose_split(points, {}, {}, {})
+    assert result["split_score"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_missing_edge_stats_falls_back_gracefully(normal_chain_stats):
+    """If learned stats lack the visible edges, no crash; defers to fallback."""
+    adj, _edges, _means, _stds = normal_chain_stats
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    # Empty stats -> no edge gets a z-score -> best_edge is None -> fallback.
+    result = compute_pose_split(points, adj, {}, {})
+    assert np.isfinite(result["split_score"])
+    assert result["split_score"] >= 0.0
+
+
+def test_nan_never_leaks(normal_chain_stats):
+    """NaN nodes never produce NaN outputs."""
+    adj, _edges, means, stds = normal_chain_stats
+    points = np.array([[i * 10.0, 0.0] for i in range(6)], dtype=float)
+    points[1] = np.nan
+    points[4] = np.nan
+    result = compute_pose_split(points, adj, means, stds)
+    for v in result.values():
+        assert not np.isnan(v)
+
+
+# ---------------------------------------------------------------------------
+# Fallback (star / short skeleton) path
+# ---------------------------------------------------------------------------
+
+
+def test_star_skeleton_uses_fallback():
+    """A star skeleton (hub + leaves) routes through the fallback.
+
+    Hub node 0 connects to all others. Leaves 1-3 are one tight cluster, leaves
+    4-6 are a far cluster -> the geometry fallback should see two clusters.
+    """
+    n_nodes = 7
+    adj: dict[int, list[int]] = {0: [1, 2, 3, 4, 5, 6]}
+    for k in range(1, n_nodes):
+        adj[k] = [0]
+    edges = edges_from_adjacency(adj)
+
+    # Tight cluster near origin, far cluster near x=300; hub between-ish.
+    points = np.array(
+        [
+            [150.0, 0.0],  # hub
+            [0.0, 0.0],
+            [5.0, 5.0],
+            [-5.0, 5.0],
+            [300.0, 0.0],
+            [305.0, 5.0],
+            [295.0, 5.0],
+        ]
+    )
+    # Provide normal-ish stats so the (non-fallback) z would be modest; we only
+    # care that the star is routed to the fallback.
+    means = {e: 150.0 for e in edges}
+    stds = {e: 30.0 for e in edges}
+
+    result = compute_pose_split(points, adj, means, stds)
+    assert result["split_score"] >= 0.0
+    assert np.isfinite(result["split_score"])
+    # Two well separated leaf groups -> meaningful gap_ratio.
+    assert result["gap_ratio"] > 1.5
+
+
+def test_fallback_clear_bimodal_high():
+    """Fallback fires on two tight, well-separated clusters."""
+    points = np.array(
+        [
+            [0.0, 0.0],
+            [4.0, 0.0],
+            [0.0, 4.0],
+            [200.0, 0.0],
+            [204.0, 0.0],
+            [200.0, 4.0],
+        ]
+    )
+    result = compute_pose_split_fallback(points)
+    assert result["split_score"] > 0.0
+    assert result["split_ratio"] == pytest.approx(0.5)
+    assert result["gap_ratio"] > 5.0
+
+
+def test_fallback_single_blob_low():
+    """Fallback stays low for a single compact blob (no real gap)."""
+    rng = np.random.default_rng(3)
+    points = rng.normal(0, 5, size=(8, 2))
+    result = compute_pose_split_fallback(points)
+    # A diffuse single blob: gap between halves is comparable to spread.
+    assert result["split_score"] < 1.0
+
+
+def test_fallback_too_few_visible_zero():
+    """Fallback returns zeros with too few visible nodes."""
+    points = np.full((6, 2), np.nan)
+    points[0] = [0.0, 0.0]
+    points[1] = [1.0, 1.0]
+    result = compute_pose_split_fallback(points)
+    assert result == {"split_score": 0.0, "split_ratio": 0.0, "gap_ratio": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Integration with sleap_io-built skeleton (smoke test)
+# ---------------------------------------------------------------------------
+
+
+def test_integration_with_sleap_io_skeleton():
+    """End-to-end style: build adjacency/stats like the detector would.
+
+    Uses SkeletonAnalyzer.get_adjacency() and edge-length stats over clean
+    instances, mirroring how the integration layer supplies arguments.
+    """
+    import sleap_io as sio
+
+    from sleap.qc.features.skeleton import SkeletonAnalyzer
+
+    node_names = ["n0", "n1", "n2", "n3", "n4", "n5"]
+    skel = sio.Skeleton(
+        nodes=node_names,
+        edges=[("n0", "n1"), ("n1", "n2"), ("n2", "n3"), ("n3", "n4"), ("n4", "n5")],
+    )
+    analyzer = SkeletonAnalyzer(skel)
+    adj = analyzer.get_adjacency()
+    edges = analyzer.edges
+
+    rng = np.random.default_rng(11)
+    base = np.array([[i * 10.0, 0.0] for i in range(6)])
+    clean = [base + rng.normal(0, 0.4, size=(6, 2)) for _ in range(40)]
+    means, stds = learn_edge_stats(clean, [tuple(sorted(e)) for e in edges])
+
+    # Normal pose -> low.
+    normal_res = compute_pose_split(base.copy(), adj, means, stds)
+    assert normal_res["split_score"] < 0.5
+
+    # Chimera -> high.
+    chimera = base.copy()
+    chimera[3:] += np.array([300.0, 0.0])
+    chimera_res = compute_pose_split(chimera, adj, means, stds)
+    assert chimera_res["split_score"] > normal_res["split_score"]
+    assert chimera_res["split_score"] > 1.0

--- a/tests/qc/test_pose_split.py
+++ b/tests/qc/test_pose_split.py
@@ -51,8 +51,7 @@ def learn_edge_stats(
                 lengths[(i, j)].append(float(np.linalg.norm(p2 - p1)))
     means = {e: (float(np.mean(v)) if v else 0.0) for e, v in lengths.items()}
     stds = {
-        e: max(float(np.std(v)) if v else min_std, min_std)
-        for e, v in lengths.items()
+        e: max(float(np.std(v)) if v else min_std, min_std) for e, v in lengths.items()
     }
     return means, stds
 
@@ -226,9 +225,7 @@ def test_translation_rotation_scale_invariance(normal_chain_stats):
 
     # Rotate 37 degrees + translate.
     theta = np.deg2rad(37.0)
-    rot = np.array(
-        [[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]]
-    )
+    rot = np.array([[np.cos(theta), -np.sin(theta)], [np.sin(theta), np.cos(theta)]])
     moved = points @ rot.T + np.array([123.4, -56.7])
     rt = compute_pose_split(moved, adj, means, stds)
 


### PR DESCRIPTION
**Consolidates the entire Label QC effort onto one branch** for review + real-life testing, superseding the stacked PRs #2765 / #2766 / #2768.

## Related issues
Closes #2769 — Label QC GUI revamp (all 7 items, plus several rounds of real-use follow-ups)

Closes #2758 — filter flagged instances by QC issue type

- Implements #2756 — the six label-error detectors (real-data calibration / threshold tuning is a follow-up, so this issue stays open)
- Part of #2751 — Master Issue: Label QC bugs and issues
- Also carries the #2753 invisible-nodes fix (already merged separately via #2759)

## Scope
- **#2753 fix** — force `invisible_as_nan=True` in QC geometry so invisible nodes never leak coordinates into edge/angle/distance stats (+ `hull_area_zscore` label bug, cleanups).
- **B1 — 5 label-error detectors:** whole-instance L/R flip (c), chimera (d), duplicate/split (a), chain-order (b), missing-node (f Tier-1). Default-ON: flip/chimera/duplicate; experimental/OFF: chain-order/missing.
- **GUI config setter** — per-detector toggles + threshold sliders + user-defined ordered chains, threaded through `QCAnalysisWorker`.
- **B2** — appearance/occluder (e) + in-sample model-prediction (f Tier-2), opt-in non-GMM channels + a model-folder picker.
- **Spine-relative flip fix** — chirality measured against the *local* spine tangent (not the straight Nose→TTI chord), midline incl. Neck/Trunk → flip false-flags **7.62% → 2.04%** on `train.slp` while synthetic reflections still flag 100%.
- **GUI revamp (#2769)** — bioscience-friendly usability: 2-line progress, per-detector "?" help, collapsible `<details>`-style panels (disclosure arrow, no checkbox), filter-by-issue-type (#2758) + "hide reviewed", reviewed checkmarks, plain-language Selected-instance/Statistics, **Restore defaults**, and chain-order tracing on the **real labeled-frame image** (zoom/pan, fit-to-instance) in a pop-up dialog. Plus real-use fixes: charts height locked + panel scroll, empty-chains warning, and a readable sensitivity value on dark themes.

## Validation
All `tests/qc` + GUI QC tests pass (~520+); `ruff check`/`format` clean. Detectors validated on a real 59k-instance CVAT project (`train.slp`); f-T2 validated with a real trained model; GUI verified live on a real `pkg.slp`.

⚠️ The detectors **over-flag at default thresholds** on real heterogeneous data — calibration is the follow-up (tracked under #2756); the GUI sliders make per-project tuning possible.

Supersedes #2765, #2766, #2768.
