### PR TITLE
fix(gui): decode inference subprocess output as UTF-8 (#2744)

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -239,6 +239,15 @@ class InferenceWorker(QtCore.QThread):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,  # Merge stderr into stdout
             text=True,  # Text mode (required for line buffering)
+            # Force UTF-8 decoding of the child's output. Without this, text mode
+            # decodes using the locale default, which is cp1252 on Windows, so any
+            # non-cp1252 byte in the subprocess output (e.g. the UTF-8 box-drawing
+            # glyphs in a `rich`-rendered traceback or progress bar) crashes the
+            # reader with `UnicodeDecodeError: 'charmap' codec can't decode byte ...`,
+            # masking the real error. `errors="replace"` keeps reading even if the
+            # child emits a stray non-UTF-8 byte. (gh discussion #2744)
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,  # Line buffered
             env=env,
         ) as proc:
@@ -700,7 +709,9 @@ class InferenceTask:
             while proc.poll() is None:
                 # Read line.
                 line = proc.stdout.readline()
-                line = line.decode().rstrip()
+                # Decode as UTF-8 with replacement so a stray non-UTF-8 byte in
+                # the subprocess output can't crash the reader (see #2744).
+                line = line.decode("utf-8", errors="replace").rstrip()
 
                 is_json = False
                 if line.startswith("{"):

--- a/tests/gui/learning/test_runners.py
+++ b/tests/gui/learning/test_runners.py
@@ -1,0 +1,52 @@
+"""Tests for inference/training subprocess runners."""
+
+import sys
+
+from unittest.mock import MagicMock
+
+from sleap.gui.learning.runners import InferenceWorker
+
+
+def test_inference_worker_reads_non_utf8_subprocess_output(qtbot, tmp_path):
+    """Reading inference subprocess output must not crash on a stray non-UTF-8 byte.
+
+    Regression test for gh discussion #2744 / sleap-nn #655: on Windows the GUI
+    decoded the inference subprocess output using the cp1252 locale default, so a
+    byte like ``0x90`` (e.g. from a ``rich``-rendered traceback or progress bar)
+    raised ``UnicodeDecodeError: 'charmap' codec can't decode byte 0x90`` and
+    masked the real error. A lone ``0x90`` is also invalid UTF-8, so it reproduces
+    the crash on any platform when the reader does not pass ``errors="replace"``.
+    """
+    # Child process emits a lone 0x90 byte (invalid UTF-8 / cp1252-undefined),
+    # stays alive briefly so the parent loop reads + decodes it, then exits
+    # non-zero so the success/load-slp branch is skipped.
+    script = (
+        "import sys, time; "
+        "sys.stdout.buffer.write(b'progress \\x90 line\\n'); "
+        "sys.stdout.flush(); "
+        "time.sleep(0.5); "
+        "sys.exit(1)"
+    )
+    output_path = str(tmp_path / "out.slp")
+
+    task = MagicMock()
+    task.make_predict_cli_call.return_value = (
+        [sys.executable, "-c", script],
+        output_path,
+    )
+
+    items = MagicMock()
+    items.total_frame_count = 0
+
+    worker = InferenceWorker(task, items)
+
+    logged = []
+    worker.logOutput.connect(logged.append)
+
+    # Must not raise UnicodeDecodeError while reading the subprocess output.
+    out_path, ret = worker._run_inference_item(MagicMock(), 0, 1)
+
+    assert out_path == output_path
+    assert ret == 1  # non-zero exit propagated; no decode crash
+    # The malformed line was still captured (with the bad byte replaced).
+    assert any("progress" in line and "line" in line for line in logged)


### PR DESCRIPTION
## Summary
- The GUI inference runner decoded the inference subprocess output using the **locale default encoding** (`cp1252` on Windows), so a single non-cp1252 byte in the child's output crashed the reader with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90`, **masking the real error**.
- Force `encoding="utf-8", errors="replace"` so the actual subprocess output — including error tracebacks — surfaces in the GUI log on all platforms.

## Background
Reported in [discussion #2744](https://github.com/talmolab/sleap/discussions/2744) (and the CLI-side view in [sleap-nn #655](https://github.com/talmolab/sleap-nn/issues/655)). A user on Windows hit `'charmap' codec can't decode byte 0x90 in position 627` during inference.

The byte `0x90` comes from UTF-8 box-drawing / block glyphs that `rich` uses when rendering tracebacks and progress bars (e.g. `▐` = `U+2590` = `E2 96 90`). In `InferenceWorker._run_inference_item`, the subprocess was opened with `text=True` but **no `encoding=`**, so Python decoded with the Windows locale default (cp1252) and raised on that byte.

Crucially, this happened **while rendering the *real* error** (sleap-nn raising `object header message is too large` when saving an oversized `metadata/json` HDF5 attribute). So the encoding crash hid the actual cause and sent the investigation down an unrelated path (HDF5 version, PATH conflicts). This PR doesn't fix that underlying save failure (tracked separately in sleap-io) — it ensures the GUI **shows** the real error instead of crashing on it.

## Changes Made
- `sleap/gui/learning/runners.py`
  - `InferenceWorker._run_inference_item`: add `encoding="utf-8", errors="replace"` to the `subprocess.Popen(..., text=True)` reader.
  - `InferenceTask` (sibling raw-bytes reader): change `line.decode()` → `line.decode("utf-8", errors="replace")` for the same stray-byte robustness.
- `tests/gui/learning/test_runners.py` (new)
  - Regression test driving the real `_run_inference_item` against a subprocess that emits a lone `0x90` byte.

## Testing
- New test `test_inference_worker_reads_non_utf8_subprocess_output` passes on the fix.
- Verified it **catches the regression**: reverting the `Popen` change makes it fail with `UnicodeDecodeError: ... byte 0x90 in position 9` — the same byte/class as the user's report.
- A lone `0x90` is invalid UTF-8, so the test reproduces the crash on **any** platform (not just Windows cp1252), making it a reliable cross-platform guard.
- `ruff format` / `ruff check` clean.

## Design Decisions
- `errors="replace"` (not strict) so a genuinely malformed byte degrades to a replacement char in the log rather than killing the run — log display should never be able to abort inference.
- Hardened the sibling `.decode()` path too; `bytes.decode()` already defaults to UTF-8, but adding `errors="replace"` makes both readers robust to the same failure mode.

## Related Issues
- Discussion #2744
- talmolab/sleap-nn#655 (same root cause, CLI-side)

> Note: the *underlying* save failure (provenance/`merge_history` exceeding HDF5's 64 KB attribute limit) is a separate sleap-io fix; this PR addresses only the GUI error-masking bug.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)