### PR TITLE
feat(gui): drive inference via `sleap predict` (sleap-nn 0.3.0 unified pipeline)

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -540,7 +540,7 @@ class InferenceTask:
         """Makes list of CLI arguments needed for running inference."""
         cli_args = [
             "sleap",
-            "track",
+            "predict",
         ]
         if gui:
             cli_args.append("--gui")
@@ -594,6 +594,14 @@ class InferenceTask:
             cli_args.extend(("--model_paths", job_path))
 
         cli_args.extend(["-o", output_path])
+        # `sleap predict` (the sleap-nn 0.3.0 unified pipeline) defaults
+        # restore_source_videos=True, which rewrites the output's video reference to
+        # the original source media. Legacy `sleap track` saved with
+        # restore_original_videos=False. Pass the negative flag to preserve the exact
+        # legacy save semantics so the post-success load + merge matches videos by
+        # filename: a no-op for non-embedded projects, but required to avoid a
+        # duplicate video when --data_path is an embedded .pkg.slp.
+        cli_args.append("--no-restore_source_videos")
 
         if "_batch_size" in self.inference_params:
             cli_args.extend(["--batch_size", str(self.inference_params["_batch_size"])])

--- a/tests/gui/learning/test_cli_construction.py
+++ b/tests/gui/learning/test_cli_construction.py
@@ -309,13 +309,14 @@ class TestInferenceTaskCLI:
         )
 
     def test_basic_cli_call(self, inference_task, video_item):
-        """Basic CLI call should include sleap track and model paths."""
+        """Basic CLI call should invoke `sleap predict` with model paths."""
         cli_args, output_path = inference_task.make_predict_cli_call(
             video_item, output_path="/path/to/output.slp"
         )
 
         assert cli_args[0] == "sleap"
-        assert cli_args[1] == "track"
+        # The GUI drives the sleap-nn 0.3.0 unified inference pipeline via `predict`.
+        assert cli_args[1] == "predict"
         assert "--model_paths" in cli_args
         # Model path should be parent directory (strip training_config.yaml)
         model_idx = cli_args.index("--model_paths") + 1
@@ -323,6 +324,9 @@ class TestInferenceTaskCLI:
         assert Path(cli_args[model_idx]).as_posix() == "/path/to/model"
         assert "-o" in cli_args
         assert "/path/to/output.slp" in cli_args
+        # Preserve legacy save semantics (no source-video restore) so the
+        # post-inference load + merge matches videos by filename.
+        assert "--no-restore_source_videos" in cli_args
 
     def test_batch_size_in_cli(self, inference_task, video_item):
         """Batch size should be included in CLI args."""
@@ -865,7 +869,9 @@ class TestFullCLIIntegration:
 
         # Check base command
         assert cli_args[0] == "sleap"
-        assert cli_args[1] == "track"
+        assert cli_args[1] == "predict"
+        # Legacy save semantics preserved across the predict switch.
+        assert "--no-restore_source_videos" in cli_args
 
         # Check data args
         assert "--data_path" in cli_args


### PR DESCRIPTION
> **Draft** — the code change is complete and unit-tested, but the inference path needs **end-to-end validation with real trained models** before merge (checklist below).

**Stacked on #2796** (base = `talmo/1.7.0-deps-upgrade-tier0`; retarget to `develop` after it merges).

## Summary

Switches the GUI's inference subprocess from the legacy `sleap track` subcommand to the new unified **`sleap predict`** pipeline (sleap-nn 0.3.0, [#530](https://github.com/talmolab/sleap-nn/pull/530)), in `InferenceTask.make_predict_cli_call`.

## Why this is safe (verified against sleap-nn 0.3.0)

`predict`'s option surface is a **strict superset** of `track`'s — `{track.params} − {predict.params}` is **empty** (68 vs 105 params, confirmed by introspecting the live click commands). Every one of the **26 options** the GUI emits — data/model/output/batch_size/peak_threshold/max_instances, the **entire tracking arg set** (`--tracking`, `--track_matching_method`, `--tracking_window_size`, `--candidates_method`, `--max_tracks`, `--use_flow`, `--post_connect_single_breaks`, `--tracking_target_instance_count`, `--scoring_reduction`, `--robust_best_instance`, `--features`, `--scoring_method`), and `--filter_overlapping*` — is accepted by `predict` under **identical primary names**. Nothing is renamed, dropped, or missing.

## Changes (2 lines + 1 defensive flag)

1. **`"track"` → `"predict"`** — the subcommand.
2. **Add `--no-restore_source_videos`.** Legacy `track` saved with `restore_original_videos=False`; `predict` defaults `restore_source_videos=True`, which rewrites the output's video reference to the original source media. For non-embedded projects this is a no-op, but for an **embedded `.pkg.slp`** input it would make the post-inference `sio.load_slp` + `Labels.merge` create a **duplicate video** instead of merging. The negative flag preserves exact legacy save semantics.

**`--gui` progress parsing is unchanged** — `predict --gui` emits byte-identical JSON (`{n_processed, n_total, rate, eta}`) to `track --gui`, so neither `predict_subprocess` nor the threaded-worker parser needs edits.

## Tests
- `tests/gui/learning/test_cli_construction.py` updated to assert `predict` + `--no-restore_source_videos`.
- Full `tests/gui/learning/` suite: **345 passed**. ruff clean.

## ⚠️ Validation required before un-drafting (needs real trained models)
- [ ] **Embedded `.pkg.slp` input** → run inference, confirm `load_slp` + `merge` folds into the existing video (no duplicate). *The one genuine behavioral delta; should be neutralized by the flag — confirm.*
- [ ] **Live `--gui` progress** end-to-end — bar advances, "Predicted: n/n FPS ETA" renders (emitter confirmed by code reading only).
- [ ] **Multi-class / ID models with `--tracking`.** Genuine divergence: legacy `track` *silently skipped* tracking for BottomUp/TopDown-MultiClass even with `--tracking`; `predict` has no such guard and will run the flow tracker. Confirm whether the GUI exposes tracking for ID configs; decide whether predict's behavior is desired (likely a fix) or needs a narrow guard.
- [ ] **Centroid-only model** — `track` hard-errors (#2724); `predict` should now work. Smoke-test.
- [ ] **`--frames` with explicit/negative indices** (GUI emits e.g. `0,-2559`).

## Scope decision
The parity analysis recommends a **clean, ungated full switch** (predict is a strict superset; progress is byte-identical) rather than a feature flag or per-model-type gate — a gate would institutionalize the legacy path we're retiring. The only thing that would justify a narrow guard is if ID-model tracking (item 3) turns out unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019w47Wyu6LYBGZdEEegteDV