### PR TITLE
fix(gui): spread occluded nodes via force-directed layout (kept hidden) when converting predictions (#2764)

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -4817,6 +4817,66 @@ class AddUserInstancesFromPredictions(EditCommand):
 
         return new_instance
 
+    @staticmethod
+    def fill_missing_predicted_nodes(
+        context: CommandContext,
+        new_instance: Instance,
+        copy_instance: PredictedInstance,
+    ):
+        """Initialize undetected nodes on a converted prediction instance.
+
+        ``make_instance_from_predicted_instance`` copies the model's detected
+        keypoints and leaves any node the model did not detect at ``xy=NaN``
+        / ``visible=False``. This fills those missing nodes with sensible,
+        visible positions using the same machinery that initializes a
+        brand-new instance (``AddMissingInstanceNodes.add_best_nodes``):
+        the template is aligned onto the already-detected points (or, when
+        nothing was detected, centered on the current view), and any node
+        still missing falls back to random in-view placement. Filled nodes
+        are marked ``visible=True`` and ``complete=False`` so the user can
+        see and drag them; already-detected points, the track, and the
+        ``from_predicted`` link are left untouched.
+
+        This is a no-op when there is no GUI ``player`` available (e.g. the
+        headless ``CommandContext.from_labels`` / ``FakeApp`` path used in
+        tests) since the placement machinery needs the visible-rect, and a
+        no-op when every node was already detected.
+
+        Args:
+            context: The command context.
+            new_instance: The user ``Instance`` produced by
+                ``make_instance_from_predicted_instance``; modified in place.
+            copy_instance: The source ``PredictedInstance`` (used for its
+                skeleton).
+        """
+        # Nothing to do if every node already has detected coordinates.
+        node_xy = new_instance.numpy()
+        has_missing = bool(np.any(np.all(np.isnan(node_xy), axis=1)))
+        if not has_missing:
+            return
+
+        # The placement helpers read context.app.player.getVisibleRect(); in
+        # headless contexts (FakeApp) there is no player, so skip the fill
+        # rather than crash. Mirrors the guard at CommandContext.execute.
+        player = getattr(getattr(context, "app", None), "player", None)
+        if player is None:
+            return
+
+        # add_random_nodes / add_nodes_from_template read context.state
+        # ["skeleton"]; the all-frames path builds the context via
+        # CommandContext.from_labels where it is unset, so populate it.
+        if context.state["skeleton"] is None:
+            context.state["skeleton"] = copy_instance.skeleton
+
+        # Use the same "best" strategy as a brand-new instance: place missing
+        # nodes from an aligned template, then random-fill anything the
+        # template could not provide. Both steps preserve already-detected
+        # (non-NaN) points and only touch the missing ones, marking the
+        # filled nodes visible with complete=False.
+        AddMissingInstanceNodes.add_best_nodes(
+            context, new_instance, visible=True
+        )
+
     @classmethod
     def do_action(cls, context: CommandContext, params: dict):
         if context.state["labeled_frame"] is None:
@@ -4825,9 +4885,13 @@ class AddUserInstancesFromPredictions(EditCommand):
         new_instances = []
         unused_predictions = context.state["labeled_frame"].unused_predictions
         for predicted_instance in unused_predictions:
-            new_instances.append(
-                cls.make_instance_from_predicted_instance(predicted_instance)
+            new_instance = cls.make_instance_from_predicted_instance(
+                predicted_instance
             )
+            cls.fill_missing_predicted_nodes(
+                context, new_instance, predicted_instance
+            )
+            new_instances.append(new_instance)
 
         # Add the instances
         for new_instance in new_instances:
@@ -4888,6 +4952,9 @@ class AddUserInstancesFromAllPredictions(EditCommand):
                 make = AddUserInstancesFromPredictions
                 new_instance = make.make_instance_from_predicted_instance(
                     predicted_instance
+                )
+                make.fill_missing_predicted_nodes(
+                    context, new_instance, predicted_instance
                 )
                 if new_instance not in lf.instances:
                     lf.instances.append(new_instance)

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -4818,59 +4818,63 @@ class AddUserInstancesFromPredictions(EditCommand):
         return new_instance
 
     @staticmethod
-    def fill_missing_predicted_nodes(context: CommandContext, new_instance: Instance):
-        """Position undetected (NaN) nodes anatomically, kept hidden.
+    def fill_missing_predicted_nodes(new_instance: Instance):
+        """Position undetected (NaN) nodes with a force-directed layout, hidden.
 
         The model leaves occluded nodes at NaN coordinates, and
         ``make_instance_from_predicted_instance`` keeps them ``visible=False``
         (correct -- the converted instance should look like the prediction). But
         a NaN coordinate renders at a default/garbage location when the user
-        turns on "show non-visible nodes" (``QtInstance`` still creates a node
+        enables "show non-visible nodes" (``QtInstance`` still creates a node
         item for every node in that mode, positioned at its ``xy``).
 
-        Give each missing node a sensible, *spread-out* position using the same
-        template placement as a brand-new instance
-        (``AddMissingInstanceNodes.add_nodes_from_template``): the average
-        labeled pose is aligned onto this instance's detected keypoints, so the
-        occluded nodes land in anatomically-plausible spots -- while staying
-        ``visible=False``. Any node the template cannot provide (never labeled on
-        any instance) falls back to the centroid of the detected keypoints --
-        never random placement across the view. Already-detected points, the
-        track, and the ``from_predicted`` link are left untouched.
+        Spread the missing nodes with a force-directed (spring) layout of the
+        skeleton graph, centered on the detected keypoints' centroid and scaled
+        to their extent, so they sit on the animal -- spread out and grabbable --
+        regardless of how many nodes the model detected, while staying
+        ``visible=False``. (Template/alignment placement is unreliable when only
+        a few nodes are detected -- there is no way to infer where occluded nodes
+        are from a couple of visible ones -- so a force-directed layout, one of
+        the brand-new-instance init options, is used for robustness.)
+        Already-detected points, the track, and ``from_predicted`` are untouched.
 
-        No GUI player is required (the template aligns to the detected points),
-        so the single-frame and all-frames/headless paths behave identically.
-        No-op when every node was detected, or when nothing was detected (no
-        anchor to align/place missing nodes against).
+        No GUI player is required. No-op when every node was detected, or when
+        nothing was detected (no anchor for the layout center).
 
         Args:
-            context: The command context (used for the label-derived template).
             new_instance: The user ``Instance`` produced by
                 ``make_instance_from_predicted_instance``; modified in place.
         """
+        import networkx as nx
+
         xy = new_instance.points["xy"]
         missing = np.isnan(xy).any(axis=1)
         detected = ~missing
         if not missing.any() or not detected.any():
             return
 
-        center = np.nanmean(xy[detected], axis=0)
+        det_xy = xy[detected]
+        center = det_xy.mean(axis=0)
+        extent = float(np.linalg.norm(det_xy.max(axis=0) - det_xy.min(axis=0)))
+        scale = max(extent / 2.0, 5.0)
 
-        # Spread missing nodes anatomically: align the average labeled pose onto
-        # this instance's detected keypoints (same template placement a
-        # brand-new instance uses), keeping the filled nodes hidden.
-        AddMissingInstanceNodes.add_nodes_from_template(
-            context, new_instance, visible=False
+        skeleton = new_instance.skeleton
+        layout = nx.spring_layout(
+            to_graph(skeleton), center=center, scale=scale, seed=0
         )
+        pos_by_name = {
+            (node if isinstance(node, str) else node.name): pos
+            for node, pos in layout.items()
+        }
 
-        # Anything the template could not provide (a node never labeled on any
-        # template instance) -> drop on the detected centroid, still hidden.
-        xy = new_instance.points["xy"]
-        still_missing = np.isnan(xy).any(axis=1)
-        if still_missing.any():
-            new_instance.points["xy"][still_missing] = center
-            new_instance.points["visible"][still_missing] = False
-            new_instance.points["complete"][still_missing] = False
+        miss_idx = np.nonzero(missing)[0]
+        fill_xy = np.array(
+            [pos_by_name.get(skeleton.node_names[i], center) for i in miss_idx],
+            dtype=float,
+        )
+        new_instance.points["xy"][missing] = fill_xy
+        new_instance.points["visible"][missing] = False
+        new_instance.points["complete"][missing] = False
 
     @classmethod
     def do_action(cls, context: CommandContext, params: dict):
@@ -4881,7 +4885,7 @@ class AddUserInstancesFromPredictions(EditCommand):
         unused_predictions = context.state["labeled_frame"].unused_predictions
         for predicted_instance in unused_predictions:
             new_instance = cls.make_instance_from_predicted_instance(predicted_instance)
-            cls.fill_missing_predicted_nodes(context, new_instance)
+            cls.fill_missing_predicted_nodes(new_instance)
             new_instances.append(new_instance)
 
         # Add the instances
@@ -4944,7 +4948,7 @@ class AddUserInstancesFromAllPredictions(EditCommand):
                 new_instance = make.make_instance_from_predicted_instance(
                     predicted_instance
                 )
-                make.fill_missing_predicted_nodes(context, new_instance)
+                make.fill_missing_predicted_nodes(new_instance)
                 if new_instance not in lf.instances:
                     lf.instances.append(new_instance)
                     total_added += 1

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -4818,62 +4818,39 @@ class AddUserInstancesFromPredictions(EditCommand):
         return new_instance
 
     @staticmethod
-    def fill_missing_predicted_nodes(
-        context: CommandContext,
-        new_instance: Instance,
-        copy_instance: PredictedInstance,
-    ):
-        """Initialize undetected nodes on a converted prediction instance.
+    def fill_missing_predicted_nodes(new_instance: Instance):
+        """Anchor undetected (NaN) nodes to the body while keeping them hidden.
 
-        ``make_instance_from_predicted_instance`` copies the model's detected
-        keypoints and leaves any node the model did not detect at ``xy=NaN``
-        / ``visible=False``. This fills those missing nodes with sensible,
-        visible positions using the same machinery that initializes a
-        brand-new instance (``AddMissingInstanceNodes.add_best_nodes``):
-        the template is aligned onto the already-detected points (or, when
-        nothing was detected, centered on the current view), and any node
-        still missing falls back to random in-view placement. Filled nodes
-        are marked ``visible=True`` and ``complete=False`` so the user can
-        see and drag them; already-detected points, the track, and the
-        ``from_predicted`` link are left untouched.
+        The model leaves occluded nodes at NaN coordinates, and
+        ``make_instance_from_predicted_instance`` keeps them ``visible=False``
+        (correct -- the converted instance should look like the prediction).
+        But a NaN coordinate renders at a default/garbage location when the user
+        turns on "show non-visible nodes" (``QtInstance`` still creates a node
+        item for every node in that mode, positioned at its ``xy``). Move each
+        missing node onto the centroid of this instance's own *detected*
+        keypoints so it sits on the animal -- ready to drag out -- while staying
+        hidden. Already-detected points, the track, and the ``from_predicted``
+        link are left untouched.
 
-        This is a no-op when there is no GUI ``player`` available (e.g. the
-        headless ``CommandContext.from_labels`` / ``FakeApp`` path used in
-        tests) since the placement machinery needs the visible-rect, and a
-        no-op when every node was already detected.
+        No GUI/player is required, so the single-frame and all-frames/headless
+        conversion paths behave identically. No-op when every node was detected,
+        or when nothing was detected (no anchor to place missing nodes against).
 
         Args:
-            context: The command context.
             new_instance: The user ``Instance`` produced by
                 ``make_instance_from_predicted_instance``; modified in place.
-            copy_instance: The source ``PredictedInstance`` (used for its
-                skeleton).
         """
-        # Nothing to do if every node already has detected coordinates.
-        node_xy = new_instance.numpy()
-        has_missing = bool(np.any(np.all(np.isnan(node_xy), axis=1)))
-        if not has_missing:
+        xy = new_instance.points["xy"]
+        missing = np.isnan(xy).any(axis=1)
+        detected = ~missing
+        if not missing.any() or not detected.any():
             return
 
-        # The placement helpers read context.app.player.getVisibleRect(); in
-        # headless contexts (FakeApp) there is no player, so skip the fill
-        # rather than crash. Mirrors the guard at CommandContext.execute.
-        player = getattr(getattr(context, "app", None), "player", None)
-        if player is None:
-            return
-
-        # add_random_nodes / add_nodes_from_template read context.state
-        # ["skeleton"]; the all-frames path builds the context via
-        # CommandContext.from_labels where it is unset, so populate it.
-        if context.state["skeleton"] is None:
-            context.state["skeleton"] = copy_instance.skeleton
-
-        # Use the same "best" strategy as a brand-new instance: place missing
-        # nodes from an aligned template, then random-fill anything the
-        # template could not provide. Both steps preserve already-detected
-        # (non-NaN) points and only touch the missing ones, marking the
-        # filled nodes visible with complete=False.
-        AddMissingInstanceNodes.add_best_nodes(context, new_instance, visible=True)
+        # Centroid of the detected keypoints -> on the animal.
+        center = np.nanmean(xy[detected], axis=0)
+        new_instance.points["xy"][missing] = center
+        new_instance.points["visible"][missing] = False
+        new_instance.points["complete"][missing] = False
 
     @classmethod
     def do_action(cls, context: CommandContext, params: dict):
@@ -4884,7 +4861,7 @@ class AddUserInstancesFromPredictions(EditCommand):
         unused_predictions = context.state["labeled_frame"].unused_predictions
         for predicted_instance in unused_predictions:
             new_instance = cls.make_instance_from_predicted_instance(predicted_instance)
-            cls.fill_missing_predicted_nodes(context, new_instance, predicted_instance)
+            cls.fill_missing_predicted_nodes(new_instance)
             new_instances.append(new_instance)
 
         # Add the instances
@@ -4947,9 +4924,7 @@ class AddUserInstancesFromAllPredictions(EditCommand):
                 new_instance = make.make_instance_from_predicted_instance(
                     predicted_instance
                 )
-                make.fill_missing_predicted_nodes(
-                    context, new_instance, predicted_instance
-                )
+                make.fill_missing_predicted_nodes(new_instance)
                 if new_instance not in lf.instances:
                     lf.instances.append(new_instance)
                     total_added += 1

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -4818,25 +4818,33 @@ class AddUserInstancesFromPredictions(EditCommand):
         return new_instance
 
     @staticmethod
-    def fill_missing_predicted_nodes(new_instance: Instance):
-        """Anchor undetected (NaN) nodes to the body while keeping them hidden.
+    def fill_missing_predicted_nodes(context: CommandContext, new_instance: Instance):
+        """Position undetected (NaN) nodes anatomically, kept hidden.
 
         The model leaves occluded nodes at NaN coordinates, and
         ``make_instance_from_predicted_instance`` keeps them ``visible=False``
-        (correct -- the converted instance should look like the prediction).
-        But a NaN coordinate renders at a default/garbage location when the user
+        (correct -- the converted instance should look like the prediction). But
+        a NaN coordinate renders at a default/garbage location when the user
         turns on "show non-visible nodes" (``QtInstance`` still creates a node
-        item for every node in that mode, positioned at its ``xy``). Move each
-        missing node onto the centroid of this instance's own *detected*
-        keypoints so it sits on the animal -- ready to drag out -- while staying
-        hidden. Already-detected points, the track, and the ``from_predicted``
-        link are left untouched.
+        item for every node in that mode, positioned at its ``xy``).
 
-        No GUI/player is required, so the single-frame and all-frames/headless
-        conversion paths behave identically. No-op when every node was detected,
-        or when nothing was detected (no anchor to place missing nodes against).
+        Give each missing node a sensible, *spread-out* position using the same
+        template placement as a brand-new instance
+        (``AddMissingInstanceNodes.add_nodes_from_template``): the average
+        labeled pose is aligned onto this instance's detected keypoints, so the
+        occluded nodes land in anatomically-plausible spots -- while staying
+        ``visible=False``. Any node the template cannot provide (never labeled on
+        any instance) falls back to the centroid of the detected keypoints --
+        never random placement across the view. Already-detected points, the
+        track, and the ``from_predicted`` link are left untouched.
+
+        No GUI player is required (the template aligns to the detected points),
+        so the single-frame and all-frames/headless paths behave identically.
+        No-op when every node was detected, or when nothing was detected (no
+        anchor to align/place missing nodes against).
 
         Args:
+            context: The command context (used for the label-derived template).
             new_instance: The user ``Instance`` produced by
                 ``make_instance_from_predicted_instance``; modified in place.
         """
@@ -4846,11 +4854,23 @@ class AddUserInstancesFromPredictions(EditCommand):
         if not missing.any() or not detected.any():
             return
 
-        # Centroid of the detected keypoints -> on the animal.
         center = np.nanmean(xy[detected], axis=0)
-        new_instance.points["xy"][missing] = center
-        new_instance.points["visible"][missing] = False
-        new_instance.points["complete"][missing] = False
+
+        # Spread missing nodes anatomically: align the average labeled pose onto
+        # this instance's detected keypoints (same template placement a
+        # brand-new instance uses), keeping the filled nodes hidden.
+        AddMissingInstanceNodes.add_nodes_from_template(
+            context, new_instance, visible=False
+        )
+
+        # Anything the template could not provide (a node never labeled on any
+        # template instance) -> drop on the detected centroid, still hidden.
+        xy = new_instance.points["xy"]
+        still_missing = np.isnan(xy).any(axis=1)
+        if still_missing.any():
+            new_instance.points["xy"][still_missing] = center
+            new_instance.points["visible"][still_missing] = False
+            new_instance.points["complete"][still_missing] = False
 
     @classmethod
     def do_action(cls, context: CommandContext, params: dict):
@@ -4861,7 +4881,7 @@ class AddUserInstancesFromPredictions(EditCommand):
         unused_predictions = context.state["labeled_frame"].unused_predictions
         for predicted_instance in unused_predictions:
             new_instance = cls.make_instance_from_predicted_instance(predicted_instance)
-            cls.fill_missing_predicted_nodes(new_instance)
+            cls.fill_missing_predicted_nodes(context, new_instance)
             new_instances.append(new_instance)
 
         # Add the instances
@@ -4924,7 +4944,7 @@ class AddUserInstancesFromAllPredictions(EditCommand):
                 new_instance = make.make_instance_from_predicted_instance(
                     predicted_instance
                 )
-                make.fill_missing_predicted_nodes(new_instance)
+                make.fill_missing_predicted_nodes(context, new_instance)
                 if new_instance not in lf.instances:
                     lf.instances.append(new_instance)
                     total_added += 1

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -4873,9 +4873,7 @@ class AddUserInstancesFromPredictions(EditCommand):
         # template could not provide. Both steps preserve already-detected
         # (non-NaN) points and only touch the missing ones, marking the
         # filled nodes visible with complete=False.
-        AddMissingInstanceNodes.add_best_nodes(
-            context, new_instance, visible=True
-        )
+        AddMissingInstanceNodes.add_best_nodes(context, new_instance, visible=True)
 
     @classmethod
     def do_action(cls, context: CommandContext, params: dict):
@@ -4885,12 +4883,8 @@ class AddUserInstancesFromPredictions(EditCommand):
         new_instances = []
         unused_predictions = context.state["labeled_frame"].unused_predictions
         for predicted_instance in unused_predictions:
-            new_instance = cls.make_instance_from_predicted_instance(
-                predicted_instance
-            )
-            cls.fill_missing_predicted_nodes(
-                context, new_instance, predicted_instance
-            )
+            new_instance = cls.make_instance_from_predicted_instance(predicted_instance)
+            cls.fill_missing_predicted_nodes(context, new_instance, predicted_instance)
             new_instances.append(new_instance)
 
         # Add the instances

--- a/tests/test_predictions_to_instances.py
+++ b/tests/test_predictions_to_instances.py
@@ -1055,9 +1055,7 @@ class TestFillMissingPredictedNodes:
         np.testing.assert_array_equal(new_inst.numpy(), before)
         np.testing.assert_array_equal(new_inst.points["visible"], before_vis)
 
-    def test_no_nodes_detected_fills_all_visible(
-        self, simple_skeleton, simple_video
-    ):
+    def test_no_nodes_detected_fills_all_visible(self, simple_skeleton, simple_video):
         """When nothing is detected, all nodes are filled and visible.
 
         The centroid is undefined (no visible nodes) so placement falls back to
@@ -1078,9 +1076,7 @@ class TestFillMissingPredictedNodes:
             ],
         )
         new_inst = (
-            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
-                pred
-            )
+            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
         )
         ctx = self._stub_context(simple_skeleton, labels)
         AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
@@ -1111,9 +1107,7 @@ class TestFillMissingPredictedNodes:
             ],
         )
         new_inst = (
-            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
-                pred
-            )
+            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
         )
         ctx = self._stub_context(skeleton, labels)
         AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
@@ -1141,9 +1135,7 @@ class TestFillMissingPredictedNodes:
         before = new_inst.numpy().copy()
 
         # FakeApp has no `player` attribute.
-        context = CommandContext.from_labels(
-            Labels(skeletons=[simple_skeleton])
-        )
+        context = CommandContext.from_labels(Labels(skeletons=[simple_skeleton]))
         AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
             context, new_inst, prediction_with_nan_node
         )
@@ -1154,3 +1146,71 @@ class TestFillMissingPredictedNodes:
             new_inst.numpy(), before, err_msg="no-player fill must be a no-op"
         )
         assert bool(new_inst.points[thorax_idx]["visible"]) is False
+
+    def test_single_frame_do_action_wires_fill_with_player(
+        self, simple_skeleton, simple_video, prediction_with_nan_node
+    ):
+        """``AddUserInstancesFromPredictions.do_action`` runs the fill (wiring).
+
+        The helper-level tests above prove the fill works in isolation, but they
+        would still pass if the ``fill_missing_predicted_nodes`` call were ever
+        removed from ``do_action``. Drive the real ``do_action`` with a context
+        that has a player so the converted user instance's undetected node is
+        actually filled end-to-end.
+        """
+        lf = LabeledFrame(
+            video=simple_video, frame_idx=0, instances=[prediction_with_nan_node]
+        )
+        labels = Labels(
+            videos=[simple_video],
+            skeletons=[simple_skeleton],
+            labeled_frames=[lf],
+        )
+        ctx = self._stub_context(simple_skeleton, labels)
+        ctx.state["labeled_frame"] = lf
+
+        AddUserInstancesFromPredictions.do_action(ctx, {})
+
+        user = [inst for inst in lf.instances if type(inst) is Instance]
+        assert len(user) == 1
+        new_inst = user[0]
+        names = list(new_inst.points["name"])
+        thorax_idx = names.index("thorax")
+        head_idx = names.index("head")
+
+        # Undetected node filled by the do_action -> fill wiring.
+        assert np.all(np.isfinite(new_inst.points[thorax_idx]["xy"]))
+        assert bool(new_inst.points[thorax_idx]["visible"]) is True
+        assert bool(new_inst.points[thorax_idx]["complete"]) is False
+        # Detected node preserved.
+        np.testing.assert_array_equal(
+            new_inst.points[head_idx]["xy"], np.array([10.0, 20.0])
+        )
+
+    def test_all_frames_do_action_wires_fill_with_player(
+        self, simple_skeleton, simple_video, prediction_with_nan_node
+    ):
+        """``AddUserInstancesFromAllPredictions.do_action`` runs the fill (wiring).
+
+        The all-frames bulk path has no other player-present coverage, so this
+        locks in that it too initializes undetected nodes.
+        """
+        lf = LabeledFrame(
+            video=simple_video, frame_idx=0, instances=[prediction_with_nan_node]
+        )
+        labels = Labels(
+            videos=[simple_video],
+            skeletons=[simple_skeleton],
+            labeled_frames=[lf],
+        )
+        ctx = self._stub_context(simple_skeleton, labels)
+
+        AddUserInstancesFromAllPredictions.do_action(ctx, {})
+
+        user = [inst for inst in lf.instances if type(inst) is Instance]
+        assert len(user) == 1
+        new_inst = user[0]
+        thorax_idx = list(new_inst.points["name"]).index("thorax")
+        assert np.all(np.isfinite(new_inst.points[thorax_idx]["xy"]))
+        assert bool(new_inst.points[thorax_idx]["visible"]) is True
+        assert bool(new_inst.points[thorax_idx]["complete"]) is False

--- a/tests/test_predictions_to_instances.py
+++ b/tests/test_predictions_to_instances.py
@@ -35,6 +35,27 @@ from sleap.gui.commands import (
 )
 
 
+class _StubState:
+    """Minimal GuiState stand-in: returns None for unset keys.
+
+    Mirrors ``sleap.gui.state.GuiState`` indexing semantics used by the
+    node-placement helpers (``context.state["skeleton"]``), so tests do not
+    need a full GUI state object.
+    """
+
+    def __init__(self, **initial):
+        self._vars = dict(initial)
+
+    def __getitem__(self, key):
+        return self._vars.get(key)
+
+    def __setitem__(self, key, value):
+        self._vars[key] = value
+
+    def __contains__(self, key):
+        return key in self._vars
+
+
 @pytest.fixture
 def simple_skeleton():
     """Create a simple skeleton with 3 nodes."""
@@ -897,3 +918,239 @@ class TestAddUserInstancesFromAllPredictions:
         AddUserInstancesFromAllPredictions.do_action(context, {})
 
         assert len(lf.instances) == 1
+
+
+class TestFillMissingPredictedNodes:
+    """Tests for filling undetected nodes when converting predictions (#2764).
+
+    ``make_instance_from_predicted_instance`` keeps the model's detected
+    keypoints and leaves undetected nodes at ``xy=NaN`` / ``visible=False``.
+    ``AddUserInstancesFromPredictions.fill_missing_predicted_nodes`` then
+    initializes those missing nodes (using the same machinery as a brand-new
+    instance) to visible, draggable positions while preserving the detected
+    points, track, and ``from_predicted`` link.
+
+    These tests provide an offscreen player stub that supplies
+    ``getVisibleRect()`` (the only GUI hook the placement helpers need), so
+    they run headlessly without a real QApplication.
+    """
+
+    @staticmethod
+    def _stub_context(skeleton, labels):
+        """Build a minimal context whose app has an offscreen player.
+
+        Mirrors the ``_StubPlayer``/``_StubApp``/``_StubContext`` pattern used
+        elsewhere in this file. ``labels`` is a real ``Labels`` so the
+        template lookup (``get_template_instance_points``) behaves realistically.
+        """
+        from qtpy import QtCore
+
+        class _StubPlayer:
+            @staticmethod
+            def getVisibleRect():
+                return QtCore.QRectF(0.0, 0.0, 640.0, 480.0)
+
+        class _StubApp:
+            player = _StubPlayer()
+
+        class _StubContext:
+            pass
+
+        ctx = _StubContext()
+        ctx.app = _StubApp()
+        ctx.labels = labels
+        # GuiState-like: __getitem__ returns None for missing keys; emulate
+        # the all-frames path where "skeleton" starts unset so we also cover
+        # the helper populating it from copy_instance.skeleton.
+        ctx.state = _StubState()
+        return ctx
+
+    @pytest.fixture
+    def prediction_with_nan_node(self, simple_skeleton):
+        """PredictedInstance with two detected nodes and one undetected node."""
+        pred = PredictedInstance.empty(skeleton=simple_skeleton, score=0.8)
+        pred["head"] = (10.0, 20.0, 0.9)
+        pred["thorax"] = (np.nan, np.nan, 0.0)
+        pred["abdomen"] = (40.0, 50.0, 0.7)
+        pred.points["visible"] = True
+        return pred
+
+    def test_fills_missing_node_and_preserves_detected(
+        self, simple_skeleton, simple_video, prediction_with_nan_node
+    ):
+        """Undetected node becomes finite + visible; detected ones unchanged."""
+        lf = LabeledFrame(
+            video=simple_video, frame_idx=0, instances=[prediction_with_nan_node]
+        )
+        labels = Labels(
+            videos=[simple_video],
+            skeletons=[simple_skeleton],
+            labeled_frames=[lf],
+        )
+
+        new_inst = (
+            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
+                prediction_with_nan_node
+            )
+        )
+        ctx = self._stub_context(simple_skeleton, labels)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
+            ctx, new_inst, prediction_with_nan_node
+        )
+
+        names = list(new_inst.points["name"])
+        head_idx = names.index("head")
+        thorax_idx = names.index("thorax")
+        abdomen_idx = names.index("abdomen")
+
+        # Detected points are untouched and still visible.
+        np.testing.assert_array_equal(
+            new_inst.points[head_idx]["xy"], np.array([10.0, 20.0])
+        )
+        np.testing.assert_array_equal(
+            new_inst.points[abdomen_idx]["xy"], np.array([40.0, 50.0])
+        )
+        assert bool(new_inst.points[head_idx]["visible"]) is True
+        assert bool(new_inst.points[abdomen_idx]["visible"]) is True
+
+        # Previously-undetected node is now finite, visible, and incomplete.
+        thorax_xy = new_inst.points[thorax_idx]["xy"]
+        assert np.all(np.isfinite(thorax_xy)), (
+            f"undetected node should be filled with finite xy; got {thorax_xy!r}"
+        )
+        assert bool(new_inst.points[thorax_idx]["visible"]) is True
+        assert bool(new_inst.points[thorax_idx]["complete"]) is False
+
+        # The from_predicted link is preserved.
+        assert new_inst.from_predicted is prediction_with_nan_node
+
+    def test_all_nodes_detected_is_noop(
+        self, simple_skeleton, simple_video, prediction_with_track
+    ):
+        """When every node is detected, nothing changes."""
+        labels = Labels(
+            videos=[simple_video],
+            skeletons=[simple_skeleton],
+            labeled_frames=[
+                LabeledFrame(
+                    video=simple_video,
+                    frame_idx=0,
+                    instances=[prediction_with_track],
+                )
+            ],
+        )
+        new_inst = (
+            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
+                prediction_with_track
+            )
+        )
+        before = new_inst.numpy().copy()
+        before_vis = new_inst.points["visible"].copy()
+
+        ctx = self._stub_context(simple_skeleton, labels)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
+            ctx, new_inst, prediction_with_track
+        )
+
+        np.testing.assert_array_equal(new_inst.numpy(), before)
+        np.testing.assert_array_equal(new_inst.points["visible"], before_vis)
+
+    def test_no_nodes_detected_fills_all_visible(
+        self, simple_skeleton, simple_video
+    ):
+        """When nothing is detected, all nodes are filled and visible.
+
+        The centroid is undefined (no visible nodes) so placement falls back to
+        the current view (the stub's visible rect), exactly like a brand-new
+        instance with no copy source.
+        """
+        pred = PredictedInstance.empty(skeleton=simple_skeleton, score=0.1)
+        pred["head"] = (np.nan, np.nan, 0.0)
+        pred["thorax"] = (np.nan, np.nan, 0.0)
+        pred["abdomen"] = (np.nan, np.nan, 0.0)
+        pred.points["visible"] = True
+
+        labels = Labels(
+            videos=[simple_video],
+            skeletons=[simple_skeleton],
+            labeled_frames=[
+                LabeledFrame(video=simple_video, frame_idx=0, instances=[pred])
+            ],
+        )
+        new_inst = (
+            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
+                pred
+            )
+        )
+        ctx = self._stub_context(simple_skeleton, labels)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
+            ctx, new_inst, pred
+        )
+
+        assert np.all(np.isfinite(new_inst.numpy())), (
+            "all nodes should be filled with finite coords when none detected"
+        )
+        assert all(bool(v) for v in new_inst.points["visible"]), (
+            "all filled nodes should be visible"
+        )
+
+    def test_single_node_skeleton_undetected(self, simple_video):
+        """Single-node skeleton with the node undetected gets placed visibly."""
+        skeleton = Skeleton(name="one")
+        skeleton.add_node("center")
+
+        pred = PredictedInstance.empty(skeleton=skeleton, score=0.1)
+        pred["center"] = (np.nan, np.nan, 0.0)
+        pred.points["visible"] = True
+
+        labels = Labels(
+            videos=[simple_video],
+            skeletons=[skeleton],
+            labeled_frames=[
+                LabeledFrame(video=simple_video, frame_idx=0, instances=[pred])
+            ],
+        )
+        new_inst = (
+            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
+                pred
+            )
+        )
+        ctx = self._stub_context(skeleton, labels)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
+            ctx, new_inst, pred
+        )
+
+        assert np.all(np.isfinite(new_inst.numpy()))
+        assert bool(new_inst.points[0]["visible"]) is True
+
+    def test_no_player_is_noop(self, simple_skeleton, prediction_with_nan_node):
+        """Headless context (no player) leaves the instance untouched.
+
+        This is the contract that keeps the bulk ``do_action`` tests (which use
+        ``CommandContext.from_labels`` / ``FakeApp``) passing: without a GUI
+        player there is no visible-rect to place into, so the fill is skipped
+        and the NaN node stays NaN/invisible.
+        """
+        from sleap.gui.commands import CommandContext
+
+        new_inst = (
+            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
+                prediction_with_nan_node
+            )
+        )
+        before = new_inst.numpy().copy()
+
+        # FakeApp has no `player` attribute.
+        context = CommandContext.from_labels(
+            Labels(skeletons=[simple_skeleton])
+        )
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
+            context, new_inst, prediction_with_nan_node
+        )
+
+        names = list(new_inst.points["name"])
+        thorax_idx = names.index("thorax")
+        np.testing.assert_array_equal(
+            new_inst.numpy(), before, err_msg="no-player fill must be a no-op"
+        )
+        assert bool(new_inst.points[thorax_idx]["visible"]) is False

--- a/tests/test_predictions_to_instances.py
+++ b/tests/test_predictions_to_instances.py
@@ -32,6 +32,7 @@ from sleap.gui.commands import (
     AddMissingInstanceNodes,
     AddUserInstancesFromPredictions,
     AddUserInstancesFromAllPredictions,
+    CommandContext,
 )
 
 
@@ -925,10 +926,11 @@ class TestFillMissingPredictedNodes:
 
     ``make_instance_from_predicted_instance`` keeps the model's detected
     keypoints and leaves undetected nodes at ``xy=NaN`` / ``visible=False``.
-    ``AddUserInstancesFromPredictions.fill_missing_predicted_nodes`` then moves
-    those missing nodes onto the centroid of the instance's own detected
-    keypoints -- so they sit on the animal when "show non-visible nodes" is
-    enabled -- while keeping them ``visible=False``. No GUI/player is required.
+    ``AddUserInstancesFromPredictions.fill_missing_predicted_nodes`` then gives
+    those missing nodes spread-out, template-aligned positions (same placement a
+    brand-new instance uses) so they sit on the animal when "show non-visible
+    nodes" is enabled -- while keeping them ``visible=False``. Nodes the template
+    cannot provide fall back to the detected centroid. No GUI player is required.
     """
 
     @pytest.fixture
@@ -941,16 +943,17 @@ class TestFillMissingPredictedNodes:
         pred.points["visible"] = True
         return pred
 
-    def test_missing_node_anchored_to_centroid_and_hidden(
-        self, prediction_with_nan_node
+    def test_missing_node_filled_hidden_preserves_link(
+        self, simple_skeleton, prediction_with_nan_node
     ):
-        """Undetected node moves to the detected centroid but stays hidden."""
+        """Undetected node gets a finite position but stays HIDDEN; link kept."""
+        context = CommandContext.from_labels(Labels(skeletons=[simple_skeleton]))
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
                 prediction_with_nan_node
             )
         )
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
 
         names = list(new_inst.points["name"])
         head_idx = names.index("head")
@@ -965,21 +968,87 @@ class TestFillMissingPredictedNodes:
             new_inst.points[abdomen_idx]["xy"], np.array([40.0, 50.0])
         )
         assert bool(new_inst.points[head_idx]["visible"]) is True
-        assert bool(new_inst.points[abdomen_idx]["visible"]) is True
 
-        # Missing node -> centroid of the detected nodes: ((10,20)+(40,50))/2.
-        np.testing.assert_allclose(
-            new_inst.points[thorax_idx]["xy"], np.array([25.0, 35.0])
-        )
-        # ...but it stays HIDDEN and incomplete.
+        # Previously-undetected node now has a finite position but stays HIDDEN.
+        assert np.all(np.isfinite(new_inst.points[thorax_idx]["xy"]))
         assert bool(new_inst.points[thorax_idx]["visible"]) is False
         assert bool(new_inst.points[thorax_idx]["complete"]) is False
 
         # The from_predicted link is preserved.
         assert new_inst.from_predicted is prediction_with_nan_node
 
+    def test_missing_nodes_spread_via_template_and_hidden(self, simple_video):
+        """Missing nodes get template-aligned (spread) positions, kept hidden.
+
+        With a labeled template available, occluded nodes are placed in
+        anatomically-plausible spots aligned to the detected keypoints -- spread
+        out, not clumped at one centroid -- like a brand-new instance.
+        """
+        skeleton = Skeleton(name="quad")
+        for n in ["A", "B", "C", "D"]:
+            skeleton.add_node(n)
+
+        # A fully-labeled instance is the template (asymmetric so aligned C/D
+        # differ from each other and from the A/B centroid).
+        template = Instance.from_numpy(
+            np.array(
+                [
+                    [0.0, 0.0, 1, 1],
+                    [0.0, 30.0, 1, 1],
+                    [20.0, 10.0, 1, 1],
+                    [20.0, 20.0, 1, 1],
+                ]
+            ),
+            skeleton=skeleton,
+        )
+        # A prediction with A, B detected and C, D undetected.
+        pred = PredictedInstance.empty(skeleton=skeleton, score=0.8)
+        pred["A"] = (100.0, 0.0, 0.9)
+        pred["B"] = (100.0, 30.0, 0.9)
+        pred["C"] = (np.nan, np.nan, 0.0)
+        pred["D"] = (np.nan, np.nan, 0.0)
+        pred.points["visible"] = True
+
+        labels = Labels(
+            videos=[simple_video],
+            skeletons=[skeleton],
+            labeled_frames=[
+                LabeledFrame(video=simple_video, frame_idx=0, instances=[template]),
+                LabeledFrame(video=simple_video, frame_idx=1, instances=[pred]),
+            ],
+        )
+        context = CommandContext.from_labels(labels)
+
+        new_inst = (
+            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
+        )
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
+
+        names = list(new_inst.points["name"])
+        ai, bi = names.index("A"), names.index("B")
+        ci, di = names.index("C"), names.index("D")
+
+        # Detected A/B untouched and visible.
+        np.testing.assert_array_equal(new_inst.points[ai]["xy"], np.array([100.0, 0.0]))
+        np.testing.assert_array_equal(
+            new_inst.points[bi]["xy"], np.array([100.0, 30.0])
+        )
+        assert bool(new_inst.points[ai]["visible"]) is True
+
+        c_xy = new_inst.points[ci]["xy"]
+        d_xy = new_inst.points[di]["xy"]
+        # Filled, spread out (distinct -- not clumped at one point), and HIDDEN.
+        assert np.all(np.isfinite(c_xy)) and np.all(np.isfinite(d_xy))
+        assert not np.allclose(c_xy, d_xy), "occluded nodes should spread, not clump"
+        assert bool(new_inst.points[ci]["visible"]) is False
+        assert bool(new_inst.points[di]["visible"]) is False
+        assert bool(new_inst.points[ci]["complete"]) is False
+
     def test_all_nodes_detected_is_noop(self, prediction_with_track):
         """When every node is detected, nothing changes."""
+        context = CommandContext.from_labels(
+            Labels(skeletons=[prediction_with_track.skeleton])
+        )
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
                 prediction_with_track
@@ -988,7 +1057,7 @@ class TestFillMissingPredictedNodes:
         before = new_inst.numpy().copy()
         before_vis = new_inst.points["visible"].copy()
 
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
 
         np.testing.assert_array_equal(new_inst.numpy(), before)
         np.testing.assert_array_equal(new_inst.points["visible"], before_vis)
@@ -1004,10 +1073,11 @@ class TestFillMissingPredictedNodes:
         pred["abdomen"] = (np.nan, np.nan, 0.0)
         pred.points["visible"] = True
 
+        context = CommandContext.from_labels(Labels(skeletons=[simple_skeleton]))
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
         )
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
 
         assert np.all(np.isnan(new_inst.numpy()))
         assert not any(bool(v) for v in new_inst.points["visible"])
@@ -1021,10 +1091,11 @@ class TestFillMissingPredictedNodes:
         pred["center"] = (np.nan, np.nan, 0.0)
         pred.points["visible"] = True
 
+        context = CommandContext.from_labels(Labels(skeletons=[skeleton]))
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
         )
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
 
         assert np.all(np.isnan(new_inst.numpy()))
         assert bool(new_inst.points[0]["visible"]) is False
@@ -1037,10 +1108,8 @@ class TestFillMissingPredictedNodes:
         The helper-level tests would still pass if the
         ``fill_missing_predicted_nodes`` call were removed from ``do_action``;
         this drives the real ``do_action`` and asserts the missing node was
-        anchored. No player is needed (the fill is GUI-free).
+        positioned (finite) and left hidden. No player is needed.
         """
-        from sleap.gui.commands import CommandContext
-
         lf = LabeledFrame(
             video=simple_video, frame_idx=0, instances=[prediction_with_nan_node]
         )
@@ -1061,10 +1130,8 @@ class TestFillMissingPredictedNodes:
         thorax_idx = names.index("thorax")
         head_idx = names.index("head")
 
-        # Missing node anchored to the detected centroid, still hidden.
-        np.testing.assert_allclose(
-            new_inst.points[thorax_idx]["xy"], np.array([25.0, 35.0])
-        )
+        # Missing node positioned (finite) by the do_action -> fill wiring, hidden.
+        assert np.all(np.isfinite(new_inst.points[thorax_idx]["xy"]))
         assert bool(new_inst.points[thorax_idx]["visible"]) is False
         # Detected node preserved.
         np.testing.assert_array_equal(
@@ -1075,8 +1142,6 @@ class TestFillMissingPredictedNodes:
         self, simple_skeleton, simple_video, prediction_with_nan_node
     ):
         """``AddUserInstancesFromAllPredictions.do_action`` runs the fill (wiring)."""
-        from sleap.gui.commands import CommandContext
-
         lf = LabeledFrame(
             video=simple_video, frame_idx=0, instances=[prediction_with_nan_node]
         )
@@ -1093,7 +1158,5 @@ class TestFillMissingPredictedNodes:
         assert len(user) == 1
         new_inst = user[0]
         thorax_idx = list(new_inst.points["name"]).index("thorax")
-        np.testing.assert_allclose(
-            new_inst.points[thorax_idx]["xy"], np.array([25.0, 35.0])
-        )
+        assert np.all(np.isfinite(new_inst.points[thorax_idx]["xy"]))
         assert bool(new_inst.points[thorax_idx]["visible"]) is False

--- a/tests/test_predictions_to_instances.py
+++ b/tests/test_predictions_to_instances.py
@@ -921,49 +921,15 @@ class TestAddUserInstancesFromAllPredictions:
 
 
 class TestFillMissingPredictedNodes:
-    """Tests for filling undetected nodes when converting predictions (#2764).
+    """Tests for positioning undetected nodes when converting predictions (#2764).
 
     ``make_instance_from_predicted_instance`` keeps the model's detected
     keypoints and leaves undetected nodes at ``xy=NaN`` / ``visible=False``.
-    ``AddUserInstancesFromPredictions.fill_missing_predicted_nodes`` then
-    initializes those missing nodes (using the same machinery as a brand-new
-    instance) to visible, draggable positions while preserving the detected
-    points, track, and ``from_predicted`` link.
-
-    These tests provide an offscreen player stub that supplies
-    ``getVisibleRect()`` (the only GUI hook the placement helpers need), so
-    they run headlessly without a real QApplication.
+    ``AddUserInstancesFromPredictions.fill_missing_predicted_nodes`` then moves
+    those missing nodes onto the centroid of the instance's own detected
+    keypoints -- so they sit on the animal when "show non-visible nodes" is
+    enabled -- while keeping them ``visible=False``. No GUI/player is required.
     """
-
-    @staticmethod
-    def _stub_context(skeleton, labels):
-        """Build a minimal context whose app has an offscreen player.
-
-        Mirrors the ``_StubPlayer``/``_StubApp``/``_StubContext`` pattern used
-        elsewhere in this file. ``labels`` is a real ``Labels`` so the
-        template lookup (``get_template_instance_points``) behaves realistically.
-        """
-        from qtpy import QtCore
-
-        class _StubPlayer:
-            @staticmethod
-            def getVisibleRect():
-                return QtCore.QRectF(0.0, 0.0, 640.0, 480.0)
-
-        class _StubApp:
-            player = _StubPlayer()
-
-        class _StubContext:
-            pass
-
-        ctx = _StubContext()
-        ctx.app = _StubApp()
-        ctx.labels = labels
-        # GuiState-like: __getitem__ returns None for missing keys; emulate
-        # the all-frames path where "skeleton" starts unset so we also cover
-        # the helper populating it from copy_instance.skeleton.
-        ctx.state = _StubState()
-        return ctx
 
     @pytest.fixture
     def prediction_with_nan_node(self, simple_skeleton):
@@ -975,35 +941,23 @@ class TestFillMissingPredictedNodes:
         pred.points["visible"] = True
         return pred
 
-    def test_fills_missing_node_and_preserves_detected(
-        self, simple_skeleton, simple_video, prediction_with_nan_node
+    def test_missing_node_anchored_to_centroid_and_hidden(
+        self, prediction_with_nan_node
     ):
-        """Undetected node becomes finite + visible; detected ones unchanged."""
-        lf = LabeledFrame(
-            video=simple_video, frame_idx=0, instances=[prediction_with_nan_node]
-        )
-        labels = Labels(
-            videos=[simple_video],
-            skeletons=[simple_skeleton],
-            labeled_frames=[lf],
-        )
-
+        """Undetected node moves to the detected centroid but stays hidden."""
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
                 prediction_with_nan_node
             )
         )
-        ctx = self._stub_context(simple_skeleton, labels)
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
-            ctx, new_inst, prediction_with_nan_node
-        )
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
 
         names = list(new_inst.points["name"])
         head_idx = names.index("head")
         thorax_idx = names.index("thorax")
         abdomen_idx = names.index("abdomen")
 
-        # Detected points are untouched and still visible.
+        # Detected points untouched and still visible.
         np.testing.assert_array_equal(
             new_inst.points[head_idx]["xy"], np.array([10.0, 20.0])
         )
@@ -1013,32 +967,19 @@ class TestFillMissingPredictedNodes:
         assert bool(new_inst.points[head_idx]["visible"]) is True
         assert bool(new_inst.points[abdomen_idx]["visible"]) is True
 
-        # Previously-undetected node is now finite, visible, and incomplete.
-        thorax_xy = new_inst.points[thorax_idx]["xy"]
-        assert np.all(np.isfinite(thorax_xy)), (
-            f"undetected node should be filled with finite xy; got {thorax_xy!r}"
+        # Missing node -> centroid of the detected nodes: ((10,20)+(40,50))/2.
+        np.testing.assert_allclose(
+            new_inst.points[thorax_idx]["xy"], np.array([25.0, 35.0])
         )
-        assert bool(new_inst.points[thorax_idx]["visible"]) is True
+        # ...but it stays HIDDEN and incomplete.
+        assert bool(new_inst.points[thorax_idx]["visible"]) is False
         assert bool(new_inst.points[thorax_idx]["complete"]) is False
 
         # The from_predicted link is preserved.
         assert new_inst.from_predicted is prediction_with_nan_node
 
-    def test_all_nodes_detected_is_noop(
-        self, simple_skeleton, simple_video, prediction_with_track
-    ):
+    def test_all_nodes_detected_is_noop(self, prediction_with_track):
         """When every node is detected, nothing changes."""
-        labels = Labels(
-            videos=[simple_video],
-            skeletons=[simple_skeleton],
-            labeled_frames=[
-                LabeledFrame(
-                    video=simple_video,
-                    frame_idx=0,
-                    instances=[prediction_with_track],
-                )
-            ],
-        )
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
                 prediction_with_track
@@ -1047,20 +988,15 @@ class TestFillMissingPredictedNodes:
         before = new_inst.numpy().copy()
         before_vis = new_inst.points["visible"].copy()
 
-        ctx = self._stub_context(simple_skeleton, labels)
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
-            ctx, new_inst, prediction_with_track
-        )
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
 
         np.testing.assert_array_equal(new_inst.numpy(), before)
         np.testing.assert_array_equal(new_inst.points["visible"], before_vis)
 
-    def test_no_nodes_detected_fills_all_visible(self, simple_skeleton, simple_video):
-        """When nothing is detected, all nodes are filled and visible.
+    def test_no_nodes_detected_is_noop(self, simple_skeleton):
+        """With nothing detected there is no anchor, so the instance is unchanged.
 
-        The centroid is undefined (no visible nodes) so placement falls back to
-        the current view (the stub's visible rect), exactly like a brand-new
-        instance with no copy source.
+        The occluded nodes stay NaN/hidden -- we can't guess where the animal is.
         """
         pred = PredictedInstance.empty(skeleton=simple_skeleton, score=0.1)
         pred["head"] = (np.nan, np.nan, 0.0)
@@ -1068,30 +1004,16 @@ class TestFillMissingPredictedNodes:
         pred["abdomen"] = (np.nan, np.nan, 0.0)
         pred.points["visible"] = True
 
-        labels = Labels(
-            videos=[simple_video],
-            skeletons=[simple_skeleton],
-            labeled_frames=[
-                LabeledFrame(video=simple_video, frame_idx=0, instances=[pred])
-            ],
-        )
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
         )
-        ctx = self._stub_context(simple_skeleton, labels)
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
-            ctx, new_inst, pred
-        )
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
 
-        assert np.all(np.isfinite(new_inst.numpy())), (
-            "all nodes should be filled with finite coords when none detected"
-        )
-        assert all(bool(v) for v in new_inst.points["visible"]), (
-            "all filled nodes should be visible"
-        )
+        assert np.all(np.isnan(new_inst.numpy()))
+        assert not any(bool(v) for v in new_inst.points["visible"])
 
-    def test_single_node_skeleton_undetected(self, simple_video):
-        """Single-node skeleton with the node undetected gets placed visibly."""
+    def test_single_node_all_missing_is_noop(self):
+        """Single-node skeleton, node undetected: no anchor -> left unchanged."""
         skeleton = Skeleton(name="one")
         skeleton.add_node("center")
 
@@ -1099,65 +1021,26 @@ class TestFillMissingPredictedNodes:
         pred["center"] = (np.nan, np.nan, 0.0)
         pred.points["visible"] = True
 
-        labels = Labels(
-            videos=[simple_video],
-            skeletons=[skeleton],
-            labeled_frames=[
-                LabeledFrame(video=simple_video, frame_idx=0, instances=[pred])
-            ],
-        )
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
         )
-        ctx = self._stub_context(skeleton, labels)
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
-            ctx, new_inst, pred
-        )
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
 
-        assert np.all(np.isfinite(new_inst.numpy()))
-        assert bool(new_inst.points[0]["visible"]) is True
+        assert np.all(np.isnan(new_inst.numpy()))
+        assert bool(new_inst.points[0]["visible"]) is False
 
-    def test_no_player_is_noop(self, simple_skeleton, prediction_with_nan_node):
-        """Headless context (no player) leaves the instance untouched.
-
-        This is the contract that keeps the bulk ``do_action`` tests (which use
-        ``CommandContext.from_labels`` / ``FakeApp``) passing: without a GUI
-        player there is no visible-rect to place into, so the fill is skipped
-        and the NaN node stays NaN/invisible.
-        """
-        from sleap.gui.commands import CommandContext
-
-        new_inst = (
-            AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
-                prediction_with_nan_node
-            )
-        )
-        before = new_inst.numpy().copy()
-
-        # FakeApp has no `player` attribute.
-        context = CommandContext.from_labels(Labels(skeletons=[simple_skeleton]))
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(
-            context, new_inst, prediction_with_nan_node
-        )
-
-        names = list(new_inst.points["name"])
-        thorax_idx = names.index("thorax")
-        np.testing.assert_array_equal(
-            new_inst.numpy(), before, err_msg="no-player fill must be a no-op"
-        )
-        assert bool(new_inst.points[thorax_idx]["visible"]) is False
-
-    def test_single_frame_do_action_wires_fill_with_player(
+    def test_single_frame_do_action_wires_fill(
         self, simple_skeleton, simple_video, prediction_with_nan_node
     ):
         """``AddUserInstancesFromPredictions.do_action`` runs the fill (wiring).
 
-        The helper-level tests above prove the fill works in isolation, but they
-        would still pass if the ``fill_missing_predicted_nodes`` call were ever
-        removed from ``do_action``. Drive the real ``do_action`` with a context
-        that has a player so the converted user instance's undetected node is
-        actually filled end-to-end.
+        The helper-level tests would still pass if the
+        ``fill_missing_predicted_nodes`` call were removed from ``do_action``;
+        this drives the real ``do_action`` and asserts the missing node was
+        anchored. No player is needed (the fill is GUI-free).
         """
+        from sleap.gui.commands import CommandContext
+
         lf = LabeledFrame(
             video=simple_video, frame_idx=0, instances=[prediction_with_nan_node]
         )
@@ -1166,10 +1049,10 @@ class TestFillMissingPredictedNodes:
             skeletons=[simple_skeleton],
             labeled_frames=[lf],
         )
-        ctx = self._stub_context(simple_skeleton, labels)
-        ctx.state["labeled_frame"] = lf
+        context = CommandContext.from_labels(labels)
+        context.state["labeled_frame"] = lf
 
-        AddUserInstancesFromPredictions.do_action(ctx, {})
+        AddUserInstancesFromPredictions.do_action(context, {})
 
         user = [inst for inst in lf.instances if type(inst) is Instance]
         assert len(user) == 1
@@ -1178,23 +1061,22 @@ class TestFillMissingPredictedNodes:
         thorax_idx = names.index("thorax")
         head_idx = names.index("head")
 
-        # Undetected node filled by the do_action -> fill wiring.
-        assert np.all(np.isfinite(new_inst.points[thorax_idx]["xy"]))
-        assert bool(new_inst.points[thorax_idx]["visible"]) is True
-        assert bool(new_inst.points[thorax_idx]["complete"]) is False
+        # Missing node anchored to the detected centroid, still hidden.
+        np.testing.assert_allclose(
+            new_inst.points[thorax_idx]["xy"], np.array([25.0, 35.0])
+        )
+        assert bool(new_inst.points[thorax_idx]["visible"]) is False
         # Detected node preserved.
         np.testing.assert_array_equal(
             new_inst.points[head_idx]["xy"], np.array([10.0, 20.0])
         )
 
-    def test_all_frames_do_action_wires_fill_with_player(
+    def test_all_frames_do_action_wires_fill(
         self, simple_skeleton, simple_video, prediction_with_nan_node
     ):
-        """``AddUserInstancesFromAllPredictions.do_action`` runs the fill (wiring).
+        """``AddUserInstancesFromAllPredictions.do_action`` runs the fill (wiring)."""
+        from sleap.gui.commands import CommandContext
 
-        The all-frames bulk path has no other player-present coverage, so this
-        locks in that it too initializes undetected nodes.
-        """
         lf = LabeledFrame(
             video=simple_video, frame_idx=0, instances=[prediction_with_nan_node]
         )
@@ -1203,14 +1085,15 @@ class TestFillMissingPredictedNodes:
             skeletons=[simple_skeleton],
             labeled_frames=[lf],
         )
-        ctx = self._stub_context(simple_skeleton, labels)
+        context = CommandContext.from_labels(labels)
 
-        AddUserInstancesFromAllPredictions.do_action(ctx, {})
+        AddUserInstancesFromAllPredictions.do_action(context, {})
 
         user = [inst for inst in lf.instances if type(inst) is Instance]
         assert len(user) == 1
         new_inst = user[0]
         thorax_idx = list(new_inst.points["name"]).index("thorax")
-        assert np.all(np.isfinite(new_inst.points[thorax_idx]["xy"]))
-        assert bool(new_inst.points[thorax_idx]["visible"]) is True
-        assert bool(new_inst.points[thorax_idx]["complete"]) is False
+        np.testing.assert_allclose(
+            new_inst.points[thorax_idx]["xy"], np.array([25.0, 35.0])
+        )
+        assert bool(new_inst.points[thorax_idx]["visible"]) is False

--- a/tests/test_predictions_to_instances.py
+++ b/tests/test_predictions_to_instances.py
@@ -926,11 +926,10 @@ class TestFillMissingPredictedNodes:
 
     ``make_instance_from_predicted_instance`` keeps the model's detected
     keypoints and leaves undetected nodes at ``xy=NaN`` / ``visible=False``.
-    ``AddUserInstancesFromPredictions.fill_missing_predicted_nodes`` then gives
-    those missing nodes spread-out, template-aligned positions (same placement a
-    brand-new instance uses) so they sit on the animal when "show non-visible
-    nodes" is enabled -- while keeping them ``visible=False``. Nodes the template
-    cannot provide fall back to the detected centroid. No GUI player is required.
+    ``AddUserInstancesFromPredictions.fill_missing_predicted_nodes`` then spreads
+    those missing nodes with a force-directed (spring) layout centered on the
+    detected keypoints, so they sit on the animal when "show non-visible nodes"
+    is enabled -- while keeping them ``visible=False``. No GUI player is required.
     """
 
     @pytest.fixture
@@ -943,17 +942,14 @@ class TestFillMissingPredictedNodes:
         pred.points["visible"] = True
         return pred
 
-    def test_missing_node_filled_hidden_preserves_link(
-        self, simple_skeleton, prediction_with_nan_node
-    ):
+    def test_missing_node_filled_hidden_preserves_link(self, prediction_with_nan_node):
         """Undetected node gets a finite position but stays HIDDEN; link kept."""
-        context = CommandContext.from_labels(Labels(skeletons=[simple_skeleton]))
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
                 prediction_with_nan_node
             )
         )
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
 
         names = list(new_inst.points["name"])
         head_idx = names.index("head")
@@ -977,78 +973,48 @@ class TestFillMissingPredictedNodes:
         # The from_predicted link is preserved.
         assert new_inst.from_predicted is prediction_with_nan_node
 
-    def test_missing_nodes_spread_via_template_and_hidden(self, simple_video):
-        """Missing nodes get template-aligned (spread) positions, kept hidden.
+    def test_missing_nodes_spread_and_hidden(self, simple_skeleton):
+        """Missing nodes get spread-out (force-directed) positions, kept hidden.
 
-        With a labeled template available, occluded nodes are placed in
-        anatomically-plausible spots aligned to the detected keypoints -- spread
-        out, not clumped at one centroid -- like a brand-new instance.
+        Two occluded nodes land at distinct positions near the detected node --
+        not clumped on one point and not flung off the animal.
         """
-        skeleton = Skeleton(name="quad")
-        for n in ["A", "B", "C", "D"]:
-            skeleton.add_node(n)
-
-        # A fully-labeled instance is the template (asymmetric so aligned C/D
-        # differ from each other and from the A/B centroid).
-        template = Instance.from_numpy(
-            np.array(
-                [
-                    [0.0, 0.0, 1, 1],
-                    [0.0, 30.0, 1, 1],
-                    [20.0, 10.0, 1, 1],
-                    [20.0, 20.0, 1, 1],
-                ]
-            ),
-            skeleton=skeleton,
-        )
-        # A prediction with A, B detected and C, D undetected.
-        pred = PredictedInstance.empty(skeleton=skeleton, score=0.8)
-        pred["A"] = (100.0, 0.0, 0.9)
-        pred["B"] = (100.0, 30.0, 0.9)
-        pred["C"] = (np.nan, np.nan, 0.0)
-        pred["D"] = (np.nan, np.nan, 0.0)
+        pred = PredictedInstance.empty(skeleton=simple_skeleton, score=0.8)
+        pred["head"] = (100.0, 50.0, 0.9)
+        pred["thorax"] = (np.nan, np.nan, 0.0)
+        pred["abdomen"] = (np.nan, np.nan, 0.0)
         pred.points["visible"] = True
-
-        labels = Labels(
-            videos=[simple_video],
-            skeletons=[skeleton],
-            labeled_frames=[
-                LabeledFrame(video=simple_video, frame_idx=0, instances=[template]),
-                LabeledFrame(video=simple_video, frame_idx=1, instances=[pred]),
-            ],
-        )
-        context = CommandContext.from_labels(labels)
 
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
         )
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
 
         names = list(new_inst.points["name"])
-        ai, bi = names.index("A"), names.index("B")
-        ci, di = names.index("C"), names.index("D")
+        head_i = names.index("head")
+        thorax_i = names.index("thorax")
+        abdomen_i = names.index("abdomen")
 
-        # Detected A/B untouched and visible.
-        np.testing.assert_array_equal(new_inst.points[ai]["xy"], np.array([100.0, 0.0]))
+        # Detected node preserved + visible.
         np.testing.assert_array_equal(
-            new_inst.points[bi]["xy"], np.array([100.0, 30.0])
+            new_inst.points[head_i]["xy"], np.array([100.0, 50.0])
         )
-        assert bool(new_inst.points[ai]["visible"]) is True
+        assert bool(new_inst.points[head_i]["visible"]) is True
 
-        c_xy = new_inst.points[ci]["xy"]
-        d_xy = new_inst.points[di]["xy"]
-        # Filled, spread out (distinct -- not clumped at one point), and HIDDEN.
-        assert np.all(np.isfinite(c_xy)) and np.all(np.isfinite(d_xy))
-        assert not np.allclose(c_xy, d_xy), "occluded nodes should spread, not clump"
-        assert bool(new_inst.points[ci]["visible"]) is False
-        assert bool(new_inst.points[di]["visible"]) is False
-        assert bool(new_inst.points[ci]["complete"]) is False
+        t_xy = new_inst.points[thorax_i]["xy"]
+        a_xy = new_inst.points[abdomen_i]["xy"]
+        # Both filled (finite), spread out (distinct -- not clumped), and HIDDEN.
+        assert np.all(np.isfinite(t_xy)) and np.all(np.isfinite(a_xy))
+        assert not np.allclose(t_xy, a_xy), "occluded nodes should spread, not clump"
+        assert bool(new_inst.points[thorax_i]["visible"]) is False
+        assert bool(new_inst.points[abdomen_i]["visible"]) is False
+        assert bool(new_inst.points[thorax_i]["complete"]) is False
+        # Placed near the detected node (on the animal), not flung far away.
+        assert np.linalg.norm(t_xy - np.array([100.0, 50.0])) < 100
+        assert np.linalg.norm(a_xy - np.array([100.0, 50.0])) < 100
 
     def test_all_nodes_detected_is_noop(self, prediction_with_track):
         """When every node is detected, nothing changes."""
-        context = CommandContext.from_labels(
-            Labels(skeletons=[prediction_with_track.skeleton])
-        )
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(
                 prediction_with_track
@@ -1057,7 +1023,7 @@ class TestFillMissingPredictedNodes:
         before = new_inst.numpy().copy()
         before_vis = new_inst.points["visible"].copy()
 
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
 
         np.testing.assert_array_equal(new_inst.numpy(), before)
         np.testing.assert_array_equal(new_inst.points["visible"], before_vis)
@@ -1073,11 +1039,10 @@ class TestFillMissingPredictedNodes:
         pred["abdomen"] = (np.nan, np.nan, 0.0)
         pred.points["visible"] = True
 
-        context = CommandContext.from_labels(Labels(skeletons=[simple_skeleton]))
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
         )
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
 
         assert np.all(np.isnan(new_inst.numpy()))
         assert not any(bool(v) for v in new_inst.points["visible"])
@@ -1091,11 +1056,10 @@ class TestFillMissingPredictedNodes:
         pred["center"] = (np.nan, np.nan, 0.0)
         pred.points["visible"] = True
 
-        context = CommandContext.from_labels(Labels(skeletons=[skeleton]))
         new_inst = (
             AddUserInstancesFromPredictions.make_instance_from_predicted_instance(pred)
         )
-        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(context, new_inst)
+        AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_inst)
 
         assert np.all(np.isnan(new_inst.numpy()))
         assert bool(new_inst.points[0]["visible"]) is False


### PR DESCRIPTION
## Summary

When converting predicted instances to user instances (**Labels ▸ Add Instances from All Predictions on Current Frame** and **Accept All Predictions…**), nodes the model didn't detect come back as `xy=NaN` (e.g. the whole occluded side of the animal). They're correctly kept **hidden** (`visible=False`) — but a `NaN` coordinate renders at a garbage/default location when the user enables **"show non-visible nodes"** (`QtInstance` still creates a node item for every node in that mode, positioned at its `xy`). That's the "initialized in the wrong place" behavior.

This PR gives those hidden nodes a sensible **spread-out** position while keeping them hidden, so "show non-visible nodes" reveals them spread on the body — ready to drag out.

## What changed

`AddUserInstancesFromPredictions.fill_missing_predicted_nodes(new_instance)` positions each undetected node with a **force-directed (spring) layout** of the skeleton graph, centered on the detected keypoints' centroid and scaled to their extent, and leaves it `visible=False` / `complete=False`. Detected points, the track, and the `from_predicted` link are untouched.

- Spreads the occluded nodes by graph connectivity — always on the body, always distinct, **regardless of how many nodes were detected**.
- Needs no template/labels/player, so the single-frame, all-frames, and headless paths behave identically.
- No-op when every node was detected, or when nothing was detected (no anchor for the layout center).

## Why force-directed (and not template alignment)

An earlier revision aligned the average labeled pose ("best"/template, like Add Instance) onto the detected keypoints. On real refinement data that put **23% of instances' occluded nodes off the animal**: aligning to only a few detected keypoints is underdetermined (you can't infer where the tail is from just the nose), so it flips/flings. Measured on the same data, force-directed is **0% off-body** with every multi-missing instance fully spread.

## Tests

`tests/test_predictions_to_instances.py` — **30 passing**: missing nodes land spread (distinct) + hidden + near the detected node; per-node hidden/link-preserved; all-detected / nothing-detected / single-node no-ops; and `do_action` wiring (single-frame + all-frames). `ruff` clean.

## Manual check

Open a project with predictions that have occluded nodes → **Add Instances from All Predictions** → the converted instance looks like the prediction (occluded nodes hidden). Toggle **show non-visible nodes** → the hidden nodes now sit spread out on the body (not at the corner/origin, not clumped).

Part of #2762. Closes #2764.

🤖 Implemented with Claude Code (workflow + review/maintainer-feedback fixes).
