### PR TITLE
feat(gui): Merge Instance — combine two partial instances into one (#2763)

### DIFF
--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -21,6 +21,7 @@ goto prev suggestion: Shift+Space
 goto prev labeled: Alt+Left
 learning: Ctrl+L
 mark negative: 'N'
+merge instance:
 new: Ctrl+N
 next video: Alt+Shift+Right
 open: Ctrl+O

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -831,6 +831,13 @@ class MainWindow(QMainWindow):
 
         add_menu_item(
             labelMenu,
+            "merge instance",
+            "Merge Instance",
+            lambda: self.commands.mergeInstance(),
+        )
+
+        add_menu_item(
+            labelMenu,
             "custom delete",
             "Custom Instance Delete...",
             self.commands.deleteDialog,
@@ -1278,6 +1285,11 @@ class MainWindow(QMainWindow):
             self.state["labeled_frame"] is not None
             and len(self.state["labeled_frame"].instances) > 1
         )
+        # Merge requires at least two *user* instances (predicted excluded).
+        has_multiple_user_instances = (
+            self.state["labeled_frame"] is not None
+            and len(self.state["labeled_frame"].user_instances) > 1
+        )
         # todo: exclude predicted instances from count
         has_nodes_selected = (
             self.skeleton_dock.skeletonEdgesSrc.currentIndex() > -1
@@ -1299,6 +1311,7 @@ class MainWindow(QMainWindow):
         self._menu_actions["extract clip labels package"].setEnabled(has_frame_range)
 
         self._menu_actions["transpose"].setEnabled(has_multiple_instances)
+        self._menu_actions["merge instance"].setEnabled(has_multiple_user_instances)
 
         self._menu_actions["save"].setEnabled(has_unsaved_changes)
 

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3819,10 +3819,10 @@ class MergeInstances(EditCommand):
           the survivor is not a user ``Instance``, or required state is
           missing, this is a no-op (with a status message when running in the
           GUI).
-        - After merging, the donor is removed from the frame via
-          ``remove_instance`` and ``labels.update()`` is called. There is no
-          dedicated undo (matching ``DeleteSelectedInstance``/``PasteInstance``);
-          ``EditCommand`` only flags the project as having unsaved changes.
+        - After merging, the donor is removed from the frame *by identity* and
+          ``labels.update()`` is called. There is no dedicated undo (matching
+          ``DeleteSelectedInstance``/``PasteInstance``); ``EditCommand`` only
+          flags the project as having unsaved changes.
     """
 
     topics = [UpdateTopic.frame, UpdateTopic.project_instances]
@@ -3893,10 +3893,13 @@ class MergeInstances(EditCommand):
                 s_pt["visible"] = d_pt["visible"]
                 s_pt["complete"] = d_pt["complete"]
 
-        # Remove the donor and persist. The donor's pose is never mutated and
-        # the survivor only gains nodes, so the survivor can never collide with
-        # the donor's pose in `remove_instance`.
-        remove_instance(context.labels, instance=donor, lf=frame)
+        # Remove the donor *by identity* and persist. We must not use pose/track
+        # matching here (e.g. ``remove_instance``): after the merge the survivor
+        # can become pose-identical to the donor (when the donor's labeled nodes
+        # are a superset of the survivor's), so for untracked or same-track
+        # instances a pose-based search could remove the survivor instead. An
+        # ``is``-based filter is unambiguous regardless of ``Instance.__eq__``.
+        frame.instances[:] = [inst for inst in frame.instances if inst is not donor]
         context.labels.update()
 
         # Keep the survivor selected.

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -673,6 +673,15 @@ class CommandContext:
         """Deletes currently selected instance."""
         self.execute(DeleteSelectedInstance)
 
+    def mergeInstance(self, donor: Optional["Instance"] = None):
+        """Merge another user instance in the frame into the selected one.
+
+        The selected instance is kept (survivor) and gains the donor's labeled
+        keypoints for any nodes it is missing. If `donor` is None and the frame
+        has exactly two user instances, the other one is used as the donor.
+        """
+        self.execute(MergeInstances, donor=donor)
+
     def deleteSelectedInstanceTrack(self):
         """Deletes all instances from track of currently selected instance."""
         self.execute(DeleteSelectedInstanceTrack)
@@ -3783,6 +3792,115 @@ class DeleteSelectedInstanceTrack(EditCommand):
                 track_instances = filter(lambda inst: inst.track == track, lf.instances)
                 for inst in track_instances:
                     remove_instance(context.labels, instance=inst, lf=lf)
+
+
+class MergeInstances(EditCommand):
+    """Merge two user instances in the current frame into a single instance.
+
+    The currently selected instance (``context.state["instance"]``) is the
+    *survivor*. The instance to merge into it is the *donor*, taken from
+    ``params["donor"]``; if no donor is given and the frame has exactly two
+    user instances, the other one is used automatically.
+
+    For every skeleton node, if the survivor's node is missing (NaN coordinates
+    or not visible) and the donor's node is labeled/visible, the donor's
+    ``xy``/``visible``/``complete`` values are copied onto the survivor. This
+    lets a "front keypoints" instance and a "back keypoints" instance be
+    combined into one. The survivor keeps its own track.
+
+    Conflict policy: if BOTH the survivor and the donor have a node
+    labeled/visible, the survivor's value is kept (the donor's value for that
+    node is discarded).
+
+    Scope/behavior decisions:
+        - Only user ``Instance``s participate. ``PredictedInstance``s are never
+          chosen as survivor or donor and are left untouched on the frame.
+        - If there are fewer than two user instances, no donor can be resolved,
+          the survivor is not a user ``Instance``, or required state is
+          missing, this is a no-op (with a status message when running in the
+          GUI).
+        - After merging, the donor is removed from the frame via
+          ``remove_instance`` and ``labels.update()`` is called. There is no
+          dedicated undo (matching ``DeleteSelectedInstance``/``PasteInstance``);
+          ``EditCommand`` only flags the project as having unsaved changes.
+    """
+
+    topics = [UpdateTopic.frame, UpdateTopic.project_instances]
+
+    @staticmethod
+    def _status(context: "CommandContext", message: str):
+        """Post a status message if the app supports it (no-op when headless)."""
+        if hasattr(context.app, "updateStatusMessage"):
+            context.app.updateStatusMessage(message)
+
+    @staticmethod
+    def do_action(context: "CommandContext", params: dict):
+        survivor = context.state["instance"]
+        frame = context.state["labeled_frame"]
+        skeleton = context.state["skeleton"]
+        donor = params.get("donor", None)
+
+        if survivor is None or frame is None or skeleton is None:
+            return
+
+        # Only user instances can be merged (skip PredictedInstance).
+        if type(survivor) is not Instance:
+            MergeInstances._status(
+                context, "Merge Instance: select a user instance first."
+            )
+            return
+
+        user_instances = frame.user_instances
+        if len(user_instances) < 2:
+            MergeInstances._status(
+                context,
+                "Merge Instance: need at least two user instances in the frame.",
+            )
+            return
+
+        # Fast path: exactly two user instances -> donor is the other one.
+        if donor is None and len(user_instances) == 2:
+            donor = next(inst for inst in user_instances if inst is not survivor)
+
+        if donor is None or donor is survivor or type(donor) is not Instance:
+            MergeInstances._status(
+                context, "Merge Instance: no valid instance to merge."
+            )
+            return
+
+        # Guard against mismatched skeletons (all instances in a frame normally
+        # share the project skeleton, but be safe).
+        if not survivor.skeleton.matches(donor.skeleton):
+            MergeInstances._status(
+                context, "Merge Instance: instances have different skeletons."
+            )
+            return
+
+        for node in skeleton.node_names:
+            s_pt = survivor[node]
+            d_pt = donor[node]
+            survivor_missing = bool(np.isnan(s_pt["xy"]).any()) or not bool(
+                s_pt["visible"]
+            )
+            donor_labeled = (not bool(np.isnan(d_pt["xy"]).any())) and bool(
+                d_pt["visible"]
+            )
+            # Conflict policy: only fill nodes the survivor is missing; nodes
+            # the survivor already has are kept as-is.
+            if survivor_missing and donor_labeled:
+                s_pt["xy"][0] = d_pt["xy"][0]
+                s_pt["xy"][1] = d_pt["xy"][1]
+                s_pt["visible"] = d_pt["visible"]
+                s_pt["complete"] = d_pt["complete"]
+
+        # Remove the donor and persist. The donor's pose is never mutated and
+        # the survivor only gains nodes, so the survivor can never collide with
+        # the donor's pose in `remove_instance`.
+        remove_instance(context.labels, instance=donor, lf=frame)
+        context.labels.update()
+
+        # Keep the survivor selected.
+        context.state["instance"] = survivor
 
 
 class DeleteDialogCommand(EditCommand):

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -3839,6 +3839,10 @@ class MergeInstances(EditCommand):
         frame = context.state["labeled_frame"]
         skeleton = context.state["skeleton"]
         donor = params.get("donor", None)
+        if donor is None:
+            # Donor picked by shift/ctrl-selecting a second instance in the list
+            # (first-selected is the survivor, second is the donor).
+            donor = context.state.get("merge_partner", default=None)
 
         if survivor is None or frame is None or skeleton is None:
             return
@@ -3902,8 +3906,9 @@ class MergeInstances(EditCommand):
         frame.instances[:] = [inst for inst in frame.instances if inst is not donor]
         context.labels.update()
 
-        # Keep the survivor selected.
+        # Keep the survivor selected; clear the donor selection.
         context.state["instance"] = survivor
+        context.state["merge_partner"] = None
 
 
 class DeleteDialogCommand(EditCommand):

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -392,6 +392,74 @@ class GenericTableView(QtWidgets.QTableView):
         return self.model().original_items[idx.row()]
 
 
+class InstancesTableView(GenericTableView):
+    """Instances table with shift/ctrl multi-select for Merge Instance.
+
+    Selecting a second instance (shift- or ctrl-click) marks it as the merge
+    *donor*: the first-selected instance is the survivor (``state["instance"]``,
+    kept) and the second is the donor (``state["merge_partner"]``, merged in and
+    removed). Single selection behaves exactly like the base view. Selection
+    order is tracked explicitly because Qt's "current" index follows the last
+    click, which would otherwise make the donor (2nd) the survivor.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("multiple_selection", True)
+        super().__init__(*args, **kwargs)
+        self._merge_order: List[Any] = []
+        self._syncing = False
+
+    def selectionChanged(self, new, old):
+        """Set survivor/donor GuiState from the click-ordered selection."""
+        # Do the visual update via QTableView; we set GuiState ourselves (the
+        # base GenericTableView would set state["instance"] to the last-clicked).
+        QtWidgets.QTableView.selectionChanged(self, new, old)
+
+        # selectionChanged can fire during super().__init__() (setModel), before
+        # our attributes exist; nothing is selected yet, so just bail.
+        if not hasattr(self, "_merge_order"):
+            return
+
+        original_items = self.model().original_items
+        selected, rows = [], set()
+        for qidx in self.selectedIndexes():
+            row = qidx.row()
+            if row in rows or row >= len(original_items):
+                continue
+            rows.add(row)
+            selected.append(original_items[row])
+
+        # Preserve prior click order, drop deselected, append newly selected.
+        selected_ids = {id(i) for i in selected}
+        self._merge_order = [i for i in self._merge_order if id(i) in selected_ids]
+        known = {id(i) for i in self._merge_order}
+        for inst in selected:
+            if id(inst) not in known:
+                self._merge_order.append(inst)
+                known.add(id(inst))
+
+        survivor = self._merge_order[0] if self._merge_order else None
+        donor = self._merge_order[1] if len(self._merge_order) >= 2 else None
+
+        # Setting state["instance"] re-enters selectRowItem (connected); guard so
+        # it can't collapse the multi-selection back to a single row.
+        self._syncing = True
+        try:
+            self.state["instance"] = survivor
+        finally:
+            self._syncing = False
+        self.state["merge_partner"] = donor
+
+        if self.row_name:
+            self.state[f"selected_batch_{self.row_name}"] = set(rows)
+
+    def selectRowItem(self, item: Any):
+        """Skip while syncing so our own state set doesn't clear the selection."""
+        if getattr(self, "_syncing", False):
+            return
+        super().selectRowItem(item)
+
+
 class VideosTableModel(GenericTableModel):
     properties = (
         "name",

--- a/sleap/gui/shortcuts.py
+++ b/sleap/gui/shortcuts.py
@@ -37,6 +37,7 @@ class Shortcuts(object):
         "add instance",
         "mark negative",
         "delete instance",
+        "merge instance",
         "delete track",
         "transpose",
         "propagate track labels",

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -27,6 +27,7 @@ from PIL import Image
 from sleap.gui.dataviews import (
     GenericTableModel,
     GenericTableView,
+    InstancesTableView,
     LabeledFrameTableModel,
     SkeletonEdgesTableModel,
     SkeletonNodeModel,
@@ -572,7 +573,9 @@ class InstancesDock(DockWidget):
         return self.model
 
     def create_tables(self) -> GenericTableView:
-        self.table = GenericTableView(
+        # InstancesTableView adds shift/ctrl multi-select so a second instance
+        # can be picked as the merge donor (see Merge Instance).
+        self.table = InstancesTableView(
             state=self.main_window.state,
             row_name="instance",
             name_prefix="",

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -615,6 +615,9 @@ class InstancesDock(DockWidget):
         self.add_button(
             hb, "Delete Instance", main_window.commands.deleteSelectedInstance
         )
+        self.add_button(
+            hb, "Merge Instance", lambda *_: main_window.commands.mergeInstance()
+        )
 
         hbw = QWidget()
         hbw.setLayout(hb)

--- a/sleap/gui/widgets/video.py
+++ b/sleap/gui/widgets/video.py
@@ -416,6 +416,34 @@ class QtVideoPlayer(QWidget):
             )
             self._menu_actions["Mark Frame as Negative"] = negative_action
 
+            # "Merge Instance with >" submenu: merge another user instance in
+            # this frame into the currently selected (user) instance.
+            selected = self.context.state["instance"]
+            if (
+                selected is not None
+                and current_lf is not None
+                and type(selected) is Instance
+            ):
+                others = [
+                    inst
+                    for inst in current_lf.instances
+                    if type(inst) is Instance and inst is not selected
+                ]
+                if others:
+                    self.context_menu.addSeparator()
+                    merge_menu = self.context_menu.addMenu("Merge Instance with")
+                    for donor in others:
+                        if donor.track is not None:
+                            label = f"Track: {donor.track.name}"
+                        else:
+                            label = f"Instance {current_lf.instances.index(donor)}"
+                        merge_menu.addAction(
+                            label,
+                            lambda checked=False, d=donor: self.context.mergeInstance(
+                                donor=d
+                            ),
+                        )
+
         return self.context_menu
 
     def show_contextual_menu(self, where: QtCore.QPoint):

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1160,6 +1160,38 @@ def test_MergeInstances(min_tracks_2node_labels: Labels):
     assert surv["head"]["xy"].tolist() == [10.0, 20.0]
     assert surv["thorax"]["xy"].tolist() == [30.0, 40.0]
 
+    # Case 8 (shift-select donor): with THREE user instances the exactly-two
+    # auto-resolve can't fire, so the donor comes from state["merge_partner"]
+    # (the 2nd shift/ctrl-selected instance); survivor is state["instance"].
+    s8 = Instance.from_numpy(
+        np.array([[10.0, 20.0, 1, 1], [np.nan, np.nan, 0, 0]]),
+        skeleton=skeleton,
+        track=Track("s8"),
+    )
+    d8 = Instance.from_numpy(
+        np.array([[np.nan, np.nan, 0, 0], [30.0, 40.0, 1, 1]]),
+        skeleton=skeleton,
+        track=Track("d8"),
+    )
+    other8 = Instance.from_numpy(
+        np.array([[5.0, 6.0, 1, 1], [7.0, 8.0, 1, 1]]),
+        skeleton=skeleton,
+        track=Track("other8"),
+    )
+    lf6 = _merge_frame(skeleton, video, 1004, [s8, d8, other8])
+    labels.append(lf6)
+    context.state["labeled_frame"] = lf6
+    context.state["instance"] = s8
+    context.state["merge_partner"] = d8
+    context.mergeInstance()  # no explicit donor -> uses merge_partner
+
+    assert d8 not in lf6.instances  # donor merged in and removed
+    assert other8 in lf6.instances  # bystander untouched
+    assert any(inst is s8 for inst in lf6.instances)
+    assert s8["thorax"]["xy"].tolist() == [30.0, 40.0]  # gained donor's node
+    assert context.state["instance"] is s8
+    assert context.state["merge_partner"] is None  # cleared after merge
+
 
 def test_CopyInstanceTrack(min_tracks_2node_labels: Labels):
     """Test that copying a track from one instance to another works."""

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1132,6 +1132,34 @@ def test_MergeInstances(min_tracks_2node_labels: Labels):
     context.state["instance"] = None
     context.mergeInstance()
 
+    # Case 7 (regression for #2763): two UNTRACKED instances where the donor is a
+    # pose-superset of the survivor. After the merge the survivor becomes
+    # pose-identical to the donor, so a pose/track-based removal could delete the
+    # survivor. The donor is placed *first* so a backwards pose-search would hit
+    # the survivor first. Removal must therefore be by identity. Assertions use
+    # ``is`` (not ``in``) so value-equality between the two cannot mask the bug.
+    surv = Instance.from_numpy(
+        np.array([[10.0, 20.0, 1, 1], [np.nan, np.nan, 0, 0]]), skeleton=skeleton
+    )
+    dono = Instance.from_numpy(
+        np.array([[10.0, 20.0, 1, 1], [30.0, 40.0, 1, 1]]), skeleton=skeleton
+    )
+    assert surv.track is None and dono.track is None
+    lf5 = _merge_frame(skeleton, video, 1003, [dono, surv])
+    labels.append(lf5)
+    context.state["labeled_frame"] = lf5
+    context.state["instance"] = surv
+    context.mergeInstance()
+
+    # The survivor (by identity) must remain; the donor must be gone.
+    assert any(inst is surv for inst in lf5.instances)
+    assert all(inst is not dono for inst in lf5.instances)
+    assert len(lf5.user_instances) == 1
+    assert context.state["instance"] is surv
+    # Survivor now carries both nodes (its own "head" + the donor's "thorax").
+    assert surv["head"]["xy"].tolist() == [10.0, 20.0]
+    assert surv["thorax"]["xy"].tolist() == [30.0, 40.0]
+
 
 def test_CopyInstanceTrack(min_tracks_2node_labels: Labels):
     """Test that copying a track from one instance to another works."""

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -1006,6 +1006,133 @@ def test_PasteInstance(min_tracks_2node_labels: Labels):
     paste_instance(lf_to_paste, assertions_prior, assertions_post)
 
 
+def _merge_frame(skeleton, video, frame_idx, instances):
+    """Build a `LabeledFrame` from instances for merge tests."""
+    return LabeledFrame(video=video, frame_idx=frame_idx, instances=instances)
+
+
+def test_MergeInstances(min_tracks_2node_labels: Labels):
+    """Test merging two user instances into one (union of labeled keypoints).
+
+    Skeleton has nodes ["head", "thorax"]. We build a survivor carrying only
+    "head" and a donor carrying both nodes so the merge fills the survivor's
+    missing "thorax" while keeping the survivor's (conflicting) "head".
+    """
+    labels = min_tracks_2node_labels
+    skeleton = labels.skeletons[0]
+    video = labels.videos[0]
+
+    # Case 1: two user instances + a predicted instance, fast-path merge.
+    survivor = Instance.from_numpy(
+        np.array([[10.0, 20.0, 1, 1], [np.nan, np.nan, 0, 0]]),
+        skeleton=skeleton,
+        track=Track("survivor"),
+    )
+    # Donor "head" conflicts (kept as survivor's), "thorax" fills the survivor.
+    donor = Instance.from_numpy(
+        np.array([[99.0, 99.0, 1, 1], [30.0, 40.0, 1, 1]]),
+        skeleton=skeleton,
+        track=Track("donor"),
+    )
+    predicted = PredictedInstance.from_numpy(
+        np.array([[1.0, 2.0, 0.9], [3.0, 4.0, 0.9]]), skeleton=skeleton
+    )
+    lf = _merge_frame(skeleton, video, 999, [survivor, donor, predicted])
+    labels.append(lf)
+
+    context: CommandContext = CommandContext.from_labels(labels)
+    context.state["labeled_frame"] = lf
+    context.state["skeleton"] = skeleton
+    context.state["instance"] = survivor
+
+    assert len(lf.user_instances) == 2
+    context.mergeInstance()
+
+    # Donor removed, predicted untouched, survivor kept and still selected.
+    assert len(lf.user_instances) == 1
+    assert survivor in lf.instances
+    assert donor not in lf.instances
+    assert predicted in lf.instances
+    assert context.state["instance"] is survivor
+    # Conflict policy: survivor's "head" value is kept.
+    assert survivor["head"]["xy"].tolist() == [10.0, 20.0]
+    # Missing "thorax" filled from donor (xy + visible + complete).
+    assert survivor["thorax"]["xy"].tolist() == [30.0, 40.0]
+    assert bool(survivor["thorax"]["visible"]) is True
+    assert bool(survivor["thorax"]["complete"]) is True
+    # Survivor keeps its own track.
+    assert survivor.track is not None and survivor.track.name == "survivor"
+
+    # Case 2: explicit donor with three user instances merges only that donor.
+    s2 = Instance.from_numpy(
+        np.array([[10.0, 20.0, 1, 1], [np.nan, np.nan, 0, 0]]),
+        skeleton=skeleton,
+        track=Track("s2"),
+    )
+    d2 = Instance.from_numpy(
+        np.array([[np.nan, np.nan, 0, 0], [30.0, 40.0, 1, 1]]),
+        skeleton=skeleton,
+        track=Track("d2"),
+    )
+    bystander = Instance.from_numpy(
+        np.array([[5.0, 6.0, 1, 1], [7.0, 8.0, 1, 1]]),
+        skeleton=skeleton,
+        track=Track("bystander"),
+    )
+    lf2 = _merge_frame(skeleton, video, 1000, [s2, d2, bystander])
+    labels.append(lf2)
+    context.state["labeled_frame"] = lf2
+    context.state["instance"] = s2
+    context.mergeInstance(donor=d2)
+
+    assert d2 not in lf2.instances
+    assert bystander in lf2.instances
+    assert s2["thorax"]["xy"].tolist() == [30.0, 40.0]
+    assert len(lf2.user_instances) == 2
+
+    # Case 3: donor=None with >2 user instances is a no-op (cannot resolve donor).
+    a = Instance.from_numpy(
+        np.array([[1.0, 1.0, 1, 1], [np.nan, np.nan, 0, 0]]), skeleton=skeleton
+    )
+    b = Instance.from_numpy(
+        np.array([[np.nan, np.nan, 0, 0], [2.0, 2.0, 1, 1]]), skeleton=skeleton
+    )
+    c = Instance.from_numpy(
+        np.array([[3.0, 3.0, 1, 1], [4.0, 4.0, 1, 1]]), skeleton=skeleton
+    )
+    lf3 = _merge_frame(skeleton, video, 1001, [a, b, c])
+    labels.append(lf3)
+    context.state["labeled_frame"] = lf3
+    context.state["instance"] = a
+    n_before = len(lf3.instances)
+    context.mergeInstance()
+    assert len(lf3.instances) == n_before
+
+    # Case 4: a single user instance (+ predicted) is a no-op; predicted kept.
+    only = Instance.from_numpy(
+        np.array([[1.0, 1.0, 1, 1], [np.nan, np.nan, 0, 0]]), skeleton=skeleton
+    )
+    pred_only = PredictedInstance.from_numpy(
+        np.array([[9.0, 9.0, 0.9], [8.0, 8.0, 0.9]]), skeleton=skeleton
+    )
+    lf4 = _merge_frame(skeleton, video, 1002, [only, pred_only])
+    labels.append(lf4)
+    context.state["labeled_frame"] = lf4
+    context.state["instance"] = only
+    context.mergeInstance()
+    assert len(lf4.instances) == 2
+    assert only in lf4.instances and pred_only in lf4.instances
+
+    # Case 5: a predicted instance selected as survivor is a no-op.
+    context.state["instance"] = pred_only
+    context.mergeInstance()
+    assert len(lf4.instances) == 2
+
+    # Case 6: no selection does not crash.
+    context.state["instance"] = None
+    context.mergeInstance()
+
+
 def test_CopyInstanceTrack(min_tracks_2node_labels: Labels):
     """Test that copying a track from one instance to another works."""
     labels = min_tracks_2node_labels

--- a/tests/gui/widgets/test_docks.py
+++ b/tests/gui/widgets/test_docks.py
@@ -257,3 +257,40 @@ def test_instances_dock_visibility_replot_and_global_toggle(
     qt1 = _qt_instance_for(main_window.player, inst1)
     assert qt0 is not None and not qt0.isVisible()
     assert qt1 is not None and qt1.isVisible()
+
+
+def test_instances_dock_merge_shift_select(qtbot, centered_pair_predictions: Labels):
+    """Shift/ctrl-selecting a 2nd instance in the list marks it as the merge donor.
+
+    First-selected = survivor (state["instance"]); second = donor
+    (state["merge_partner"]). Collapsing back to one row clears the donor.
+    """
+    from qtpy import QtCore
+
+    main_window = MainWindow(labels=centered_pair_predictions)
+    target = centered_pair_predictions.labeled_frames[13]
+    main_window.state["frame_idx"] = target.frame_idx
+
+    table = main_window.instances_dock.table
+    model = table.model()
+    assert model.rowCount() >= 2
+    inst0 = model.original_items[0]
+    inst1 = model.original_items[1]
+
+    # Select row 0 -> survivor; no donor yet.
+    table.selectRow(0)
+    assert main_window.state["instance"] is inst0
+    assert main_window.state["merge_partner"] is None
+
+    # Add row 1 to the selection -> donor (survivor unchanged).
+    table.selectionModel().select(
+        model.index(1, 0),
+        QtCore.QItemSelectionModel.Select | QtCore.QItemSelectionModel.Rows,
+    )
+    assert main_window.state["instance"] is inst0
+    assert main_window.state["merge_partner"] is inst1
+
+    # Collapsing back to a single row clears the donor.
+    table.selectRow(1)
+    assert main_window.state["instance"] is inst1
+    assert main_window.state["merge_partner"] is None


### PR DESCRIPTION
**Related issues:** Closes #2763 (Label GUI: "Merge Instance") · part of #2762 (Master Issue: Label GUI Improvements).

## Summary

Adds **Merge Instance**: combine two user instances in the same frame (e.g. one carrying the anterior keypoints, the other the posterior) into a single labeled instance — the union of their labeled nodes (#2763).

## Selecting the pair (shift-select)

In the **Instances dock**:
1. **Click** the instance to keep (survivor).
2. **Ctrl-click** (or Shift-click) the instance to merge in (donor) → two rows selected.
3. Trigger **Merge** (Label menu / Instances-dock button).

**First-selected = survivor** (keeps its track); **second = donor** (merged in and removed). This works with **3+ instances** in the frame — you pick exactly which donor. With exactly two user instances it still auto-resolves; a right-click **"Merge Instance with…"** submenu also picks a donor explicitly.

Shift-select lives in the **list** because the canvas Shift/Ctrl-click are already bound (mark-points-complete / duplicate). The survivor stays highlighted on the canvas; both selected rows show in the dock.

## Merge behavior

- Donor fills only the survivor's missing/hidden nodes; **survivor wins** any overlapping visible node; survivor keeps its track; predicted instances are excluded.
- Donor removed **by identity** (`is`), so even when the merged survivor becomes pose-identical to an untracked donor it can't delete the wrong one.
- No dedicated undo (matches `DeleteSelectedInstance`/`PasteInstance`).

## Implementation

- `InstancesTableView` (`dataviews.py`): multi-select with explicit click-order tracking (1st = survivor, 2nd = donor), a re-entrancy guard so setting the survivor doesn't collapse the selection, and an init guard for Qt's setup-order quirk.
- `state["merge_partner"]` holds the donor; `MergeInstances` uses it (after an explicit submenu donor, before the exactly-two auto-resolve) and clears it after merging.

## Tests

- Command (`test_MergeInstances`): merge logic + conflict policy, predicted excluded, no-op cases, untracked-superset identity regression, and donor-from-`merge_partner` with a 3rd bystander.
- Dock (`test_instances_dock_merge_shift_select`): selection order — 1st → survivor, 2nd → donor, single-select clears the donor.

🤖 Implemented with Claude Code.
