### PR TITLE
fix(util): use current sleap-io API in plot_instance edge drawing

### DIFF
--- a/sleap/util.py
+++ b/sleap/util.py
@@ -544,8 +544,8 @@ def plot_instance(
 
     else:
         for k, (src_node, dst_node) in enumerate(skeleton.edges):
-            src_pt = instance.points_array[instance.skeleton.node_to_index(src_node)]
-            dst_pt = instance.points_array[instance.skeleton.node_to_index(dst_node)]
+            src_pt = inst_pts[skeleton.node_names.index(src_node.name)]
+            dst_pt = inst_pts[skeleton.node_names.index(dst_node.name)]
 
             x = np.array([src_pt[0], dst_pt[0]])
             y = np.array([src_pt[1], dst_pt[1]])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,26 @@
 import pytest
+import matplotlib
+
+matplotlib.use("Agg")
 
 from sleap.util import *
+
+
+def test_plot_instance_edge_coloring(centered_pair_predictions):
+    """Test that `plot_instance` can draw skeleton edges.
+
+    Regression test: the `color_by_node=False` branch used to access the
+    removed `PredictedInstance.points_array` attribute and the removed
+    `Skeleton.node_to_index` method directly, raising an AttributeError as
+    soon as it was called on a skeleton with edges.
+    """
+    lf = centered_pair_predictions[0]
+    instance = lf.instances[0]
+    skeleton = instance.skeleton
+    assert len(skeleton.edges) > 0
+
+    h_lines = plot_instance(instance, skeleton=skeleton, color_by_node=False)
+    assert len(h_lines) == len(skeleton.edges)
 
 
 def test_json():


### PR DESCRIPTION
## Summary
- Follow-up to #2822. While auditing the repo for other call sites hit by the same sleap-io reframe migration gap, found `sleap.util.plot_instance()` has the same class of bug (actually two, on the same two lines).
- `plot_instance()`'s `color_by_node=False` branch (skeleton edge drawing) accessed `instance.points_array` (removed from `PredictedInstance`/`Instance`) and `instance.skeleton.node_to_index(...)` (removed from `Skeleton`) directly, raising `AttributeError: 'PredictedInstance' object has no attribute 'points_array'` as soon as it tried to plot a skeleton with edges.
- This function isn't currently wired into any GUI menu, CLI command, or other call site in this repo (only called by `plot_instances()` in the same file, which itself has no other callers) — but it is public API (`sleap.util.plot_instance`) that would break for any external script/notebook importing it directly.

## Changes Made
- `sleap/util.py`: `plot_instance()`'s edge-drawing branch now reuses the already-computed `inst_pts` array (via `instance.numpy()`, same as the `color_by_node=True` branch above it) instead of `instance.points_array`, and looks up node indices via `skeleton.node_names.index(node.name)` instead of the removed `Skeleton.node_to_index()` method — matching the pattern already used in `sleap/gui/commands.py`.
  - Kept the fix in-file (no new imports) since `sleap/util.py` has an explicit project convention of not depending on other modules in the package, to avoid circular imports and keep import time fast.
- `tests/test_util.py`: added `test_plot_instance_edge_coloring`, a regression test that reproduces the original crash against the pre-fix code (confirmed to fail with the same `AttributeError`) and passes with the fix.

## Testing
- Regression test confirmed to fail with `AttributeError: 'PredictedInstance' object has no attribute 'points_array'` against the pre-fix code, and pass with the fix.
- `uv run pytest tests/test_util.py` — 11 passed.
- Manually exercised `plot_instance()` for both `color_by_node=True` and `color_by_node=False` against real fixture data (`centered_pair_predictions`).

## Related
- Same root cause as #2822 (Menu -> Labels -> "Delete Predictions from Area" crash) — leftover call sites from the sleap-io data model reframe that weren't migrated to the existing compatibility shims/patterns.
- Did a repo-wide sweep for other occurrences of this bug class (`.points_array`, `.scores`, `same_pose_as`, `node_to_index`, `edge_to_index`, `find_node`, including docs/notebooks) and found no other affected call sites.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)