### PR TITLE
chore: bump version to 1.6.5 and update sleap-nn pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,38 +66,38 @@ jupyter = [
 ]
 
 nn = [
-    "sleap-nn[torch]>=0.3.1,<0.4.0"
+    "sleap-nn[torch]>=0.3.2,<0.4.0"
 ]
 
 nn-cpu = [
-    "sleap-nn[torch]>=0.3.1,<0.4.0"
+    "sleap-nn[torch]>=0.3.2,<0.4.0"
 ]
 
 nn-cuda128 = [
-    "sleap-nn[torch]>=0.3.1,<0.4.0"
+    "sleap-nn[torch]>=0.3.2,<0.4.0"
 ]
 
 nn-cuda118 = [
-    "sleap-nn[torch]>=0.3.1,<0.4.0"
+    "sleap-nn[torch]>=0.3.2,<0.4.0"
 ]
 
 nn-cuda130 = [
-    "sleap-nn[torch]>=0.3.1,<0.4.0"
+    "sleap-nn[torch]>=0.3.2,<0.4.0"
 ]
 
 # Export extras - self-contained with torch
 # Can be used alone (defaults to cu128) or combined with nn-cuda* for specific CUDA version
 nn-export = [
-    "sleap-nn[torch,export]>=0.3.1,<0.4.0"
+    "sleap-nn[torch,export]>=0.3.2,<0.4.0"
 ]
 
 nn-export-gpu = [
-    "sleap-nn[torch,export-gpu]>=0.3.1,<0.4.0"
+    "sleap-nn[torch,export-gpu]>=0.3.2,<0.4.0"
 ]
 
 # TensorRT - Linux/Windows only (not supported on macOS)
 nn-tensorrt = [
-    "sleap-nn[torch,tensorrt]>=0.3.1,<0.4.0; sys_platform != 'darwin'"
+    "sleap-nn[torch,tensorrt]>=0.3.2,<0.4.0; sys_platform != 'darwin'"
 ]
 
 [dependency-groups]

--- a/sleap/version.py
+++ b/sleap/version.py
@@ -11,7 +11,7 @@ For example, if you set the version to X.Y.Z, then the tag should be "vX.Y.Z".
 Must be a semver string, "aN" should be appended for alpha releases.
 """
 
-__version__ = "1.6.4"
+__version__ = "1.6.5"
 
 
 def versions():


### PR DESCRIPTION
## Summary
- Bumps SLEAP version from 1.6.4 to 1.6.5 ahead of the v1.6.5 release.
- Bumps `sleap-nn` pin from `>=0.3.1,<0.4.0` to `>=0.3.2,<0.4.0` across all `nn`/`nn-cpu`/`nn-cuda*`/`nn-export*`/`nn-tensorrt` extras.
- `sleap-io` pin stays at `>=0.9.2,<0.10.0` — 0.9.2 remains the latest release on both PyPI and GitHub, so no bump needed.

## Changes Made
- `sleap/version.py`: `__version__` 1.6.4 → 1.6.5
- `pyproject.toml`: `sleap-nn` pin bumped in all 8 extras

## sleap-nn 0.3.1 → 0.3.2

Small correctness follow-up (10 PRs): fixes `predict`/`track` parity (empty-frame retention, `--input_scale` override, tracking-log fidelity), guards eval against zero-matched-instance crashes/warning-spam, fixes sparse eval metrics in `training_log.csv`, adds a JSON sibling for evaluation metrics, fixes `.pkg.slp` inference outputs referencing the wrong video by default, and fixes legacy config conversion silently dropping flip augmentation. Two breaking changes (both CLI default flips) — see [sleap-nn v0.3.2 release notes](https://github.com/talmolab/sleap-nn/releases/tag/v0.3.2).

## Testing
- `uv sync --extra nn` resolves cleanly with the new pins (sleap-nn 0.3.1 → 0.3.2 installed).
- `uv run ruff format --check` / `uv run ruff check` pass on changed files.
- Smoke-tested `import sleap; sleap.__version__ == "1.6.5"`.

## Related Issues
Part of the v1.6.5 release process.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)