### PR TITLE
feat(gui): guide crop size / input scaling for top-down models (#2792)

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -164,6 +164,8 @@ class LearningDialog(QtWidgets.QDialog):
 
         self.message_widget = QtWidgets.QLabel("")
         self.message_widget.setWordWrap(True)
+        # Hidden until there is something to say, so it takes no space otherwise.
+        self.message_widget.setVisible(False)
 
         # Frame target selector is now owned by MainTabWidget
         self.frame_target_selector = self.pipeline_form_widget.frame_target_selector
@@ -173,7 +175,6 @@ class LearningDialog(QtWidgets.QDialog):
         content_widget = QtWidgets.QWidget()
         content_layout = QtWidgets.QVBoxLayout(content_widget)
         content_layout.addWidget(self.tab_widget)
-        content_layout.addWidget(self.message_widget)
 
         scroll_area = QtWidgets.QScrollArea()
         scroll_area.setWidgetResizable(True)
@@ -181,9 +182,13 @@ class LearningDialog(QtWidgets.QDialog):
         scroll_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
         scroll_area.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
 
-        # Main layout: scrollable content + buttons
+        # Main layout: scrollable content + validation message + buttons. The
+        # message widget lives outside the scroll area so warnings/errors are
+        # always visible above the buttons rather than below the (scrollable) tab
+        # content.
         layout = QtWidgets.QVBoxLayout(self)
         layout.addWidget(scroll_area)
+        layout.addWidget(self.message_widget)
         layout.addWidget(buttons_layout_widget)
 
         self.adjust_initial_size()
@@ -1340,8 +1345,10 @@ class LearningDialog(QtWidgets.QDialog):
 
                 can_run = False
 
-        # Non-blocking warning: negative frames enabled but none are marked.
-        warning = ""
+        # Non-blocking warnings.
+        warnings: List[str] = []
+
+        # Negative frames enabled but none are marked.
         if (
             self.mode == "training"
             and self.labels is not None
@@ -1355,21 +1362,46 @@ class LearningDialog(QtWidgets.QDialog):
                 if tab_name in self.tabs
             )
             if uses_negatives:
-                warning = (
+                warnings.append(
                     'The "Use Negative Frames" option is enabled, but no frames '
                     "are marked as negative, so it will have no effect. Mark "
                     "frames in the labeling window with Labels &gt; Mark Frame as "
                     "Negative (N)."
                 )
 
-        if not can_run and message:
-            message = f"<b>Unable to run:</b><br />{message}"
-        if warning:
-            if message:
-                message += "<br />"
-            message += f"<b>Warning:</b><br />{warning}"
+        # Per-head crop size / input scaling warnings (top-down models).
+        if self.mode == "training":
+            for tab_name in self.shown_tab_names:
+                tab = self.tabs.get(tab_name)
+                if tab is not None:
+                    warnings.extend(tab.get_config_warnings())
 
-        self.message_widget.setText(message)
+        # Compose the message with a bold colored header so errors/warnings stand
+        # out above the buttons. Colors are mid-tones that stay legible on both
+        # light and dark themes; no background box (which doesn't adapt to theme).
+        sections = []
+        if not can_run and message:
+            sections.append(
+                '<span style="color:#e74c3c; font-weight:bold; font-size:14px;">'
+                "&#9888; CANNOT RUN</span>"
+                f'<div style="margin-top:2px;">{message}</div>'
+            )
+        if warnings:
+            body = "".join(f"&#8226;&nbsp;{w}<br/>" for w in warnings)
+            sections.append(
+                '<span style="color:#e67e22; font-weight:bold; font-size:14px;">'
+                "&#9888; WARNING</span>"
+                f'<div style="margin-top:2px;">{body}</div>'
+            )
+
+        banner = (
+            '<div style="line-height:135%;">' + "<br/>".join(sections) + "</div>"
+            if sections
+            else ""
+        )
+
+        self.message_widget.setText(banner)
+        self.message_widget.setVisible(bool(banner))
         self.run_button.setEnabled(can_run)
 
     def run(self):
@@ -1606,6 +1638,10 @@ class TrainingEditorWidget(QtWidgets.QWidget):
         self._require_trained = require_trained
         self.head = head
 
+        # Cache for the largest labeled instance bounding box (computed lazily and
+        # reused across crop-size validations, see `get_config_warnings`).
+        self._max_instance_bbox_size: Optional[float] = None
+
         yaml_name = "training_editor_form"
 
         self.form_widgets: Dict[str, YamlFormWidget] = dict()
@@ -1645,6 +1681,9 @@ class TrainingEditorWidget(QtWidgets.QWidget):
 
         # Enable the negative loss weight field only when negative frames are on
         self._setup_negative_frames_toggle()
+
+        # Add an info button next to Input Scaling for crop-based (top-down) heads
+        self._setup_input_scaling_info()
 
         if hasattr(skeleton, "node_names"):
             for field_name in NODE_LIST_FIELDS:
@@ -1995,6 +2034,128 @@ class TrainingEditorWidget(QtWidgets.QWidget):
             crop_field.setVisible(False)
             if crop_label is not None:
                 crop_label.setVisible(False)
+
+    def _setup_input_scaling_info(self):
+        """Add an info button next to Input Scaling for crop-based (top-down) heads.
+
+        Centered instance (and multi-class top-down) models already operate on
+        cropped instances, so input scaling can usually be left at 1.0. This adds a
+        small clickable info button next to the Input Scaling field on those tabs to
+        surface that guidance without disabling the field.
+        """
+        if self.head not in ("centered_instance", "multi_class_topdown"):
+            return
+
+        data_form = self.form_widgets["data"]
+        form_layout = data_form.form_layout
+        scale_field = data_form.fields.get("data_config.preprocessing.scale")
+        if scale_field is None:
+            return
+
+        row, role = form_layout.getWidgetPosition(scale_field)
+        if row < 0:
+            return
+
+        note = (
+            "Centered instance models already operate on cropped instances, so "
+            "input scaling can usually be left at 1.0."
+        )
+
+        info_button = QtWidgets.QToolButton()
+        info_button.setIcon(
+            self.style().standardIcon(QtWidgets.QStyle.SP_MessageBoxInformation)
+        )
+        info_button.setAutoRaise(True)
+        info_button.setToolTip(note)
+        info_button.setCursor(QtCore.Qt.WhatsThisCursor)
+        info_button.clicked.connect(
+            lambda: QtWidgets.QMessageBox.information(self, "Input Scaling", note)
+        )
+
+        # Wrap the existing field and the info button in a horizontal container so
+        # the button sits immediately to the right of the Input Scaling field.
+        container = QtWidgets.QWidget()
+        hbox = QtWidgets.QHBoxLayout(container)
+        hbox.setContentsMargins(0, 0, 0, 0)
+        hbox.setSpacing(4)
+        form_layout.removeWidget(scale_field)
+        hbox.addWidget(scale_field)
+        hbox.addWidget(info_button)
+        hbox.addStretch(1)
+        form_layout.setWidget(row, role, container)
+
+    def _get_max_instance_bbox_size(self) -> Optional[float]:
+        """Return the largest labeled-instance bbox dimension (px), cached.
+
+        Labels do not change over the dialog's lifetime, so the (potentially
+        expensive) scan over all instances is computed once and reused.
+        """
+        if self._labels is None:
+            return None
+        if self._max_instance_bbox_size is None:
+            try:
+                self._max_instance_bbox_size = (
+                    receptivefield.find_max_instance_bbox_size(self._labels)
+                )
+            except Exception:
+                self._max_instance_bbox_size = None
+        return self._max_instance_bbox_size
+
+    def get_config_warnings(self) -> List[str]:
+        """Return inline warnings about crop size / input scaling.
+
+        Only crop-based (top-down) heads are checked. Warns when:
+          - the model's effective (post-scale) input crop would be < 100px, since
+            centered instance models perform poorly below that size; and
+          - an explicit crop size is smaller than the largest labeled instance, in
+            which case instances would be clipped by the crop.
+        """
+        warnings: List[str] = []
+        if self.head not in ("centered_instance", "multi_class_topdown"):
+            return warnings
+        if self._labels is None:
+            return warnings
+
+        try:
+            data_cfg = get_omegaconf_from_gui_form(
+                self.form_widgets["data"].get_form_data()
+            )
+            model_cfg = get_omegaconf_from_gui_form(
+                self.form_widgets["model"].get_form_data()
+            )
+            aug_form_data = self.form_widgets["augmentation"].get_form_data()
+        except Exception:
+            return warnings
+
+        # Effective (post-scale) crop size too small for the centered instance model.
+        try:
+            effective_crop = receptivefield.compute_crop_size_from_cfg(
+                data_cfg, model_cfg, self._labels, aug_form_data
+            )
+        except Exception:
+            effective_crop = None
+        if effective_crop is not None and effective_crop < 100:
+            warnings.append(
+                f"The centered instance model's input crop will be only "
+                f"{int(effective_crop)}px after input scaling, but these models "
+                "perform poorly below 100px. Set Input Scaling to 1.0 and Crop Size "
+                "to Auto."
+            )
+
+        # Explicit crop size smaller than the largest labeled instance (clipping).
+        crop_size = OmegaConf.select(
+            data_cfg, "data_config.preprocessing.crop_size", default=None
+        )
+        if crop_size is not None:
+            max_bbox = self._get_max_instance_bbox_size()
+            if max_bbox is not None and crop_size < max_bbox:
+                warnings.append(
+                    f"Crop size ({int(crop_size)}px) is smaller than the largest "
+                    f"labeled instance ({int(round(max_bbox))}px), so instances will "
+                    "be clipped. Increase the crop size or set it to Auto."
+                )
+
+        return warnings
 
     def _setup_ohkm_visibility(self):
         """Hide OHKM fields for centroid models.

--- a/tests/gui/learning/test_learning_dialog.py
+++ b/tests/gui/learning/test_learning_dialog.py
@@ -337,6 +337,31 @@ class TestValidation:
         """Message widget should exist for validation messages."""
         assert training_dialog.message_widget is not None
 
+    def test_message_widget_hidden_when_no_message(self, training_dialog):
+        """Message widget should be hidden when there is nothing to report."""
+        training_dialog.set_pipeline("single")
+        training_dialog._validate_pipeline()
+        assert training_dialog.message_widget.text() == ""
+        # isHidden() reflects the explicit visibility flag regardless of whether
+        # the (un-shown) dialog's ancestors are visible in the test.
+        assert training_dialog.message_widget.isHidden() is True
+
+    def test_message_widget_shown_when_warning_present(self, training_dialog):
+        """Crop-size warnings should make the message widget visible.
+
+        Regression test for #2792: the warning text was being set but the widget
+        lived below the (scrollable) tab content, so it was effectively invisible.
+        """
+        training_dialog.set_pipeline("top-down")
+        ci_tab = training_dialog.tabs["centered_instance"]
+        with patch.object(
+            ci_tab, "get_config_warnings", return_value=["something is off"]
+        ):
+            training_dialog._validate_pipeline()
+
+        assert "something is off" in training_dialog.message_widget.text()
+        assert training_dialog.message_widget.isHidden() is False
+
 
 # =============================================================================
 # Signal Connection Tests
@@ -535,6 +560,164 @@ class TestTrainingEditorWidget:
         assert inference_editor_widget._radio_train_scratch is None
         assert inference_editor_widget._radio_resume is None
         assert inference_editor_widget._radio_use_trained is None
+
+
+# =============================================================================
+# Training Config Warning Tests (#2792)
+# =============================================================================
+
+
+class TestTrainingConfigWarnings:
+    """Tests for crop-size / input-scaling UX guidance (issue #2792)."""
+
+    def _make_editor(self, qtbot, skeleton, cfg_getter, head, labels=None):
+        widget = TrainingEditorWidget(
+            skeleton=skeleton,
+            head=head,
+            cfg_getter=cfg_getter,
+            require_trained=False,
+            labels=labels,
+        )
+        qtbot.addWidget(widget)
+        return widget
+
+    def test_input_scaling_info_button_on_centered_instance(
+        self, qtbot, minimal_skeleton, mock_cfg_getter
+    ):
+        """Centered instance tab gets an info button next to Input Scaling."""
+        from qtpy import QtWidgets
+
+        widget = self._make_editor(
+            qtbot, minimal_skeleton, mock_cfg_getter, "centered_instance"
+        )
+        buttons = widget.form_widgets["data"].findChildren(QtWidgets.QToolButton)
+        assert len(buttons) == 1
+
+    def test_no_info_button_on_single_instance(
+        self, qtbot, minimal_skeleton, mock_cfg_getter
+    ):
+        """Non-crop heads do not get the Input Scaling info button."""
+        from qtpy import QtWidgets
+
+        widget = self._make_editor(
+            qtbot, minimal_skeleton, mock_cfg_getter, "single_instance"
+        )
+        buttons = widget.form_widgets["data"].findChildren(QtWidgets.QToolButton)
+        assert len(buttons) == 0
+
+    def test_warnings_empty_for_non_crop_head(
+        self, qtbot, minimal_skeleton, mock_cfg_getter, minimal_labels
+    ):
+        """Non-crop heads never produce crop-size warnings."""
+        widget = self._make_editor(
+            qtbot,
+            minimal_skeleton,
+            mock_cfg_getter,
+            "single_instance",
+            labels=minimal_labels,
+        )
+        assert widget.get_config_warnings() == []
+
+    def test_warnings_empty_without_labels(
+        self, qtbot, minimal_skeleton, mock_cfg_getter
+    ):
+        """No labels means no instance-based warnings can be computed."""
+        widget = self._make_editor(
+            qtbot, minimal_skeleton, mock_cfg_getter, "centered_instance"
+        )
+        assert widget._labels is None
+        assert widget.get_config_warnings() == []
+
+    def test_warning_when_effective_crop_below_100px(
+        self, qtbot, minimal_skeleton, mock_cfg_getter, minimal_labels
+    ):
+        """Effective (post-scale) crop < 100px warns to use scale 1.0 + Auto."""
+        widget = self._make_editor(
+            qtbot,
+            minimal_skeleton,
+            mock_cfg_getter,
+            "centered_instance",
+            labels=minimal_labels,
+        )
+        with patch(
+            "sleap.gui.learning.dialog.receptivefield.compute_crop_size_from_cfg",
+            return_value=64,
+        ):
+            warnings = widget.get_config_warnings()
+
+        assert any("100px" in w and "Input Scaling" in w for w in warnings)
+
+    def test_no_warning_when_effective_crop_at_or_above_100px(
+        self, qtbot, minimal_skeleton, mock_cfg_getter, minimal_labels
+    ):
+        """Effective crop >= 100px (and Auto crop) produces no warnings."""
+        widget = self._make_editor(
+            qtbot,
+            minimal_skeleton,
+            mock_cfg_getter,
+            "centered_instance",
+            labels=minimal_labels,
+        )
+        with patch(
+            "sleap.gui.learning.dialog.receptivefield.compute_crop_size_from_cfg",
+            return_value=256,
+        ):
+            warnings = widget.get_config_warnings()
+
+        # crop_size is Auto (None) by default, so no clipping warning either.
+        assert warnings == []
+
+    def test_warning_when_crop_smaller_than_largest_instance(
+        self, qtbot, minimal_skeleton, mock_cfg_getter, minimal_labels
+    ):
+        """Explicit crop smaller than the largest instance warns about clipping."""
+        from omegaconf import OmegaConf
+
+        widget = self._make_editor(
+            qtbot,
+            minimal_skeleton,
+            mock_cfg_getter,
+            "centered_instance",
+            labels=minimal_labels,
+        )
+        # Pretend the largest labeled instance spans 500px.
+        widget._max_instance_bbox_size = 500.0
+
+        data_cfg = OmegaConf.create(
+            {"data_config": {"preprocessing": {"crop_size": 64, "scale": 1.0}}}
+        )
+        with patch(
+            "sleap.gui.learning.dialog.get_omegaconf_from_gui_form",
+            return_value=data_cfg,
+        ), patch(
+            "sleap.gui.learning.dialog.receptivefield.compute_crop_size_from_cfg",
+            return_value=64,  # below 100 too, but we assert on the clipping message
+        ):
+            warnings = widget.get_config_warnings()
+
+        assert any("clipped" in w and "64px" in w and "500px" in w for w in warnings)
+
+    def test_max_instance_bbox_size_is_cached(
+        self, qtbot, minimal_skeleton, mock_cfg_getter, minimal_labels
+    ):
+        """The largest-instance scan is computed once and cached."""
+        widget = self._make_editor(
+            qtbot,
+            minimal_skeleton,
+            mock_cfg_getter,
+            "centered_instance",
+            labels=minimal_labels,
+        )
+        with patch(
+            "sleap.gui.learning.dialog.receptivefield.find_max_instance_bbox_size",
+            return_value=123.0,
+        ) as mock_scan:
+            first = widget._get_max_instance_bbox_size()
+            second = widget._get_max_instance_bbox_size()
+
+        assert first == 123.0
+        assert second == 123.0
+        assert mock_scan.call_count == 1
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Steer users away from common top-down (centered instance) model failures caused by bad input-scaling / crop-size choices, by adding inline guidance to the training config dialog.
- Centered instance models perform poorly when their input tensor is `< 100px` and usually should not have input scaling applied (they already operate on cropped instances). This PR surfaces that guidance directly in the UI.
- Also fixes a latent bug where the dialog's validation message was rendered below the fold (inside the scroll area) and was effectively invisible.

Motivated by repeated user reports: #2748, #2786, #2670.

## Changes Made
- **Info (ⓘ) button next to Input Scaling** on the `centered_instance` / `multi_class_topdown` tabs. Clicking it explains that input scaling can usually be left at 1.0 because the model already crops instances. (`_setup_input_scaling_info`)
- **Inline warning when the effective (post-scale) crop is `< 100px`**, advising the user to set Input Scaling to 1.0 and Crop Size to Auto. The effective size is `crop_size × scale`, matching `receptivefield.compute_crop_size_from_cfg`.
- **Inline warning when an explicit crop size is smaller than the largest labeled instance**, since instances would be clipped. The largest-instance bbox scan is cached on the editor widget to avoid rescanning labels on every form change. (`get_config_warnings`, `_get_max_instance_bbox_size`)
- **Fix message-widget visibility/placement**: the validation `message_widget` previously lived inside the scroll area below the (tall) tab content, so warnings/errors were rendered below the fold and never seen. It now sits outside the scroll area, just above the Run/Cancel buttons, and hides itself when there is no message.
- **Restyle the validation banner**: bold colored header — orange `⚠ WARNING` for non-blocking warnings, red `⚠ CANNOT RUN` for blocking errors. Mid-tone header colors and default-palette body text keep it legible on both light and dark themes (no hardcoded background box).

## Example
Setting Crop Size to `99` on the Centered Instance tab now shows, just above the Run button:

> **⚠ WARNING**
> • The centered instance model's input crop will be only 99px after input scaling, but these models perform poorly below 100px. Set Input Scaling to 1.0 and Crop Size to Auto.

## API Changes
- New methods on `TrainingEditorWidget`: `_setup_input_scaling_info()`, `_get_max_instance_bbox_size()`, `get_config_warnings()`.
- `LearningDialog._validate_pipeline()` now aggregates per-tab `get_config_warnings()` into the shared message banner (the existing negative-frames warning was refactored into the same `warnings` list).
- No changes to public/training-config APIs or on-disk formats.

## Testing
- Added `TestTrainingConfigWarnings` (8 tests): info button presence per head, warnings empty for non-crop heads / without labels, `< 100px` effective-crop warning, no warning at `>= 100px`, crop-smaller-than-instance clipping warning, and bbox-size caching.
- Added 2 regression tests for message-widget visibility toggling (the below-the-fold bug).
- Full `test_learning_dialog.py` + `test_edge_cases.py` suites pass (108 tests). Lint + format clean.
- Manual/offscreen visual verification in light and dark mode (info button placement, warning banner, blocking-error banner).

## Design Decisions
- **Inline banner, not a modal popup.** Reuses the existing non-blocking `message_widget` channel so guidance doesn't nag on every receptive-field update.
- **Info button instead of disabling input scaling.** The original issue suggested greying out input scaling; an info button is softer/more educational and keeps the field usable for advanced cases.
- **Post-scale threshold.** The `< 100px` check uses the effective input tensor (`crop_size × scale`), which is the size the model actually sees.
- **Applied to both top-down crop heads** (`centered_instance` and `multi_class_topdown`), consistent with the existing crop-size visibility logic.

## Related Issues
Addresses #2792. Motivated by #2748, #2786, #2670.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)