### PR TITLE
feat(gui): per-instance visibility & view-only toggles in the Instances dock (#2755)

### DIFF
--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -106,7 +106,11 @@ from sleap.gui.overlays.instance import InstanceOverlay
 from sleap.gui.overlays.negative_frame import NegativeFrameOverlay
 from sleap.gui.overlays.tracks import TrackListOverlay, TrackTrailOverlay
 from sleap.gui.shortcuts import Shortcuts
-from sleap.gui.state import GuiState
+from sleap.gui.state import (
+    GuiState,
+    INSTANCE_HIDDEN_KEY,
+    VIEW_ONLY_INSTANCE_KEY,
+)
 from sleap.gui.web import ping_analytics
 from sleap.gui.widgets.docks import (
     InstancesDock,
@@ -193,6 +197,10 @@ class MainWindow(QMainWindow):
         self.state["show instances"] = True
         self.state["show labels"] = True
         self.state["show edges"] = True
+        # Transient per-instance canvas visibility (Instances dock checkboxes).
+        # Reset on every frame change in `_after_plot_change`; never persisted.
+        self.state[INSTANCE_HIDDEN_KEY] = set()
+        self.state[VIEW_ONLY_INSTANCE_KEY] = None
         self.state["edge style"] = prefs["edge style"]
         self.state["fit"] = False
         self.state["fit_selection"] = False
@@ -1452,6 +1460,14 @@ class MainWindow(QMainWindow):
             if frame_idx is not None
             else None
         )
+
+        # Reset transient per-instance visibility on every frame change:
+        # instances differ per frame and both the canvas and the Instances dock
+        # table rebuild here, so the defaults (all visible, no view-only) are the
+        # natural state for the new frame. Must run BEFORE the overlay redraw
+        # below so the instance overlay applies the cleared state.
+        self.state[INSTANCE_HIDDEN_KEY] = set()
+        self.state[VIEW_ONLY_INSTANCE_KEY] = None
 
         # Show instances, etc, for this frame
         for overlay in self.overlays.values():

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -198,9 +198,13 @@ class MainWindow(QMainWindow):
         self.state["show labels"] = True
         self.state["show edges"] = True
         # Transient per-instance canvas visibility (Instances dock checkboxes).
-        # Reset on every frame change in `_after_plot_change`; never persisted.
+        # Reset on each real frame change in `_after_plot_change`; never persisted.
         self.state[INSTANCE_HIDDEN_KEY] = set()
         self.state[VIEW_ONLY_INSTANCE_KEY] = None
+        # (video, frame_idx) of the last plotted frame, so `_after_plot_change`
+        # clears the transient visibility above only when the frame truly changes
+        # (not on same-frame replots like marker-size or add-instance).
+        self._vis_last_frame_key = None
         self.state["edge style"] = prefs["edge style"]
         self.state["fit"] = False
         self.state["fit_selection"] = False
@@ -1461,13 +1465,18 @@ class MainWindow(QMainWindow):
             else None
         )
 
-        # Reset transient per-instance visibility on every frame change:
-        # instances differ per frame and both the canvas and the Instances dock
-        # table rebuild here, so the defaults (all visible, no view-only) are the
-        # natural state for the new frame. Must run BEFORE the overlay redraw
-        # below so the instance overlay applies the cleared state.
-        self.state[INSTANCE_HIDDEN_KEY] = set()
-        self.state[VIEW_ONLY_INSTANCE_KEY] = None
+        # Reset transient per-instance visibility only when the frame actually
+        # changes: the instances (and thus the id()-keyed visibility state)
+        # differ per frame. `_after_plot_change` also fires on same-frame replots
+        # (marker size, add instance, palette, etc.); resetting there would wipe
+        # the user's hide / view-only selections, so gate on the (video,
+        # frame_idx) key. Must run BEFORE the overlay redraw below so the
+        # instance overlay applies the cleared state.
+        frame_key = (self.state["video"], frame_idx)
+        if frame_key != self._vis_last_frame_key:
+            self._vis_last_frame_key = frame_key
+            self.state[INSTANCE_HIDDEN_KEY] = set()
+            self.state[VIEW_ONLY_INSTANCE_KEY] = None
 
         # Show instances, etc, for this frame
         for overlay in self.overlays.values():

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -24,7 +24,12 @@ import numpy as np
 from qtpy import QtCore, QtGui, QtWidgets
 
 from sleap.gui.commands import CommandContext
-from sleap.gui.state import GuiState
+from sleap.gui.state import (
+    GuiState,
+    INSTANCE_HIDDEN_KEY,
+    VIEW_ONLY_INSTANCE_KEY,
+    instance_visible,
+)
 from sleap_io.model.skeleton import Skeleton
 from sleap_io import Video
 from sleap_io import LabeledFrame
@@ -469,12 +474,36 @@ class LabeledFrameTableModel(GenericTableModel):
 
     Allows editing track names.
 
+    In addition to the informational columns, two checkbox columns control
+    per-instance rendering on the video canvas (transient, session-only state;
+    see `sleap.gui.state.instance_visible`):
+
+    - "visibility": checked by default; unchecking hides that instance on the
+      canvas while keeping its row in the table.
+    - "view only": unchecked by default; checking exactly one row makes only
+      that instance visible and disables the whole visibility column. Checking
+      another row's "view only" auto-unchecks the previous (radio-like).
+      Toggling any "visibility" box exits view-only mode.
+
     Args:
         labeled_frame: `LabeledFrame` to show
         labels: `Labels` datasource
     """
 
-    properties = ("points", "track", "score", "mean node score", "skeleton")
+    # The two checkbox columns are appended LAST so existing name-indexed
+    # lookups (e.g. ``properties.index("mean node score")``) stay valid.
+    VISIBILITY_KEY = "visibility"
+    VIEW_ONLY_KEY = "view only"
+
+    properties = (
+        "points",
+        "track",
+        "score",
+        "mean node score",
+        "skeleton",
+        VISIBILITY_KEY,
+        VIEW_ONLY_KEY,
+    )
 
     def object_to_items(self, labeled_frame: LabeledFrame):
         if not labeled_frame:
@@ -526,6 +555,155 @@ class LabeledFrameTableModel(GenericTableModel):
     def set_item(self, item, key, value):
         if key == "track":
             self.context.setTrackName(item.track, value)
+
+    # -- Per-instance visibility checkbox columns -------------------------------
+
+    @property
+    def _checkbox_keys(self):
+        return (self.VISIBILITY_KEY, self.VIEW_ONLY_KEY)
+
+    @property
+    def _vis_state(self) -> GuiState:
+        """The `GuiState` holding the transient visibility keys.
+
+        Uses the command context's `GuiState` (shared with the app and the
+        instance overlay) when available. Falls back to a private `GuiState`
+        when there is no context (e.g. unit tests that build the model without
+        a `MainWindow`), so the checkbox columns still work in isolation.
+        """
+        if self.context is not None and self.context.state is not None:
+            return self.context.state
+        if getattr(self, "_local_vis_state", None) is None:
+            self._local_vis_state = GuiState()
+        return self._local_vis_state
+
+    def _apply_canvas_visibility(self):
+        """Re-apply effective per-instance visibility to the canvas, if any.
+
+        Iterates the live `QtInstance` objects on the player and shows/hides
+        each according to `instance_visible`. No-op when there is no player
+        (headless/unit-test paths), since the overlay re-applies on the next
+        replot regardless.
+        """
+        app = getattr(self.context, "app", None) if self.context else None
+        player = getattr(app, "player", None)
+        if player is None:
+            return
+        state = self._vis_state
+        for qt_inst in player.view.all_instances:
+            qt_inst.setVisible(instance_visible(state, qt_inst.instance))
+
+    def is_visibility_checked(self, instance) -> bool:
+        """Whether the "visibility" box is checked for the given instance."""
+        hidden = self._vis_state.get(INSTANCE_HIDDEN_KEY, default=None)
+        return not hidden or id(instance) not in hidden
+
+    def is_view_only_checked(self, instance) -> bool:
+        """Whether the "view only" box is checked for the given instance."""
+        view_only = self._vis_state.get(VIEW_ONLY_INSTANCE_KEY, default=None)
+        return view_only is not None and id(instance) == view_only
+
+    def data(self, index: QtCore.QModelIndex, role=QtCore.Qt.DisplayRole):
+        """Overrides Qt method to add checkbox state for the new columns."""
+        if not index.isValid():
+            return None
+
+        key = self.properties[index.column()]
+        if key in self._checkbox_keys:
+            if role == QtCore.Qt.CheckStateRole:
+                instance = self.original_items[index.row()]
+                if key == self.VISIBILITY_KEY:
+                    checked = self.is_visibility_checked(instance)
+                else:
+                    checked = self.is_view_only_checked(instance)
+                return QtCore.Qt.Checked if checked else QtCore.Qt.Unchecked
+            # No text/color/tooltip for the checkbox columns.
+            return None
+
+        return super().data(index, role)
+
+    def flags(self, index: QtCore.QModelIndex):
+        """Overrides Qt method to make the new columns user-checkable.
+
+        The "visibility" column is disabled (greyed out) while a "view only"
+        instance is active, but the row stays selectable so clicking it still
+        selects the instance.
+        """
+        key = self.properties[index.column()]
+        if key not in self._checkbox_keys:
+            return super().flags(index)
+
+        flags = QtCore.Qt.ItemIsSelectable
+        view_only_active = (
+            self._vis_state.get(VIEW_ONLY_INSTANCE_KEY, default=None) is not None
+        )
+        if key == self.VISIBILITY_KEY and view_only_active:
+            # Disabled (greyed out) and not checkable during view-only mode.
+            return flags
+        flags |= QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsUserCheckable
+        return flags
+
+    def setData(self, index: QtCore.QModelIndex, value, role=QtCore.Qt.EditRole):
+        """Overrides Qt method to toggle the per-instance visibility state."""
+        if index.isValid() and role == QtCore.Qt.CheckStateRole:
+            key = self.properties[index.column()]
+            if key in self._checkbox_keys:
+                instance = self.original_items[index.row()]
+                # ``value`` may be a plain int (PySide6 passes 0/2 from the view)
+                # or a ``Qt.CheckState`` enum (e.g. our tests, or other
+                # bindings). ``Qt.CheckState`` is a non-int Enum in PySide6, so
+                # normalize via its ``.value`` before comparing (mirrors the
+                # convention in sleap/gui/dialogs/qc.py:230).
+                checked = getattr(value, "value", value) == QtCore.Qt.Checked.value
+                if key == self.VISIBILITY_KEY:
+                    self._set_visibility(instance, checked)
+                else:
+                    self._set_view_only(instance, checked)
+                return True
+
+        return super().setData(index, value, role)
+
+    def _set_visibility(self, instance, checked: bool):
+        """Toggle an instance's visibility box (also exits view-only mode)."""
+        state = self._vis_state
+        # Spec: clicking any visibility box exits view-only mode.
+        state[VIEW_ONLY_INSTANCE_KEY] = None
+
+        hidden = set(state.get(INSTANCE_HIDDEN_KEY, default=None) or set())
+        if checked:
+            hidden.discard(id(instance))
+        else:
+            hidden.add(id(instance))
+        state[INSTANCE_HIDDEN_KEY] = hidden
+
+        self._refresh_after_toggle()
+
+    def _set_view_only(self, instance, checked: bool):
+        """Toggle an instance's view-only box (radio-like exclusivity)."""
+        state = self._vis_state
+        if checked:
+            # Overwriting auto-unchecks any previously selected view-only row.
+            state[VIEW_ONLY_INSTANCE_KEY] = id(instance)
+        elif state.get(VIEW_ONLY_INSTANCE_KEY, default=None) == id(instance):
+            state[VIEW_ONLY_INSTANCE_KEY] = None
+
+        self._refresh_after_toggle()
+
+    def _refresh_after_toggle(self):
+        """Apply the new state to the canvas and repaint the whole table.
+
+        The full-table ``dataChanged`` re-queries both `data` (checkbox states)
+        and `flags` (so the visibility column greys out / re-enables when
+        view-only mode changes).
+        """
+        self._apply_canvas_visibility()
+        rows = self.rowCount()
+        cols = self.columnCount()
+        if rows and cols:
+            self.dataChanged.emit(
+                self.index(0, 0),
+                self.index(rows - 1, cols - 1),
+            )
 
 
 class SuggestionsTableModel(GenericTableModel):

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -617,7 +617,18 @@ class LabeledFrameTableModel(GenericTableModel):
                 else:
                     checked = self.is_view_only_checked(instance)
                 return QtCore.Qt.Checked if checked else QtCore.Qt.Unchecked
-            # No text/color/tooltip for the checkbox columns.
+            if (
+                role == QtCore.Qt.BackgroundRole
+                and key == self.VISIBILITY_KEY
+                and self._vis_state.get(VIEW_ONLY_INSTANCE_KEY, default=None)
+                is not None
+            ):
+                # Greyed-but-clickable: tint the visibility column while a
+                # view-only instance is active to show it is overridden. The
+                # cell stays checkable (see `flags`) so clicking it exits
+                # view-only mode.
+                return QtGui.QColor(128, 128, 128, 64)
+            # No text/color/tooltip for the checkbox columns otherwise.
             return None
 
         return super().data(index, role)
@@ -625,23 +636,20 @@ class LabeledFrameTableModel(GenericTableModel):
     def flags(self, index: QtCore.QModelIndex):
         """Overrides Qt method to make the new columns user-checkable.
 
-        The "visibility" column is disabled (greyed out) while a "view only"
-        instance is active, but the row stays selectable so clicking it still
-        selects the instance.
+        Both checkbox columns stay enabled and user-checkable at all times.
+        During view-only mode the "visibility" column is rendered greyed (see
+        `data`) to signal it is overridden, but it remains clickable so that
+        toggling any visibility box exits view-only mode (per the feature spec).
         """
         key = self.properties[index.column()]
         if key not in self._checkbox_keys:
             return super().flags(index)
 
-        flags = QtCore.Qt.ItemIsSelectable
-        view_only_active = (
-            self._vis_state.get(VIEW_ONLY_INSTANCE_KEY, default=None) is not None
+        return (
+            QtCore.Qt.ItemIsSelectable
+            | QtCore.Qt.ItemIsEnabled
+            | QtCore.Qt.ItemIsUserCheckable
         )
-        if key == self.VISIBILITY_KEY and view_only_active:
-            # Disabled (greyed out) and not checkable during view-only mode.
-            return flags
-        flags |= QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsUserCheckable
-        return flags
 
     def setData(self, index: QtCore.QModelIndex, value, role=QtCore.Qt.EditRole):
         """Overrides Qt method to toggle the per-instance visibility state."""

--- a/sleap/gui/overlays/instance.py
+++ b/sleap/gui/overlays/instance.py
@@ -5,7 +5,7 @@ Overlay for showing instances.
 import attr
 
 from sleap.gui.overlays.base import BaseOverlay
-from sleap.gui.state import GuiState
+from sleap.gui.state import GuiState, instance_visible
 from sleap.sleap_io_adaptors.lf_labels_utils import get_instances_to_show
 
 
@@ -54,6 +54,13 @@ class InstanceOverlay(BaseOverlay):
         self.player.showInstances(self.state.get("show instances", default=True))
         self.player.showLabels(self.state.get("show labels", default=True))
         self.player.showEdges(self.state.get("show edges", default=True))
+
+        # Re-apply per-instance visibility (driven by the Instances dock
+        # checkboxes). This MUST stay AFTER the global show* calls above, which
+        # un-hide everything; otherwise per-instance hides would be clobbered on
+        # every replot. See `sleap.gui.state.instance_visible`.
+        for qt_inst in self.player.view.all_instances:
+            qt_inst.setVisible(instance_visible(self.state, qt_inst.instance))
 
         if has_user and has_predicted:
             self.player.highlightPredictions("not in training data")

--- a/sleap/gui/state.py
+++ b/sleap/gui/state.py
@@ -56,11 +56,20 @@ def instance_visible(state: "GuiState", instance: Any) -> bool:
 
     Returns:
         ``True`` if the instance should be drawn, ``False`` if it should be
-        hidden. If a view-only instance is set, only that instance is visible;
-        otherwise an instance is visible unless its id is in the hidden set.
+        hidden. The global "show instances" toggle takes precedence: when it is
+        off, every instance is hidden. Otherwise, if a view-only instance is
+        set, only that instance is visible; else an instance is visible unless
+        its id is in the hidden set.
     """
     if state is None:
         return True
+
+    # The global "show instances" toggle wins: per-instance state can only
+    # further hide instances, never force a globally-hidden one back on. Without
+    # this, the per-instance re-apply loop in `InstanceOverlay.add_to_scene`
+    # would override the global Hide toggle on every replot.
+    if not state.get("show instances", default=True):
+        return False
 
     view_only = state.get(VIEW_ONLY_INSTANCE_KEY, default=None)
     if view_only is not None:

--- a/sleap/gui/state.py
+++ b/sleap/gui/state.py
@@ -27,6 +27,50 @@ from typing import Any, Callable, List, Union, Optional
 GSVarType = str
 NO_ARG = object()
 
+# Transient (session-only) GuiState keys for per-instance canvas visibility.
+# These are intentionally NOT persisted to the `.slp`/`Labels` model; they are a
+# view preference that resets when the frame changes (instances differ per
+# frame). See `sleap.gui.dataviews.LabeledFrameTableModel` (the checkbox columns
+# that drive them) and `sleap.gui.overlays.instance.InstanceOverlay` (which
+# re-applies them on every replot).
+#
+# - INSTANCE_HIDDEN_KEY -> set of ``id(instance)`` whose "Visibility" box is
+#   unchecked (hidden on the canvas).
+# - VIEW_ONLY_INSTANCE_KEY -> ``id(instance)`` of the single "View Only"
+#   instance, or ``None``. When set, only that instance is visible and the whole
+#   Visibility column is disabled (radio-like exclusivity).
+INSTANCE_HIDDEN_KEY = "instance_hidden"
+VIEW_ONLY_INSTANCE_KEY = "view_only_instance"
+
+
+def instance_visible(state: "GuiState", instance: Any) -> bool:
+    """Return the effective canvas visibility for an instance.
+
+    This is the single source of truth shared by the table model (which sets
+    the state) and the instance overlay (which applies it on every replot), so
+    the two cannot drift.
+
+    Args:
+        state: The `GuiState` holding the transient visibility keys.
+        instance: The `Instance`/`PredictedInstance` object (keyed by identity).
+
+    Returns:
+        ``True`` if the instance should be drawn, ``False`` if it should be
+        hidden. If a view-only instance is set, only that instance is visible;
+        otherwise an instance is visible unless its id is in the hidden set.
+    """
+    if state is None:
+        return True
+
+    view_only = state.get(VIEW_ONLY_INSTANCE_KEY, default=None)
+    if view_only is not None:
+        return id(instance) == view_only
+
+    hidden = state.get(INSTANCE_HIDDEN_KEY, default=None)
+    if not hidden:
+        return True
+    return id(instance) not in hidden
+
 
 class GuiState(object):
     """

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
     QDockWidget,
     QGroupBox,
     QHBoxLayout,
+    QHeaderView,
     QLabel,
     QLayout,
     QMainWindow,
@@ -586,7 +587,24 @@ class InstancesDock(DockWidget):
             lambda _: self._apply_mean_node_score_visibility(),
         )
 
+        # Keep the per-instance checkbox columns ("visibility"/"view only")
+        # narrow so they don't crowd out the informational columns.
+        self._size_checkbox_columns()
+
         return self.table
+
+    def _size_checkbox_columns(self) -> None:
+        """Resize the visibility/view-only checkbox columns to their contents."""
+        header = self.table.horizontalHeader()
+        for key in (
+            LabeledFrameTableModel.VISIBILITY_KEY,
+            LabeledFrameTableModel.VIEW_ONLY_KEY,
+        ):
+            try:
+                col_idx = self.model.properties.index(key)
+            except ValueError:
+                continue
+            header.setSectionResizeMode(col_idx, QHeaderView.ResizeToContents)
 
     def _apply_mean_node_score_visibility(self) -> None:
         """Hide or show the 'mean node score' column based on the View toggle."""

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -136,3 +136,157 @@ def test_labeled_frame_mean_node_score_all_nan(qtbot, centered_pair_predictions)
 
     model = LabeledFrameTableModel(items=lf)
     assert model._data[0]["mean node score"] == ""
+
+
+def _checkstate(model, row, key):
+    """Return the CheckStateRole value for the given row and column key."""
+    col = model.properties.index(key)
+    index = model.index(row, col)
+    return model.data(index, QtCore.Qt.CheckStateRole)
+
+
+def _set_checkstate(model, row, key, checked):
+    """Set the CheckStateRole for the given row and column key."""
+    col = model.properties.index(key)
+    index = model.index(row, col)
+    value = QtCore.Qt.Checked if checked else QtCore.Qt.Unchecked
+    return model.setData(index, value, QtCore.Qt.CheckStateRole)
+
+
+def test_labeled_frame_visibility_columns_present(qtbot, centered_pair_predictions):
+    """The visibility and view-only checkbox columns should exist."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+    assert "visibility" in model.properties
+    assert "view only" in model.properties
+    # Appended last so existing name-indexed lookups stay valid.
+    assert model.properties.index("visibility") > model.properties.index("skeleton")
+
+
+def test_labeled_frame_visibility_defaults(qtbot, centered_pair_predictions):
+    """By default every visibility box is checked and view-only is unchecked."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+    for row in range(model.rowCount()):
+        assert _checkstate(model, row, "visibility") == QtCore.Qt.Checked
+        assert _checkstate(model, row, "view only") == QtCore.Qt.Unchecked
+
+
+def test_labeled_frame_uncheck_visibility(qtbot, centered_pair_predictions):
+    """Unchecking visibility marks the instance hidden but keeps its row."""
+    from sleap.gui.state import instance_visible
+
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+    n_rows = model.rowCount()
+
+    inst0 = model.original_items[0]
+    inst1 = model.original_items[1]
+
+    assert _set_checkstate(model, 0, "visibility", False)
+    assert _checkstate(model, 0, "visibility") == QtCore.Qt.Unchecked
+    # Other rows unaffected.
+    assert _checkstate(model, 1, "visibility") == QtCore.Qt.Checked
+    # Row count unchanged: hidden instances stay listed.
+    assert model.rowCount() == n_rows
+
+    # Effective visibility reflects the hidden set.
+    assert not instance_visible(model._vis_state, inst0)
+    assert instance_visible(model._vis_state, inst1)
+
+    # Re-checking restores visibility.
+    assert _set_checkstate(model, 0, "visibility", True)
+    assert _checkstate(model, 0, "visibility") == QtCore.Qt.Checked
+    assert instance_visible(model._vis_state, inst0)
+
+
+def test_labeled_frame_view_only_exclusivity(qtbot, centered_pair_predictions):
+    """Checking view-only on one row auto-unchecks the previous (radio-like)."""
+    from sleap.gui.state import instance_visible
+
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+
+    inst0 = model.original_items[0]
+    inst1 = model.original_items[1]
+
+    # Check view-only on row 0.
+    assert _set_checkstate(model, 0, "view only", True)
+    assert _checkstate(model, 0, "view only") == QtCore.Qt.Checked
+    assert _checkstate(model, 1, "view only") == QtCore.Qt.Unchecked
+    # Only instance 0 is visible.
+    assert instance_visible(model._vis_state, inst0)
+    assert not instance_visible(model._vis_state, inst1)
+
+    # Visibility column should be disabled (greyed out) during view-only.
+    vis_col = model.properties.index("visibility")
+    flags = model.flags(model.index(0, vis_col))
+    assert not (flags & QtCore.Qt.ItemIsEnabled)
+    assert not (flags & QtCore.Qt.ItemIsUserCheckable)
+    # Row still selectable.
+    assert flags & QtCore.Qt.ItemIsSelectable
+
+    # Check view-only on row 1: row 0 auto-unchecks.
+    assert _set_checkstate(model, 1, "view only", True)
+    assert _checkstate(model, 0, "view only") == QtCore.Qt.Unchecked
+    assert _checkstate(model, 1, "view only") == QtCore.Qt.Checked
+    assert not instance_visible(model._vis_state, inst0)
+    assert instance_visible(model._vis_state, inst1)
+
+
+def test_labeled_frame_visibility_click_exits_view_only(
+    qtbot, centered_pair_predictions
+):
+    """Clicking any visibility box exits view-only mode."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+
+    # Enter view-only on row 0.
+    _set_checkstate(model, 0, "view only", True)
+    assert _checkstate(model, 0, "view only") == QtCore.Qt.Checked
+
+    # Toggling any visibility box exits view-only.
+    _set_checkstate(model, 1, "visibility", False)
+    assert _checkstate(model, 0, "view only") == QtCore.Qt.Unchecked
+
+    # Visibility column re-enabled.
+    vis_col = model.properties.index("visibility")
+    flags = model.flags(model.index(0, vis_col))
+    assert flags & QtCore.Qt.ItemIsEnabled
+    assert flags & QtCore.Qt.ItemIsUserCheckable
+
+
+def test_labeled_frame_visibility_uncheck_view_only(qtbot, centered_pair_predictions):
+    """Unchecking the active view-only row clears view-only mode."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+
+    _set_checkstate(model, 0, "view only", True)
+    assert _checkstate(model, 0, "view only") == QtCore.Qt.Checked
+
+    # Unchecking it returns to the default (all visible) state.
+    _set_checkstate(model, 0, "view only", False)
+    assert _checkstate(model, 0, "view only") == QtCore.Qt.Unchecked
+    for row in range(model.rowCount()):
+        assert _checkstate(model, row, "visibility") == QtCore.Qt.Checked
+
+
+def test_labeled_frame_track_column_unaffected(qtbot, centered_pair_predictions):
+    """Adding checkbox columns must not break the existing track column."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+
+    track_col = model.properties.index("track")
+    points_col = model.properties.index("points")
+
+    # Non-checkbox columns still return text via DisplayRole.
+    assert model.data(model.index(1, points_col)) == "21/24"
+
+    # Track column flags delegate to the base implementation.
+    track_flags = model.flags(model.index(0, track_col))
+    assert track_flags & QtCore.Qt.ItemIsSelectable
+    assert track_flags & QtCore.Qt.ItemIsEnabled
+
+    # Checkbox columns have no DisplayRole text.
+    vis_col = model.properties.index("visibility")
+    assert model.data(model.index(0, vis_col), QtCore.Qt.DisplayRole) is None

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -218,13 +218,17 @@ def test_labeled_frame_view_only_exclusivity(qtbot, centered_pair_predictions):
     assert instance_visible(model._vis_state, inst0)
     assert not instance_visible(model._vis_state, inst1)
 
-    # Visibility column should be disabled (greyed out) during view-only.
+    # During view-only the visibility column is greyed but STAYS enabled and
+    # user-checkable, so clicking a visibility box can exit view-only mode (per
+    # the spec). The greying is conveyed via a BackgroundRole brush, not by
+    # disabling the cell (a disabled cell would make the exit gesture
+    # unreachable in the real view).
     vis_col = model.properties.index("visibility")
     flags = model.flags(model.index(0, vis_col))
-    assert not (flags & QtCore.Qt.ItemIsEnabled)
-    assert not (flags & QtCore.Qt.ItemIsUserCheckable)
-    # Row still selectable.
+    assert flags & QtCore.Qt.ItemIsEnabled
+    assert flags & QtCore.Qt.ItemIsUserCheckable
     assert flags & QtCore.Qt.ItemIsSelectable
+    assert model.data(model.index(0, vis_col), QtCore.Qt.BackgroundRole) is not None
 
     # Check view-only on row 1: row 0 auto-unchecks.
     assert _set_checkstate(model, 1, "view only", True)
@@ -290,3 +294,32 @@ def test_labeled_frame_track_column_unaffected(qtbot, centered_pair_predictions)
     # Checkbox columns have no DisplayRole text.
     vis_col = model.properties.index("visibility")
     assert model.data(model.index(0, vis_col), QtCore.Qt.DisplayRole) is None
+
+
+def test_instance_visible_respects_global_show_instances():
+    """Global "show instances" off hides everything (regression for #2755).
+
+    The instance overlay re-applies `instance_visible` on every replot, so if it
+    ignored the global toggle it would override the global Hide. Per-instance
+    state may only further hide instances, never force a globally-hidden one back
+    on.
+    """
+    from sleap.gui.state import GuiState, instance_visible, VIEW_ONLY_INSTANCE_KEY
+
+    state = GuiState()
+    inst_a, inst_b = object(), object()
+
+    # Global on: default per-instance state -> both visible.
+    state["show instances"] = True
+    assert instance_visible(state, inst_a)
+    assert instance_visible(state, inst_b)
+
+    # View-only on A (global on): only A visible.
+    state[VIEW_ONLY_INSTANCE_KEY] = id(inst_a)
+    assert instance_visible(state, inst_a)
+    assert not instance_visible(state, inst_b)
+
+    # Global off: nothing visible, even the view-only instance.
+    state["show instances"] = False
+    assert not instance_visible(state, inst_a)
+    assert not instance_visible(state, inst_b)

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -210,3 +210,50 @@ def test_instances_dock_visibility_columns(qtbot, centered_pair_predictions: Lab
     main_window.state["frame_idx"] = other.frame_idx
     assert main_window.state[VIEW_ONLY_INSTANCE_KEY] is None
     assert main_window.state[INSTANCE_HIDDEN_KEY] == set()
+
+
+def test_instances_dock_visibility_replot_and_global_toggle(
+    qtbot, centered_pair_predictions: Labels
+):
+    """Per-instance visibility survives a same-frame replot and is overridden by
+    the global "show instances" toggle (regressions for #2755)."""
+    from qtpy import QtCore
+
+    main_window = MainWindow(labels=centered_pair_predictions)
+    target = centered_pair_predictions.labeled_frames[13]
+    main_window.state["frame_idx"] = target.frame_idx
+
+    model = main_window.instances_dock.table.model()
+    assert model.rowCount() >= 2
+    inst0 = model.original_items[0]
+    inst1 = model.original_items[1]
+    vis_col = model.properties.index("visibility")
+
+    # Hide instance 0 via its visibility box.
+    model.setData(
+        model.index(0, vis_col), QtCore.Qt.Unchecked, QtCore.Qt.CheckStateRole
+    )
+    assert id(inst0) in main_window.state[INSTANCE_HIDDEN_KEY]
+
+    # A same-frame replot (what a marker-size/add-instance change triggers) must
+    # NOT reset the hide -- only a real frame change does.
+    main_window.plotFrame()
+    assert id(inst0) in main_window.state[INSTANCE_HIDDEN_KEY]
+    qt0 = _qt_instance_for(main_window.player, inst0)
+    qt1 = _qt_instance_for(main_window.player, inst1)
+    assert qt0 is not None and not qt0.isVisible()
+    assert qt1 is not None and qt1.isVisible()
+
+    # Global "show instances" off hides everything, even the still-visible inst1.
+    main_window.state["show instances"] = False
+    qt0 = _qt_instance_for(main_window.player, inst0)
+    qt1 = _qt_instance_for(main_window.player, inst1)
+    assert qt0 is not None and not qt0.isVisible()
+    assert qt1 is not None and not qt1.isVisible()
+
+    # Turning it back on restores per-instance state (inst0 hidden, inst1 shown).
+    main_window.state["show instances"] = True
+    qt0 = _qt_instance_for(main_window.player, inst0)
+    qt1 = _qt_instance_for(main_window.player, inst1)
+    assert qt0 is not None and not qt0.isVisible()
+    assert qt1 is not None and qt1.isVisible()

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -7,6 +7,7 @@ import numpy as np
 from sleap import Labels, Video
 from sleap.gui.app import MainWindow
 from sleap.gui.commands import AddInstance, OpenSkeleton
+from sleap.gui.state import INSTANCE_HIDDEN_KEY, VIEW_ONLY_INSTANCE_KEY
 from sleap.gui.widgets.docks import (
     InstancesDock,
     SkeletonDock,
@@ -138,3 +139,74 @@ def test_instances_dock(qtbot, centered_pair_predictions: Labels):
     new_inst = lf.instances[-1]
     diff = np.nan_to_num(new_inst.numpy() - copy_instance.numpy(), nan=offset)
     assert np.all(diff == offset)
+
+
+def _qt_instance_for(player, instance):
+    """Return the `QtInstance` on the canvas for the given `Instance`."""
+    for qt_inst in player.view.all_instances:
+        if qt_inst.instance is instance:
+            return qt_inst
+    return None
+
+
+def test_instances_dock_visibility_columns(qtbot, centered_pair_predictions: Labels):
+    """The Instances dock exposes visibility/view-only checkbox columns that
+    toggle per-instance rendering on the canvas."""
+    from qtpy import QtCore
+
+    main_window = MainWindow(labels=centered_pair_predictions)
+
+    # Navigate to a frame with multiple instances.
+    target = centered_pair_predictions.labeled_frames[13]
+    main_window.state["frame_idx"] = target.frame_idx
+
+    model = main_window.instances_dock.table.model()
+    assert "visibility" in model.properties
+    assert "view only" in model.properties
+
+    assert model.rowCount() >= 2
+    inst0 = model.original_items[0]
+    inst1 = model.original_items[1]
+
+    qt0 = _qt_instance_for(main_window.player, inst0)
+    qt1 = _qt_instance_for(main_window.player, inst1)
+    assert qt0 is not None and qt1 is not None
+
+    # Default: both visible.
+    assert qt0.isVisible()
+    assert qt1.isVisible()
+
+    vis_col = model.properties.index("visibility")
+    view_col = model.properties.index("view only")
+
+    # Uncheck visibility on row 0 -> that instance hides, the other stays.
+    model.setData(
+        model.index(0, vis_col), QtCore.Qt.Unchecked, QtCore.Qt.CheckStateRole
+    )
+    assert not qt0.isVisible()
+    assert qt1.isVisible()
+
+    # Re-check -> reappears.
+    model.setData(model.index(0, vis_col), QtCore.Qt.Checked, QtCore.Qt.CheckStateRole)
+    assert qt0.isVisible()
+
+    # View-only on row 1 -> only instance 1 visible.
+    model.setData(model.index(1, view_col), QtCore.Qt.Checked, QtCore.Qt.CheckStateRole)
+    assert not qt0.isVisible()
+    assert qt1.isVisible()
+
+    # Clicking a visibility box exits view-only -> both visible again.
+    model.setData(model.index(0, vis_col), QtCore.Qt.Checked, QtCore.Qt.CheckStateRole)
+    assert qt0.isVisible()
+    assert qt1.isVisible()
+
+    # Visibility/view-only reset on frame change.
+    other = next(
+        lf
+        for lf in centered_pair_predictions.labeled_frames
+        if lf.frame_idx != target.frame_idx and len(lf.instances) >= 1
+    )
+    model.setData(model.index(0, view_col), QtCore.Qt.Checked, QtCore.Qt.CheckStateRole)
+    main_window.state["frame_idx"] = other.frame_idx
+    assert main_window.state[VIEW_ONLY_INSTANCE_KEY] is None
+    assert main_window.state[INSTANCE_HIDDEN_KEY] == set()


### PR DESCRIPTION
## Summary

Adds per-instance visibility control to the **Instances dock**, so you can hide/show individual instances on the canvas and isolate a single one — implementing the interaction from #2755:

- Two checkbox columns per row: **visibility** (checked by default) and **view only** (unchecked by default).
- Unchecking **visibility** hides that instance on the canvas.
- Checking **view only** shows only that instance and greys the visibility column; checking another row's "view only" auto-unchecks the previous (radio-like).
- Clicking any **visibility** box exits view-only mode.

State is transient (session-only, never written to the `.slp`) and `instance_visible()` in `sleap/gui/state.py` is the single source of truth shared by the table model and the instance overlay.

## Review fixes included

1. **Global-toggle regression** — the per-instance re-apply loop ignored the global "show instances" flag and force-showed everything on each replot, breaking the global Hide. The global flag is now folded into `instance_visible()`: per-instance state can only *further* hide, never override global Hide.
2. **Reset scope** — the transient state was reset on *every* replot (marker size, add-instance, palette…), wiping selections. Reset is now gated on a real `(video, frame_idx)` change.
3. **View-only column "greyed but clickable"** — previously the visibility column was fully disabled during view-only, so the spec's "click a visibility box to exit view-only" gesture was unreachable in the real view. The cells now stay enabled + checkable and are greyed via `BackgroundRole`.

## Tests

`tests/gui/test_dataviews.py` (14 passing, incl. a global-toggle regression test and the updated view-only contract) and `tests/gui/widgets/test_docks.py` (incl. a new test that a same-frame replot preserves state and the global toggle hides all). Run foreground. `ruff` clean.

## Known minor items (follow-up candidates)

- State is keyed by `id(instance)` and relies on **eager** Labels loading (true today; would need hardening under lazy loading).
- Setting "view only" on a predicted instance that has no visible nodes (not drawn) blanks the canvas.

Part of #2762. Closes #2755.

🤖 Implemented with Claude Code (workflow + review fixes).
