### PR TITLE
feat(gui): per-instance & Label QC node-visibility controls (#2781, #2782, #2783)

### DIFF
--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -31,6 +31,7 @@ save: Ctrl+S
 select next: '`'
 select to frame: Ctrl+Shift+J
 show instances: H
+show non-visible nodes: Shift+V
 show edges: Ctrl+Shift+Tab
 show labels: Ctrl+Tab
 show trails: 

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -208,11 +208,13 @@ class MainWindow(QMainWindow):
         self.state[INSTANCE_HIDDEN_KEY] = set()
         self.state[VIEW_ONLY_INSTANCE_KEY] = None
         self.state[SHOW_NONVISIBLE_OVERRIDE_KEY] = {}
-        # Label QC "display mode" (#2783): a PERSISTED view preference (NOT a
-        # transient per-frame key), so it is restored from prefs and is never
-        # reset on frame change. "manual" keeps the Instances-dock columns in
-        # control; other modes drive the transient keys above on each recompute.
-        self.state[QC_DISPLAY_MODE_KEY] = prefs["qc display mode"]
+        # Label QC "display mode" (#2783): a transient, session-only review aid.
+        # It always starts in "manual" (normal view) and is intentionally NOT
+        # persisted across launches -- a selection-relative mode that hides
+        # instances would look like a bug on the next startup. "manual" keeps the
+        # Instances-dock columns in control; other modes drive the transient keys
+        # above. Not reset on frame change (the mode persists within a session).
+        self.state[QC_DISPLAY_MODE_KEY] = QC_MODE_MANUAL
         # (video, frame_idx) of the last plotted frame, so `_after_plot_change`
         # clears the transient visibility above only when the frame truly changes
         # (not on same-frame replots like marker-size or add-instance).
@@ -309,7 +311,6 @@ class MainWindow(QMainWindow):
         prefs["window state"] = self.saveState()
         prefs["marker size"] = self.state["marker size"]
         prefs["show non-visible nodes"] = self.state["show non-visible nodes"]
-        prefs["qc display mode"] = self.state[QC_DISPLAY_MODE_KEY]
         prefs["show mean node score"] = self.state["show mean node score"]
         prefs["node label size"] = self.state["node label size"]
         prefs["edge style"] = self.state["edge style"]

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -241,7 +241,7 @@ class MainWindow(QMainWindow):
 
         self.state.connect("marker size", self.plotFrame)
         self.state.connect("node label size", self.plotFrame)
-        self.state.connect("show non-visible nodes", self.plotFrame)
+        self.state.connect("show non-visible nodes", self._on_show_non_visible_toggled)
         # Label QC display mode (#2783): a non-manual mode derives the
         # per-instance visibility from the mode + selection and replots; switching
         # back to "manual" clears the mode-driven state. Selection changes are
@@ -1553,6 +1553,19 @@ class MainWindow(QMainWindow):
         """
         if self.state[QC_DISPLAY_MODE_KEY] == QC_MODE_MANUAL:
             return
+        self._recompute_qc_flags_into_state()
+        self.plotFrame()
+
+    def _on_show_non_visible_toggled(self, *args):
+        """Global "Show Non-Visible Nodes" toggled (Shift+V): re-derive + replot.
+
+        The toggle is a master gate even inside an Instance Focus mode (#2783): in
+        a non-manual mode, re-derive the per-instance occluded flags with the new
+        global value (`compute_qc_visibility` ANDs the mode's occluded display with
+        it), so turning it off hides occluded keypoints for every instance. The
+        recompute is a no-op in manual mode, where the global flag is just the
+        per-instance default as before -- either way we then replot.
+        """
         self._recompute_qc_flags_into_state()
         self.plotFrame()
 

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -110,6 +110,10 @@ from sleap.gui.state import (
     GuiState,
     INSTANCE_HIDDEN_KEY,
     VIEW_ONLY_INSTANCE_KEY,
+    SHOW_NONVISIBLE_OVERRIDE_KEY,
+    QC_DISPLAY_MODE_KEY,
+    QC_MODE_MANUAL,
+    compute_qc_visibility,
 )
 from sleap.gui.web import ping_analytics
 from sleap.gui.widgets.docks import (
@@ -197,10 +201,18 @@ class MainWindow(QMainWindow):
         self.state["show instances"] = True
         self.state["show labels"] = True
         self.state["show edges"] = True
-        # Transient per-instance canvas visibility (Instances dock checkboxes).
-        # Reset on each real frame change in `_after_plot_change`; never persisted.
+        # Transient per-instance canvas visibility (Instances dock checkboxes:
+        # hidden set, view-only instance, and per-instance "show non-visible
+        # nodes" override). Reset on each real frame change in
+        # `_after_plot_change`; never persisted.
         self.state[INSTANCE_HIDDEN_KEY] = set()
         self.state[VIEW_ONLY_INSTANCE_KEY] = None
+        self.state[SHOW_NONVISIBLE_OVERRIDE_KEY] = {}
+        # Label QC "display mode" (#2783): a PERSISTED view preference (NOT a
+        # transient per-frame key), so it is restored from prefs and is never
+        # reset on frame change. "manual" keeps the Instances-dock columns in
+        # control; other modes drive the transient keys above on each recompute.
+        self.state[QC_DISPLAY_MODE_KEY] = prefs["qc display mode"]
         # (video, frame_idx) of the last plotted frame, so `_after_plot_change`
         # clears the transient visibility above only when the frame truly changes
         # (not on same-frame replots like marker-size or add-instance).
@@ -227,6 +239,13 @@ class MainWindow(QMainWindow):
         self.state.connect("marker size", self.plotFrame)
         self.state.connect("node label size", self.plotFrame)
         self.state.connect("show non-visible nodes", self.plotFrame)
+        # Label QC display mode (#2783): a non-manual mode derives the
+        # per-instance visibility from the mode + selection and replots; switching
+        # back to "manual" clears the mode-driven state. Selection changes are
+        # followed only in a non-manual mode -- in the default "manual" mode
+        # selecting an instance stays lightweight (no replot), as before.
+        self.state.connect(QC_DISPLAY_MODE_KEY, self._on_qc_display_mode_changed)
+        self.state.connect("instance", self._on_qc_selection_changed)
 
         if self.state["share usage data"]:
             ping_analytics()
@@ -290,6 +309,7 @@ class MainWindow(QMainWindow):
         prefs["window state"] = self.saveState()
         prefs["marker size"] = self.state["marker size"]
         prefs["show non-visible nodes"] = self.state["show non-visible nodes"]
+        prefs["qc display mode"] = self.state[QC_DISPLAY_MODE_KEY]
         prefs["show mean node score"] = self.state["show mean node score"]
         prefs["node label size"] = self.state["node label size"]
         prefs["edge style"] = self.state["edge style"]
@@ -1455,6 +1475,65 @@ class MainWindow(QMainWindow):
         if _has_topic([UpdateTopic.frame, UpdateTopic.project_instances]):
             self.state["last_interacted_frame"] = self.state["labeled_frame"]
 
+    def _recompute_qc_flags_into_state(self):
+        """Recompute the transient per-instance keys from the QC display mode.
+
+        Does NOT replot -- callers either replot themselves (the QC display-mode
+        callbacks) or are already inside the plot path (`_after_plot_change`). In
+        "manual" mode this is a no-op so the Instances-dock columns (#2755/#2782)
+        stay in control. Otherwise the mode OWNS all three transient keys: it
+        overwrites the hidden set and the show-non-visible override wholesale, and
+        forces view-only off (the mode decides visibility, not a per-row radio).
+        See `sleap.gui.state.compute_qc_visibility` for the mode -> flags mapping.
+        """
+        mode = self.state[QC_DISPLAY_MODE_KEY]
+        if mode == QC_MODE_MANUAL:
+            return
+        instances = get_instances_to_show(self.state["labeled_frame"])
+        selected = self.state["instance"]
+        global_snv = self.state.get("show non-visible nodes", default=True)
+        flags = compute_qc_visibility(mode, selected, instances, global_snv)
+        self.state[INSTANCE_HIDDEN_KEY] = {
+            iid for iid, (vis, _) in flags.items() if not vis
+        }
+        self.state[VIEW_ONLY_INSTANCE_KEY] = None
+        self.state[SHOW_NONVISIBLE_OVERRIDE_KEY] = {
+            iid: snv for iid, (_, snv) in flags.items()
+        }
+
+    def _on_qc_display_mode_changed(self, *args):
+        """The Label QC display mode itself changed (#2783): re-derive + replot.
+
+        A non-manual mode derives the transient per-instance keys from the
+        current selection; switching back to "manual" clears the mode-driven
+        keys so the Instances-dock columns (#2755/#2782) regain control. Either
+        way a full `plotFrame` is REQUIRED because `show_non_visible` is baked
+        into each `QtInstance` at creation -- `setVisible` cannot resurrect
+        node/edge children that were never built.
+        """
+        if self.state[QC_DISPLAY_MODE_KEY] == QC_MODE_MANUAL:
+            # Hand control back to the Instances-dock columns.
+            self.state[INSTANCE_HIDDEN_KEY] = set()
+            self.state[VIEW_ONLY_INSTANCE_KEY] = None
+            self.state[SHOW_NONVISIBLE_OVERRIDE_KEY] = {}
+        else:
+            self._recompute_qc_flags_into_state()
+        self.plotFrame()
+
+    def _on_qc_selection_changed(self, *args):
+        """Selection changed: follow it only when a non-manual QC mode is active.
+
+        In the default "manual" mode selecting an instance must stay lightweight
+        (NO replot), matching pre-#2783 behavior -- otherwise every canvas click
+        would rebuild the whole frame. A non-manual mode re-derives the
+        per-instance flags for the new selection and replots (e.g. `selected_only`
+        follows the active instance).
+        """
+        if self.state[QC_DISPLAY_MODE_KEY] == QC_MODE_MANUAL:
+            return
+        self._recompute_qc_flags_into_state()
+        self.plotFrame()
+
     def plotFrame(self, *args, **kwargs):
         """Plots (or replots) current frame."""
         if self.state["video"] is None:
@@ -1490,6 +1569,12 @@ class MainWindow(QMainWindow):
             self._vis_last_frame_key = frame_key
             self.state[INSTANCE_HIDDEN_KEY] = set()
             self.state[VIEW_ONLY_INSTANCE_KEY] = None
+            self.state[SHOW_NONVISIBLE_OVERRIDE_KEY] = {}
+            # A non-manual QC display mode (#2783) owns these transient keys, so
+            # re-derive them for the freshly navigated frame. No `plotFrame` here:
+            # we are already inside the plot path and the overlay redraw below
+            # will apply the recomputed state (calling plotFrame would recurse).
+            self._recompute_qc_flags_into_state()
 
         # Show instances, etc, for this frame
         for overlay in self.overlays.values():

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -113,6 +113,7 @@ from sleap.gui.state import (
     SHOW_NONVISIBLE_OVERRIDE_KEY,
     QC_DISPLAY_MODE_KEY,
     QC_MODE_MANUAL,
+    QC_MODE_CHOICES,
     compute_qc_visibility,
 )
 from sleap.gui.web import ping_analytics
@@ -772,6 +773,26 @@ class MainWindow(QMainWindow):
         add_menu_check_item(viewMenu, "show labels", "Show Node Names")
         add_menu_check_item(viewMenu, "show edges", "Show Edges")
         add_menu_check_item(viewMenu, "show mean node score", "Show Mean Node Score")
+
+        # Label QC display-mode selector (#2783), mirrored from the QC dock's
+        # "Display:" combo so the modes are reachable from the menu too. Kept in
+        # sync with QC_DISPLAY_MODE_KEY: menu clicks set it; external changes
+        # (e.g. the dock combo) re-check the matching item.
+        qc_display_menu = viewMenu.addMenu("Label QC Display")
+        self._qc_display_actions = {}
+        for _label, _mode in QC_MODE_CHOICES:
+            _act = qc_display_menu.addAction(
+                _label, lambda m=_mode: self.state.set(QC_DISPLAY_MODE_KEY, m)
+            )
+            _act.setCheckable(True)
+            self._qc_display_actions[_mode] = _act
+
+        def _sync_qc_display_menu(mode):
+            for _m, _a in self._qc_display_actions.items():
+                _a.setChecked(_m == mode)
+
+        self.state.connect(QC_DISPLAY_MODE_KEY, _sync_qc_display_menu)
+        self.state.emit(QC_DISPLAY_MODE_KEY)
 
         add_submenu_choices(
             menu=viewMenu,

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -774,11 +774,11 @@ class MainWindow(QMainWindow):
         add_menu_check_item(viewMenu, "show edges", "Show Edges")
         add_menu_check_item(viewMenu, "show mean node score", "Show Mean Node Score")
 
-        # Label QC display-mode selector (#2783), mirrored from the QC dock's
-        # "Display:" combo so the modes are reachable from the menu too. Kept in
-        # sync with QC_DISPLAY_MODE_KEY: menu clicks set it; external changes
-        # (e.g. the dock combo) re-check the matching item.
-        qc_display_menu = viewMenu.addMenu("Label QC Display")
+        # Instance-focus display-mode selector (#2783), mirrored from the QC
+        # dock's "Display:" combo so the modes are reachable from the menu too.
+        # Kept in sync with QC_DISPLAY_MODE_KEY: menu clicks set it; external
+        # changes (e.g. the dock combo) re-check the matching item.
+        qc_display_menu = viewMenu.addMenu("Instance Focus")
         self._qc_display_actions = {}
         for _label, _mode in QC_MODE_CHOICES:
             _act = qc_display_menu.addAction(

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -490,6 +490,15 @@ class CommandContext:
             if 0 <= instance_idx < len(user_instances):
                 instance_to_highlight = user_instances[instance_idx]
 
+        # Make the navigated instance the app-selected instance (not just a
+        # player-view highlight) so anything keyed off ``state["instance"]``
+        # follows it -- in particular the Label QC display modes (#2783), which
+        # focus on the selected instance. Without this, navigating to a flagged
+        # instance left ``state["instance"]`` unchanged, so those modes saw no
+        # on-frame selection and fell back to the first instance.
+        if instance_to_highlight is not None:
+            self.state["instance"] = instance_to_highlight
+
         # Use a timer to highlight and select after the frame is redrawn
         # (state changes trigger plot() which recreates instances via overlay)
         player = getattr(self.app, "player", None)

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -29,6 +29,8 @@ from sleap.gui.state import (
     INSTANCE_HIDDEN_KEY,
     VIEW_ONLY_INSTANCE_KEY,
     SHOW_NONVISIBLE_OVERRIDE_KEY,
+    QC_DISPLAY_MODE_KEY,
+    QC_MODE_MANUAL,
     instance_visible,
     instance_shows_non_visible,
 )
@@ -747,6 +749,13 @@ class LabeledFrameTableModel(GenericTableModel):
                 # normalize via its ``.value`` before comparing (mirrors the
                 # convention in sleap/gui/dialogs/qc.py:230).
                 checked = getattr(value, "value", value) == QtCore.Qt.Checked.value
+                # A manual per-instance visibility edit means the user is taking
+                # over from any active Label QC display mode (#2783) -- which would
+                # otherwise overwrite this edit on its next recompute. Drop back to
+                # "manual" first so the edit sticks (no-op if already manual; in
+                # manual mode this clears the mode-driven hides, giving a clean
+                # slate the edit below then applies on top of).
+                self._vis_state[QC_DISPLAY_MODE_KEY] = QC_MODE_MANUAL
                 if key == self.VISIBILITY_KEY:
                     self._set_visibility(instance, checked)
                 elif key == self.VIEW_ONLY_KEY:

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -28,7 +28,9 @@ from sleap.gui.state import (
     GuiState,
     INSTANCE_HIDDEN_KEY,
     VIEW_ONLY_INSTANCE_KEY,
+    SHOW_NONVISIBLE_OVERRIDE_KEY,
     instance_visible,
+    instance_shows_non_visible,
 )
 from sleap_io.model.skeleton import Skeleton
 from sleap_io import Video
@@ -542,9 +544,10 @@ class LabeledFrameTableModel(GenericTableModel):
 
     Allows editing track names.
 
-    In addition to the informational columns, two checkbox columns control
+    In addition to the informational columns, three checkbox columns control
     per-instance rendering on the video canvas (transient, session-only state;
-    see `sleap.gui.state.instance_visible`):
+    see `sleap.gui.state.instance_visible` /
+    `sleap.gui.state.instance_shows_non_visible`):
 
     - "visibility": checked by default; unchecking hides that instance on the
       canvas while keeping its row in the table.
@@ -552,16 +555,21 @@ class LabeledFrameTableModel(GenericTableModel):
       that instance visible and disables the whole visibility column. Checking
       another row's "view only" auto-unchecks the previous (radio-like).
       Toggling any "visibility" box exits view-only mode.
+    - "invisible nodes": per-instance override of the global "Show Non-Visible
+      Nodes" flag; defaults to the effective value (override if present, else
+      the global flag). Because non-visible nodes are baked into the canvas
+      instance at creation time, toggling this forces a full replot.
 
     Args:
         labeled_frame: `LabeledFrame` to show
         labels: `Labels` datasource
     """
 
-    # The two checkbox columns are appended LAST so existing name-indexed
+    # The checkbox columns are appended LAST so existing name-indexed
     # lookups (e.g. ``properties.index("mean node score")``) stay valid.
     VISIBILITY_KEY = "visibility"
     VIEW_ONLY_KEY = "view only"
+    SHOW_NONVISIBLE_KEY = "invisible nodes"
 
     properties = (
         "points",
@@ -571,6 +579,7 @@ class LabeledFrameTableModel(GenericTableModel):
         "skeleton",
         VISIBILITY_KEY,
         VIEW_ONLY_KEY,
+        SHOW_NONVISIBLE_KEY,
     )
 
     def object_to_items(self, labeled_frame: LabeledFrame):
@@ -628,7 +637,7 @@ class LabeledFrameTableModel(GenericTableModel):
 
     @property
     def _checkbox_keys(self):
-        return (self.VISIBILITY_KEY, self.VIEW_ONLY_KEY)
+        return (self.VISIBILITY_KEY, self.VIEW_ONLY_KEY, self.SHOW_NONVISIBLE_KEY)
 
     @property
     def _vis_state(self) -> GuiState:
@@ -671,6 +680,11 @@ class LabeledFrameTableModel(GenericTableModel):
         view_only = self._vis_state.get(VIEW_ONLY_INSTANCE_KEY, default=None)
         return view_only is not None and id(instance) == view_only
 
+    def is_show_nonvisible_checked(self, instance) -> bool:
+        """Whether the "invisible nodes" box is checked (effective value)."""
+        global_default = self._vis_state.get("show non-visible nodes", default=True)
+        return instance_shows_non_visible(self._vis_state, instance, global_default)
+
     def data(self, index: QtCore.QModelIndex, role=QtCore.Qt.DisplayRole):
         """Overrides Qt method to add checkbox state for the new columns."""
         if not index.isValid():
@@ -682,8 +696,10 @@ class LabeledFrameTableModel(GenericTableModel):
                 instance = self.original_items[index.row()]
                 if key == self.VISIBILITY_KEY:
                     checked = self.is_visibility_checked(instance)
-                else:
+                elif key == self.VIEW_ONLY_KEY:
                     checked = self.is_view_only_checked(instance)
+                else:
+                    checked = self.is_show_nonvisible_checked(instance)
                 return QtCore.Qt.Checked if checked else QtCore.Qt.Unchecked
             if (
                 role == QtCore.Qt.BackgroundRole
@@ -733,8 +749,10 @@ class LabeledFrameTableModel(GenericTableModel):
                 checked = getattr(value, "value", value) == QtCore.Qt.Checked.value
                 if key == self.VISIBILITY_KEY:
                     self._set_visibility(instance, checked)
-                else:
+                elif key == self.VIEW_ONLY_KEY:
                     self._set_view_only(instance, checked)
+                else:
+                    self._set_show_nonvisible(instance, checked)
                 return True
 
         return super().setData(index, value, role)
@@ -765,6 +783,14 @@ class LabeledFrameTableModel(GenericTableModel):
 
         self._refresh_after_toggle()
 
+    def _set_show_nonvisible(self, instance, checked: bool):
+        """Toggle an instance's "invisible nodes" override (forces a replot)."""
+        state = self._vis_state
+        override = dict(state.get(SHOW_NONVISIBLE_OVERRIDE_KEY, default=None) or {})
+        override[id(instance)] = checked  # explicit True/False, never popped
+        state[SHOW_NONVISIBLE_OVERRIDE_KEY] = override
+        self._replot_after_show_nonvisible_toggle()
+
     def _refresh_after_toggle(self):
         """Apply the new state to the canvas and repaint the whole table.
 
@@ -773,6 +799,27 @@ class LabeledFrameTableModel(GenericTableModel):
         view-only mode changes).
         """
         self._apply_canvas_visibility()
+        rows = self.rowCount()
+        cols = self.columnCount()
+        if rows and cols:
+            self.dataChanged.emit(
+                self.index(0, 0),
+                self.index(rows - 1, cols - 1),
+            )
+
+    def _replot_after_show_nonvisible_toggle(self):
+        """Full replot after an "invisible nodes" toggle, then repaint the table.
+
+        ``show_non_visible`` is baked into the canvas `QtInstance` at creation
+        time, so ``setVisible`` cannot resurrect node/edge children that were
+        never built -> a full replot is required (unlike the visibility/view-only
+        columns, which only ``setVisible``). The ``getattr`` guard makes this a
+        no-op headless / in unit tests (``context is None``), like
+        `_apply_canvas_visibility`.
+        """
+        app = getattr(self.context, "app", None) if self.context else None
+        if app is not None:
+            app.plotFrame()
         rows = self.rowCount()
         cols = self.columnCount()
         if rows and cols:

--- a/sleap/gui/dialogs/qc.py
+++ b/sleap/gui/dialogs/qc.py
@@ -12,6 +12,7 @@ from typing import Callable, Optional, TYPE_CHECKING
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 
+from sleap.gui.state import QC_DISPLAY_MODE_KEY, QC_MODE_MANUAL
 from sleap.gui.widgets.qc import QCWidget
 
 if TYPE_CHECKING:
@@ -135,6 +136,9 @@ class QCDockWidget(QtWidgets.QDockWidget):
         if self._navigate_callback is not None:
             self._widget.navigate_to_instance.connect(self._on_navigate)
 
+        # Bridge the QC display-mode selector to the main window's state (#2783).
+        self._widget.display_mode_changed.connect(self._on_display_mode_changed)
+
         # Update dock button text when dock state changes (e.g., via dragging)
         self.topLevelChanged.connect(self._update_dock_button)
 
@@ -151,6 +155,16 @@ class QCDockWidget(QtWidgets.QDockWidget):
             # Connect to state changes
             parent.state.connect("fit_selection", self._on_fit_selection_state_changed)
             self._state_connected = True
+
+            # Initial sync + connect for the QC display mode (#2783). The combo
+            # only reflects the persisted mode here; the app state callback owns
+            # the recompute + replot.
+            self._widget.set_display_mode(
+                parent.state.get(QC_DISPLAY_MODE_KEY, QC_MODE_MANUAL)
+            )
+            parent.state.connect(
+                QC_DISPLAY_MODE_KEY, self._on_display_mode_state_changed
+            )
 
     def _on_visibility_changed(self, visible: bool):
         """Track visibility changes and update labels if needed.
@@ -174,6 +188,10 @@ class QCDockWidget(QtWidgets.QDockWidget):
                 # Sync fit_selection checkbox (connection made in _connect_signals)
                 if hasattr(parent, "state"):
                     self._sync_fit_selection_checkbox()
+                    # Reflect the persisted QC display mode on dock re-show (#2783).
+                    self._widget.set_display_mode(
+                        parent.state.get(QC_DISPLAY_MODE_KEY, QC_MODE_MANUAL)
+                    )
 
     def _on_navigate(self, video_idx: int, frame_idx: int, instance_idx: int):
         """Handle navigation request from widget."""
@@ -240,6 +258,23 @@ class QCDockWidget(QtWidgets.QDockWidget):
         """
         self._sync_fit_selection_checkbox(value)
         self._apply_fit_selection_zoom(value)
+
+    def _on_display_mode_changed(self, mode: str):
+        """Handle the widget's display-mode change: push it into main state (#2783).
+
+        The app's ``QC_DISPLAY_MODE_KEY`` callback does the recompute + replot.
+        """
+        parent = self._main_window
+        if parent is not None and hasattr(parent, "state"):
+            parent.state[QC_DISPLAY_MODE_KEY] = mode
+
+    def _on_display_mode_state_changed(self, value: str):
+        """Sync the combo when the QC display mode changes in state (#2783).
+
+        ``set_display_mode`` blocks the combo's signals, so this does not loop
+        back into state.
+        """
+        self._widget.set_display_mode(value)
 
     def _apply_fit_selection_zoom(self, enabled: bool):
         """Apply or clear the fit-to-selection zoom.

--- a/sleap/gui/overlays/instance.py
+++ b/sleap/gui/overlays/instance.py
@@ -5,7 +5,7 @@ Overlay for showing instances.
 import attr
 
 from sleap.gui.overlays.base import BaseOverlay
-from sleap.gui.state import GuiState, instance_visible
+from sleap.gui.state import GuiState, instance_visible, instance_shows_non_visible
 from sleap.sleap_io_adaptors.lf_labels_utils import get_instances_to_show
 
 
@@ -48,7 +48,11 @@ class InstanceOverlay(BaseOverlay):
                 frame=lf,
                 markerRadius=self.state.get("marker size", 4),
                 nodeLabelSize=self.state.get("node label size", 12),
-                show_non_visible=self.state.get("show non-visible nodes", default=True),
+                show_non_visible=instance_shows_non_visible(
+                    self.state,
+                    instance,
+                    self.state.get("show non-visible nodes", default=True),
+                ),
             )
 
         self.player.showInstances(self.state.get("show instances", default=True))

--- a/sleap/gui/shortcuts.py
+++ b/sleap/gui/shortcuts.py
@@ -52,6 +52,7 @@ class Shortcuts(object):
         "goto prev suggestion",
         "goto next track spawn",
         "show instances",
+        "show non-visible nodes",
         "show labels",
         "show edges",
         "show trails",

--- a/sleap/gui/state.py
+++ b/sleap/gui/state.py
@@ -148,8 +148,9 @@ def compute_qc_visibility(
         mode: One of the ``QC_MODE_*`` constants.
         selected_instance: The currently selected instance, or ``None``.
         instances: The instances shown on the current frame.
-        global_show_non_visible: The global "show non-visible nodes" flag (unused
-            by the locked modes, kept for symmetry / future modes).
+        global_show_non_visible: The global "show non-visible nodes" flag, used as
+            a master gate: when off, no instance draws occluded keypoints (even the
+            focused one); when on, the mode decides which instances show them.
 
     Returns:
         A dict ``{id(instance): (visible, show_non_visible)}`` (empty for manual).
@@ -180,12 +181,17 @@ def compute_qc_visibility(
     for inst in instances:
         iid = id(inst)
         is_sel = sel_present and iid == sel_id
+        # The global "show non-visible nodes" flag is a master GATE: occluded
+        # keypoints can only be drawn when it is on. The mode then decides WHICH
+        # instances show them (here, the focused/selected one). Off hides occluded
+        # for every instance even inside a focus mode.
+        show_sel_occluded = is_sel and global_show_non_visible
         if mode == QC_MODE_SELECTED_ONLY:
-            flags[iid] = (is_sel, is_sel)  # show only selected; its hidden pts on
+            flags[iid] = (is_sel, show_sel_occluded)  # only selected
         elif mode == QC_MODE_ALL_VISIBLE:
-            flags[iid] = (True, False)  # all visible, occluded pts hidden
+            flags[iid] = (True, False)  # all visible, no occluded
         elif mode == QC_MODE_ALL_PLUS_SELECTED:
-            flags[iid] = (True, is_sel)  # all visible; selected also shows hidden pts
+            flags[iid] = (True, show_sel_occluded)  # all visible + selected's occluded
         else:
             flags[iid] = (True, False)  # unknown mode -> safe "all visible"
     return flags

--- a/sleap/gui/state.py
+++ b/sleap/gui/state.py
@@ -130,8 +130,9 @@ def compute_qc_visibility(
     Returns ``{id(instance): (visible, show_non_visible)}``. An empty dict is the
     "manual" sentinel: the caller leaves the per-instance transient state alone.
     Selection match is by ``id()``; if ``selected_instance`` is ``None`` or not in
-    ``instances``, every non-manual mode degrades to ``all_visible_only`` so the
-    canvas is never blank (it narrows once a valid instance is selected).
+    ``instances``, the selection-relative modes fall back to the FIRST instance
+    (so the mode stays visible and the canvas is never blank), narrowing to the
+    real instance once one is selected.
 
     Args:
         mode: One of the ``QC_MODE_*`` constants.
@@ -150,15 +151,20 @@ def compute_qc_visibility(
     ids_present = {id(i) for i in instances}
     sel_present = sel_id in ids_present
 
-    # `selected_only` with no valid on-frame selection would hide every instance
-    # (blank canvas) -- e.g. right after frame navigation (the selection is not
-    # restored until later in `_after_plot_change`) or at startup when the mode
-    # is restored from prefs with no selection yet. Degrade to "all visible" so
-    # the user always sees their data; it narrows to the single instance once a
-    # valid one is selected. (The `*_selected` modes already degrade to
-    # all-visible via `is_sel == False`.)
-    if mode == QC_MODE_SELECTED_ONLY and not sel_present:
-        mode = QC_MODE_ALL_VISIBLE
+    # The selection-relative modes (`selected_only`, `all_plus_selected_invisible`)
+    # need a target instance. When there is no valid on-frame selection -- right
+    # after switching modes, navigating frames, or opening QC before clicking a
+    # flag -- fall back to the FIRST instance so the mode stays visibly meaningful
+    # (it shows/keeps one instance) instead of collapsing to "show all", and so it
+    # never blanks the canvas. It narrows to the real instance once the user
+    # selects one.
+    if (
+        not sel_present
+        and instances
+        and mode in (QC_MODE_SELECTED_ONLY, QC_MODE_ALL_PLUS_SELECTED)
+    ):
+        sel_id = id(instances[0])
+        sel_present = True
 
     flags = {}
     for inst in instances:

--- a/sleap/gui/state.py
+++ b/sleap/gui/state.py
@@ -39,8 +39,19 @@ NO_ARG = object()
 # - VIEW_ONLY_INSTANCE_KEY -> ``id(instance)`` of the single "View Only"
 #   instance, or ``None``. When set, only that instance is visible and the whole
 #   Visibility column is disabled (radio-like exclusivity).
+# - SHOW_NONVISIBLE_OVERRIDE_KEY -> dict ``{id(instance): bool}``, a per-instance
+#   override of the global "show non-visible nodes" flag. An absent key means
+#   "use the global default"; an explicit ``True``/``False`` overrides it.
 INSTANCE_HIDDEN_KEY = "instance_hidden"
 VIEW_ONLY_INSTANCE_KEY = "view_only_instance"
+SHOW_NONVISIBLE_OVERRIDE_KEY = "show_nonvisible_override"
+
+# Label QC "display mode" (persisted app preference, NOT per-instance/per-frame).
+QC_DISPLAY_MODE_KEY = "qc_display_mode"
+QC_MODE_MANUAL = "manual"
+QC_MODE_SELECTED_ONLY = "selected_only"
+QC_MODE_ALL_VISIBLE = "all_visible_only"
+QC_MODE_ALL_PLUS_SELECTED = "all_plus_selected_invisible"
 
 
 def instance_visible(state: "GuiState", instance: Any) -> bool:
@@ -79,6 +90,89 @@ def instance_visible(state: "GuiState", instance: Any) -> bool:
     if not hidden:
         return True
     return id(instance) not in hidden
+
+
+def instance_shows_non_visible(
+    state: "GuiState", instance: Any, global_default: bool
+) -> bool:
+    """Return whether THIS instance's non-visible (occluded/NaN) nodes are drawn.
+
+    Orthogonal to `instance_visible`: that decides whether the instance is drawn
+    at all; this decides whether its occluded keypoints draw. Per-instance
+    overrides (the "Invisible Nodes" column / a non-manual QC mode) beat the
+    global "show non-visible nodes" flag; absent override -> the global default.
+
+    Args:
+        state: The `GuiState` holding the transient override key.
+        instance: The `Instance`/`PredictedInstance` object (keyed by identity).
+        global_default: The current global "show non-visible nodes" flag, used
+            when there is no per-instance override.
+
+    Returns:
+        ``True`` if this instance's non-visible nodes should be drawn.
+    """
+    if state is None:
+        return global_default
+    override = state.get(SHOW_NONVISIBLE_OVERRIDE_KEY, default=None)
+    if not override:
+        return global_default
+    return override.get(id(instance), global_default)
+
+
+def compute_qc_visibility(
+    mode: str,
+    selected_instance: Any,
+    instances: list,
+    global_show_non_visible: bool,
+) -> dict:
+    """Map a QC display mode + selection -> per-instance visibility flags.
+
+    Returns ``{id(instance): (visible, show_non_visible)}``. An empty dict is the
+    "manual" sentinel: the caller leaves the per-instance transient state alone.
+    Selection match is by ``id()``; if ``selected_instance`` is ``None`` or not in
+    ``instances``, every non-manual mode degrades to ``all_visible_only`` so the
+    canvas is never blank (it narrows once a valid instance is selected).
+
+    Args:
+        mode: One of the ``QC_MODE_*`` constants.
+        selected_instance: The currently selected instance, or ``None``.
+        instances: The instances shown on the current frame.
+        global_show_non_visible: The global "show non-visible nodes" flag (unused
+            by the locked modes, kept for symmetry / future modes).
+
+    Returns:
+        A dict ``{id(instance): (visible, show_non_visible)}`` (empty for manual).
+    """
+    if mode == QC_MODE_MANUAL:
+        return {}
+
+    sel_id = id(selected_instance) if selected_instance is not None else None
+    ids_present = {id(i) for i in instances}
+    sel_present = sel_id in ids_present
+
+    # `selected_only` with no valid on-frame selection would hide every instance
+    # (blank canvas) -- e.g. right after frame navigation (the selection is not
+    # restored until later in `_after_plot_change`) or at startup when the mode
+    # is restored from prefs with no selection yet. Degrade to "all visible" so
+    # the user always sees their data; it narrows to the single instance once a
+    # valid one is selected. (The `*_selected` modes already degrade to
+    # all-visible via `is_sel == False`.)
+    if mode == QC_MODE_SELECTED_ONLY and not sel_present:
+        mode = QC_MODE_ALL_VISIBLE
+
+    flags = {}
+    for inst in instances:
+        iid = id(inst)
+        is_sel = sel_present and iid == sel_id
+        if mode == QC_MODE_SELECTED_ONLY:
+            flags[iid] = (is_sel, is_sel)  # show only selected; its hidden pts on
+        elif mode == QC_MODE_ALL_VISIBLE:
+            flags[iid] = (True, False)  # all visible, occluded pts hidden
+        elif mode == QC_MODE_ALL_PLUS_SELECTED:
+            flags[iid] = (True, is_sel)  # all visible; selected also shows hidden pts
+        else:
+            flags[iid] = (True, False)  # unknown mode -> safe "all visible"
+    return flags
 
 
 class GuiState(object):

--- a/sleap/gui/state.py
+++ b/sleap/gui/state.py
@@ -53,6 +53,16 @@ QC_MODE_SELECTED_ONLY = "selected_only"
 QC_MODE_ALL_VISIBLE = "all_visible_only"
 QC_MODE_ALL_PLUS_SELECTED = "all_plus_selected_invisible"
 
+# (label, mode) pairs for the Label QC display-mode selectors -- the QC dock's
+# "Display:" combo and the View-menu submenu both build from this, so the two
+# selectors cannot drift apart.
+QC_MODE_CHOICES = (
+    ("Manual", QC_MODE_MANUAL),
+    ("Only selected (with hidden points)", QC_MODE_SELECTED_ONLY),
+    ("All instances, visible points only", QC_MODE_ALL_VISIBLE),
+    ("All visible + selected hidden points", QC_MODE_ALL_PLUS_SELECTED),
+)
+
 
 def instance_visible(state: "GuiState", instance: Any) -> bool:
     """Return the effective canvas visibility for an instance.

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -29,6 +29,13 @@ else:
 
 from matplotlib.figure import Figure
 
+from sleap.gui.state import (
+    QC_MODE_MANUAL,
+    QC_MODE_SELECTED_ONLY,
+    QC_MODE_ALL_VISIBLE,
+    QC_MODE_ALL_PLUS_SELECTED,
+)
+
 if TYPE_CHECKING:
     import sleap_io as sio
     from sleap.qc.config import QCConfig
@@ -1677,9 +1684,14 @@ class QCWidget(QtWidgets.QWidget):
     Signals:
         navigate_to_instance: Emitted when user wants to navigate to an instance.
             Arguments are (video_idx, frame_idx, instance_idx).
+        display_mode_changed: Emitted with the new QC display-mode string (one of
+            the ``QC_MODE_*`` constants) when the user picks a "Display:" option.
+            The widget itself never mutates visibility state; the dock bridges
+            this to ``MainWindow.state`` (#2783).
     """
 
     navigate_to_instance = QtCore.Signal(int, int, int)
+    display_mode_changed = QtCore.Signal(str)
 
     def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         """Initialize the widget.
@@ -1910,6 +1922,36 @@ class QCWidget(QtWidgets.QWidget):
             "as you tick rows reviewed."
         )
         toolbar.addWidget(self._hide_reviewed_check)
+
+        # Display-mode selector (#2783): pick how instances draw on the canvas
+        # while reviewing. "Manual" (default) leaves the Instances-dock columns
+        # (#2755/#2782) fully in control; the other modes drive per-instance
+        # visibility from the selected instance. The widget only EMITS the chosen
+        # mode string -- the dock bridges it to the main window's state, which
+        # does the recompute + replot.
+        toolbar.addWidget(QtWidgets.QLabel("Display:"))
+        self._display_mode_combo = QtWidgets.QComboBox()
+        self._display_mode_combo.addItem("Manual", QC_MODE_MANUAL)
+        self._display_mode_combo.addItem(
+            "Only selected (with hidden points)", QC_MODE_SELECTED_ONLY
+        )
+        self._display_mode_combo.addItem(
+            "All instances, visible points only", QC_MODE_ALL_VISIBLE
+        )
+        self._display_mode_combo.addItem(
+            "All visible + selected hidden points", QC_MODE_ALL_PLUS_SELECTED
+        )
+        self._display_mode_combo.setToolTip(
+            "How instances are drawn on the canvas while reviewing:\n"
+            "- Manual: use the Instances panel checkboxes (default).\n"
+            "- Only selected: hide all but the selected instance and show its "
+            "occluded points.\n"
+            "- All instances, visible points only: show every instance but hide "
+            "occluded points.\n"
+            "- All visible + selected hidden points: show every instance; only "
+            "the selected one also shows its occluded points."
+        )
+        toolbar.addWidget(self._display_mode_combo)
 
         toolbar.addStretch()
 
@@ -3105,6 +3147,37 @@ class QCWidget(QtWidgets.QWidget):
         self._table_model.dataChanged.connect(self._on_reviewed_changed)
         # Re-apply the filters whenever the "Hide reviewed" toggle changes.
         self._hide_reviewed_check.toggled.connect(self._on_hide_reviewed_toggled)
+        # Emit the chosen display mode (#2783); the dock bridges it to state.
+        self._display_mode_combo.currentIndexChanged.connect(
+            self._on_display_mode_changed
+        )
+
+    def _on_display_mode_changed(self, _index: int):
+        """Emit the newly selected QC display-mode string (#2783).
+
+        Reads the combo's ``userData`` (a ``QC_MODE_*`` constant) and emits it.
+        Deliberately mutates no visibility state here -- the dock forwards it to
+        the main window's state, which owns the recompute + replot.
+        """
+        mode = self._display_mode_combo.currentData()
+        self.display_mode_changed.emit(mode)
+
+    def set_display_mode(self, mode: str):
+        """Select the combo entry matching ``mode`` without re-emitting (#2783).
+
+        Used to sync the combo FROM the persisted/app state, so combo signals are
+        blocked to avoid a feedback loop back into the state.
+        """
+        idx = self._display_mode_combo.findData(mode)
+        if idx < 0:
+            return
+        self._display_mode_combo.blockSignals(True)
+        self._display_mode_combo.setCurrentIndex(idx)
+        self._display_mode_combo.blockSignals(False)
+
+    def current_display_mode(self) -> str:
+        """Return the current display-mode string (a ``QC_MODE_*`` constant)."""
+        return self._display_mode_combo.currentData()
 
     def _update_spinner(self):
         """Update the spinner animation character."""

--- a/sleap/gui/widgets/qc.py
+++ b/sleap/gui/widgets/qc.py
@@ -29,12 +29,7 @@ else:
 
 from matplotlib.figure import Figure
 
-from sleap.gui.state import (
-    QC_MODE_MANUAL,
-    QC_MODE_SELECTED_ONLY,
-    QC_MODE_ALL_VISIBLE,
-    QC_MODE_ALL_PLUS_SELECTED,
-)
+from sleap.gui.state import QC_MODE_CHOICES
 
 if TYPE_CHECKING:
     import sleap_io as sio
@@ -1931,16 +1926,8 @@ class QCWidget(QtWidgets.QWidget):
         # does the recompute + replot.
         toolbar.addWidget(QtWidgets.QLabel("Display:"))
         self._display_mode_combo = QtWidgets.QComboBox()
-        self._display_mode_combo.addItem("Manual", QC_MODE_MANUAL)
-        self._display_mode_combo.addItem(
-            "Only selected (with hidden points)", QC_MODE_SELECTED_ONLY
-        )
-        self._display_mode_combo.addItem(
-            "All instances, visible points only", QC_MODE_ALL_VISIBLE
-        )
-        self._display_mode_combo.addItem(
-            "All visible + selected hidden points", QC_MODE_ALL_PLUS_SELECTED
-        )
+        for _label, _mode in QC_MODE_CHOICES:
+            self._display_mode_combo.addItem(_label, _mode)
         self._display_mode_combo.setToolTip(
             "How instances are drawn on the canvas while reviewing:\n"
             "- Manual: use the Instances panel checkboxes (default).\n"

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -34,7 +34,6 @@ class Preferences(object):
         "window state": b"",
         "node label size": 12,
         "show non-visible nodes": True,
-        "qc display mode": "manual",
         "show mean node score": False,
         "share usage data": True,
         "node marker sizes": (1, 2, 3, 4, 6, 8, 12),

--- a/sleap/prefs.py
+++ b/sleap/prefs.py
@@ -34,6 +34,7 @@ class Preferences(object):
         "window state": b"",
         "node label size": 12,
         "show non-visible nodes": True,
+        "qc display mode": "manual",
         "show mean node score": False,
         "share usage data": True,
         "node marker sizes": (1, 2, 3, 4, 6, 8, 12),

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -73,6 +73,25 @@ def test_delete_user_dialog(centered_pair_predictions):
     assert len(context.state["labeled_frame"].user_instances) == 2
 
 
+def test_goto_video_frame_instance_selects_instance(centered_pair_labels):
+    """`gotoVideoAndFrameAndInstance` makes the navigated user instance the
+    app-selected instance (``state["instance"]``), so selection-relative views --
+    e.g. the Label QC display modes (#2783) -- follow the flagged instance the
+    user navigated to, instead of falling back to the first instance.
+    """
+    labels = centered_pair_labels
+    video = labels.videos[0]
+    lf = labels.find(video, 0)[0]
+    user = lf.user_instances
+    assert len(user) >= 2
+
+    context = CommandContext.from_labels(labels)
+    context.gotoVideoAndFrameAndInstance(video, 0, 1)
+    assert context.state["instance"] is user[1]
+    context.gotoVideoAndFrameAndInstance(video, 0, 0)
+    assert context.state["instance"] is user[0]
+
+
 def test_import_labels_from_dlc_folder():
     csv_files = ImportDeepLabCutFolder.find_dlc_files_in_folder(
         "tests/data/dlc_multiple_datasets"

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -323,3 +323,156 @@ def test_instance_visible_respects_global_show_instances():
     state["show instances"] = False
     assert not instance_visible(state, inst_a)
     assert not instance_visible(state, inst_b)
+
+
+# -- "Invisible Nodes" per-instance override column (#2782) ----------------------
+
+
+def test_labeled_frame_invisible_nodes_column_present(qtbot, centered_pair_predictions):
+    """The per-instance "invisible nodes" checkbox column should exist last."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+    assert "invisible nodes" in model.properties
+    # Appended LAST, after the #2755 columns.
+    assert model.properties.index("invisible nodes") > model.properties.index(
+        "view only"
+    )
+
+
+def test_labeled_frame_invisible_nodes_default_checked(
+    qtbot, centered_pair_predictions
+):
+    """With no override and no global flag set, the effective default is True."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+    for row in range(model.rowCount()):
+        assert _checkstate(model, row, "invisible nodes") == QtCore.Qt.Checked
+
+
+def test_labeled_frame_invisible_nodes_default_follows_global(
+    qtbot, centered_pair_predictions
+):
+    """The default checkbox follows the global "show non-visible nodes" flag."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+    model._vis_state["show non-visible nodes"] = False
+    for row in range(model.rowCount()):
+        assert _checkstate(model, row, "invisible nodes") == QtCore.Qt.Unchecked
+
+
+def test_labeled_frame_toggle_invisible_nodes_sets_override(
+    qtbot, centered_pair_predictions
+):
+    """Toggling the column writes an explicit per-instance override."""
+    from sleap.gui.state import (
+        SHOW_NONVISIBLE_OVERRIDE_KEY,
+        instance_shows_non_visible,
+    )
+
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+
+    inst0 = model.original_items[0]
+    inst1 = model.original_items[1]
+
+    assert _set_checkstate(model, 0, "invisible nodes", False)
+    assert _checkstate(model, 0, "invisible nodes") == QtCore.Qt.Unchecked
+    # Other rows unaffected.
+    assert _checkstate(model, 1, "invisible nodes") == QtCore.Qt.Checked
+
+    override = model._vis_state.get(SHOW_NONVISIBLE_OVERRIDE_KEY)
+    assert override[id(inst0)] is False
+    # Effective value reflects the override for inst0, default for inst1.
+    assert instance_shows_non_visible(model._vis_state, inst0, True) is False
+    assert instance_shows_non_visible(model._vis_state, inst1, True) is True
+
+    # Re-checking stores an explicit True (never popped).
+    assert _set_checkstate(model, 0, "invisible nodes", True)
+    assert _checkstate(model, 0, "invisible nodes") == QtCore.Qt.Checked
+    override = model._vis_state.get(SHOW_NONVISIBLE_OVERRIDE_KEY)
+    assert override[id(inst0)] is True
+
+
+def test_labeled_frame_invisible_nodes_independent_of_visibility(
+    qtbot, centered_pair_predictions
+):
+    """The override map is orthogonal to the visibility / view-only columns."""
+    from sleap.gui.state import SHOW_NONVISIBLE_OVERRIDE_KEY
+
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+    inst0 = model.original_items[0]
+
+    _set_checkstate(model, 0, "invisible nodes", False)
+    assert model._vis_state.get(SHOW_NONVISIBLE_OVERRIDE_KEY)[id(inst0)] is False
+
+    # Toggling visibility off/on does not touch the override entry.
+    _set_checkstate(model, 0, "visibility", False)
+    _set_checkstate(model, 0, "visibility", True)
+    assert model._vis_state.get(SHOW_NONVISIBLE_OVERRIDE_KEY)[id(inst0)] is False
+    assert _checkstate(model, 0, "invisible nodes") == QtCore.Qt.Unchecked
+
+    # Toggling view only does not touch the override map either.
+    _set_checkstate(model, 0, "view only", True)
+    assert model._vis_state.get(SHOW_NONVISIBLE_OVERRIDE_KEY)[id(inst0)] is False
+
+
+def test_labeled_frame_invisible_nodes_flags_checkable(
+    qtbot, centered_pair_predictions
+):
+    """The "invisible nodes" cell is user-checkable with no DisplayRole text."""
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+
+    col = model.properties.index("invisible nodes")
+    index = model.index(0, col)
+    flags = model.flags(index)
+    assert flags & QtCore.Qt.ItemIsEnabled
+    assert flags & QtCore.Qt.ItemIsUserCheckable
+    assert flags & QtCore.Qt.ItemIsSelectable
+    assert model.data(index, QtCore.Qt.DisplayRole) is None
+
+
+# -- QC display mode -> shared transient keys (#2783 <-> shared model) ------------
+
+
+def test_qc_mode_maps_onto_transient_keys(qtbot, centered_pair_predictions):
+    """A non-manual QC mode's flags drive the same model the overlay reads.
+
+    Emulates `MainWindow._recompute_qc_flags_into_state` (writing the three
+    transient keys from `compute_qc_visibility`) and confirms `instance_visible`
+    / `instance_shows_non_visible` agree with the computed flags -- i.e. the
+    #2783 mode result is consistent with the shared per-instance model that the
+    instance overlay applies on replot. No player / replot is involved.
+    """
+    from sleap.gui.state import (
+        GuiState,
+        INSTANCE_HIDDEN_KEY,
+        VIEW_ONLY_INSTANCE_KEY,
+        SHOW_NONVISIBLE_OVERRIDE_KEY,
+        QC_MODE_SELECTED_ONLY,
+        compute_qc_visibility,
+        instance_visible,
+        instance_shows_non_visible,
+    )
+    from sleap.sleap_io_adaptors.lf_labels_utils import get_instances_to_show
+
+    lf = centered_pair_predictions.labeled_frames[13]
+    instances = get_instances_to_show(lf)
+    assert len(instances) >= 2
+
+    state = GuiState()
+    selected = instances[0]
+    flags = compute_qc_visibility(
+        QC_MODE_SELECTED_ONLY, selected, instances, global_show_non_visible=False
+    )
+    # Write the three transient keys exactly as the app helper does.
+    state[INSTANCE_HIDDEN_KEY] = {iid for iid, (vis, _) in flags.items() if not vis}
+    state[VIEW_ONLY_INSTANCE_KEY] = None
+    state[SHOW_NONVISIBLE_OVERRIDE_KEY] = {iid: snv for iid, (_, snv) in flags.items()}
+
+    # selected_only: only the selected instance is drawn, with its hidden points.
+    assert instance_visible(state, instances[0]) is True
+    assert instance_visible(state, instances[1]) is False
+    assert instance_shows_non_visible(state, instances[0], False) is True
+    assert instance_shows_non_visible(state, instances[1], False) is False

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -485,14 +485,15 @@ def test_qc_mode_maps_onto_transient_keys(qtbot, centered_pair_predictions):
     state = GuiState()
     selected = instances[0]
     flags = compute_qc_visibility(
-        QC_MODE_SELECTED_ONLY, selected, instances, global_show_non_visible=False
+        QC_MODE_SELECTED_ONLY, selected, instances, global_show_non_visible=True
     )
     # Write the three transient keys exactly as the app helper does.
     state[INSTANCE_HIDDEN_KEY] = {iid for iid, (vis, _) in flags.items() if not vis}
     state[VIEW_ONLY_INSTANCE_KEY] = None
     state[SHOW_NONVISIBLE_OVERRIDE_KEY] = {iid: snv for iid, (_, snv) in flags.items()}
 
-    # selected_only: only the selected instance is drawn, with its hidden points.
+    # selected_only with the global gate on: only the selected instance, with its
+    # hidden points.
     assert instance_visible(state, instances[0]) is True
     assert instance_visible(state, instances[1]) is False
     assert instance_shows_non_visible(state, instances[0], False) is True

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -433,6 +433,27 @@ def test_labeled_frame_invisible_nodes_flags_checkable(
     assert model.data(index, QtCore.Qt.DisplayRole) is None
 
 
+def test_checkbox_toggle_falls_back_to_manual_qc_mode(
+    qtbot, centered_pair_predictions
+):
+    """A manual per-instance checkbox edit drops an active Label QC display mode
+    back to "manual" (#2783), so the mode stops clobbering the user's edit."""
+    from sleap.gui.state import (
+        QC_DISPLAY_MODE_KEY,
+        QC_MODE_SELECTED_ONLY,
+        QC_MODE_MANUAL,
+    )
+
+    lf = centered_pair_predictions.labeled_frames[13]
+    model = LabeledFrameTableModel(items=lf)
+
+    # Every per-instance checkbox column resets the mode to manual.
+    for column in ("visibility", "view only", "invisible nodes"):
+        model._vis_state[QC_DISPLAY_MODE_KEY] = QC_MODE_SELECTED_ONLY
+        assert _set_checkstate(model, 0, column, False)
+        assert model._vis_state[QC_DISPLAY_MODE_KEY] == QC_MODE_MANUAL
+
+
 # -- QC display mode -> shared transient keys (#2783 <-> shared model) ------------
 
 

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -433,9 +433,7 @@ def test_labeled_frame_invisible_nodes_flags_checkable(
     assert model.data(index, QtCore.Qt.DisplayRole) is None
 
 
-def test_checkbox_toggle_falls_back_to_manual_qc_mode(
-    qtbot, centered_pair_predictions
-):
+def test_checkbox_toggle_falls_back_to_manual_qc_mode(qtbot, centered_pair_predictions):
     """A manual per-instance checkbox edit drops an active Label QC display mode
     back to "manual" (#2783), so the mode stops clobbering the user's edit."""
     from sleap.gui.state import (

--- a/tests/gui/test_shortcuts.py
+++ b/tests/gui/test_shortcuts.py
@@ -14,3 +14,26 @@ def test_shortcuts():
 
     # "propagate track labels" toggle shortcut (discussion #1638)
     assert shortcuts["propagate track labels"] == QKeySequence.fromString("P")
+
+
+def test_show_non_visible_nodes_shortcut():
+    # "show non-visible nodes" toggle shortcut (#2781)
+    shortcuts = Shortcuts()
+
+    assert shortcuts["show non-visible nodes"] == QKeySequence.fromString("Shift+V")
+    assert shortcuts["show non-visible nodes"] != QKeySequence()
+
+
+def test_no_duplicate_shortcuts():
+    """No two named actions may share the same non-empty key sequence."""
+    shortcuts = Shortcuts()
+
+    seen = set()
+    for i in range(len(shortcuts)):
+        value = shortcuts[i]
+        # Unbound shortcuts come back as "" (str); bound ones as QKeySequence.
+        key_string = value.toString() if isinstance(value, QKeySequence) else value
+        if not key_string:
+            continue
+        assert key_string not in seen, f"Duplicate shortcut: {key_string}"
+        seen.add(key_string)

--- a/tests/gui/test_state.py
+++ b/tests/gui/test_state.py
@@ -225,6 +225,25 @@ def test_compute_qc_visibility_all_plus_selected_invisible():
     assert flags[id(instances[1])] == (True, False)
 
 
+def test_compute_qc_visibility_global_gate_off():
+    """Global "show non-visible nodes" off gates occluded keypoints off for every
+    instance, even the focused one (master gate)."""
+    instances = [object(), object(), object()]
+
+    # selected_only, gate off: selected is still the only visible instance, but
+    # now with NO occluded keypoints.
+    flags = compute_qc_visibility(QC_MODE_SELECTED_ONLY, instances[1], instances, False)
+    assert flags[id(instances[1])] == (True, False)
+    assert flags[id(instances[0])] == (False, False)
+
+    # all_plus_selected, gate off: all visible, nobody shows occluded points.
+    flags = compute_qc_visibility(
+        QC_MODE_ALL_PLUS_SELECTED, instances[1], instances, False
+    )
+    for inst in instances:
+        assert flags[id(inst)] == (True, False)
+
+
 def test_compute_qc_visibility_selected_none_or_foreign():
     """No/foreign selection falls back to the FIRST instance (never blank)."""
     a, b = object(), object()

--- a/tests/gui/test_state.py
+++ b/tests/gui/test_state.py
@@ -226,25 +226,27 @@ def test_compute_qc_visibility_all_plus_selected_invisible():
 
 
 def test_compute_qc_visibility_selected_none_or_foreign():
-    """No/foreign selection degrades every mode to all_visible (never blank)."""
-    instances = [object(), object()]
+    """No/foreign selection falls back to the FIRST instance (never blank)."""
+    a, b = object(), object()
+    instances = [a, b]
 
-    # selected=None -> selected_only degrades to "all visible" so navigation /
-    # startup never blanks the canvas (it narrows once a valid instance is set).
+    # selected=None -> selected_only keeps only the FIRST instance (with its
+    # hidden points), so the mode is visibly doing something and never blanks.
     flags = compute_qc_visibility(QC_MODE_SELECTED_ONLY, None, instances, True)
-    for inst in instances:
-        assert flags[id(inst)] == (True, False)
+    assert flags[id(a)] == (True, True)
+    assert flags[id(b)] == (False, False)
 
-    # selected=None -> *_selected modes also behave like all_visible_only.
+    # selected=None -> all_plus_selected shows all, with the FIRST instance's
+    # hidden points.
     flags = compute_qc_visibility(QC_MODE_ALL_PLUS_SELECTED, None, instances, True)
-    for inst in instances:
-        assert flags[id(inst)] == (True, False)
+    assert flags[id(a)] == (True, True)
+    assert flags[id(b)] == (True, False)
 
     # A selected instance NOT in the list behaves identically to None.
     foreign = object()
     flags = compute_qc_visibility(QC_MODE_SELECTED_ONLY, foreign, instances, True)
-    for inst in instances:
-        assert flags[id(inst)] == (True, False)
+    assert flags[id(a)] == (True, True)
+    assert flags[id(b)] == (False, False)
     flags = compute_qc_visibility(QC_MODE_ALL_PLUS_SELECTED, foreign, instances, True)
-    for inst in instances:
-        assert flags[id(inst)] == (True, False)
+    assert flags[id(a)] == (True, True)
+    assert flags[id(b)] == (True, False)

--- a/tests/gui/test_state.py
+++ b/tests/gui/test_state.py
@@ -1,6 +1,15 @@
 import pytest
 
-from sleap.gui.state import GuiState
+from sleap.gui.state import (
+    GuiState,
+    SHOW_NONVISIBLE_OVERRIDE_KEY,
+    QC_MODE_MANUAL,
+    QC_MODE_SELECTED_ONLY,
+    QC_MODE_ALL_VISIBLE,
+    QC_MODE_ALL_PLUS_SELECTED,
+    instance_shows_non_visible,
+    compute_qc_visibility,
+)
 
 
 def test_gui_state():
@@ -144,3 +153,98 @@ def test_gui_state_callbacks():
         state.connect("y", [f, 5])
 
     state["x"] = "value to trigger callbacks"
+
+
+# -- Per-instance "show non-visible nodes" override (#2782 shared model) ---------
+
+
+def test_instance_shows_non_visible_default():
+    """With no override, the global default is returned verbatim."""
+    state = GuiState()
+    inst = object()
+    assert instance_shows_non_visible(state, inst, True) is True
+    assert instance_shows_non_visible(state, inst, False) is False
+
+
+def test_instance_shows_non_visible_override_wins():
+    """An explicit per-instance override beats the global default."""
+    state = GuiState()
+    inst = object()
+    other = object()
+
+    state[SHOW_NONVISIBLE_OVERRIDE_KEY] = {id(inst): False}
+    assert instance_shows_non_visible(state, inst, True) is False
+    # A second un-overridden instance still falls back to the global default.
+    assert instance_shows_non_visible(state, other, True) is True
+
+    state[SHOW_NONVISIBLE_OVERRIDE_KEY] = {id(inst): True}
+    assert instance_shows_non_visible(state, inst, False) is True
+    assert instance_shows_non_visible(state, other, False) is False
+
+
+def test_instance_shows_non_visible_none_state():
+    """A ``None`` state returns the global default (no override possible)."""
+    assert instance_shows_non_visible(None, object(), True) is True
+    assert instance_shows_non_visible(None, object(), False) is False
+
+
+# -- QC display-mode -> per-instance flags (#2783 pure helper) -------------------
+
+
+def test_compute_qc_visibility_manual_returns_empty():
+    """Manual mode is the no-op sentinel: an empty dict."""
+    instances = [object(), object()]
+    assert compute_qc_visibility(QC_MODE_MANUAL, instances[0], instances, True) == {}
+
+
+def test_compute_qc_visibility_selected_only():
+    """selected_only: only the selected instance is visible (with hidden pts)."""
+    instances = [object(), object(), object()]
+    flags = compute_qc_visibility(QC_MODE_SELECTED_ONLY, instances[1], instances, True)
+    assert flags[id(instances[1])] == (True, True)
+    assert flags[id(instances[0])] == (False, False)
+    assert flags[id(instances[2])] == (False, False)
+
+
+def test_compute_qc_visibility_all_visible_only():
+    """all_visible_only: every instance visible, occluded points hidden."""
+    instances = [object(), object(), object()]
+    flags = compute_qc_visibility(QC_MODE_ALL_VISIBLE, instances[0], instances, True)
+    for inst in instances:
+        assert flags[id(inst)] == (True, False)
+
+
+def test_compute_qc_visibility_all_plus_selected_invisible():
+    """all_plus_selected_invisible: all visible; only selected shows hidden pts."""
+    instances = [object(), object(), object()]
+    flags = compute_qc_visibility(
+        QC_MODE_ALL_PLUS_SELECTED, instances[2], instances, True
+    )
+    assert flags[id(instances[2])] == (True, True)
+    assert flags[id(instances[0])] == (True, False)
+    assert flags[id(instances[1])] == (True, False)
+
+
+def test_compute_qc_visibility_selected_none_or_foreign():
+    """No/foreign selection degrades every mode to all_visible (never blank)."""
+    instances = [object(), object()]
+
+    # selected=None -> selected_only degrades to "all visible" so navigation /
+    # startup never blanks the canvas (it narrows once a valid instance is set).
+    flags = compute_qc_visibility(QC_MODE_SELECTED_ONLY, None, instances, True)
+    for inst in instances:
+        assert flags[id(inst)] == (True, False)
+
+    # selected=None -> *_selected modes also behave like all_visible_only.
+    flags = compute_qc_visibility(QC_MODE_ALL_PLUS_SELECTED, None, instances, True)
+    for inst in instances:
+        assert flags[id(inst)] == (True, False)
+
+    # A selected instance NOT in the list behaves identically to None.
+    foreign = object()
+    flags = compute_qc_visibility(QC_MODE_SELECTED_ONLY, foreign, instances, True)
+    for inst in instances:
+        assert flags[id(inst)] == (True, False)
+    flags = compute_qc_visibility(QC_MODE_ALL_PLUS_SELECTED, foreign, instances, True)
+    for inst in instances:
+        assert flags[id(inst)] == (True, False)

--- a/tests/gui/widgets/test_qc.py
+++ b/tests/gui/widgets/test_qc.py
@@ -3397,3 +3397,124 @@ class TestQCChainTraceDialog:
         widget._cb_chain.setChecked(True)
         assert widget._chain_config_btn.isEnabled()
         assert widget._chain_summary_label.isEnabled()
+
+
+class TestQCDisplayMode:
+    """Tests for the #2783 Label QC "Display:" mode selector and its bridge.
+
+    These exercise the combo <-> signal <-> state wiring at the model/state level
+    only; no MainWindow is built and no event loop is started.
+    """
+
+    def test_display_mode_combo_present(self, qtbot):
+        """The combo exists with the four modes and defaults to Manual."""
+        from sleap.gui.state import (
+            QC_MODE_MANUAL,
+            QC_MODE_SELECTED_ONLY,
+            QC_MODE_ALL_VISIBLE,
+            QC_MODE_ALL_PLUS_SELECTED,
+        )
+
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        combo = widget._display_mode_combo
+        assert combo.count() == 4
+        modes = [combo.itemData(i) for i in range(combo.count())]
+        assert modes == [
+            QC_MODE_MANUAL,
+            QC_MODE_SELECTED_ONLY,
+            QC_MODE_ALL_VISIBLE,
+            QC_MODE_ALL_PLUS_SELECTED,
+        ]
+        # Manual is the default (index 0).
+        assert widget.current_display_mode() == QC_MODE_MANUAL
+
+    def test_display_mode_combo_emits_signal(self, qtbot):
+        """Selecting each option emits display_mode_changed with its mode."""
+        from sleap.gui.state import (
+            QC_MODE_MANUAL,
+            QC_MODE_SELECTED_ONLY,
+            QC_MODE_ALL_VISIBLE,
+            QC_MODE_ALL_PLUS_SELECTED,
+        )
+
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        emitted = []
+        widget.display_mode_changed.connect(emitted.append)
+
+        # Start on Manual; switch through the other three and back.
+        for mode in (
+            QC_MODE_SELECTED_ONLY,
+            QC_MODE_ALL_VISIBLE,
+            QC_MODE_ALL_PLUS_SELECTED,
+            QC_MODE_MANUAL,
+        ):
+            idx = widget._display_mode_combo.findData(mode)
+            widget._display_mode_combo.setCurrentIndex(idx)
+
+        assert emitted == [
+            QC_MODE_SELECTED_ONLY,
+            QC_MODE_ALL_VISIBLE,
+            QC_MODE_ALL_PLUS_SELECTED,
+            QC_MODE_MANUAL,
+        ]
+
+    def test_set_display_mode_roundtrip_no_emit(self, qtbot):
+        """set_display_mode selects the right item WITHOUT re-emitting."""
+        from sleap.gui.state import QC_MODE_ALL_VISIBLE
+
+        widget = QCWidget()
+        qtbot.addWidget(widget)
+
+        emitted = []
+        widget.display_mode_changed.connect(emitted.append)
+
+        widget.set_display_mode(QC_MODE_ALL_VISIBLE)
+        assert widget.current_display_mode() == QC_MODE_ALL_VISIBLE
+        # Syncing FROM state must not loop back into state.
+        assert emitted == []
+
+    def test_dock_bridges_display_mode_to_state(self, qtbot):
+        """The dock bridges the combo <-> a real GuiState on the parent (#2783)."""
+        from qtpy.QtWidgets import QMainWindow
+        from sleap.gui.dialogs.qc import QCDockWidget
+        from sleap.gui.state import (
+            GuiState,
+            QC_DISPLAY_MODE_KEY,
+            QC_MODE_MANUAL,
+            QC_MODE_SELECTED_ONLY,
+            QC_MODE_ALL_PLUS_SELECTED,
+        )
+
+        # Minimal parent exposing a real GuiState, mirroring MainWindow.state.
+        class _ParentWindow(QMainWindow):
+            def __init__(self):
+                super().__init__()
+                self.state = GuiState()
+
+        parent = _ParentWindow()
+        parent.state[QC_DISPLAY_MODE_KEY] = QC_MODE_MANUAL
+        qtbot.addWidget(parent)
+
+        mock_labels = MagicMock()
+        mock_labels.__len__ = MagicMock(return_value=10)
+        mock_labels.__iter__ = MagicMock(return_value=iter([]))
+
+        dock = QCDockWidget(labels=mock_labels, parent=parent)
+        qtbot.addWidget(dock)
+
+        # Initial sync: combo reflects the persisted mode.
+        assert dock._widget.current_display_mode() == QC_MODE_MANUAL
+
+        # Combo -> state: changing the widget pushes the mode into parent.state.
+        idx = dock._widget._display_mode_combo.findData(QC_MODE_SELECTED_ONLY)
+        dock._widget._display_mode_combo.setCurrentIndex(idx)
+        assert parent.state[QC_DISPLAY_MODE_KEY] == QC_MODE_SELECTED_ONLY
+
+        # State -> combo: setting the mode from the other side syncs the combo
+        # via the state callback (without feedback-looping back into state).
+        parent.state[QC_DISPLAY_MODE_KEY] = QC_MODE_ALL_PLUS_SELECTED
+        assert dock._widget.current_display_mode() == QC_MODE_ALL_PLUS_SELECTED


### PR DESCRIPTION
## Summary

Three Label GUI improvements (sub-issues of master #2762), implemented together because they all build on **one shared per-instance node-visibility model**:

| Issue | Change |
|-------|--------|
| #2781 | Keyboard shortcut (**Shift+V**) for the existing **Show Non-Visible Nodes** View-menu toggle |
| #2782 | New per-instance **"Invisible Nodes"** checkbox column in the Instances dock (next to Visibility / View Only) |
| #2783 | **Label QC "Display:" mode selector** to de-clutter QC of crowded frames |

Closes #2781, closes #2782, closes #2783.

## Design — one shared model

These compose on a single transient, per-instance "show non-visible nodes" override added to `sleap/gui/state.py`, mirroring the #2755 visibility/view-only model:

- `SHOW_NONVISIBLE_OVERRIDE_KEY` — `{id(instance): bool}`, reset on real frame change (like the #2755 keys), never persisted.
- `instance_shows_non_visible(state, instance, global_default)` — per-instance override beats the global flag; absent → global default.
- `compute_qc_visibility(mode, selected, instances, global_snv)` — a **pure** mapping from a QC display mode + selection → `{id: (visible, show_non_visible)}` (unit-testable, no Qt).
- `overlays/instance.py` now computes `show_non_visible` **per instance** instead of passing the single global flag to every instance.

So **#2782** writes the override map from a checkbox; **#2783**'s modes write it (plus the existing instance-hiding) programmatically from the selected instance; **#2781** is a 2-line shortcut registration on the existing global toggle.

### #2783 modes (matches the issue's request)
- **Manual** (default) — current behavior; the Instances-dock columns stay in control.
- **Only selected (with hidden points)** — show only the selected instance + its occluded keypoints.
- **All instances, visible points only** — show every instance, occluded points hidden.
- **All visible + selected hidden points** — show every instance's visible points + the selected instance's occluded points.

The mode is a transient, session-only review aid: it always starts in **Manual** and is **not** persisted across launches (a selection-relative mode that hides instances would read as a bug on the next startup). It follows the selected instance; with no selection, the selection-relative modes fall back to the **first** instance so switching is always visibly effective and narrows to the real instance once one is clicked.

Selecting an instance is what these modes key off, so **navigating to a flagged instance now selects it** (`gotoVideoAndFrameAndInstance` sets `state["instance"]`, not just the player-view highlight) — the display follows the flagged instance you click in the QC table. The selector is reachable from **View → Instance Focus** as well as the QC dock's **Display:** dropdown (both built from one shared list and kept in sync). Manually toggling a per-instance checkbox (Visibility / View Only / Invisible Nodes) drops the mode back to **Manual** so your edit isn't overwritten on the next recompute. The global **Show Non-Visible Nodes** toggle (Shift+V) acts as a **master gate** even inside a focus mode: off hides occluded keypoints for every instance (even the focused one), on lets the mode show them — so the toggle stays meaningful without leaving the mode.

## Notes on two issues caught in review (and fixed here)

1. **Default path stays lightweight.** The mode/selection wiring is split so that in the default **manual** mode, selecting an instance does **not** trigger a full `plotFrame()` (matches pre-PR behavior); only a non-manual mode recomputes + replots.
2. **Modes always do something visible / canvas never blanks.** The selection-relative modes are driven by the selected instance; with no valid selection they **fall back to the first instance** (rather than collapsing to "show all" or blanking), so switching modes is visibly effective even before you click a flag, and narrows to the real instance once one is selected. *(Refined after play-testing — see commit `23e0f958a`; an earlier revision persisted the mode and degraded to "all visible", which made switching look like a no-op.)*

## Implementation note
`show_non_visible` is baked into each `QtInstance` at **creation** time, so toggling it requires a **full replot** (unlike the visibility/view-only columns, which only `setVisible`). The new column and the QC modes replot accordingly.

## Testing
- New unit tests (no GUI launch): state helpers (`compute_qc_visibility`, `instance_shows_non_visible`), the Instances-dock "Invisible Nodes" column, the Shift+V shortcut, and the QC display-mode selector + dock↔state bridge.
- Ran foreground locally (offscreen Qt): `test_state.py` (15), `test_shortcuts.py` (3), `test_dataviews.py` (21, incl. #2755 regression), `test_qc.py` (185) — **all pass**.
- `ruff check` + `ruff format --check` clean on all changed files.
- Headless `MainWindow` smoke test: construction + QC-mode init + manual-mode no-replot + mode-switch reset all verified.

> ⚠️ `tests/gui/test_app.py` could not be run in my local environment (it produces no output / is unstable under offscreen Qt here, independent of this change) — please let **CI** run the full GUI suite. Module imports + all targeted tests pass locally.

## Needs GUI verification
Opening as **draft** — the canvas/rendering behavior (the 3 QC modes actually redrawing, the per-instance column, the Shift+V accelerator showing in the View menu) should be confirmed in the running app before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
