### PR TITLE
fix(gui): accept `phase` arg in ExportPackageThread progress callback (#2854)

### DIFF
--- a/sleap/gui/commands.py
+++ b/sleap/gui/commands.py
@@ -1821,7 +1821,11 @@ class ExportPackageThread(QtCore.QThread):
     def run(self):
         """Run the export in background thread."""
 
-        def on_progress(current, total):
+        def on_progress(current, total, phase=None):
+            # `phase` ("embed" or "write") is passed by sleap-io >= 0.9.0's
+            # save_slp progress_callback (see sleap-io PR #543). Accept it as an
+            # optional arg so the callback stays compatible with both the newer
+            # 3-arg API and any 2-arg caller. See issue #2854.
             self.progress.emit(current, total)
             return not self._cancelled
 

--- a/tests/gui/test_commands.py
+++ b/tests/gui/test_commands.py
@@ -24,6 +24,7 @@ from sleap.gui.commands import (
     ExportAnalysisFile,
     ExportDatasetWithImages,
     ExportFullPackage,
+    ExportPackageThread,
     ExportVideoClip,
     GenerateSuggestionsThread,
     ImportDeepLabCutFolder,
@@ -1472,6 +1473,49 @@ def test_exportLabelsPackage(export_extension, centered_pair_labels: Labels, tmp
     context = CommandContext.from_labels(deepcopy(centered_pair_labels))
     context.exportFullPackage()
     assert_loaded_package_similar(path_to_pkg, sugg=True, pred=True)
+
+
+def test_ExportPackageThread_progress_callback(
+    qtbot, centered_pair_labels: Labels, tmpdir
+):
+    """Regression test for #2854.
+
+    sleap-io >= 0.9.0 calls `save_slp`'s `progress_callback` with three
+    positional args `(current, total, phase)` where `phase` is "embed" or
+    "write" (sleap-io PR #543). `ExportPackageThread.run`'s `on_progress`
+    callback must accept the extra `phase` argument, otherwise embedding a
+    package raises `TypeError: on_progress() takes 2 positional arguments but 3
+    were given`. This test runs the real embed path (not the `verbose=False`
+    shortcut that skips the callback) to catch future signature drift.
+    """
+    out_path = Path(tmpdir, "test_export_progress.pkg.slp")
+
+    thread = ExportPackageThread(
+        labels=centered_pair_labels,
+        filename=out_path.as_posix(),
+        embed_option="user",
+    )
+
+    progress_events: List[tuple] = []
+    finished_files: List[str] = []
+    errors: List[str] = []
+
+    thread.progress.connect(
+        lambda current, total: progress_events.append((current, total))
+    )
+    thread.finished.connect(lambda fname: finished_files.append(fname))
+    thread.error.connect(lambda msg: errors.append(msg))
+
+    # Run synchronously in the current thread so the direct signal connections
+    # fire before we make assertions (no event loop needed).
+    thread.run()
+
+    # The callback must not have blown up on the 3-arg invocation.
+    assert errors == [], f"Export errored: {errors}"
+    assert finished_files == [out_path.as_posix()]
+    assert out_path.exists()
+    # sleap-io reports progress during the "embed" and "write" phases.
+    assert len(progress_events) > 0
 
 
 def test_newInstance(qtbot, centered_pair_predictions: Labels):


### PR DESCRIPTION
## Summary
- Fixes a `TypeError` that breaks **Export Training Job Package** / labels package export with embedded frames from the GUI on `sleap-io >= 0.9.0`.
- `ExportPackageThread.run`'s `on_progress` callback now accepts the `phase` argument that newer `sleap-io` passes to `save_slp`'s `progress_callback`.
- Adds a regression test that exercises the real embed path (which the existing package test skipped).

## Root Cause
`sleap-io >= 0.9.0` changed the SLP-embedding `progress_callback` signature used by `save_file`/`save_slp` from `(current, total)` to `(current, total, phase)`, where `phase` is `"embed"` or `"write"` (sleap-io PR #543). `sleap`'s GUI export code was never updated, so `save_slp` invoking the callback with 3 positional args raised:

```
TypeError: ExportPackageThread.run.<locals>.on_progress() takes 2 positional arguments but 3 were given
```

Current `develop` pins `sleap-io[all]>=0.9.2,<0.10.0`, so any normal dev install reproduces it.

## Changes Made
- `sleap/gui/commands.py`: `ExportPackageThread.run`'s nested `on_progress(current, total)` → `on_progress(current, total, phase=None)`. The `phase` default keeps the callback compatible with both the 3-arg API and any 2-arg caller.
- `tests/gui/test_commands.py`: new `test_ExportPackageThread_progress_callback` that constructs an `ExportPackageThread` with embedded frames and runs `.run()`, asserting no error, `finished` emitted, the package written, and progress reported.

## API Changes
None (internal callback signature only; the `progress` Qt `Signal(int, int)` is unchanged).

## Testing
- New regression test fails on the old 2-arg callback (verified by temporarily reverting the fix) and passes with the fix.
- The pre-existing `test_exportLabelsPackage` uses `verbose=False`, which routes to the synchronous path that calls `save_file` **without** a `progress_callback` — so it never exercised `on_progress`. That's why the bug slipped through; the new test runs the actual callback path.
- `uv run pytest tests/gui/test_commands.py::test_ExportPackageThread_progress_callback tests/gui/test_commands.py::test_exportLabelsPackage` → passing (macOS, `sleap-io` 0.9.2).

## Notes
- Deliberately did **not** touch `RenderVideoThread.run`'s sibling `on_progress`: `sio.render_video`'s callback signature was not changed by sleap-io and still uses `(current, total)`.
- The two GUI progress dialogs (`export_dataset_gui` and the render dialog) connect to the `worker.progress` `Signal(int, int)` and only consume `current`/`total`, so they are unaffected.
- Optional future UX (not in scope): surface `phase` in the dialog text ("Embedding frames…" vs "Writing file…").

## Related Issues
Fixes #2854.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
