### PR TITLE
fix(gui): default training config file dialog to show JSON and YAML together

### DIFF
--- a/sleap/gui/learning/configs.py
+++ b/sleap/gui/learning/configs.py
@@ -613,7 +613,11 @@ class TrainingConfigFilesWidget(FieldComboWidget):
 
     def doFileSelection(self):
         """Shows file browser to add training profile for given model type."""
-        filters = ["JSON (*.json)", "YAML (*.yaml *.yml)"]
+        filters = [
+            "Config files (*.json *.yaml *.yml)",
+            "JSON (*.json)",
+            "YAML (*.yaml *.yml)",
+        ]
         filename, _ = FileDialog.open(
             None,
             dir=None,

--- a/tests/gui/learning/test_edge_cases.py
+++ b/tests/gui/learning/test_edge_cases.py
@@ -454,6 +454,31 @@ class TestNoTrainedModelMessage:
         assert "cannot be used for" in text
 
 
+class TestFileSelectionFilter:
+    """The file browser for picking a training config should default to
+    showing both JSON and YAML files instead of requiring the user to
+    switch the filter dropdown."""
+
+    def test_default_filter_includes_both_extensions(self, qtbot):
+        getter = TrainingConfigsGetter(dir_paths=[])
+        widget = TrainingConfigFilesWidget(
+            cfg_getter=getter, head_name="centered_instance"
+        )
+        qtbot.addWidget(widget)
+
+        with patch(
+            "sleap.gui.learning.configs.FileDialog.open", return_value=("", "")
+        ) as mock_dialog:
+            widget.doFileSelection()
+
+        mock_dialog.assert_called_once()
+        filter_arg = mock_dialog.call_args.kwargs["filter"]
+        default_filter = filter_arg.split(";;")[0]
+        assert "*.json" in default_filter
+        assert "*.yaml" in default_filter
+        assert "*.yml" in default_filter
+
+
 # =============================================================================
 # Subprocess Error Handling Tests
 # =============================================================================


### PR DESCRIPTION
## Summary
- The file browser used to pick a training config (`TrainingConfigFilesWidget.doFileSelection`) opened with only the "JSON (*.json)" filter active by default, hiding `.yaml`/`.yml` files until the user manually switched the filter dropdown.
- Adds a combined `"Config files (*.json *.yaml *.yml)"` filter as the default option, so both file types show up immediately without extra clicks.

## Changes Made
- `sleap/gui/learning/configs.py`: added the combined filter as the first (default) entry in the `QFileDialog` filter list, keeping the individual "JSON" and "YAML" filters available afterward for users who want to narrow the list.

## Testing
- Added `TestFileSelectionFilter` in `tests/gui/learning/test_edge_cases.py`, which mocks `FileDialog.open` and asserts the default filter (first entry, `;;`-split) contains `*.json`, `*.yaml`, and `*.yml`.
- `uv run pytest tests/gui/learning/test_edge_cases.py -q` → 37 passed.
- `uv run ruff format` / `uv run ruff check --fix` → clean.

## Design Decisions
- Kept the original "JSON" and "YAML" filters as secondary options rather than removing them, so users who want to filter down to just one type still can via the dropdown.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)