### PR TITLE
fix(gui): render videos table row when a video backend fails to open (#2794)

### DIFF
--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -480,8 +480,18 @@ class VideosTableModel(GenericTableModel):
 
     def item_to_data(self, obj, item: "VideoBackend"):
         data = {}
-        if isinstance(item, Video):
-            item = item.backend
+        video = item if isinstance(item, Video) else None
+        if video is not None:
+            item = video.backend
+
+        # sleap-io leaves `Video.backend` as None when the file is inaccessible at
+        # open time (a lock, an AV scan, a flaky/slow drive, or a still-flushing
+        # recording). The `Video` still carries its filename and cached shape, so
+        # render a best-effort row from that instead of dereferencing a None
+        # backend and crashing the whole table (#2794). This extends the #2742
+        # hardening below, which only guarded the per-frame `img_shape` read.
+        if item is None:
+            return self._row_from_unopened_video(video)
 
         # `img_shape` reads a frame from disk, which can fail intermittently for a
         # video on a flaky network drive or a truncated file. Read it once (instead
@@ -514,6 +524,37 @@ class VideosTableModel(GenericTableModel):
             else:
                 data[property] = getattr(item, property)
         return data
+
+    def _row_from_unopened_video(self, video: "Video | None") -> dict:
+        """Build a videos-table row for a `Video` whose backend failed to open.
+
+        Falls back to the `Video`'s filename and cached
+        ``backend_metadata["shape"]`` (``[frames, height, width, channels]``); any
+        field that can't be resolved is shown as ``"?"``. See #2794.
+        """
+        filename = video.filename if video is not None else None
+        shape = (
+            (video.backend_metadata or {}).get("shape") if video is not None else None
+        )
+        if not (isinstance(shape, (list, tuple)) and len(shape) >= 4):
+            shape = None
+
+        if isinstance(filename, str):
+            name, filepath = Path(filename).name, str(Path(filename).parent)
+        elif filename:  # list of filenames (e.g. an image sequence)
+            name = filepath = filename[0]
+        else:
+            name = filepath = "?"
+
+        values = {
+            "name": name,
+            "filepath": filepath,
+            "frames": shape[0] if shape is not None else "?",
+            "height": shape[1] if shape is not None else "?",
+            "width": shape[2] if shape is not None else "?",
+            "channels": shape[3] if shape is not None else "?",
+        }
+        return {prop: values.get(prop, "?") for prop in self.properties}
 
 
 class SkeletonNodesTableModel(GenericTableModel):

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -508,6 +508,74 @@ def test_checkbox_toggle_falls_back_to_manual_qc_mode(qtbot, centered_pair_predi
         assert model._vis_state[QC_DISPLAY_MODE_KEY] == QC_MODE_MANUAL
 
 
+# -- Videos table tolerates a Video whose backend failed to open (#2794) ----------
+
+
+def _videos_table_row(video):
+    """Render a single videos-table row dict via VideosTableModel."""
+    model = VideosTableModel(items=[video])
+    return model._data[0]
+
+
+def test_videos_table_unopened_backend_renders_from_metadata(qtbot, tmp_path):
+    """A Video whose file is inaccessible has `backend is None`; the row must
+    fall back to filename + cached shape instead of crashing (#2794).
+
+    Reproduces the reporter's `AttributeError: 'NoneType' object has no
+    attribute 'filename'`: before the fix, `item_to_data` dereferenced the None
+    backend's `.filename` and the whole videos table refresh raised.
+    """
+    missing = tmp_path / "sub" / "1-doi1.mp4"  # never created -> backend stays None
+    video = sio.Video(
+        filename=str(missing),
+        backend_metadata={"shape": [9746, 1080, 1920, 1], "type": "MediaVideo"},
+    )
+    assert video.backend is None  # precondition: the exact crash trigger
+
+    row = _videos_table_row(video)
+    assert row["name"] == "1-doi1.mp4"
+    assert row["filepath"] == str(missing.parent)
+    assert row["frames"] == 9746
+    assert row["height"] == 1080
+    assert row["width"] == 1920
+    assert row["channels"] == 1
+
+
+def test_videos_table_unopened_backend_without_metadata(qtbot, tmp_path):
+    """No cached shape -> '?' placeholders for shape fields, still no crash."""
+    missing = tmp_path / "missing.mp4"
+    video = sio.Video(filename=str(missing))
+    assert video.backend is None
+
+    row = _videos_table_row(video)
+    assert row["name"] == "missing.mp4"
+    assert row["filepath"] == str(missing.parent)
+    assert row["frames"] == "?"
+    assert row["height"] == row["width"] == row["channels"] == "?"
+
+
+def test_videos_table_none_item_does_not_crash(qtbot):
+    """A bare None among the videos renders an all-'?' row rather than crashing."""
+    model = VideosTableModel(items=[None])
+    row = model._data[0]
+    assert all(row[prop] == "?" for prop in model.properties)
+
+
+def test_videos_table_open_backend_row_unchanged(qtbot, centered_pair_predictions):
+    """Regression: a normally-openable video still renders its full row -- the
+    None-backend fallback must not alter the happy path (#2794)."""
+    video = centered_pair_predictions.videos[0]
+    assert video.backend is not None  # fixture video opens normally
+
+    row = _videos_table_row(video)
+    assert row["name"].endswith("centered_pair_low_quality.mp4")
+    assert row["filepath"]  # non-empty parent directory
+    assert isinstance(row["frames"], int) and row["frames"] > 0
+    # height/width/channels come from a frame read; present as int or "?".
+    for key in ("height", "width", "channels"):
+        assert row[key] == "?" or (isinstance(row[key], int) and row[key] > 0)
+
+
 # -- QC display mode -> shared transient keys (#2783 <-> shared model) ------------
 
 


### PR DESCRIPTION
## Summary

Fixes a GUI crash where the videos table raises `AttributeError: 'NoneType' object has no attribute 'filename'` whenever a `Video` in `labels.videos` has `backend is None`. This typically fires during the **post-training table refresh** in the active-learning loop and aborts the session (reported in #2794; details in #2798).

Closes #2798. Refs discussion #2794.

## Root cause

`VideosTableModel.item_to_data` reassigns `item` to the video's backend and then dereferences `item.filename`:

```python
if isinstance(item, Video):
    item = item.backend     # -> None when the backend failed to open
...
Path(item.filename)         # None.filename -> AttributeError
```

sleap-io leaves `Video.backend` as `None` whenever the file is inaccessible at open time — `Video.__attrs_post_init__` only opens the backend `if open_backend and backend is None and self.exists()`, and `exists()` → `is_file_accessible()` does a real one-byte read that returns `False` on `FileNotFoundError/PermissionError/OSError`. A momentary lock, an AV scan, Windows indexing, a slow/flaky drive, or a still-flushing recording is enough. The `Video` still retains its `filename` and cached `backend_metadata["shape"]`.

This is the same failure family as #2742 / #2743, one line further down: that fix guarded the per-frame `img_shape` read, but the `item.filename` access remained unguarded for a fully-`None` backend — so `develop` still crashes here.

## Fix

Capture the `Video` before reassigning to its backend; when the backend is `None`, render a best-effort row from the `Video`'s `filename` + cached shape (`[frames, height, width, channels]`), with `"?"` placeholders for anything unresolved, instead of crashing. The happy path (open backend) is left byte-for-byte unchanged. A bare `None` item is also handled gracefully.

## Testing

- `tests/gui/test_dataviews.py` — **28 passed** (24 existing + 4 new). New tests cover: unopened backend with cached shape (reproduces the exact #2794 `AttributeError` pre-fix), unopened backend without metadata (`"?"` placeholders), a bare `None` item, and the unchanged happy path.
- `tests/gui/test_missingfiles_sequences.py` — **30 passed** (missing-file / None-backend / image-sequence path; closest neighbor to this change).
- `ruff check` clean; `ruff format --check` clean.

> Note: `tests/gui/test_commands.py` does not execute in my local headless sandbox — it exits cleanly mid-collection before any test body runs. I confirmed this reproduces identically on unmodified `develop` (changes stashed), so it is a pre-existing environment limitation, not a regression from this PR. CI should run it normally.
