### PR TITLE
Hotkeys moving between labeled frames

### DIFF
--- a/docs/learnings/gui.md
+++ b/docs/learnings/gui.md
@@ -27,7 +27,7 @@ The SLEAP labeling interface is launched via the `sleap label` command (or legac
 |---------|-------------|
 | **Next Predicted Frame** / **Previous Predicted Frame** | Jump to next/previous frame with any instances (user or predicted) |
 | **Next Labeled Frame** / **Previous Labeled Frame** | Jump to next/previous frame with user-confirmed instances only |
-| **Next User Labeled Frame** | Jump to next frame with user labels only |
+| **Next User Labeled Frame** | Jump to next frame with human labels or human-corrected/confirmed predictions |
 | **Previous User Labeled Frame** | Jump to previous frame with user labels only |
 | **Next Suggestion** | Jump to the next suggested frame |
 | **Next Track Spawn Frame** | Jump to where a new track starts (useful for proofreading) |

--- a/docs/learnings/gui.md
+++ b/docs/learnings/gui.md
@@ -25,7 +25,8 @@ The SLEAP labeling interface is launched via the `sleap label` command (or legac
 
 | Command | Description |
 |---------|-------------|
-| **Next Labeled Frame** | Jump to next frame with any labels (user or predicted) |
+| **Next Predicted Frame** / **Previous Predicted Frame** | Jump to next/previous frame with any instances (user or predicted) |
+| **Next Labeled Frame** / **Previous Labeled Frame** | Jump to next/previous frame with user-confirmed instances only |
 | **Next User Labeled Frame** | Jump to next frame with user labels only |
 | **Previous User Labeled Frame** | Jump to previous frame with user labels only |
 | **Next Suggestion** | Jump to the next suggested frame |

--- a/sleap/config/shortcuts.yaml
+++ b/sleap/config/shortcuts.yaml
@@ -16,9 +16,11 @@ goto next suggestion: Space
 goto next track spawn: Ctrl+E
 goto next user: Ctrl+U
 goto prev user: Ctrl+Shift+U
-goto next labeled: Alt+Right
+goto next pred: Alt+Right
 goto prev suggestion: Shift+Space
-goto prev labeled: Alt+Left
+goto prev pred: Alt+Left
+goto next labeled: ']'
+goto prev labeled: '['
 learning: Ctrl+L
 mark negative: 'N'
 merge instance:

--- a/sleap/gui/app.py
+++ b/sleap/gui/app.py
@@ -630,15 +630,27 @@ class MainWindow(QMainWindow):
 
         add_menu_item(
             goMenu,
+            "goto next pred",
+            "Next Predicted Frame",
+            self.commands.nextPredFrame,
+        )
+        add_menu_item(
+            goMenu,
+            "goto prev pred",
+            "Previous Predicted Frame",
+            self.commands.previousPredFrame,
+        )
+        add_menu_item(
+            goMenu,
             "goto next labeled",
             "Next Labeled Frame",
-            self.commands.nextLabeledFrame,
+            self.commands.nextUserLabeledFrame,
         )
         add_menu_item(
             goMenu,
             "goto prev labeled",
             "Previous Labeled Frame",
-            self.commands.previousLabeledFrame,
+            self.commands.prevUserLabeledFrame,
         )
         add_menu_item(
             goMenu,
@@ -1392,8 +1404,8 @@ class MainWindow(QMainWindow):
         self._menu_actions["next video"].setEnabled(has_multiple_videos)
         self._menu_actions["prev video"].setEnabled(has_multiple_videos)
 
-        self._menu_actions["goto next labeled"].setEnabled(has_labeled_frames)
-        self._menu_actions["goto prev labeled"].setEnabled(has_labeled_frames)
+        self._menu_actions["goto next pred"].setEnabled(has_labeled_frames)
+        self._menu_actions["goto prev pred"].setEnabled(has_labeled_frames)
 
         # Enable suggestion navigation if there are suggestions OR QC flags
         has_qc_flags = hasattr(self, "_qc_dock") and self._qc_dock.has_flags

--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -410,13 +410,13 @@ class CommandContext:
 
     # Navigation Commands
 
-    def previousLabeledFrame(self):
-        """Goes to labeled frame prior to current frame."""
-        self.execute(GoPreviousLabeledFrame)
+    def previousPredFrame(self):
+        """Goes to nearest frame before current with any instances (user or pred)."""
+        self.execute(GoPreviousPredFrame)
 
-    def nextLabeledFrame(self):
-        """Goes to labeled frame after current frame."""
-        self.execute(GoNextLabeledFrame)
+    def nextPredFrame(self):
+        """Goes to nearest frame after current with any instances (user or pred)."""
+        self.execute(GoNextPredFrame)
 
     def nextUserLabeledFrame(self):
         """Goes to next labeled frame with user instances."""
@@ -2600,7 +2600,7 @@ class GoIteratorCommand(AppCommand):
         cls._plot_if_next(context, frames)
 
 
-class GoPreviousLabeledFrame(GoIteratorCommand):
+class GoPreviousPredFrame(GoIteratorCommand):
     @staticmethod
     def _get_frame_iterator(context: CommandContext):
         return iterate_labeled_frames(
@@ -2611,7 +2611,7 @@ class GoPreviousLabeledFrame(GoIteratorCommand):
         )
 
 
-class GoNextLabeledFrame(GoIteratorCommand):
+class GoNextPredFrame(GoIteratorCommand):
     @staticmethod
     def _get_frame_iterator(context: CommandContext):
         return iterate_labeled_frames(

--- a/sleap/gui/shortcuts.py
+++ b/sleap/gui/shortcuts.py
@@ -43,6 +43,8 @@ class Shortcuts(object):
         "propagate track labels",
         "select next",
         "clear selection",
+        "goto next pred",
+        "goto prev pred",
         "goto next labeled",
         "goto prev labeled",
         "goto last interacted",


### PR DESCRIPTION
Currently, the "Goto Next/Prev Labeled Frame" hotkeys (alt+right/left) actually move between *predicted* frames, not labeled frames (i.e., manually labeled or corrected frames).

This PR renames the existing hotkeys to "Goto Next/Prev *Predicted* Frame" and add two new hotkeys for moving between actual labeled frames.

For the keyboard shortcut, the ctrl/alt/shift+left/right combinations seem rather busy right now (also taking into account system hotkeys in GNOME), so for now I set the default shortcuts to `[` and `]`. LMK if you want me to change this.