### PR TITLE
fix(gui): run "Predict on entire video" on the video file, not the project .slp

### DIFF
--- a/sleap/gui/learning/runners.py
+++ b/sleap/gui/learning/runners.py
@@ -430,14 +430,15 @@ class VideoItemForInference(ItemForInference):
     This allows for inference on an arbitrary list of frames from video.
 
     Attributes:
-        video: the :py:class:`Video` object (which already stores its own path)
-        frames: list of frames for inference; if None, then all frames are used
-        use_absolute_path: whether to use absolute path for inference cli call
         video: The :py:class:`Video` object (which already stores its own path)
         frames: List of frames for inference; if None, then all frames are used
-        labels_path: Path to .slp project; if None, then use video path instead.
-        video_idx: Video index for inference; if None, then first video is used. Only
-            used if labels_path is specified.
+        use_absolute_path: Whether to use absolute path for inference cli call
+        labels_path: Path to the .slp project the video belongs to, if any. Used as
+            `--data_path` only when the video has no video file of its own to point at
+            (see `uses_labels_path`); a video with its own file is inferred on
+            directly, so unlabeled frames aren't skipped.
+        video_idx: Index of this video within the project's videos. Passed as
+            `--video_index` only when `--data_path` is the project .slp.
     """
 
     video: Video
@@ -447,18 +448,55 @@ class VideoItemForInference(ItemForInference):
     video_idx: int = 0
 
     @property
+    def uses_labels_path(self) -> bool:
+        """Whether inference has to run on the project rather than a video file.
+
+        True only when the video has no single video file of its own to point
+        `--data_path` at:
+
+        * Embedded projects (`.pkg.slp`): the images live inside the project file, so
+          `video.filename` *is* a `.slp` (with `backend.dataset` naming the embedded
+          video). This is also the only correct source -- the frames that exist for an
+          embedded video are exactly the ones stored in the project.
+        * Image-sequence videos: `filename` is a list of image paths, which is not
+          something a single `--data_path` can express.
+
+        Both cases need `--video_index` to scope the run to this video. Falls back to
+        the video file when there is no project path to use.
+        """
+        if not self.labels_path:
+            return False
+        filename = self.video.filename
+        if not isinstance(filename, (str, Path)):
+            # Image sequence: a list of per-frame image paths.
+            return True
+        return str(filename).endswith(".slp")
+
+    @property
     def path(self):
-        if self.labels_path is not None:
+        # Prefer the video's own file: this item runs on an arbitrary list of frame
+        # *indices*, most of which are typically unlabeled (e.g. "entire video"). A
+        # .slp `--data_path` routes sleap-nn through `LabelsProvider`, which can only
+        # subset the frames already labeled in the project, so the run would silently
+        # cap at the labeled-frame count. Pointing at the video instead uses
+        # `VideoProvider`, which reads any frame index.
+        if self.uses_labels_path:
             return self.labels_path
-        if self.use_absolute_path:
-            return os.path.abspath(self.video.filename)
-        return self.video.filename
+        filename = self.video.filename
+        # Remote videos are passed through verbatim; `abspath` would rewrite a URL
+        # into a cwd-relative path. Local relative paths are already resolved
+        # against the project location by `sleap_io.load_slp`.
+        if self.use_absolute_path and "://" not in str(filename):
+            return os.path.abspath(filename)
+        return filename
 
     @property
     def cli_args(self):
         arg_list = list()
         arg_list.extend(["--data_path", f"{self.path}"])
-        if self.labels_path is not None:
+        # `--video_index` picks one video out of a `.slp`; it has no meaning when
+        # `--data_path` is the video file itself (there is only one video then).
+        if self.uses_labels_path:
             arg_list.extend(["--video_index", str(self.video_idx)])
 
         # TODO: better support for video params
@@ -476,12 +514,15 @@ class VideoItemForInference(ItemForInference):
         ):
             arg_list.extend(("--video_input_format", self.video.backend.input_format))
 
-        # -Y represents endpoint of [X, Y) range but inference cli expects
-        # [X, Y-1] range (so add 1 since negative).
-        frame_int_list = list(set([i + 1 if i < 0 else i for i in self.frames]))
-        frame_int_list.sort(reverse=min(frame_int_list) < 0)  # Assumes len of 2 if neg.
+        # No frames means every frame, which is what omitting `--frames` does.
+        if self.frames:
+            # -Y represents endpoint of [X, Y) range but inference cli expects
+            # [X, Y-1] range (so add 1 since negative).
+            frame_int_list = list(set([i + 1 if i < 0 else i for i in self.frames]))
+            # Assumes len of 2 if neg.
+            frame_int_list.sort(reverse=min(frame_int_list) < 0)
 
-        arg_list.extend(("--frames", ",".join(map(str, frame_int_list))))
+            arg_list.extend(("--frames", ",".join(map(str, frame_int_list))))
 
         return arg_list
 
@@ -578,7 +619,7 @@ class InferenceTask:
             cli_args.append("--gui")
         cli_args.extend(
             item_for_inference.cli_args
-        )  # sample inference CLI args: ['--data_path', '...', '--video_index', '0',
+        )  # sample inference CLI args: ['--data_path', '.../video.mp4',
         # '--video_input_format', 'channels_last', '--frames', '0,-2559']
 
         # Make path where we'll save predictions (if not specified)
@@ -594,23 +635,22 @@ class InferenceTask:
                 # as the video
                 predictions_dir = os.path.dirname(item_for_inference.video.filename)
 
-            # Build filename with video name and timestamp
+            # Build filename with source name and timestamp. The basename of `path`
+            # identifies the source on its own when it's a video file. When it's a
+            # project .slp scoped by `--video_index` (embedded/image-sequence videos,
+            # which all share one filename), add the index so per-video runs don't
+            # collide on a single output path.
             timestamp = datetime.now().strftime("%y%m%d_%H%M%S")
             video_name_prefix = ""
             if "--video_index" in item_for_inference.cli_args:
-                video_index = int(
-                    item_for_inference.cli_args[
-                        item_for_inference.cli_args.index("--video_index") + 1
-                    ]
-                )
-                video_name_prefix = Path(self.labels.videos[video_index].filename).name
-            video_name_prefix = (
-                video_name_prefix + "_" if video_name_prefix != "" else ""
-            )
+                video_index = item_for_inference.cli_args[
+                    item_for_inference.cli_args.index("--video_index") + 1
+                ]
+                video_name_prefix = f"video{video_index}_"
             output_path = os.path.join(
                 predictions_dir,
-                f"{video_name_prefix}{os.path.basename(item_for_inference.path)}.{timestamp}."
-                "predictions.slp",
+                f"{video_name_prefix}{os.path.basename(item_for_inference.path)}"
+                f".{timestamp}.predictions.slp",
             )
 
         for job_path in self.trained_job_paths:

--- a/tests/gui/learning/test_cli_construction.py
+++ b/tests/gui/learning/test_cli_construction.py
@@ -48,6 +48,32 @@ def mock_video_with_backend():
 
 
 @pytest.fixture
+def mock_embedded_video():
+    """Create a mock Video whose images are embedded in a `.pkg.slp`.
+
+    Matches what sleap-io reports for an embedded project: `filename` is the
+    `.pkg.slp` itself and `backend.dataset` names the embedded video.
+    """
+    video = MagicMock(spec=Video)
+    video.filename = "/path/to/train.pkg.slp"
+    video.backend = MagicMock()
+    video.backend.dataset = "video3/video"
+    video.backend.input_format = "channels_last"
+    return video
+
+
+@pytest.fixture
+def mock_image_sequence_video():
+    """Create a mock Video backed by a list of image files."""
+    video = MagicMock(spec=Video)
+    video.filename = ["/path/to/imgs/img0.png", "/path/to/imgs/img1.png"]
+    video.backend = MagicMock()
+    video.backend.dataset = None
+    video.backend.input_format = None
+    return video
+
+
+@pytest.fixture
 def mock_labels(mock_video):
     """Create a mock Labels object."""
     labels = MagicMock(spec=Labels)
@@ -64,7 +90,7 @@ class TestVideoItemForInferenceCLI:
     """Tests for VideoItemForInference CLI argument construction."""
 
     def test_basic_cli_args(self, mock_video):
-        """Basic CLI args should include data path and frames."""
+        """Basic CLI args should include the video data path and frames."""
         item = VideoItemForInference(
             video=mock_video,
             frames=[0, 1, 2, 3, 4],
@@ -75,14 +101,23 @@ class TestVideoItemForInferenceCLI:
         cli_args = item.cli_args
 
         assert "--data_path" in cli_args
-        assert "/path/to/labels.slp" in cli_args
+        data_idx = cli_args.index("--data_path") + 1
+        assert cli_args[data_idx] == "/path/to/video.mp4"
+        assert "/path/to/labels.slp" not in cli_args
         assert "--frames" in cli_args
         # Frames should be comma-separated
         frames_idx = cli_args.index("--frames") + 1
         assert cli_args[frames_idx] == "0,1,2,3,4"
 
-    def test_cli_args_with_video_index(self, mock_video):
-        """CLI args should include video index when labels_path is provided."""
+    def test_cli_args_never_include_video_index(self, mock_video):
+        """CLI args should not include --video_index even with a labels_path.
+
+        Regression test: `--data_path` is the video file itself, so there is
+        exactly one video and no index to select. Passing a `.slp` data path plus
+        `--video_index`/`--frames` routed sleap-nn through `LabelsProvider`, which
+        can only subset frames that are *already labeled* in the project -- so
+        "predict on entire video" silently capped at the labeled-frame count.
+        """
         item = VideoItemForInference(
             video=mock_video,
             frames=[0, 1, 2],
@@ -92,9 +127,100 @@ class TestVideoItemForInferenceCLI:
 
         cli_args = item.cli_args
 
+        assert "--video_index" not in cli_args
+        data_idx = cli_args.index("--data_path") + 1
+        assert cli_args[data_idx] == "/path/to/video.mp4"
+
+    def test_entire_video_range_targets_video_file(self, mock_video):
+        """Entire-video mode on a sparsely labeled project must target the video.
+
+        Regression test for the frame-count cap: a project with 20 labeled frames
+        out of 2560 asked for `--frames 0,-1499` against the `.slp`, and sleap-nn
+        logged `source=LabelsProvider | frames=20`. The full frame range must go to
+        the video file so `VideoProvider` reads every requested index.
+        """
+        # "Entire video" encodes the full range as [0, -num_frames] (see
+        # `MainWindow._get_frame_selection`); 1500 frames requested here.
+        item = VideoItemForInference(
+            video=mock_video,
+            frames=[0, -1500],
+            labels_path="/path/to/labels.slp",
+            video_idx=0,
+        )
+
+        cli_args = item.cli_args
+
+        data_idx = cli_args.index("--data_path") + 1
+        assert cli_args[data_idx] == "/path/to/video.mp4"
+        assert not cli_args[data_idx].endswith(".slp")
+        assert "--video_index" not in cli_args
+        frames_idx = cli_args.index("--frames") + 1
+        assert cli_args[frames_idx] == "0,-1499"
+
+    def test_embedded_pkg_slp_keeps_labels_path_and_video_index(
+        self, mock_embedded_video
+    ):
+        """An embedded `.pkg.slp` video must stay on the project + --video_index.
+
+        There is no separate video file for an embedded video -- `video.filename` is
+        the `.pkg.slp` itself -- so pointing `--data_path` at it would hand sleap-nn a
+        `.slp` with no `--video_index`, running unscoped across every video in the
+        project. The frames that exist for an embedded video are exactly the ones
+        stored in the project, so `LabelsProvider` is the right source here.
+        """
+        item = VideoItemForInference(
+            video=mock_embedded_video,
+            frames=[0, -80],
+            labels_path="/path/to/train.pkg.slp",
+            video_idx=3,
+        )
+
+        assert item.uses_labels_path
+        assert item.path == "/path/to/train.pkg.slp"
+
+        cli_args = item.cli_args
+        data_idx = cli_args.index("--data_path") + 1
+        assert cli_args[data_idx] == "/path/to/train.pkg.slp"
         assert "--video_index" in cli_args
-        idx_pos = cli_args.index("--video_index") + 1
-        assert cli_args[idx_pos] == "2"
+        assert cli_args[cli_args.index("--video_index") + 1] == "3"
+
+    def test_image_sequence_video_keeps_labels_path(self, mock_image_sequence_video):
+        """A video backed by a list of images must stay on the project path.
+
+        `Video.filename` is a list for image-sequence backends, which cannot be
+        expressed as a single `--data_path` (and would be stringified into a Python
+        list repr on the command line).
+        """
+        item = VideoItemForInference(
+            video=mock_image_sequence_video,
+            frames=[0, -2],
+            labels_path="/path/to/labels.slp",
+            video_idx=1,
+        )
+
+        assert item.uses_labels_path
+        assert item.path == "/path/to/labels.slp"
+
+        cli_args = item.cli_args
+        data_idx = cli_args.index("--data_path") + 1
+        assert cli_args[data_idx] == "/path/to/labels.slp"
+        assert "[" not in cli_args[data_idx]
+        assert "--video_index" in cli_args
+
+    def test_absolute_path_not_applied_to_list_filename(
+        self, mock_image_sequence_video
+    ):
+        """use_absolute_path must not try to abspath() a list of image paths."""
+        item = VideoItemForInference(
+            video=mock_image_sequence_video,
+            frames=[0, -2],
+            labels_path="/path/to/labels.slp",
+            video_idx=0,
+            use_absolute_path=True,
+        )
+
+        # Would raise TypeError if abspath() were handed the list.
+        assert item.path == "/path/to/labels.slp"
 
     def test_cli_args_with_hdf5_backend(self, mock_video_with_backend):
         """CLI args should include video_dataset and video_input_format for HDF5."""
@@ -132,8 +258,58 @@ class TestVideoItemForInferenceCLI:
         # -100 becomes -99 (endpoint adjustment)
         assert "-99" in cli_args[frames_idx]
 
+    def test_remote_url_video_not_mangled_by_absolute_path(self):
+        """A remote video URL must pass through verbatim.
+
+        `os.path.abspath()` would rewrite `https://h/v.mp4` into
+        `<cwd>/https:/h/v.mp4`. sleap-nn passes URL data paths through as-is.
+        """
+        video = MagicMock(spec=Video)
+        video.filename = "https://host/videos/vid.mp4"
+        video.backend = MagicMock()
+        video.backend.dataset = None
+        video.backend.input_format = None
+
+        item = VideoItemForInference(
+            video=video,
+            frames=[0, -100],
+            labels_path="/path/to/labels.slp",
+            video_idx=0,
+            use_absolute_path=True,
+        )
+
+        assert not item.uses_labels_path
+        assert item.path == "https://host/videos/vid.mp4"
+
+    def test_no_labels_path_still_uses_video(self, mock_video):
+        """An empty labels_path must not be used as the data path."""
+        for labels_path in (None, ""):
+            item = VideoItemForInference(
+                video=mock_video,
+                frames=[0],
+                labels_path=labels_path,
+                video_idx=0,
+            )
+            assert not item.uses_labels_path
+            assert item.path == mock_video.filename
+
+    def test_no_frames_omits_frames_arg(self, mock_video):
+        """frames=None means all frames, which is `--frames` omitted, not a crash."""
+        item = VideoItemForInference(
+            video=mock_video,
+            frames=None,
+            labels_path="/path/to/labels.slp",
+            video_idx=0,
+        )
+
+        cli_args = item.cli_args  # Used to raise TypeError.
+
+        assert "--frames" not in cli_args
+        data_idx = cli_args.index("--data_path") + 1
+        assert cli_args[data_idx] == "/path/to/video.mp4"
+
     def test_path_property_with_labels(self, mock_video):
-        """path property should return labels_path when provided."""
+        """path property should return the video filename even with a labels_path."""
         item = VideoItemForInference(
             video=mock_video,
             frames=[0],
@@ -141,7 +317,7 @@ class TestVideoItemForInferenceCLI:
             video_idx=0,
         )
 
-        assert item.path == "/path/to/labels.slp"
+        assert item.path == mock_video.filename
 
     def test_path_property_without_labels(self, mock_video):
         """path property should return video filename when no labels_path."""
@@ -190,6 +366,20 @@ class TestDatasetItemForInferenceCLI:
         assert "--only_suggested_frames" in cli_args
         assert "--only_labeled_frames" not in cli_args
 
+    def test_predicted_frames_cli_args(self):
+        """Predicted frames should add --only_predicted_frames."""
+        item = DatasetItemForInference(
+            labels_path="/path/to/labels.slp",
+            frame_filter="predicted",
+        )
+
+        cli_args = item.cli_args
+
+        assert "--data_path" in cli_args
+        assert "--only_predicted_frames" in cli_args
+        assert "--only_labeled_frames" not in cli_args
+        assert "--only_suggested_frames" not in cli_args
+
     def test_path_property(self):
         """path property should return labels_path."""
         item = DatasetItemForInference(
@@ -235,6 +425,27 @@ class TestItemsForInference:
         assert len(items) == 1
         assert items.total_frame_count == 5
         assert isinstance(items.items[0], VideoItemForInference)
+
+    def test_from_video_frames_dict_targets_video_not_labels(
+        self, mock_video, mock_labels
+    ):
+        """Frame-range items must run on the video file, not the project .slp.
+
+        `labels_path`/`video_idx` are still recorded on the item (they identify the
+        project the video came from), they just no longer choose `--data_path`.
+        """
+        items = ItemsForInference.from_video_frames_dict(
+            video_frames_dict={mock_video: [0, -2560]},
+            total_frame_count=2560,
+            labels=mock_labels,
+            labels_path="/path/to/labels.slp",
+        )
+
+        item = items.items[0]
+        assert item.path == "/path/to/video.mp4"
+        assert item.labels_path == "/path/to/labels.slp"
+        assert item.video_idx == 0
+        assert "--video_index" not in item.cli_args
 
     def test_from_video_frames_dict_multiple_videos(self, mock_labels):
         """from_video_frames_dict should handle multiple videos."""
@@ -974,6 +1185,96 @@ class TestOutputPathGeneration:
         # Should contain predictions and timestamp pattern
         assert "predictions" in output_path
         assert ".predictions.slp" in output_path
+
+    def test_auto_output_path_named_after_video(self, mock_labels, video_item):
+        """Auto-generated output path should be named after the video, once.
+
+        The video name used to be added as a *prefix* to the `.slp` basename
+        (`video.mp4_labels.slp....`) because `--data_path` was the project `.slp`.
+        Now that `--data_path` is the video itself, the basename carries the video
+        name directly -- so it must neither be duplicated nor lost.
+        """
+        task = InferenceTask(
+            trained_job_paths=["/path/to/model"],
+            inference_params={},
+            labels=mock_labels,
+            labels_filename="/tmp/test_labels.slp",
+        )
+
+        with patch("sleap.gui.learning.runners.os.makedirs"):
+            _, output_path = task.make_predict_cli_call(video_item)
+
+        name = Path(output_path).name
+        assert name.startswith("video.mp4.")
+        assert name.endswith(".predictions.slp")
+        assert name.count("video.mp4") == 1
+        assert "video_None" not in name
+        assert "test_labels.slp" not in name
+        # Predictions still land in a `predictions` dir next to the project file.
+        assert Path(output_path).parent.as_posix() == "/tmp/predictions"
+
+    def test_auto_output_path_without_labels_filename_uses_video_dir(
+        self, mock_labels, video_item
+    ):
+        """With no project filename, predictions land next to the video."""
+        task = InferenceTask(
+            trained_job_paths=["/path/to/model"],
+            inference_params={},
+            labels=mock_labels,
+            labels_filename=None,
+        )
+
+        _, output_path = task.make_predict_cli_call(video_item)
+
+        assert Path(output_path).parent.as_posix() == "/path/to"
+        assert Path(output_path).name.startswith("video.mp4.")
+
+    def test_auto_output_path_disambiguates_embedded_videos(
+        self, mock_labels, mock_embedded_video
+    ):
+        """Embedded videos share one filename, so the index must disambiguate.
+
+        Every video in a `.pkg.slp` reports the same `filename` (the project file), so
+        per-video runs would otherwise collide on a single output path.
+        """
+        task = InferenceTask(
+            trained_job_paths=["/path/to/model"],
+            inference_params={},
+            labels=mock_labels,
+            labels_filename="/tmp/train.pkg.slp",
+        )
+        item = VideoItemForInference(
+            video=mock_embedded_video,
+            frames=[0, -80],
+            labels_path="/tmp/train.pkg.slp",
+            video_idx=3,
+        )
+
+        with patch("sleap.gui.learning.runners.os.makedirs"):
+            _, output_path = task.make_predict_cli_call(item)
+
+        name = Path(output_path).name
+        assert name.startswith("video3_train.pkg.slp.")
+        assert name.endswith(".predictions.slp")
+
+    def test_auto_output_path_for_dataset_item_unchanged(self, mock_labels):
+        """Annotation-status items should still be named after the project .slp."""
+        task = InferenceTask(
+            trained_job_paths=["/path/to/model"],
+            inference_params={},
+            labels=mock_labels,
+            labels_filename="/tmp/test_labels.slp",
+        )
+        item = DatasetItemForInference(
+            labels_path="/tmp/test_labels.slp", frame_filter="user"
+        )
+
+        with patch("sleap.gui.learning.runners.os.makedirs"):
+            _, output_path = task.make_predict_cli_call(item)
+
+        name = Path(output_path).name
+        assert name.startswith("test_labels.slp.")
+        assert name.endswith(".predictions.slp")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- "Run Inference → entire video" silently capped at however many frames were **already labeled** in the project, because the GUI pointed `--data_path` at the project `.slp` instead of the video file.
- `VideoItemForInference` now targets the video's own file (and drops `--video_index`) whenever the video *has* a file of its own, so `sleap-nn` reads every requested frame via `VideoProvider` instead of subsetting labeled frames via `LabelsProvider`.
- Embedded (`.pkg.slp`) and image-sequence videos have no separate video file, so they keep the project + `--video_index` route — which is also the only correct source for them.

## The bug

`VideoItemForInference` is the item used for "inference on an arbitrary list of frames from a video" (entire video, clip, current frame, random sample). Its `path` returned `labels_path` whenever one was set — and `ItemsForInference.from_video_frames_dict` always sets it — so the CLI became `--data_path <project.slp> --video_index N --frames 0,-1499`.

On the `sleap-nn` side, `.slp` + `--video_index` + `--frames` routes through `LabelsProvider`, which can only *subset frames that already have a `LabeledFrame`*; it never synthesizes frames for indices that were never labeled. So "predict on frames 0–1499" against a `.slp` with 20 labeled frames can never yield more than those 20, no matter what range is requested.

Repro (`sleap-nn 0.3.3`), on a project with 20 labeled frames of a 1500-frame video:

```
sleap predict --gui --data_path .../test_inference.slp --video_index 0 --frames 0,-1499 \
  --model_paths .../260428_082921.centroid.n=2560 \
  --model_paths .../260428_113349.centered_instance.n=2560 -o .../predictions.slp

Starting inference | source=LabelsProvider | frames=20 | ...
```

1500 frames requested, 20 processed. Detection quality was never the problem (2.00 instances/frame) — the run was scoped to the wrong frame set.

`DatasetItemForInference` (the user-labeled / suggested / predicted filters) is genuinely annotation-status based and does **not** have this bug; it is untouched here.

## Changes Made

`sleap/gui/learning/runners.py`:

- **`VideoItemForInference.uses_labels_path`** (new): true only when the video has no single video file to point `--data_path` at — an embedded `.pkg.slp` (where `video.filename` *is* a `.slp`) or an image-sequence video (where `filename` is a `list`). Those cases need `--video_index` to scope the run.
- **`VideoItemForInference.path`**: returns the video's filename unless `uses_labels_path`. Remote URLs are passed through verbatim (`os.path.abspath()` would rewrite `https://h/v.mp4` into `<cwd>/https:/h/v.mp4`); relative paths need no handling because `sleap_io.load_slp` already resolves them against the project location and rewrites `filename`.
- **`VideoItemForInference.cli_args`**: emits `--video_index` exactly when `--data_path` is the project `.slp`. Also omits `--frames` when the frame list is empty instead of raising `TypeError` — "no frames" means all frames, which is what omitting the flag does, and matches what the `frames` attribute's docstring already promised.
- **`InferenceTask.make_predict_cli_call`**: output filenames are derived from `os.path.basename(item.path)`, which now carries the video name directly. The old `video_name_prefix` (from `--video_index` → `labels.videos[i].filename`) would have duplicated it (`video_1.mp4_video_1.mp4…`). The prefix is kept only for the `.slp`-scoped case, keyed on the **index** (`video3_train.pkg.slp.<ts>.predictions.slp`) — every video in a `.pkg.slp` reports the same filename, so the old name-based prefix disambiguated nothing there.

## API Changes

- `VideoItemForInference.path` no longer returns `labels_path` for videos that have their own file. `labels_path` and `video_idx` are still populated and are still used for embedded/image-sequence videos and for output naming.
- `VideoItemForInference.cli_args` no longer emits `--video_index` for file-backed videos.
- New public property `VideoItemForInference.uses_labels_path`.
- Auto-generated prediction filenames change: `video_1.mp4_project.slp.<ts>.predictions.slp` → `video_1.mp4.<ts>.predictions.slp` (and `video3_train.pkg.slp.<ts>.predictions.slp` for embedded videos). Explicit `-o` paths are unaffected.

## Testing

11 new tests in `tests/gui/learning/test_cli_construction.py` (48 total in the file), plus 3 existing assertions inverted to the corrected behavior. Full `tests/gui`: 881 passed, 2 skipped.

Verified end-to-end against real projects and models, not just unit-level CLI construction:

| Video backend | `--data_path` | `--video_index` | Live check |
|---|---|---|---|
| `MediaVideo` (`.mp4`) | the video file | no | 20 labeled / 1500 frames → `source=.../video_1.mp4 \| frames=30` for `--frames 0,-29` (was `frames=0`) |
| `HDF5Video`, plain (`.h5` + dataset) | the `.h5` | no | 3 labeled / 40 frames → `source=VideoProvider \| frames=40` |
| `HDF5Video`, embedded (`.pkg.slp`) | project `.slp` | yes | 30-video training package, per-video scoping intact |
| `ImageVideo` (1 or N images) | project `.slp` | yes | real `sio.Video` objects |
| Remote URL | the URL verbatim | no | unit test |

Also confirmed: `InferenceTask.merge_results` attaches the video-sourced predictions to the existing project video (video count unchanged, no duplicate video added); `--only_labeled_frames` runs still log `source=LabelsProvider | frames=20` exactly as before; `labels.videos.index(video)` is identity-based, so index scoping is correct even with 30 identically-named embedded videos; channel handling comes from the model's preprocess config (`ensure_rgb`/`ensure_grayscale`), so switching providers cannot change it.

## Design Decisions

- **Gate on "does this video have its own file", not on "was a `labels_path` supplied".** An embedded video's `filename` is the `.pkg.slp` itself, so switching it to the "video path" would hand `sleap-nn` a `.slp` *without* `--video_index` — running unscoped across every video in the project. For embedded videos the frames that exist are exactly the ones stored in the project, so `LabelsProvider` is the right source.
- **Index-based output prefix for the `.slp` case.** After this change that branch is only embedded/image-sequence videos, which all share one filename; the video index is the only discriminator that actually disambiguates per-video runs.
- **`DatasetItemForInference` left alone.** It selects frames by annotation status, which is exactly what a `.slp` `--data_path` expresses.

## Future Considerations / Known Limitations

Out of scope here, each pre-existing or inherent:

1. **Image-sequence videos still cap at labeled frames.** `sleap-nn`'s `--data_path` has no directory or image-list form, so there is no video route to give them.
2. **Entire-video mode on an embedded `.pkg.slp` yields 0 frames.** The GUI encodes the range as `[0, len(video))` over *embedded positions*, while the labeled frames carry their original source indices (e.g. `6760, 7436, …`), so the two index spaces don't intersect. Verified: `--frames 0,-79` on a pkg → `frames=0`. Needs an embedded-position ↔ source-`frame_idx` mapping (or restricting embedded videos to annotation-status targets).
3. **"Skip user labeled" (`--exclude_user_labeled`) is inert on the raw-video route** — `sleap-nn` warns and runs all frames. Entire-video mode encodes frames as a `[0, -N]` range, so it can't be filtered GUI-side without expanding to a huge explicit index list; a proper fix needs annotation-status filtering for a video source in `sleap-nn`.
4. **Two videos with the same basename in different directories** can collide on one output filename within the same second. Equally true before this change (the old prefix was also just the basename).
5. A companion `sleap-nn` defensive-UX fix (warn on out-of-range `--frames` for a `.slp` source) is tracked separately.

## Related Issues

- #2808 — same code path (`VideoItemForInference.cli_args`), fragile `--frames 0,-N` encoding that can request an out-of-range index. Not fixed here, but this PR is a prerequisite for its proposed fix: `cli_args` now omits `--frames` when the frame list is empty, so "entire video → no `--frames`, let the reader decide" becomes a selection-encoding change only. Stays open.
- Discussion #2844 ("Find instances on suggestion but not on entire video") — same symptom shape. Its root cause was assessed separately as the `sleap-nn` centroid/centered-instance scale-sharing bug (fixed in `sleap-nn` 0.3.3); the scoping defect fixed here may also have contributed. Not claimed as closed.

Full investigation notes live in the `sleap-nn` repo under `scratch/2026-08-12-gui-entire-video-frame-cap/`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
