### PR TITLE
fix: treat trainer_accelerator as machine-specific when loading a saved profile

### DIFF
--- a/sleap/gui/learning/dialog.py
+++ b/sleap/gui/learning/dialog.py
@@ -2318,9 +2318,13 @@ class TrainingEditorWidget(QtWidgets.QWidget):
 
         # Filter out system-specific settings that should come from preferences,
         # not from the training profile. These are machine-specific (GPU count,
-        # workers) and should default to "auto" regardless of what the profile says.
+        # accelerator, workers) and should default to "auto" regardless of what
+        # the profile says. Without this, a profile trained on one machine (e.g.
+        # `trainer_accelerator: mps` from a Mac) would silently carry that stale,
+        # possibly-unavailable value over when reloaded on a different machine.
         system_specific_keys = [
             "trainer_config.trainer_devices",
+            "trainer_config.trainer_accelerator",
             "trainer_config.train_data_loader.num_workers",
         ]
         for key in system_specific_keys:

--- a/tests/gui/learning/test_learning_dialog.py
+++ b/tests/gui/learning/test_learning_dialog.py
@@ -542,6 +542,39 @@ class TestTrainingEditorWidget:
         with qtbot.waitSignal(editor_widget.valueChanged, timeout=1000):
             editor_widget.emitValueChanged()
 
+    def test_load_config_strips_system_specific_keys(self, editor_widget):
+        """`_load_config` should not carry machine-specific settings over from a
+        saved profile (#accelerator-staleness): trainer_devices, num_workers, and
+        trainer_accelerator should all come from the current machine's
+        preferences/defaults, not from whatever machine the profile was saved on.
+
+        Reproduces the reported bug: a profile trained on a Mac
+        (`trainer_accelerator: mps`) should not silently populate the accelerator
+        field with `"mps"` when reloaded on a different machine (e.g. Linux+CUDA),
+        where that accelerator may not even exist.
+        """
+        from omegaconf import OmegaConf
+        from sleap.gui.learning.configs import ConfigFileInfo
+
+        saved_cfg = OmegaConf.create(
+            {
+                "trainer_config": {
+                    "trainer_accelerator": "mps",
+                    "trainer_devices": 2,
+                    "train_data_loader": {"num_workers": 4},
+                }
+            }
+        )
+        cfg_info = ConfigFileInfo(config=saved_cfg)
+
+        with patch.object(editor_widget, "set_fields_from_key_val_dict") as mock_set:
+            editor_widget._load_config(cfg_info)
+
+        applied_dict = mock_set.call_args[0][0]
+        assert "trainer_config.trainer_accelerator" not in applied_dict
+        assert "trainer_config.trainer_devices" not in applied_dict
+        assert "trainer_config.train_data_loader.num_workers" not in applied_dict
+
     @pytest.fixture
     def inference_editor_widget(self, qtbot, minimal_skeleton, mock_cfg_getter):
         """Create a TrainingEditorWidget for inference (require_trained=True)."""


### PR DESCRIPTION
## Summary
- `TrainingEditorWidget._load_config` already strips `trainer_config.trainer_devices` and `trainer_config.train_data_loader.num_workers` from a reloaded training profile because they're machine-specific — but `trainer_config.trainer_accelerator` was missing from that list.
- As a result, a profile trained on one machine (e.g. `trainer_accelerator: mps` from a Mac) silently carries that value verbatim into the Accelerator dropdown when the same profile is reloaded on a different machine (e.g. Linux + CUDA, or a CPU-only box) — even though that accelerator may not exist there.
- Adds `trainer_config.trainer_accelerator` to `system_specific_keys` in `sleap/gui/learning/dialog.py`, matching the existing treatment of `trainer_devices`/`num_workers`, so it's left at the current machine's preference/default (normally `"auto"`) instead of parroting back whatever the profile said.

## Changes Made
- `sleap/gui/learning/dialog.py`: add `"trainer_config.trainer_accelerator"` to the `system_specific_keys` list filtered out in `_load_config`.
- `tests/gui/learning/test_learning_dialog.py`: add `test_load_config_strips_system_specific_keys`, which loads a fake saved profile with `trainer_accelerator: mps`, `trainer_devices: 2`, and `num_workers: 4`, and asserts none of the three keys reach `set_fields_from_key_val_dict`.

## Design Decisions
- This is a GUI-side UX fix scoped to the training-profile-loading dialog. It complements (but does not replace) a corresponding backend fix landing in `sleap-nn` (`ModelTrainer.setup_config()` now verifies the configured accelerator is actually available on the current machine before training starts, falling back to `"auto"` with a log note if not) — that backend check is what protects direct CLI/script usage of a stale config, since the GUI always delegates the actual training run to `sleap_nn.cli.train` in a subprocess.
- Chose to strip the key entirely (matching the existing `trainer_devices`/`num_workers` pattern) rather than special-casing "reset to auto", so the dropdown simply falls back to whatever the widget/prefs already default to.

## Testing
- `uv run pytest tests/gui/learning/test_learning_dialog.py tests/gui/learning/test_main_tab.py tests/gui/learning/test_config_bindings.py -q` → 238 passed.
- `uv run ruff check sleap tests` and `uv run ruff format --check sleap tests` (scoped to changed files) → clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)