### PR TITLE
fix(gui): set parent widget on seekbar tooltip to fix Wayland popup warnings (#2779)

### DIFF
--- a/sleap/gui/widgets/slider.py
+++ b/sleap/gui/widgets/slider.py
@@ -1173,7 +1173,10 @@ class VideoSlider(QtWidgets.QGraphicsView):
         if self._get_val_tooltip:
             hover_frame_idx = self._toVal(self.mapMouseXToHandleX(scenePos.x()))
             tooltip = self._get_val_tooltip(hover_frame_idx)
-            QtWidgets.QToolTip.showText(event.globalPos(), tooltip)
+            # Pass `self` as the parent widget so the tooltip popup has a
+            # transientParent; without it Wayland fails to create the popup and
+            # floods stderr with warnings (see #2779).
+            QtWidgets.QToolTip.showText(event.globalPos(), tooltip, self)
 
         self.mouseMoved.emit(scenePos.x(), scenePos.y())
 

--- a/tests/gui/test_slider.py
+++ b/tests/gui/test_slider.py
@@ -1,4 +1,5 @@
 from sleap.gui.widgets.slider import VideoSlider, set_slider_marks_from_labels
+from qtpy import QtCore, QtGui, QtWidgets
 import pytest
 
 
@@ -180,3 +181,41 @@ def test_toVal_invalid_input(qtbot, invalid_value, expected_error_msg):
 
     # Verify the exact error message
     assert str(excinfo.value) == expected_error_msg
+
+
+def test_slider_tooltip_has_parent_widget(qtbot, monkeypatch):
+    """Hover tooltip is shown with the slider as its parent widget.
+
+    Without a parent widget, ``QToolTip.showText`` produces a popup with no
+    ``transientParent``, which Wayland refuses to create and floods stderr with
+    warnings (see #2779).
+    """
+    slider = VideoSlider(min=0, max=100, val=0)
+    qtbot.addWidget(slider)
+    slider.setTooltipCallable(lambda val: f"frame {val}")
+
+    calls = []
+    monkeypatch.setattr(
+        QtWidgets.QToolTip,
+        "showText",
+        lambda *args, **kwargs: calls.append(args),
+    )
+
+    event = QtGui.QMouseEvent(
+        QtCore.QEvent.MouseMove,
+        QtCore.QPointF(10, 5),
+        QtCore.Qt.NoButton,
+        QtCore.Qt.NoButton,
+        QtCore.Qt.NoModifier,
+    )
+    slider.mouseMoveEvent(event)
+
+    # The tooltip must be shown with the slider as the parent widget (3rd arg)
+    # so the popup has a transientParent on Wayland.
+    assert len(calls) == 1
+    args = calls[0]
+    assert len(args) >= 3, (
+        "tooltip shown without a parent widget; the popup will lack a "
+        "transientParent and Wayland will fail to create it (see #2779)"
+    )
+    assert args[2] is slider


### PR DESCRIPTION
## Description

Fixes #2779.

On Wayland, opening a project and hovering over the seekbar floods stderr with one warning per mouse-move:

```
qt.qpa.wayland: Failed to create popup. Ensure popup QWidgetWindow(..., name="qtooltip_labelWindow") has a transientParent set.
```

## Root cause

The seekbar (`VideoSlider`) shows a per-frame tooltip on every `mouseMoveEvent` via `QToolTip.showText(pos, text)` — **without a parent widget**.

A tooltip is a top-level *popup* window. On Wayland, popups are only allowed to exist relative to a parent surface (their **transientParent**); they cannot use arbitrary screen coordinates the way X11 allows. Qt can only derive that transient parent from an owner widget. With the 2-argument `showText`, no owner is given, so Qt must infer one from the app's activation state — which on Wayland isn't established until the window receives genuine compositor input. That's why the warnings only stop **after the first real click** on the slider (the well-known "works after clicking once" workaround) and why X11 was unaffected.

## Fix

Pass `self` as the parent widget:

```python
QtWidgets.QToolTip.showText(event.globalPos(), tooltip, self)
```

Now the popup always has an explicit transientParent — it works from the very first hover, with no click required, in any activation state.

## Testing

- **Unit (CI):** added `test_slider_tooltip_has_parent_widget`, which intercepts `QToolTip.showText`, fires a hover, and asserts the slider is passed as the parent widget. Verified it **fails** without the fix (`assert 2 >= 3`) and **passes** with it.
- **Wayland (manual):** reproduced the real symptom under `QT_QPA_PLATFORM=wayland` driving the actual `mouseMoveEvent` across 5 hover positions:
  - old code → **5** `Failed to create popup` warnings
  - new code → **0** warnings (no click needed)
- Full `tests/gui/test_slider.py` suite: 14 passed. `ruff` clean.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)