### PR TITLE
feat(gui): expose motion-trail options in the render/export dialog

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1630,6 +1630,20 @@ class ExportLabeledClip(AppCommand):
         params["start"] = export_params.get("start")
         params["end"] = export_params.get("end")
 
+        # Motion trail params are only present in export_params when the user
+        # enabled trails; copy through whatever is there.
+        for key in (
+            "show_trails",
+            "trail_length",
+            "trail_node",
+            "trail_width",
+            "trail_alpha_fade",
+            "trail_alpha",
+            "trail_color",
+        ):
+            if key in export_params:
+                params[key] = export_params[key]
+
         return True
 
     @classmethod
@@ -1661,6 +1675,22 @@ class ExportLabeledClip(AppCommand):
         # Add background if not "video"
         if params.get("background"):
             render_params["background"] = params["background"]
+
+        # Motion trails. Only forward when enabled so the default render path is
+        # untouched. trail_color / trail_alpha_fade may legitimately be falsy,
+        # so guard on presence rather than truthiness once trails are on.
+        if params.get("show_trails"):
+            render_params["show_trails"] = True
+            for key in (
+                "trail_length",
+                "trail_node",
+                "trail_width",
+                "trail_alpha_fade",
+                "trail_alpha",
+                "trail_color",
+            ):
+                if key in params:
+                    render_params[key] = params[key]
 
         # When the user opts in to include unlabeled frames, hand sleap-io the
         # full range instead of a labeled-only frame_inds list — otherwise the

--- a/sleap/gui/dialogs/render_clip.py
+++ b/sleap/gui/dialogs/render_clip.py
@@ -149,6 +149,9 @@ class RenderClipDialog(QtWidgets.QDialog):
         # Appearance
         layout.addWidget(self._create_appearance_group())
 
+        # Motion trails
+        layout.addWidget(self._create_trails_group())
+
         # Quality
         layout.addWidget(self._create_quality_group())
 
@@ -383,6 +386,115 @@ class RenderClipDialog(QtWidgets.QDialog):
 
         return group
 
+    def _skeleton_node_names(self) -> list[str]:
+        """Return the node names of the first skeleton, or ``[]`` if none.
+
+        Used to populate the trail-node picker. Guarded because a Labels object
+        may have no skeleton (e.g. an empty project) or an unusual node type.
+        """
+        try:
+            skeletons = self.labels.skeletons
+        except Exception:
+            return []
+        if not skeletons:
+            return []
+        names = []
+        for node in skeletons[0].nodes:
+            names.append(getattr(node, "name", None) or str(node))
+        return names
+
+    def _create_trails_group(self) -> QtWidgets.QGroupBox:
+        """Create motion-trail options group.
+
+        These map 1:1 to sleap-io's `render_video`/`render_image` trail kwargs.
+        Trails work for untracked / single-instance data too: sleap-io keys
+        trails by instance position when no tracks are present, so no track
+        assignment is required.
+        """
+        group = QtWidgets.QGroupBox("Motion Trails")
+        layout = QtWidgets.QFormLayout(group)
+        layout.setFieldGrowthPolicy(QtWidgets.QFormLayout.ExpandingFieldsGrow)
+
+        # Master toggle
+        self.show_trails = QtWidgets.QCheckBox("Show motion trails")
+        self.show_trails.setToolTip(
+            "Draw motion trails tracing node/centroid positions over past "
+            "frames.\n"
+            "Works for single-instance / untracked data — trails follow each "
+            "instance's position across frames, no tracks required."
+        )
+        layout.addRow("", self.show_trails)
+
+        # Trail length (past frames)
+        self.trail_length = QtWidgets.QSpinBox()
+        self.trail_length.setRange(1, 1000)
+        self.trail_length.setValue(10)
+        self.trail_length.setToolTip("Number of past frames included in each trail")
+        layout.addRow("Length (frames):", self.trail_length)
+
+        # Trail node (which point the trail follows)
+        self.trail_node = QtWidgets.QComboBox()
+        self.trail_node.addItem("Centroid", "centroid")
+        for name in self._skeleton_node_names():
+            self.trail_node.addItem(name, name)
+        self.trail_node.setToolTip(
+            "Which point each trail follows: the instance centroid (mean of "
+            "visible nodes) or a specific skeleton node"
+        )
+        layout.addRow("Node:", self.trail_node)
+
+        # Trail width
+        self.trail_width = QtWidgets.QDoubleSpinBox()
+        self.trail_width.setRange(0.5, 15.0)
+        self.trail_width.setValue(2.0)
+        self.trail_width.setSingleStep(0.5)
+        self.trail_width.setToolTip("Trail line width in pixels")
+        layout.addRow("Width:", self.trail_width)
+
+        # Trail opacity
+        self.trail_alpha = QtWidgets.QDoubleSpinBox()
+        self.trail_alpha.setRange(0.0, 1.0)
+        self.trail_alpha.setSingleStep(0.1)
+        self.trail_alpha.setValue(1.0)
+        self.trail_alpha.setToolTip("Global trail opacity (0.0-1.0)")
+        layout.addRow("Opacity:", self.trail_alpha)
+
+        # Fade
+        self.trail_fade = QtWidgets.QCheckBox("Fade older segments")
+        self.trail_fade.setChecked(True)
+        self.trail_fade.setToolTip("Fade trails from faint (oldest) to opaque (newest)")
+        layout.addRow("", self.trail_fade)
+
+        # Trail color (uniform override, or match pose colors)
+        self.trail_color = QtWidgets.QComboBox()
+        self.trail_color.addItem("Match poses", None)
+        for c in ["white", "black", "red", "green", "blue", "yellow", "cyan"]:
+            self.trail_color.addItem(c, c)
+        self.trail_color.setToolTip(
+            "Uniform trail color, or 'Match poses' to color trails by "
+            "track/instance like the skeleton"
+        )
+        layout.addRow("Color:", self.trail_color)
+
+        # Sub-controls are only meaningful when trails are enabled.
+        self._trail_controls = [
+            self.trail_length,
+            self.trail_node,
+            self.trail_width,
+            self.trail_alpha,
+            self.trail_fade,
+            self.trail_color,
+        ]
+        self.show_trails.toggled.connect(self._on_show_trails_toggled)
+        self._on_show_trails_toggled(self.show_trails.isChecked())
+
+        return group
+
+    def _on_show_trails_toggled(self, checked: bool):
+        """Enable/disable trail sub-controls with the master toggle."""
+        for widget in self._trail_controls:
+            widget.setEnabled(checked)
+
     def _create_quality_group(self) -> QtWidgets.QGroupBox:
         """Create quality/encoding options group."""
         group = QtWidgets.QGroupBox("Quality")
@@ -552,6 +664,15 @@ class RenderClipDialog(QtWidgets.QDialog):
         self.show_edges.toggled.connect(self._update_preview)
         self.background.currentTextChanged.connect(self._update_preview)
 
+        # Motion trail controls
+        self.show_trails.toggled.connect(self._update_preview)
+        self.trail_length.valueChanged.connect(self._update_preview)
+        self.trail_node.currentTextChanged.connect(self._update_preview)
+        self.trail_width.valueChanged.connect(self._update_preview)
+        self.trail_alpha.valueChanged.connect(self._update_preview)
+        self.trail_fade.toggled.connect(self._update_preview)
+        self.trail_color.currentTextChanged.connect(self._update_preview)
+
         # Quality controls that affect preview
         self.preset.currentTextChanged.connect(self._update_preview)
         self.scale.valueChanged.connect(self._update_preview)
@@ -592,6 +713,20 @@ class RenderClipDialog(QtWidgets.QDialog):
         bg = self.background.currentText()
         if bg != "video":
             params["background"] = bg
+
+        # Motion trails. Only forwarded when enabled so that, when off, both the
+        # preview and export keep sleap-io's default (show_trails=False) and the
+        # preview stays on its lightweight bare-LabeledFrame render path.
+        if self.show_trails.isChecked():
+            params["show_trails"] = True
+            params["trail_length"] = self.trail_length.value()
+            params["trail_node"] = self.trail_node.currentData()
+            params["trail_width"] = self.trail_width.value()
+            params["trail_alpha_fade"] = self.trail_fade.isChecked()
+            params["trail_alpha"] = self.trail_alpha.value()
+            trail_color = self.trail_color.currentData()
+            if trail_color is not None:
+                params["trail_color"] = trail_color
 
         # Scale: always 1.0 for preview (accurate display), use setting for export
         if for_preview:

--- a/sleap/gui/widgets/rendering_preview.py
+++ b/sleap/gui/widgets/rendering_preview.py
@@ -195,8 +195,21 @@ class RenderingPreviewWidget(QtWidgets.QWidget):
         lf = lfs[0]
 
         try:
-            # Render using sleap-io
-            img = sio.render_image(lf, **self._render_params)
+            if self._render_params.get("show_trails"):
+                # Trails need temporal context (the preceding frames), which
+                # render_image only has when the source is the Labels object —
+                # a bare LabeledFrame has no access to past frames, so trails
+                # would silently render nothing. Locate the same frame via
+                # video + frame_idx so the visible frame is unchanged.
+                img = sio.render_image(
+                    self.labels,
+                    video=self.video,
+                    frame_idx=self._current_frame_idx,
+                    **self._render_params,
+                )
+            else:
+                # Render using sleap-io
+                img = sio.render_image(lf, **self._render_params)
             self._display_image(img)
         except Exception as e:
             self._show_error_message(str(e))

--- a/tests/gui/test_render_clip.py
+++ b/tests/gui/test_render_clip.py
@@ -307,3 +307,128 @@ def test_include_unlabeled_export_params_forward_range(centered_pair_predictions
         assert params["end"] == 18
     finally:
         dialog.deleteLater()
+
+
+def test_trail_params_absent_when_disabled(centered_pair_predictions):
+    """With trails off (the default), no trail kwargs are forwarded so both the
+    preview and export keep sleap-io's ``show_trails=False`` default.
+    """
+    pytest.importorskip("qtpy.QtWidgets")
+
+    from qtpy import QtWidgets
+
+    from sleap.gui.dialogs.render_clip import RenderClipDialog
+
+    _ = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    labels: sio.Labels = centered_pair_predictions
+    video = labels.videos[0]
+
+    dialog = RenderClipDialog(labels=labels, video=video)
+    try:
+        assert not dialog.show_trails.isChecked()
+        params = dialog.get_export_params()
+        for key in (
+            "show_trails",
+            "trail_length",
+            "trail_node",
+            "trail_width",
+            "trail_alpha_fade",
+            "trail_alpha",
+            "trail_color",
+        ):
+            assert key not in params
+    finally:
+        dialog.deleteLater()
+
+
+def test_trail_params_forwarded_when_enabled(centered_pair_predictions):
+    """Enabling trails forwards the full sleap-io trail kwarg set with values
+    read from the widgets. ``trail_color`` is omitted for the "Match poses"
+    default (sleap-io then colors trails by track/instance).
+    """
+    pytest.importorskip("qtpy.QtWidgets")
+
+    from qtpy import QtWidgets
+
+    from sleap.gui.dialogs.render_clip import RenderClipDialog
+
+    _ = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    labels: sio.Labels = centered_pair_predictions
+    video = labels.videos[0]
+
+    dialog = RenderClipDialog(labels=labels, video=video)
+    try:
+        # Node picker offers "Centroid" plus every skeleton node.
+        node_items = [
+            dialog.trail_node.itemData(i) for i in range(dialog.trail_node.count())
+        ]
+        assert node_items[0] == "centroid"
+        for node in labels.skeletons[0].nodes:
+            assert node.name in node_items
+
+        # Sub-controls disabled until the master toggle is on.
+        assert not dialog.trail_length.isEnabled()
+        dialog.show_trails.setChecked(True)
+        assert dialog.trail_length.isEnabled()
+
+        dialog.trail_length.setValue(25)
+        dialog.trail_node.setCurrentIndex(1)  # first real node
+        dialog.trail_width.setValue(3.5)
+        dialog.trail_alpha.setValue(0.5)
+        dialog.trail_fade.setChecked(False)
+
+        params = dialog.get_export_params()
+        assert params["show_trails"] is True
+        assert params["trail_length"] == 25
+        assert params["trail_node"] == labels.skeletons[0].nodes[0].name
+        assert params["trail_width"] == 3.5
+        assert params["trail_alpha"] == 0.5
+        assert params["trail_alpha_fade"] is False
+        # "Match poses" -> no uniform color forwarded.
+        assert "trail_color" not in params
+
+        # A named color is forwarded verbatim.
+        idx = dialog.trail_color.findData("red")
+        dialog.trail_color.setCurrentIndex(idx)
+        params = dialog.get_export_params()
+        assert params["trail_color"] == "red"
+    finally:
+        dialog.deleteLater()
+
+
+def test_trail_params_render_without_tracks():
+    """The trail params the dialog produces must actually render — including for
+    single-instance / untracked data, where sleap-io keys trails by instance
+    position (no tracks required). This guards the end-to-end passthrough into
+    ``sio.render_image``.
+    """
+    skel = _skeleton()
+    video = sio.Video(filename="a.mp4")
+
+    # Single moving instance across several frames, NO tracks assigned.
+    lfs = [
+        sio.LabeledFrame(
+            video=video, frame_idx=i, instances=[_pred(skel, (10.0 + i, 20.0 + i))]
+        )
+        for i in range(6)
+    ]
+    labels = sio.Labels(labeled_frames=lfs, videos=[video], skeletons=[skel])
+    assert len(labels.tracks) == 0
+
+    # Provide a solid background so no real video decode is needed.
+    img = sio.render_image(
+        labels,
+        video=video,
+        frame_idx=5,
+        background="black",
+        show_trails=True,
+        trail_length=5,
+        trail_node="centroid",
+        trail_width=2.0,
+        trail_alpha_fade=True,
+        trail_alpha=1.0,
+    )
+    assert img is not None
+    assert img.shape[-1] in (3, 4)


### PR DESCRIPTION
## Description

The **Render Video Clip** dialog already delegates to sleap-io's `render_video` / `render_image`,
which fully support motion trails — but **none of the trail options were surfaced in the GUI**. As a
result, exported clips never showed trails and users had to drop to the `sio render --trails` CLI to
get a trailed video. This was reported in [Discussion #2817](https://github.com/talmolab/sleap/discussions/2817)
("Trail Length - where is this supposed to appear?") and tracked in #2818.

This PR adds a **Motion Trails** group to `RenderClipDialog`, mapping 1:1 to sleap-io's trail kwargs,
so trails can be previewed and baked into exported clips directly from the GUI.

Part 1 of the reframe in #2818 (export dialog). A follow-up will address the live in-player overlay
(dropping its track requirement, adding a node picker, true alpha fade).

## What's included

New **Motion Trails** group in the export dialog:

| GUI control | sleap-io kwarg | Default |
|---|---|---|
| ☑ Show motion trails | `show_trails` | off |
| Length (frames) | `trail_length` | 10 |
| Node (Centroid + skeleton nodes) | `trail_node` | `"centroid"` |
| Width | `trail_width` | 2.0 |
| Opacity | `trail_alpha` | 1.0 |
| ☑ Fade older segments | `trail_alpha_fade` | on |
| Color (Match poses / named color) | `trail_color` | match poses |

Key details:
- **Trail params are only forwarded when trails are enabled**, so the default render/export path is
  byte-for-byte unchanged when trails are off.
- **Live preview now renders trails.** Trails need past-frame context, which `render_image` only has
  when the source is the `Labels` object — a bare `LabeledFrame` has no history and would silently
  draw nothing. When trails are on, the preview renders from `labels` via `video` + `frame_idx`
  (same visible frame, now with history available).
- **Works for single-instance / untracked data with no tracks assigned** — sleap-io keys trails by
  instance position when no tracks are present. This directly resolves the single-animal case from
  #2817.

## Screenshot

Trails rendering live in the export dialog preview (fly pair predictions), with the new Motion Trails
group on the right:

<!-- Screenshot saved in investigation folder: scratch/2026-07-08-trails-view-rendering-reframe/render_dialog_trails_on.png -->
_See `scratch/2026-07-08-trails-view-rendering-reframe/render_dialog_trails_on.png` (screenshots are gitignored)._

## Testing

- `tests/gui/test_render_clip.py` — 3 new tests:
  - `test_trail_params_absent_when_disabled` — no trail kwargs forwarded when trails off.
  - `test_trail_params_forwarded_when_enabled` — full trail kwarg set forwarded with widget values;
    node picker offers Centroid + every skeleton node; "Match poses" omits `trail_color`; enable/
    disable of sub-controls tracks the master toggle.
  - `test_trail_params_render_without_tracks` — end-to-end `sio.render_image` with the dialog's trail
    params on a single-instance, **untracked** Labels (0 tracks) renders without error.
- Verified the full export path end-to-end: `sio.render_video(..., show_trails=True, ...)` writes a
  valid MP4 for untracked single-instance data.
- Visually verified the dialog + live trail preview via offscreen Qt capture.

```
$ uv run pytest tests/gui/test_render_clip.py -q
10 passed
```

## Files changed

- `sleap/gui/dialogs/render_clip.py` — Motion Trails group, node-name helper, param forwarding,
  preview signal wiring.
- `sleap/gui/widgets/rendering_preview.py` — render preview from `Labels` source when trails on.
- `sleap/gui/commands.py` — carry trail keys through `ExportLabeledClip.ask()` → `do_action()` →
  `render_params`.
- `tests/gui/test_render_clip.py` — trail plumbing + render tests.

## Related

- Closes part 1 of #2818
- Addresses [Discussion #2817](https://github.com/talmolab/sleap/discussions/2817)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
