### PR TITLE
chore: bump sleap-nn pin to >=0.3.3,<0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,38 +66,38 @@ jupyter = [
 ]
 
 nn = [
-    "sleap-nn[torch]>=0.3.2,<0.4.0"
+    "sleap-nn[torch]>=0.3.3,<0.4.0"
 ]
 
 nn-cpu = [
-    "sleap-nn[torch]>=0.3.2,<0.4.0"
+    "sleap-nn[torch]>=0.3.3,<0.4.0"
 ]
 
 nn-cuda128 = [
-    "sleap-nn[torch]>=0.3.2,<0.4.0"
+    "sleap-nn[torch]>=0.3.3,<0.4.0"
 ]
 
 nn-cuda118 = [
-    "sleap-nn[torch]>=0.3.2,<0.4.0"
+    "sleap-nn[torch]>=0.3.3,<0.4.0"
 ]
 
 nn-cuda130 = [
-    "sleap-nn[torch]>=0.3.2,<0.4.0"
+    "sleap-nn[torch]>=0.3.3,<0.4.0"
 ]
 
 # Export extras - self-contained with torch
 # Can be used alone (defaults to cu128) or combined with nn-cuda* for specific CUDA version
 nn-export = [
-    "sleap-nn[torch,export]>=0.3.2,<0.4.0"
+    "sleap-nn[torch,export]>=0.3.3,<0.4.0"
 ]
 
 nn-export-gpu = [
-    "sleap-nn[torch,export-gpu]>=0.3.2,<0.4.0"
+    "sleap-nn[torch,export-gpu]>=0.3.3,<0.4.0"
 ]
 
 # TensorRT - Linux/Windows only (not supported on macOS)
 nn-tensorrt = [
-    "sleap-nn[torch,tensorrt]>=0.3.2,<0.4.0; sys_platform != 'darwin'"
+    "sleap-nn[torch,tensorrt]>=0.3.3,<0.4.0; sys_platform != 'darwin'"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- Bumps `sleap-nn`'s lower pin from `>=0.3.2` to `>=0.3.3` across all 8 `nn*` extras in `pyproject.toml`.
- Fixes a confirmed top-down inference regression before it ships in a SLEAP release (v1.6.5's GitHub release hasn't been published yet).

## Why

sleap-nn 0.3.2 has a regression in the top-down inference pipeline builders (`_build_topdown`/`_build_topdown_segmentation`/`_build_topdown_multiclass`): when a centroid model and a centered-instance model are trained with **different** `preprocessing.scale` values (a common setup — centroid models are often trained at lower resolution for speed; it's literally the GUI's own default training-profile pairing), the centered-instance stage silently inherits the centroid model's scale instead of its own. This corrupts confidence-map peak-finding badly enough to drop detections almost entirely.

Caught via manual GUI testing before the v1.6.5 release was published — real repro on a 2560-frame project (centroid scale=0.5, centered_instance scale=1.0): `predict` went from 10 correct instances (sleap-nn 0.3.1) to 0 (sleap-nn 0.3.2), on identical input/model weights.

sleap-nn v0.3.3 fixes this (talmolab/sleap-nn#725) plus two smaller correctness issues from the same batch:
- #728 — `predict` never recorded `input_scale`/`crop_size` in its output provenance metadata.
- #729 — `anchor_part` had no upfront validation (crashed confusingly deep with a misleading error) + LR scheduler priority order was silently ignored.

sleap-io pin is unchanged (still latest at 0.9.2).

## Testing

Re-verified against the real published PyPI wheel (`sleap-nn==0.3.3`, not just the source checkout):
- **Original bug repro**, real project + real models (centroid scale=0.5 / centered_instance scale=1.0): `instances=10 (2.00/frame)` — matches pre-regression 0.3.1 behavior.
- **Fresh end-to-end train→load check**: trained a centroid (scale=0.5) and centered_instance (scale=1.0) model via `sleap-nn train` CLI with deliberately mismatched scales, then confirmed via `load_model_assets()` that `centroid_crop.input_scale=0.5` and `instance_peaks.input_scale=1.0` — each stage keeps its own scale.
- **sleap-nn test suites**: `tests/inference/` 864 passed, `tests/training/` 259 passed, targeted regression tests for this fix (`test_loaders.py`/`test_predictors.py`) 41 passed.
- **SLEAP test suites**: `tests/gui/learning/` + `tests/test_cli.py` passed against both an editable local sleap-nn checkout and the real PyPI 0.3.3 wheel; full SLEAP suite 1395 passed / 3 skipped.
- `uv.lock` regenerated locally to validate resolution (not committed — gitignored as usual).

## Related

Part of the v1.6.5 release effort. No issue to close — caught during manual pre-release testing, documented in `scratch/2026-08-07-release-v1.6.5/sleap-nn-0.3.2-topdown-scale-bug.md` and `scratch/2026-08-11-release-v1.6.5/README.md` (gitignored, not part of this diff).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)