### PR TITLE
fix(gui): omit --frames for entire-video inference (#2808)

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -432,6 +432,30 @@ class VideoItemForInference(ItemForInference):
         return self.video.filename
 
     @property
+    def is_entire_video(self) -> bool:
+        """Whether `frames` selects every frame of the video.
+
+        The "entire video" option encodes its selection as the half-open range
+        ``[0, len(video))`` (i.e. ``frames == [0, -len(video)]`` via the
+        ``encode_range`` helper in `MainWindow._get_frames_for_prediction`).
+        Detecting this lets `cli_args` omit ``--frames`` so the inference CLI
+        predicts on all frames using its own frame count, rather than a count
+        derived from the GUI (which may differ by one).
+        """
+        if self.frames is None:
+            return False
+        frames = list(self.frames)
+        negatives = [f for f in frames if f < 0]
+        non_negatives = [f for f in frames if f >= 0]
+        if len(negatives) != 1 or len(non_negatives) != 1:
+            return False
+        try:
+            video_length = len(self.video)
+        except (TypeError, AttributeError):
+            return False
+        return non_negatives[0] == 0 and -negatives[0] == video_length
+
+    @property
     def cli_args(self):
         arg_list = list()
         arg_list.extend(["--data_path", f"{self.path}"])
@@ -453,12 +477,25 @@ class VideoItemForInference(ItemForInference):
         ):
             arg_list.extend(("--video_input_format", self.video.backend.input_format))
 
-        # -Y represents endpoint of [X, Y) range but inference cli expects
-        # [X, Y-1] range (so add 1 since negative).
-        frame_int_list = list(set([i + 1 if i < 0 else i for i in self.frames]))
-        frame_int_list.sort(reverse=min(frame_int_list) < 0)  # Assumes len of 2 if neg.
+        # `frames` is either an explicit list of (non-negative) frame indices or
+        # a half-open range [X, Y) whose exclusive endpoint Y is stored as a
+        # negative value (see `MainWindow._get_frames_for_prediction`).
+        #
+        # For the entire video, omit `--frames` and let the inference CLI default
+        # to predicting on all frames. This avoids emitting the fragile "0,-N"
+        # range encoding, and avoids pinning the endpoint to the frame count seen
+        # by the GUI -- which can be one greater than the number of frames the
+        # inference video reader actually decodes, causing an out-of-range
+        # `IndexError` on the final frame.
+        if not self.is_entire_video:
+            # -Y represents endpoint of [X, Y) range but inference cli expects
+            # [X, Y-1] range (so add 1 since negative).
+            frame_int_list = list(set([i + 1 if i < 0 else i for i in self.frames]))
+            frame_int_list.sort(
+                reverse=min(frame_int_list) < 0
+            )  # Assumes len of 2 if neg.
 
-        arg_list.extend(("--frames", ",".join(map(str, frame_int_list))))
+            arg_list.extend(("--frames", ",".join(map(str, frame_int_list))))
 
         return arg_list
 

--- a/tests/gui/learning/test_cli_construction.py
+++ b/tests/gui/learning/test_cli_construction.py
@@ -132,6 +132,52 @@ class TestVideoItemForInferenceCLI:
         # -100 becomes -99 (endpoint adjustment)
         assert "-99" in cli_args[frames_idx]
 
+    def test_cli_args_entire_video_omits_frames(self, mock_video):
+        """Entire-video selection should omit --frames (predict all frames).
+
+        The entire video is encoded as ``[0, -len(video)]``; emitting an
+        explicit ``--frames 0,-N`` here pins the endpoint to the GUI's frame
+        count, which can request a frame past the end of the video and crash
+        inference with an ``IndexError`` (see discussion #2807).
+        """
+        mock_video.__len__.return_value = 100
+        item = VideoItemForInference(
+            video=mock_video,
+            frames=[0, -100],  # encode_range(0, len(video)) for a 100-frame video
+            labels_path="/path/to/labels.slp",
+            video_idx=0,
+        )
+
+        assert item.is_entire_video
+        assert "--frames" not in item.cli_args
+
+    def test_cli_args_clip_not_treated_as_entire_video(self, mock_video):
+        """A clip shorter than the video should still emit --frames."""
+        mock_video.__len__.return_value = 100
+        item = VideoItemForInference(
+            video=mock_video,
+            frames=[0, -50],  # frames 0..49 of a 100-frame video
+            labels_path="/path/to/labels.slp",
+            video_idx=0,
+        )
+
+        assert not item.is_entire_video
+        cli_args = item.cli_args
+        assert "--frames" in cli_args
+        assert cli_args[cli_args.index("--frames") + 1] == "0,-49"
+
+    def test_cli_args_explicit_frame_list_not_entire_video(self, mock_video):
+        """An explicit list of frames is never treated as the entire video."""
+        mock_video.__len__.return_value = 5
+        item = VideoItemForInference(
+            video=mock_video,
+            frames=[0, 1, 2, 3, 4],
+            labels_path="/path/to/labels.slp",
+        )
+
+        assert not item.is_entire_video
+        assert "--frames" in item.cli_args
+
     def test_path_property_with_labels(self, mock_video):
         """path property should return labels_path when provided."""
         item = VideoItemForInference(


### PR DESCRIPTION
## Problem

Running inference from the GUI with the frame range set to **"Entire video"** builds a command containing `--frames 0,-N` (e.g. `--frames 0,-10245`). This was reported in discussion #2807, where it crashes with `IndexError: Failed to read frame index N`.

Two things are wrong with the `0,-N` encoding:

1. **It's fragile.** `MainWindow._get_frames_for_prediction` encodes "Entire video" as the half-open range `[0, len(video))` → `[0, -len(video)]`, and `VideoItemForInference.cli_args` serializes that to `--frames 0,-N`. That string only decodes back into a range because sleap-nn's `frame_list` happens to do `min_max[0].rstrip(",")`. It reads like the two-frame list `[0, -N]` (exactly how the reporter interpreted it).
2. **It pins the endpoint to the GUI's frame count.** If that count is one greater than the number of frames the inference reader actually decodes — the 1-indexed/0-indexed discrepancy in #2790, or a video whose metadata over-reports its length — inference iterates to a nonexistent frame and raises `IndexError: Failed to read frame index N`.

## Fix

Add `VideoItemForInference.is_entire_video` and, when it's true, omit `--frames` so the inference CLI predicts on all frames using **its own** frame count (the documented default when `--frames` is not passed). This drops the fragile encoding and decouples the run from the GUI's count.

| Selection | Before | After |
|---|---|---|
| Entire video | `--frames 0,-N` | *(omitted → all frames)* |
| Clip `[a, b)` | `--frames a,-(b-1)` | unchanged |
| Explicit frames | `--frames 0,1,2,…` | unchanged |
| Current frame | `--frames k` | unchanged |

## Testing

- `tests/gui/learning/test_cli_construction.py::TestVideoItemForInferenceCLI` — added 3 tests (entire-video omits `--frames`; a shorter clip still emits `--frames`; explicit lists are never treated as entire-video). All 9 tests in the class pass.
- Existing frame-range / CLI-construction tests unchanged and green.

> One unrelated test (`TestWritePipelineFiles::test_train_script_does_not_contain_zmq`) fails locally with `ModuleNotFoundError: No module named 'sleap_nn'` — pre-existing in this environment (confirmed on a clean branch), not touched by this change.

## Notes

If the crash still reproduces for a specific video after this change, the video's own metadata over-reports its decodable frame count (a corrupted / variable-frame-rate file). That is a separate reader-robustness concern in sleap-nn / sleap-io, and the plan is to confirm with the reporter and request the video if needed.

Fixes #2808. Reported in #2807.
