### PR TITLE
fix(gui): properly quote Hydra overrides in exported train-script.sh

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -8,6 +8,7 @@ from omegaconf import OmegaConf
 from copy import deepcopy
 import psutil
 import json
+import shlex
 import subprocess
 import tempfile
 import time
@@ -883,13 +884,27 @@ def write_pipeline_files(
                     ).as_posix()
                 )
 
-                # Add a line to the script for training this model
-                # Quote values to handle special characters in Hydra overrides
+                # Add a line to the script for training this model.
+                # Hydra overrides need literal quote characters around values
+                # containing special characters (e.g. "=" from run names like
+                # "run.n=181") to survive Hydra's own override grammar. Shell
+                # quoting alone doesn't do this: bash strips shell-level quotes
+                # before the value ever reaches Hydra's parser. So we embed a
+                # literal quote pair in the override value itself, then use
+                # shlex.quote() to shell-escape the whole token so those inner
+                # quote characters (and any other shell metacharacters) survive
+                # bash's argument parsing intact.
+                ckpt_dir_override = shlex.quote(
+                    f"trainer_config.ckpt_dir='{Path(ckpt_path).parent.as_posix()}'"
+                )
+                run_name_override = shlex.quote(
+                    f"trainer_config.run_name='{Path(ckpt_path).name}'"
+                )
                 train_script += (
                     f"sleap train --config-name {new_cfg_filename} "
                     f"--config-dir . "
-                    f"trainer_config.ckpt_dir='{Path(ckpt_path).parent.as_posix()}' "
-                    f"trainer_config.run_name='{Path(ckpt_path).name}' "
+                    f"{ckpt_dir_override} "
+                    f"{run_name_override} "
                     "\n"
                 )
 

--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -890,15 +890,16 @@ def write_pipeline_files(
                 # "run.n=181") to survive Hydra's own override grammar. Shell
                 # quoting alone doesn't do this: bash strips shell-level quotes
                 # before the value ever reaches Hydra's parser. So we embed a
-                # literal quote pair in the override value itself, then use
-                # shlex.quote() to shell-escape the whole token so those inner
-                # quote characters (and any other shell metacharacters) survive
+                # literal double-quote pair (Hydra accepts either quote style)
+                # in the override value itself, then use shlex.quote() to
+                # shell-escape the whole token with single quotes so the inner
+                # double quotes (and any other shell metacharacters) survive
                 # bash's argument parsing intact.
                 ckpt_dir_override = shlex.quote(
-                    f"trainer_config.ckpt_dir='{Path(ckpt_path).parent.as_posix()}'"
+                    f'trainer_config.ckpt_dir="{Path(ckpt_path).parent.as_posix()}"'
                 )
                 run_name_override = shlex.quote(
-                    f"trainer_config.run_name='{Path(ckpt_path).name}'"
+                    f'trainer_config.run_name="{Path(ckpt_path).name}"'
                 )
                 train_script += (
                     f"sleap train --config-name {new_cfg_filename} "

--- a/tests/gui/learning/test_cli_construction.py
+++ b/tests/gui/learning/test_cli_construction.py
@@ -773,6 +773,106 @@ class TestWritePipelineFiles:
         assert "--config-name" in train_script_content
         assert "--config-dir" in train_script_content
 
+    def test_train_script_run_name_with_equals_survives_shell_and_hydra(
+        self, tmp_path, mock_labels
+    ):
+        """Regression test for issue #2611.
+
+        Auto-generated run names include "n=<num_labeled_frames>" (e.g.
+        "260212_121024.centroid.n=181"), which contains a literal "=". The
+        fix in #2612 wrapped Hydra override values in shell single quotes,
+        but bash strips shell-level quotes before "sleap" ever sees the
+        argument, so Hydra's own override parser still choked on the
+        embedded "=" with `OverrideParseException`. The values must carry
+        literal quote characters that survive shell word-splitting and are
+        still present when Hydra parses argv.
+        """
+        import shlex
+
+        from sleap.gui.learning.runners import write_pipeline_files
+        from sleap.gui.learning.configs import ConfigFileInfo
+        from omegaconf import OmegaConf
+        from hydra.core.override_parser.overrides_parser import OverridesParser
+
+        # No custom run_name, so write_pipeline_files auto-generates one that
+        # includes "n=<num_user_labeled_frames>" (matches training behavior).
+        config_dict = {
+            "trainer_config": {
+                "ckpt_dir": str(tmp_path / "models"),
+                "run_name": "",
+                "save_ckpt": True,
+            },
+            "data_config": {
+                "train_labels_path": ["labels.slp"],
+            },
+            "model_config": {
+                "head_configs": {},
+            },
+        }
+        config = OmegaConf.create(config_dict)
+
+        cfg_info = ConfigFileInfo(
+            config=config,
+            path="test_config.yaml",
+            filename="test_config.yaml",
+            head_name="centroid",
+            dont_retrain=False,
+        )
+
+        output_dir = tmp_path / "export"
+        output_dir.mkdir()
+        labels_path = tmp_path / "labels.slp"
+        labels_path.touch()
+
+        video_item = VideoItemForInference(
+            video=mock_labels.videos[0],
+            frames=[0, 1, 2],
+            labels_path=str(labels_path),
+            video_idx=0,
+        )
+        items_for_inference = ItemsForInference(
+            items=[video_item],
+            total_frame_count=3,
+        )
+
+        with patch(
+            "sleap_nn.config.training_job_config.verify_training_cfg",
+            side_effect=lambda cfg: cfg,
+        ), patch(
+            "sleap.gui.config_utils.filter_cfg",
+            side_effect=lambda cfg: cfg,
+        ):
+            write_pipeline_files(
+                output_dir=str(output_dir),
+                labels_filename=str(labels_path),
+                config_info_list=[cfg_info],
+                inference_params={},
+                items_for_inference=items_for_inference,
+                num_user_labeled_frames=181,
+            )
+
+        train_script_content = (output_dir / "train-script.sh").read_text()
+        train_line = next(
+            line for line in train_script_content.splitlines() if "sleap train" in line
+        )
+
+        # Sanity check: the auto-generated run_name does contain "=".
+        assert "run_name=" in train_line
+        assert ".n=181" in train_line
+
+        # Emulate bash's word-splitting/quote-stripping (shlex.split matches
+        # bash here since we only use single/double quotes, no globs/vars),
+        # then feed the resulting argv to Hydra's real override parser --
+        # this is the exact failure point from the traceback in #2611.
+        argv = shlex.split(train_line)
+        overrides = [a for a in argv if a.startswith("trainer_config.")]
+        assert len(overrides) == 2
+
+        parser = OverridesParser.create()
+        parsed = parser.parse_overrides(overrides)  # must not raise
+        values = {p.key_or_group: p.value() for p in parsed}
+        assert values["trainer_config.run_name"].endswith(".centroid.n=181")
+
 
 class TestOutputPathGeneration:
     """Tests for output path generation."""


### PR DESCRIPTION
## Summary
- PR #2612 tried to fix `OverrideParseException` errors in exported `train-script.sh` by wrapping Hydra override values in shell single quotes (`trainer_config.run_name='...'`), but this doesn't work: bash strips shell-level quotes before the `sleap` process starts, so Hydra's own override parser still receives an unquoted value and chokes on the literal `=` in auto-generated run names (e.g. `260212_121024.centroid.n=181`).
- This PR embeds the quote characters *in the override value itself* (so they survive to reach Hydra's argv) and shell-escapes the whole token with `shlex.quote()` so it also survives bash's own parsing intact.

## Changes Made
- `sleap/gui/learning/runners.py`: build each Hydra override as `key="value"` (literal double quotes meant for Hydra, which accepts either quote style), then `shlex.quote()` the whole token before writing it into `train-script.sh`.
- Added a regression test in `tests/gui/learning/test_cli_construction.py` (`test_train_script_run_name_with_equals_survives_shell_and_hydra`) that emulates bash's word-splitting via `shlex.split()` and feeds the result into Hydra's real `OverridesParser` — confirmed it reproduces the exact `OverrideParseException` on the pre-fix code and passes with this fix.

## Example Usage
Given a run name like `260212_121024.centroid.n=181`, the generated line in `train-script.sh` now looks like:
```bash
sleap train --config-name centroid.yaml --config-dir . 'trainer_config.ckpt_dir="models"' 'trainer_config.run_name="260212_121024.centroid.n=181"'
```
After bash word-splitting, `sleap`'s argv receives `trainer_config.run_name="260212_121024.centroid.n=181"` (embedded double quotes intact), which Hydra correctly parses as the value `260212_121024.centroid.n=181`.

## Testing
- `uv run pytest tests/gui/learning/test_cli_construction.py` — 35 passed
- `uv run ruff check` / `uv run ruff format --check` — clean
- Manually verified end-to-end (bash subprocess → Hydra's `OverridesParser`) that the previous quoting strips to an unquoted string and still fails, while the new quoting round-trips correctly.

## Related Issues
Fixes #2611

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
