### PR TITLE
fix(gui): use points_array compatibility shim in DeleteAreaPredictions

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -93,6 +93,7 @@ from sleap.sleap_io_adaptors.skeleton_utils import (
     to_graph,
 )
 from sleap.sleap_io_adaptors.video_utils import video_util_reset
+from sleap.sleap_io_adaptors.instance_utils import instance_get_points_array
 from sleap.sleap_io_adaptors.lf_labels_utils import (
     get_next_suggestion,
     track_swap,
@@ -3525,7 +3526,7 @@ class DeleteAreaPredictions(InstanceDeleteCommand):
         max_corner = params["max_corner"]
 
         def is_bounded(inst):
-            points_array = inst.points_array
+            points_array = instance_get_points_array(inst)
             valid_points = points_array[~np.isnan(points_array).any(axis=1)]
 
             is_gt_min = np.all(valid_points >= min_corner)

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -33,6 +33,7 @@ from sleap.gui.commands import (
     ReplaceVideo,
     OpenSkeleton,
     SaveProjectAs,
+    DeleteAreaPredictions,
     DeleteFrameLimitPredictions,
     get_new_version_filename,
 )
@@ -1353,6 +1354,36 @@ def test_DeleteFrameLimitPredictions(
     )
 
     assert len(instances_to_delete) == 2070
+
+
+def test_DeleteAreaPredictions(centered_pair_predictions: Labels):
+    """Test finding predicted instances contained within a selected area.
+
+    Regression test: `is_bounded` used to access the removed
+    `PredictedInstance.points_array` attribute directly, raising an
+    AttributeError as soon as an area was selected in the GUI.
+    """
+    labels = centered_pair_predictions
+
+    # Set-up command context
+    context = CommandContext.from_labels(labels)
+    context.state["video"] = labels.videos[0]
+
+    total_predicted_instances = sum(
+        1 for lf in labels for inst in lf if isinstance(inst, PredictedInstance)
+    )
+
+    # An area covering the whole frame should contain every predicted instance
+    params = {"min_corner": (0, 0), "max_corner": (384, 384)}
+    instances_in_full_frame = DeleteAreaPredictions.get_frame_instance_list(
+        context, params
+    )
+    assert len(instances_in_full_frame) == total_predicted_instances
+
+    # A small area in the corner of the frame should contain none
+    params = {"min_corner": (0, 0), "max_corner": (10, 10)}
+    instances_in_corner = DeleteAreaPredictions.get_frame_instance_list(context, params)
+    assert len(instances_in_corner) == 0
 
 
 @pytest.mark.parametrize("export_extension", [".slp"])


### PR DESCRIPTION
## Summary
- Fixes a crash in Menu -> Labels -> "Delete Predictions from Area": as soon as a selection box was drawn, SLEAP raised `AttributeError: 'PredictedInstance' object has no attribute 'points_array'`.
- Root cause: `sleap-io`'s current data model no longer exposes `PredictedInstance.points_array` (dropped as part of the sleap-io reframe). `DeleteAreaPredictions.is_bounded()` in `sleap/gui/commands.py` was one of the few call sites that hadn't been migrated to the existing compatibility shim.
- Fix: use `instance_get_points_array()` from `sleap.sleap_io_adaptors.instance_utils`, the same shim already used elsewhere in the codebase (e.g. `sleap/info/summary.py`, `sleap/info/metrics.py`).

## Changes Made
- `sleap/gui/commands.py`: `DeleteAreaPredictions.get_frame_instance_list.is_bounded()` now calls `instance_get_points_array(inst)` instead of `inst.points_array`.
- `tests/gui/test_commands.py`: added `test_DeleteAreaPredictions`, a regression test that reproduces the original crash against the pre-fix code and verifies correct area-bounded filtering (full-frame area returns all predicted instances, a small corner area returns none) against the fix.

## Testing
- Added regression test confirmed to fail with the original `AttributeError` against the pre-fix code, and pass with the fix.
- `uv run pytest tests/gui/test_commands.py` — 44 passed, 1 skipped.
- Manually verified in the running GUI: "Delete Predictions from Area" now works without crashing.

## Related
- Regression introduced during the sleap-io data model reframe; same class of bug as previously fixed call sites in `sleap/info/summary.py` and `sleap/info/metrics.py`.
- Not in scope here: `sleap/util.py:547-548` (`plot_instance`, matplotlib skeleton-edge plotting) has the same latent `instance.points_array` access pattern in a separate code path. Flagging for a possible follow-up but out of scope for this fix since it wasn't part of the reported bug.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)