### PR TITLE
fix: import predict from sleap_nn.cli, not sleap_nn.export.cli

### DIFF
--- a/sleap/cli.py
+++ b/sleap/cli.py
@@ -67,10 +67,10 @@ try:
         track as nn_track,
         eval as nn_eval,
         system as nn_system,
+        predict as nn_predict,
     )
     from sleap_nn.export.cli import (
         export as nn_export,
-        predict as nn_predict,
     )
 
     _SLEAP_NN_AVAILABLE = True


### PR DESCRIPTION
## Summary
- `sleap/cli.py` imported `predict` from `sleap_nn.export.cli`, but sleap-nn moved `predict` into `sleap_nn.cli` as its unified inference entry point. The stale import was never updated.
- Because that import lived inside one broad `try/except ImportError`, the failure silently disabled **all** sleap-nn commands (`train`, `track`, `eval`, `export-model`, `predict`, `system`) — not just `predict` — so `sleap.cli` believed sleap-nn wasn't installed even when it was, and GUI training fell back to a stub command with `Error: No such option '--config-name'.`

## Changes Made
- Moved the `predict` import in `sleap/cli.py` from `sleap_nn.export.cli` to `sleap_nn.cli`, matching the actual module layout of sleap-nn 0.3.1 (verified against both the PyPI wheel and the `v0.3.1` git tag).

## Testing
- Reproduced in a clean `uv venv --python 3.13` with the exact reported versions (`sleap[nn]==1.6.4`, `sleap-io==0.9.2`, `sleap-nn==0.3.1`): `python -m sleap.cli train -h` showed the "sleap-nn is not installed" stub before the fix, and the real sleap-nn train help after.
- `uv run pytest tests/ -k cli` — 123 passed.
- `uv run ruff check sleap/cli.py` — clean.

## Related Issues
Closes #2835

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)