### PR TITLE
fix(gui): warn when picked inference config has no trained model (#2787)

### DIFF
--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -170,24 +170,42 @@ class ConfigFileInfo:
     def has_trained_model(self) -> bool:
         """Check if this config has a trained model (best.ckpt or best_model.h5).
 
-        This method is optimized to avoid loading the full config. It only checks
+        This is optimized to avoid loading the full config. It first checks
         path_dir (the directory containing the config file), which is where
-        checkpoints are saved by sleap-nn training. The result is cached.
+        sleap-nn saves checkpoints. If the full config happens to be already
+        loaded (e.g., a user-picked file), it also honors a custom
+        ``trainer_config.ckpt_dir`` so genuinely-trained models in non-standard
+        layouts aren't missed. The result is cached.
 
-        Note: This does not check ckpt_dir from the config because:
-        1. sleap-nn saves best.ckpt to the model directory (path_dir)
-        2. Baseline configs don't have ckpt_dir set
-        3. Loading config just for this check is too slow (~30-40ms per file)
+        Note: the ckpt_dir fallback is intentionally guarded on the config
+        already being loaded. Forcing a full load here just for this check is
+        too slow (~30-40ms per file) during bulk config-list population, and
+        baseline configs don't set ckpt_dir anyway.
         """
         if self._has_trained_model_cache is not None:
             return self._has_trained_model_cache
 
-        # Check path_dir for checkpoint files (no config load needed)
+        # Fast path: check path_dir for checkpoint files (no config load needed)
         path_dir = self.path_dir
         for filename in ("best.ckpt", "best_model.h5"):
             if os.path.exists(os.path.join(path_dir, filename)):
                 self._has_trained_model_cache = True
                 return True
+
+        # Fallback: honor a custom ckpt_dir, but only when the config is already
+        # loaded so we never trigger a slow load during bulk list population.
+        if self._config is not None:
+            ckpt_dir = OmegaConf.select(
+                self._config, "trainer_config.ckpt_dir", default=None
+            )
+            if ckpt_dir:
+                # Resolve relative ckpt_dir against the config's own directory.
+                if not os.path.isabs(ckpt_dir):
+                    ckpt_dir = os.path.join(path_dir, ckpt_dir)
+                for filename in ("best.ckpt", "best_model.h5"):
+                    if os.path.exists(os.path.join(ckpt_dir, filename)):
+                        self._has_trained_model_cache = True
+                        return True
 
         self._has_trained_model_cache = False
         return False
@@ -606,7 +624,11 @@ class TrainingConfigFilesWidget(FieldComboWidget):
         if not filename:
             logging.debug("No file selected for training config.")
             return None
-        return self._cfg_getter.try_loading_path(filename)
+        # Fully load the picked file (not just a quick metadata scan) so that
+        # has_trained_model can honor a custom trainer_config.ckpt_dir. This is
+        # a single user-picked file, not bulk list population, so the load cost
+        # is acceptable.
+        return self._cfg_getter.try_loading_path(filename, full_load=True)
 
     def _add_file_selection_to_menu(self, cfg_info: Optional[ConfigFileInfo] = None):
         if cfg_info:
@@ -620,6 +642,18 @@ class TrainingConfigFilesWidget(FieldComboWidget):
                     text=f"The file you selected was a training config for "
                     f"{cfg_info.head_name} and cannot be used for "
                     f"{self._head_name}."
+                ).exec_()
+            elif self._require_trained and not cfg_info.has_trained_model:
+                # Config is valid and matches the head, but has no trained model
+                # checkpoint. In inference mode such configs are filtered out of
+                # the menu, so without this message the dropdown would silently
+                # stay empty and the Run button stay disabled (see #2787).
+                QtWidgets.QMessageBox(
+                    text=f"The selected training config has no trained model "
+                    f"(best.ckpt or best_model.h5) in its model directory:\n\n"
+                    f"{cfg_info.path_dir}\n\n"
+                    f"A trained model is required to run inference. Select a "
+                    f"config from a directory that contains a trained model."
                 ).exec_()
         else:
             # We couldn't load a valid config, so change menu to initial

--- a/tests/gui/learning/test_edge_cases.py
+++ b/tests/gui/learning/test_edge_cases.py
@@ -413,9 +413,7 @@ class TestNoTrainedModelMessage:
         """Valid config, matching head, no checkpoint, inference mode -> warn."""
         widget = self._make_widget(qtbot)
         cfg = self._make_cfg(tmp_path, trained=False)
-        with patch(
-            "sleap.gui.learning.configs.QtWidgets.QMessageBox"
-        ) as mock_box:
+        with patch("sleap.gui.learning.configs.QtWidgets.QMessageBox") as mock_box:
             widget._add_file_selection_to_menu(cfg)
 
         mock_box.assert_called_once()
@@ -428,9 +426,7 @@ class TestNoTrainedModelMessage:
         """A trained config populates the menu without any warning."""
         widget = self._make_widget(qtbot)
         cfg = self._make_cfg(tmp_path, trained=True)
-        with patch(
-            "sleap.gui.learning.configs.QtWidgets.QMessageBox"
-        ) as mock_box:
+        with patch("sleap.gui.learning.configs.QtWidgets.QMessageBox") as mock_box:
             widget._add_file_selection_to_menu(cfg)
 
         mock_box.assert_not_called()
@@ -440,9 +436,7 @@ class TestNoTrainedModelMessage:
         """In training mode an untrained config is fine -> no warning."""
         widget = self._make_widget(qtbot, require_trained=False)
         cfg = self._make_cfg(tmp_path, trained=False)
-        with patch(
-            "sleap.gui.learning.configs.QtWidgets.QMessageBox"
-        ) as mock_box:
+        with patch("sleap.gui.learning.configs.QtWidgets.QMessageBox") as mock_box:
             widget._add_file_selection_to_menu(cfg)
 
         mock_box.assert_not_called()
@@ -452,9 +446,7 @@ class TestNoTrainedModelMessage:
         """A head mismatch is reported (not the no-trained-model message)."""
         widget = self._make_widget(qtbot, head_name="centroid")
         cfg = self._make_cfg(tmp_path, head_name="centered_instance", trained=False)
-        with patch(
-            "sleap.gui.learning.configs.QtWidgets.QMessageBox"
-        ) as mock_box:
+        with patch("sleap.gui.learning.configs.QtWidgets.QMessageBox") as mock_box:
             widget._add_file_selection_to_menu(cfg)
 
         mock_box.assert_called_once()

--- a/tests/gui/learning/test_edge_cases.py
+++ b/tests/gui/learning/test_edge_cases.py
@@ -19,7 +19,12 @@ from sleap.sleap_io_adaptors.skeleton_utils import (
     in_degree_over_one,
     cycles,
 )
-from sleap.gui.learning.configs import ConfigFileInfo, _quick_scan_yaml_metadata
+from sleap.gui.learning.configs import (
+    ConfigFileInfo,
+    TrainingConfigFilesWidget,
+    TrainingConfigsGetter,
+    _quick_scan_yaml_metadata,
+)
 from sleap.gui.learning.runners import InferenceTask
 
 
@@ -339,6 +344,122 @@ trainer_config:
         config_info = ConfigFileInfo(path=str(config_file))
 
         assert config_info.has_trained_model is True
+
+    def test_has_trained_model_honors_ckpt_dir_when_loaded(self, tmp_path):
+        """ckpt_dir fallback finds a checkpoint outside the config's directory,
+        but only once the config is loaded (so bulk scans stay fast)."""
+        model_dir = tmp_path / "model"
+        ckpt_dir = model_dir / "ckpts"
+        ckpt_dir.mkdir(parents=True)
+        config_file = model_dir / "training_config.yaml"
+        config_file.write_text("trainer_config:\n  ckpt_dir: ckpts\n")
+        (ckpt_dir / "best.ckpt").touch()
+
+        # Not loaded: only the fast path (config's own dir) is checked, so the
+        # checkpoint in the custom ckpt_dir is not found.
+        lazy = ConfigFileInfo(path=str(config_file))
+        assert lazy.has_trained_model is False
+
+        # Loaded: the ckpt_dir fallback finds the checkpoint.
+        loaded = ConfigFileInfo(path=str(config_file))
+        loaded._load_full_config()
+        assert loaded.has_trained_model is True
+
+    def test_has_trained_model_honors_absolute_ckpt_dir(self, tmp_path):
+        """ckpt_dir fallback honors an absolute ckpt_dir when loaded."""
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        ckpt_dir = tmp_path / "elsewhere"
+        ckpt_dir.mkdir()
+        config_file = model_dir / "training_config.yaml"
+        config_file.write_text(f"trainer_config:\n  ckpt_dir: {ckpt_dir}\n")
+        (ckpt_dir / "best_model.h5").touch()
+
+        config_info = ConfigFileInfo(path=str(config_file))
+        config_info._load_full_config()
+        assert config_info.has_trained_model is True
+
+
+# =============================================================================
+# No-Trained-Model Message Tests (#2787)
+# =============================================================================
+
+
+class TestNoTrainedModelMessage:
+    """Picking a valid-but-untrained config in inference mode should warn
+    instead of silently leaving the dropdown empty (see #2787)."""
+
+    def _make_widget(self, qtbot, head_name="centered_instance", require_trained=True):
+        getter = TrainingConfigsGetter(dir_paths=[])
+        widget = TrainingConfigFilesWidget(
+            cfg_getter=getter, head_name=head_name, require_trained=require_trained
+        )
+        qtbot.addWidget(widget)
+        widget.update()
+        return widget
+
+    def _make_cfg(self, tmp_path, head_name="centered_instance", trained=False):
+        model_dir = tmp_path / "model"
+        model_dir.mkdir(exist_ok=True)
+        cfg_path = model_dir / "training_config.yaml"
+        cfg_path.write_text("trainer_config:\n  run_name: test\n")
+        if trained:
+            (model_dir / "best.ckpt").touch()
+        return ConfigFileInfo(
+            path=str(cfg_path), filename=cfg_path.name, head_name=head_name
+        )
+
+    def test_untrained_inference_shows_message(self, qtbot, tmp_path):
+        """Valid config, matching head, no checkpoint, inference mode -> warn."""
+        widget = self._make_widget(qtbot)
+        cfg = self._make_cfg(tmp_path, trained=False)
+        with patch(
+            "sleap.gui.learning.configs.QtWidgets.QMessageBox"
+        ) as mock_box:
+            widget._add_file_selection_to_menu(cfg)
+
+        mock_box.assert_called_once()
+        text = mock_box.call_args.kwargs.get("text", "")
+        assert "no trained model" in text
+        # The untrained config is filtered out, so nothing is selected.
+        assert widget.getSelectedConfigInfo() is None
+
+    def test_trained_inference_no_message(self, qtbot, tmp_path):
+        """A trained config populates the menu without any warning."""
+        widget = self._make_widget(qtbot)
+        cfg = self._make_cfg(tmp_path, trained=True)
+        with patch(
+            "sleap.gui.learning.configs.QtWidgets.QMessageBox"
+        ) as mock_box:
+            widget._add_file_selection_to_menu(cfg)
+
+        mock_box.assert_not_called()
+        assert widget.getSelectedConfigInfo() is not None
+
+    def test_untrained_training_mode_no_message(self, qtbot, tmp_path):
+        """In training mode an untrained config is fine -> no warning."""
+        widget = self._make_widget(qtbot, require_trained=False)
+        cfg = self._make_cfg(tmp_path, trained=False)
+        with patch(
+            "sleap.gui.learning.configs.QtWidgets.QMessageBox"
+        ) as mock_box:
+            widget._add_file_selection_to_menu(cfg)
+
+        mock_box.assert_not_called()
+        assert widget.getSelectedConfigInfo() is not None
+
+    def test_head_mismatch_takes_precedence(self, qtbot, tmp_path):
+        """A head mismatch is reported (not the no-trained-model message)."""
+        widget = self._make_widget(qtbot, head_name="centroid")
+        cfg = self._make_cfg(tmp_path, head_name="centered_instance", trained=False)
+        with patch(
+            "sleap.gui.learning.configs.QtWidgets.QMessageBox"
+        ) as mock_box:
+            widget._add_file_selection_to_menu(cfg)
+
+        mock_box.assert_called_once()
+        text = mock_box.call_args.kwargs.get("text", "")
+        assert "cannot be used for" in text
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

Addresses #2787. In **Predict → Run Inference**, after picking a model config the dropdown could stay **empty with no error** and the **Run button greyed out**.

Root cause: in inference mode the config menu is filtered with `only_trained=True`, so a picked config with no trained checkpoint is dropped from the menu. But `_add_file_selection_to_menu` only showed a popup for (a) a head mismatch or (b) a config that fails to parse. A config that **loads fine, matches the head, but has no checkpoint** fell through silently — empty dropdown, greyed Run, zero feedback as to why.

Separately, `has_trained_model` only looked in the config's **own** directory for `best.ckpt`/`best_model.h5`, so a genuinely-trained model whose checkpoint lives in a custom `trainer_config.ckpt_dir` was also silently treated as untrained.

## Changes (`sleap/gui/learning/configs.py`)

1. **Feedback popup** — `_add_file_selection_to_menu` now warns when a valid, head-matching config has no trained model in inference mode:
   > The selected training config has no trained model (best.ckpt or best_model.h5) in its model directory: `<dir>` …
2. **`doFileSelection`** fully loads the single picked file (`try_loading_path(..., full_load=True)`) so the check can read the config.
3. **`has_trained_model`** now also honors `trainer_config.ckpt_dir` (relative resolved against the config dir, or absolute) — **only when the config is already loaded**, so bulk dropdown population keeps the fast quick-scan path and does not regress.

## Tests (`tests/gui/learning/test_edge_cases.py`)

New `TestNoTrainedModelMessage`: untrained+inference → popup & nothing selected; trained+inference → no popup & selected; untrained+training-mode → no popup; head mismatch still takes precedence. Plus `has_trained_model` ckpt_dir tests (relative, absolute, and ignored-when-not-loaded).

```
test_edge_cases.py      36 passed
test_learning_dialog.py 62 passed
test_integration.py     18 passed
ruff                    All checks passed!
```

## Verification notes

- Draft: still want an interactive confirmation in the real GUI.
- The original repro model (`finetune_final/centered_instance/`) has `best.ckpt` next to its `training_config.yaml`, so it was already detected as trained and populates correctly headless. This PR makes the *silent* failure path explain itself and broadens checkpoint detection. If the dropdown is still empty interactively, change #1 now names the directory it checked.
- A separate latent Wayland issue exists (parentless `FileDialog.open(None, …)` / `QMessageBox` popups fail to create on Wayland, same class as #2779/#2780); not addressed here.

With the help of Claude.
