### PR TITLE
feat(gui): infer/add left-right symmetries — startup prompt + node-name dropdown (#2806)

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -566,6 +566,12 @@ class CommandContext:
         """Sets node symmetry in skeleton."""
         self.execute(SetNodeSymmetry, skeleton=skeleton, node=node, symmetry=symmetry)
 
+    def addInferredSymmetries(self, skeleton, symmetry_pairs):
+        """Add name-inferred symmetric node pairs to the skeleton."""
+        self.execute(
+            AddInferredSymmetries, skeleton=skeleton, symmetry_pairs=symmetry_pairs
+        )
+
     def updateEdges(self):
         """Called when edges in skeleton have been changed."""
         self.signal_update([UpdateTopic.skeleton])
@@ -772,6 +778,64 @@ class NewProject(AppCommand):
         window.showMaximized()
 
 
+def find_inferrable_symmetries(
+    labels: Labels,
+) -> List[Tuple[Skeleton, List[Tuple[int, int]]]]:
+    """Skeletons in `labels` with no symmetries but name-inferrable pairs.
+
+    Returns a list of `(skeleton, [(left_idx, right_idx), ...])` for each
+    skeleton that has no symmetries defined yet whose node names imply some (via
+    `Skeleton.infer_symmetries_by_name`). Skeletons that already have
+    symmetries, yield no candidates, or whose sleap-io version predates the
+    resolver are skipped.
+    """
+    results = []
+    for skeleton in labels.skeletons:
+        if skeleton.symmetries:
+            continue
+        infer = getattr(skeleton, "infer_symmetries_by_name", None)
+        if infer is None:
+            continue  # older sleap-io without the resolver
+        pairs = infer()
+        if pairs:
+            results.append((skeleton, pairs))
+    return results
+
+
+def _prompt_inferred_symmetries(context: "CommandContext"):
+    """Ask whether to add name-inferred symmetries to symmetry-less skeletons.
+
+    Shows one confirmation per skeleton flagged by `find_inferrable_symmetries`,
+    adding the pairs to that skeleton if the user accepts.
+    """
+    for skeleton, pairs in find_inferrable_symmetries(context.labels):
+        names = skeleton.node_names
+        pair_lines = "\n".join(f"    {names[a]}  ↔  {names[b]}" for a, b in pairs)
+        count = len(pairs)
+        response = QtWidgets.QMessageBox.question(
+            context.app,
+            "Add symmetric node pairs?",
+            f"This skeleton has no left/right symmetries defined, but {count} "
+            f"likely symmetric pair{'' if count == 1 else 's'} were found from "
+            f"the node names:\n\n{pair_lines}\n\n"
+            "Symmetries are used for left/right flip augmentation and quality "
+            "control. Add them to the skeleton?",
+        )
+        if response == QtWidgets.QMessageBox.Yes:
+            context.addInferredSymmetries(skeleton, pairs)
+
+
+def _maybe_prompt_inferred_symmetries(context: "CommandContext"):
+    """Run `_prompt_inferred_symmetries` only when the main window is visible.
+
+    Skipped when the window is not shown (headless/programmatic loads, e.g. in
+    tests), so a modal dialog never blocks a non-interactive load.
+    """
+    is_visible = getattr(context.app, "isVisible", None)
+    if callable(is_visible) and is_visible():
+        _prompt_inferred_symmetries(context)
+
+
 class LoadLabelsObject(AppCommand):
     @staticmethod
     def do_action(context: "CommandContext", params: dict):
@@ -810,6 +874,12 @@ class LoadLabelsObject(AppCommand):
 
         # This is not listed as an edit command since we want a clean changestack
         context.app.on_data_update([UpdateTopic.project, UpdateTopic.all])
+
+        # Offer to add left/right symmetries inferred from node names when a
+        # loaded skeleton has none defined (used by flip augmentation and QC).
+        # Deferred so it runs once the window is shown, and gated on visibility
+        # so non-interactive/headless loads never block on the dialog.
+        QtCore.QTimer.singleShot(0, lambda: _maybe_prompt_inferred_symmetries(context))
 
 
 class LoadProjectFile(LoadLabelsObject):
@@ -3345,6 +3415,15 @@ class SetNodeSymmetry(EditCommand):
             symmetric_to = get_symmetry_node(skeleton, node)
             if symmetric_to is not None:
                 delete_symmetry(skeleton, node, symmetric_to)
+
+
+class AddInferredSymmetries(EditCommand):
+    topics = [UpdateTopic.skeleton]
+
+    @staticmethod
+    def do_action(context: CommandContext, params: dict):
+        skeleton = params["skeleton"]
+        skeleton.add_symmetries(params["symmetry_pairs"])
 
 
 class NewEdge(EditCommand):

--- a/sleap/gui/dataviews.py
+++ b/sleap/gui/dataviews.py
@@ -579,6 +579,39 @@ class SkeletonNodesTableModel(GenericTableModel):
             self.context.setNodeSymmetry(skeleton=self.obj, node=item, symmetry=value)
 
 
+class NodeSymmetryComboDelegate(QtWidgets.QStyledItemDelegate):
+    """Combo-box editor for the skeleton Nodes table "symmetry" column.
+
+    Constrains the symmetric partner to an existing node name (or blank to
+    clear the symmetry) instead of a free-text field. Besides being easier to
+    use, this prevents a typo from silently creating a phantom node: setting a
+    symmetry routes through ``Skeleton.add_symmetry``, which adds any unknown
+    partner name as a brand new node.
+    """
+
+    def createEditor(self, parent, option, index):
+        """Return a combo box listing the other node names (plus a blank)."""
+        combo = QtWidgets.QComboBox(parent)
+        combo.addItem("")  # blank clears the symmetry
+        model = index.model()
+        skeleton = getattr(model, "skeleton", None)
+        names = list(skeleton.node_names) if skeleton is not None else []
+        # A node can't be symmetric with itself, so drop this row's own node.
+        own_name = model.data(model.index(index.row(), 0), QtCore.Qt.EditRole)
+        combo.addItems([name for name in names if name != own_name])
+        return combo
+
+    def setEditorData(self, editor, index):
+        """Select the current symmetric partner in the combo box."""
+        value = index.model().data(index, QtCore.Qt.EditRole) or ""
+        pos = editor.findText(value)
+        editor.setCurrentIndex(pos if pos >= 0 else 0)
+
+    def setModelData(self, editor, model, index):
+        """Write the chosen node name (or blank) back through the model."""
+        model.setData(index, editor.currentText(), QtCore.Qt.EditRole)
+
+
 class SkeletonEdgesTableModel(GenericTableModel):
     """Table model for skeleton edges."""
 

--- a/sleap/gui/widgets/docks.py
+++ b/sleap/gui/widgets/docks.py
@@ -29,6 +29,7 @@ from sleap.gui.dataviews import (
     GenericTableView,
     InstancesTableView,
     LabeledFrameTableModel,
+    NodeSymmetryComboDelegate,
     SkeletonEdgesTableModel,
     SkeletonNodeModel,
     SkeletonNodesTableModel,
@@ -250,6 +251,13 @@ class SkeletonDock(DockWidget):
             state=main_window.state,
             row_name="node",
             model=self.nodes_model,
+        )
+        # Edit the "symmetry" column via a node-name dropdown instead of free
+        # text, so a symmetric partner can only be an existing node (a typo
+        # would otherwise create a phantom node via ``add_symmetry``).
+        self.nodes_table.setItemDelegateForColumn(
+            self.nodes_model.properties.index("symmetry"),
+            NodeSymmetryComboDelegate(self.nodes_table),
         )
 
         self.edges_table = GenericTableView(

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -20,6 +20,8 @@ from sleap.gui.app import MainWindow
 from sleap.gui.commands import (
     AddInstance,
     CommandContext,
+    find_inferrable_symmetries,
+    _prompt_inferred_symmetries,
     DeleteNode,
     ExportAnalysisFile,
     ExportDatasetWithImages,
@@ -2084,3 +2086,72 @@ def test_AddInstance_clears_negative(qtbot, centered_pair_predictions: Labels):
     context.newInstance()
 
     assert not lf.is_negative
+
+
+# The symmetry-inference features need sleap-io#534
+# (`Skeleton.infer_symmetries_by_name`), which is unreleased at the time of
+# writing. Skip until the pinned sleap-io provides it (see PR #2810).
+requires_infer = pytest.mark.skipif(
+    not hasattr(Skeleton, "infer_symmetries_by_name"),
+    reason="requires sleap-io#534 (Skeleton.infer_symmetries_by_name)",
+)
+
+
+@requires_infer
+def test_find_inferrable_symmetries():
+    """Skeletons with L/R node names but no symmetries are flagged."""
+    skel = Skeleton(["nose", "eye_L", "eye_R"])
+    labels = Labels(skeletons=[skel])
+    assert find_inferrable_symmetries(labels) == [(skel, [(1, 2)])]
+
+    # Once symmetries are defined, the skeleton is no longer flagged.
+    skel.add_symmetry("eye_L", "eye_R")
+    assert find_inferrable_symmetries(labels) == []
+
+    # A skeleton whose names imply no pairs is skipped.
+    plain = Labels(skeletons=[Skeleton(["a", "b", "c"])])
+    assert find_inferrable_symmetries(plain) == []
+
+
+@requires_infer
+def test_add_inferred_symmetries_command():
+    """`addInferredSymmetries` adds the pairs and marks the project changed."""
+    skel = Skeleton(["nose", "eye_L", "eye_R", "ear_L", "ear_R"])
+    context = CommandContext.from_labels(Labels(skeletons=[skel]))
+
+    context.addInferredSymmetries(skel, skel.infer_symmetries_by_name())
+
+    assert skel.symmetry_names == [("eye_L", "eye_R"), ("ear_L", "ear_R")]
+    assert context.state["has_changes"]
+
+
+@requires_infer
+def test_prompt_inferred_symmetries_accept(qtbot, monkeypatch):
+    """Accepting the prompt adds the inferred symmetries."""
+    skel = Skeleton(["nose", "eye_L", "eye_R"])
+    context = CommandContext.from_labels(Labels(skeletons=[skel]))
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.Yes,
+    )
+
+    _prompt_inferred_symmetries(context)
+
+    assert skel.symmetry_names == [("eye_L", "eye_R")]
+
+
+@requires_infer
+def test_prompt_inferred_symmetries_decline(qtbot, monkeypatch):
+    """Declining the prompt leaves the skeleton unchanged."""
+    skel = Skeleton(["nose", "eye_L", "eye_R"])
+    context = CommandContext.from_labels(Labels(skeletons=[skel]))
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.No,
+    )
+
+    _prompt_inferred_symmetries(context)
+
+    assert skel.symmetries == []

--- a/tests/gui/test_dataviews.py
+++ b/tests/gui/test_dataviews.py
@@ -620,3 +620,39 @@ def test_qc_mode_maps_onto_transient_keys(qtbot, centered_pair_predictions):
     assert instance_visible(state, instances[1]) is False
     assert instance_shows_non_visible(state, instances[0], False) is True
     assert instance_shows_non_visible(state, instances[1], False) is False
+
+
+def test_node_symmetry_combo_delegate(qtbot):
+    """The Nodes table symmetry column edits via a node-name dropdown."""
+    from sleap.gui.commands import CommandContext
+    from sleap.sleap_io_adaptors.skeleton_utils import get_symmetry_node
+
+    skeleton = sio.Skeleton(["nose", "eye_L", "eye_R"])
+    labels = sio.Labels(skeletons=[skeleton])
+    context = CommandContext.from_labels(labels)
+    model = SkeletonNodesTableModel(items=skeleton, context=context)
+    table = GenericTableView(model=model)
+    delegate = NodeSymmetryComboDelegate(table)
+    sym_col = model.properties.index("symmetry")
+
+    # The editor for the "nose" row lists the OTHER nodes plus a blank, and
+    # excludes the row's own node (no self-symmetry, no free-text phantom nodes).
+    index = model.index(0, sym_col)
+    editor = delegate.createEditor(table, None, index)
+    assert [editor.itemText(i) for i in range(editor.count())] == [
+        "",
+        "eye_L",
+        "eye_R",
+    ]
+
+    # Choosing a partner routes through the command and sets the symmetry.
+    editor.setCurrentText("eye_L")
+    delegate.setModelData(editor, model, index)
+    assert get_symmetry_node(skeleton, "nose") == "eye_L"
+
+    # setEditorData reflects the current partner back into the combo box.
+    model.items = skeleton  # refresh cached rows after the edit
+    index = model.index(0, sym_col)
+    editor = delegate.createEditor(table, None, index)
+    delegate.setEditorData(editor, index)
+    assert editor.currentText() == "eye_L"


### PR DESCRIPTION
## Summary

**Draft** — part of #2806 (*QC Detector does not support defining arbitrary L/R relationships*). Adds two GUI affordances for left/right symmetries, which drive flip augmentation and QC and are commonly missing on imported skeletons:

1. **Startup prompt** — when a project loads and a skeleton has no symmetries defined but its node names imply some, offer to add them.
2. **Symmetry dropdown** — edit the Nodes-table *symmetry* column via a node-name dropdown instead of free text (also fixes a phantom-node footgun).

Both consume the new `Skeleton.infer_symmetries_by_name()` from talmolab/sleap-io#534.

## ⚠️ Merge gate (dependency)

**Do not merge until a sleap-io release that includes talmolab/sleap-io#534 is published**, then bump sleap's pin to it. sleap currently pins `sleap-io[all]>=0.7.1,<0.8.0`; #534 is on sleap-io `main` (post-0.8.0) and unreleased. Developed and validated locally against a `v0.7.1 + #534` build. The new API call is `getattr`-guarded, so an older sleap-io degrades gracefully (no prompt) — the feature only activates once the released sleap-io provides the method.

## Key changes

**Startup prompt — `sleap/gui/commands.py`**
- `find_inferrable_symmetries(labels)` — pure helper returning skeletons with no symmetries but name-inferrable pairs.
- `AddInferredSymmetries` command + `CommandContext.addInferredSymmetries` — marks the project changed.
- The prompt is **deferred** (`QTimer.singleShot`) and **visibility-gated** (`isVisible()`), so non-interactive/headless loads never block on the modal (existing tests unaffected; the real app shows the window before the deferred prompt runs, so CLI-startup opens still prompt).

**Symmetry dropdown — `sleap/gui/dataviews.py`, `sleap/gui/widgets/docks.py`**
- `NodeSymmetryComboDelegate` — combobox constrained to existing node names (plus a blank to clear), attached to the Nodes table's symmetry column. Prevents a typo from creating a phantom node via `add_symmetry`.

## Testing
- `tests/gui/test_commands.py`: detection helper; command (+ dirty flag); prompt accept/decline (monkeypatched dialog).
- `tests/gui/test_dataviews.py`: delegate lists the other node names + blank and routes the selection to `setNodeSymmetry`.
- Verified in-context: the delegate attaches to the live Skeleton dock, and the load-time prompt fires only when the window is visible (adds pairs on accept) and is skipped when hidden.

## Before merge
- [ ] sleap-io release with #534 published
- [ ] bump `sleap-io[all]` pin to that release
- [ ] (local dev-pin to `../sleap-io-072dev` is intentionally **not** committed)
